### PR TITLE
do not hardcode thumbnail dimensions

### DIFF
--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -1,4 +1,5 @@
 $thumbnail-width: 256px;
+$thumbnail-height: 144px;
 
 #gamepicker-layout {
   text-align: right;
@@ -8,6 +9,7 @@ $thumbnail-width: 256px;
   display: grid;
   justify-content: center;
   grid-template-columns: repeat(auto-fill, $thumbnail-width + $gutter-width);
+  grid-auto-rows: $thumbnail-height + $gutter-width;
 
   > .game-thumbnail {
     margin: $half-gutter !important;

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -112,8 +112,9 @@ $thumbnail-width: 256px;
   }
 
   .thumbnail-img {
-    max-width: 256px;
-    max-height: 144px;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 }
 

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -1,5 +1,4 @@
 $thumbnail-width: 256px;
-$thumbnail-height: 144px;
 
 #gamepicker-layout {
   text-align: right;
@@ -9,7 +8,6 @@ $thumbnail-height: 144px;
   display: grid;
   justify-content: center;
   grid-template-columns: repeat(auto-fill, $thumbnail-width + $gutter-width);
-  grid-auto-rows: $thumbnail-height + $gutter-width;
 
   > .game-thumbnail {
     margin: $half-gutter !important;
@@ -115,7 +113,7 @@ $thumbnail-height: 144px;
 
   .thumbnail-img {
     width: 100%;
-    height: 100%;
+    aspect-ratio: 16 / 9;
     object-fit: cover;
   }
 }


### PR DESCRIPTION
Came across this while working on a Vortex theme.

**Issue:**
The max dimensions of the thumbnail is hardcoded, and will break if the container size is changed.

**Solution:**
Instead of hardcoding the max dimensions, the image should adapt to the container size.
Using `object-fit: cover` will achieve the goal.
https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit