### PR TITLE
Updated the "Open on Nexus Mods" icon

### DIFF
--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -804,7 +804,7 @@ function guessIds(api: IExtensionApi, instanceIds: string[]) {
 
 function init(context: IExtensionContextExt): boolean {
   context.registerAction('application-icons', 200, LoginIcon, {}, () => ({ nexus }));
-  context.registerAction('mod-action-icons', 999, 'nexus', {}, 'Open on Nexus Mods',
+  context.registerAction('mods-action-icons', 999, 'nexus', {}, 'Open on Nexus Mods',
                          instanceIds => {
     const state: IState = context.api.store.getState();
     const gameMode = activeGameId(state);

--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -804,7 +804,7 @@ function guessIds(api: IExtensionApi, instanceIds: string[]) {
 
 function init(context: IExtensionContextExt): boolean {
   context.registerAction('application-icons', 200, LoginIcon, {}, () => ({ nexus }));
-  context.registerAction('nexus', 999, 'open-ext', {}, 'Open on Nexus Mods',
+  context.registerAction('mod-actions-icons', 999, 'nexus', {}, 'Open on Nexus Mods',
                          instanceIds => {
     const state: IState = context.api.store.getState();
     const gameMode = activeGameId(state);

--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -804,7 +804,7 @@ function guessIds(api: IExtensionApi, instanceIds: string[]) {
 
 function init(context: IExtensionContextExt): boolean {
   context.registerAction('application-icons', 200, LoginIcon, {}, () => ({ nexus }));
-  context.registerAction('mod-actions-icons', 999, 'nexus', {}, 'Open on Nexus Mods',
+  context.registerAction('mod-action-icons', 999, 'nexus', {}, 'Open on Nexus Mods',
                          instanceIds => {
     const state: IState = context.api.store.getState();
     const gameMode = activeGameId(state);

--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -804,7 +804,7 @@ function guessIds(api: IExtensionApi, instanceIds: string[]) {
 
 function init(context: IExtensionContextExt): boolean {
   context.registerAction('application-icons', 200, LoginIcon, {}, () => ({ nexus }));
-  context.registerAction('mods-action-icons', 999, 'open-ext', {}, 'Open on Nexus Mods',
+  context.registerAction('nexus', 999, 'open-ext', {}, 'Open on Nexus Mods',
                          instanceIds => {
     const state: IState = context.api.store.getState();
     const gameMode = activeGameId(state);


### PR DESCRIPTION
This PR uses the Nexus Mods icon, but the "open external" icon may also be a good fit.

Ideally something to imply you're opening it externally and not using an icon that already appears in the menu 
![image](https://user-images.githubusercontent.com/31670524/79565603-f6b2de80-80a8-11ea-8f52-fd504bbfc2e5.png)
