### PR TITLE
Small fix to radio buttons

### DIFF
--- a/src/views/Dialog.tsx
+++ b/src/views/Dialog.tsx
@@ -244,7 +244,9 @@ class Dialog extends ComponentEx<IProps, IComponentState> {
     } else if (content.choices !== undefined) {
       controls.push((
         <div key='dialog-content-choices' className='dialog-content-choices'>
-          {content.choices.map(this.renderRadiobutton)}
+          <div>
+            {content.choices.map(this.renderRadiobutton)}
+          </div>
         </div>
       ));
     } else if (content.input !== undefined) {


### PR DESCRIPTION
This is a small fix for radio buttons rendered within `showDialog` window, so that they do not render on top of each other if there is not enough space, but rather maintain usual vertical separation and show scrollbars instead. Checkboxes already make use of this fix (`overflow: auto` for divs within `.dialog-content-choices`).