### PR TITLE
fix nativeName of Korean

### DIFF
--- a/src/extensions/settings_interface/languagemap.ts
+++ b/src/extensions/settings_interface/languagemap.ts
@@ -343,7 +343,7 @@ const languageMap = {
   },
   ko: {
     name: 'Korean',
-    nativeName: '한국어 (韓國語), 조선말 (朝鮮語)',
+    nativeName: '한국어',
   },
   ku: {
     name: 'Kurdish',


### PR DESCRIPTION
`조선말` is wrong translation. And we don't use Hanja(Chinese characters) at all.
`한국어` is the right translation. (ex. [Microsoft](https://www.microsoft.com/en-us/locale.aspx), [Google](https://www.google.com/preferences#languages), [Wikipedia](https://www.google.com/preferences#languages))