### PR TITLE
fixed #83: game search can get stuck in an endless loop

### DIFF
--- a/src/extensions/gamemode_management/util/discovery.ts
+++ b/src/extensions/gamemode_management/util/discovery.ts
@@ -192,7 +192,7 @@ function walk(searchPath: string,
         progress.setStepCount(estimatedDirectories);
         progress.completed(lastCompleted, doneCount);
       }
-    }, { terminators: true });
+    }, { terminators: true, skipLinks: true });
 }
 
 function verifyToolDir(tool: ITool, testPath: string): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7910,8 +7910,8 @@ tunnel-agent@~0.4.1:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
 turbowalk@Nexus-Mods/node-turbowalk:
-  version "1.0.0"
-  resolved "https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/d9e673df0ded0e091b8c813b8a7517bc82fb1706"
+  version "1.0.1"
+  resolved "https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/90d2cbd7dc099f8f84bc813c1e0727e6cd02a1ad"
   dependencies:
     autogypi "^0.2.2"
     nan "^2.8.0"


### PR DESCRIPTION
If we don't follow symlinks, we can't get stuck.