### PR TITLE
Remove win32 specific path strings from About page

### DIFF
--- a/src/extensions/about_dialog/views/AboutPage.tsx
+++ b/src/extensions/about_dialog/views/AboutPage.tsx
@@ -186,7 +186,7 @@ class AboutPage extends ComponentEx<IProps, IComponentState> {
     const mod: ILicense = modules[modKey];
     const license = typeof (mod.licenses) === 'string' ? mod.licenses : mod.licenses[0];
     const licenseFile = mod.licenseFile !== undefined
-      ? path.resolve(getVortexPath('modules'), '..', mod.licenseFile)
+      ? path.resolve(getVortexPath('modules'), '..', ...mod.licenseFile)
       : path.join(getVortexPath('assets'), 'licenses', license + '.md');
     fs.readFile(licenseFile, { }, (err, licenseText) => {
       if (!this.mMounted) {

--- a/updateLicenses.js
+++ b/updateLicenses.js
@@ -26,7 +26,7 @@ checker.init(
       // make the license path relative. license-checker has an option
       // to do that for us but that causes errors
       if (json[key].licenseFile) {
-        json[key].licenseFile = path.relative(basePath, json[key].licenseFile);
+        json[key].licenseFile = path.relative(basePath, json[key].licenseFile).split(path.sep);
       }
       delete json[key].path;
     });


### PR DESCRIPTION
Replaces the path strings with an array of path segments.
This will let Linux users read the software licenses too.

This commit doesn't include an updated modules.json file since my modules are updated/dirty.
A follow-up commit saving the latest changes to modules.json is required.