### PR TITLE
import Bluebird from 'bluebird', not Promise(BB)

### DIFF
--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -6,7 +6,7 @@ import {truthy} from '../util/util';
 
 import safeCreateAction from './safeCreateAction';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ipcMain, ipcRenderer } from 'electron';
 
 import * as reduxAct from 'redux-act';
@@ -120,7 +120,7 @@ export function addNotification(notification: INotification) {
     const noti = { ...notification };
 
     if ((noti.id !== undefined) && (suppressNotification(noti.id))) {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
 
     if (noti.id === undefined) {
@@ -149,7 +149,7 @@ export function addNotification(notification: INotification) {
 
     dispatch(startNotification(storeNoti));
     if (noti.displayMS !== undefined) {
-      return new Promise((resolve) => {
+      return new Bluebird((resolve) => {
         timers[noti.id] = setTimeout(() =>
           resolve()
           , noti.displayMS);
@@ -161,7 +161,7 @@ export function addNotification(notification: INotification) {
 }
 
 export function dismissNotification(id: string) {
-  return dispatch => new Promise<void>((resolve, reject) => {
+  return dispatch => new Bluebird<void>((resolve, reject) => {
     delete timers[id];
     delete notificationActions[id];
     dispatch(stopNotification(id));
@@ -195,7 +195,7 @@ export function showDialog(type: DialogType, title: string,
                            content: IDialogContent, actions: DialogActions,
                            inId?: string) {
   return (dispatch) => {
-    return new Promise<IDialogResult>((resolve, reject) => {
+    return new Bluebird<IDialogResult>((resolve, reject) => {
       const id = inId || shortid();
       const defaultAction = actions.find(iter => iter.default === true);
       const defaultLabel = defaultAction !== undefined ? defaultAction.label : undefined;

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -35,7 +35,7 @@ import SplashScreenT from './SplashScreen';
 import TrayIconT from './TrayIcon';
 
 import * as msgpackT from '@msgpack/msgpack';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import crashDumpT from 'crash-dump';
 import {app, crashReporter as crashReporterT, dialog, ipcMain, protocol, shell} from 'electron';
 import contextMenu from 'electron-context-menu';
@@ -175,7 +175,7 @@ class Application {
     });
   }
 
-  private startUi(): Promise<void> {
+  private startUi(): Bluebird<void> {
     const MainWindow = require('./MainWindow').default;
     this.mMainWindow = new MainWindow(this.mStore, this.mArgs.inspector);
     log('debug', 'creating main window');
@@ -193,11 +193,11 @@ class Application {
       if (didIgnoreError()) {
         webContents.send('did-ignore-error', true);
       }
-      return Promise.resolve();
+      return Bluebird.resolve();
     });
   }
 
-  private startSplash(): Promise<SplashScreenT> {
+  private startSplash(): Bluebird<SplashScreenT> {
     const SplashScreen = require('./SplashScreen').default;
     const splash: SplashScreenT = new SplashScreen();
     return splash.create(this.mArgs.disableGPU)
@@ -304,7 +304,7 @@ class Application {
     };
   }
 
-  private regularStart(args: IParameters): Promise<void> {
+  private regularStart(args: IParameters): Bluebird<void> {
     let splash: SplashScreenT;
     return fs.writeFileAsync(this.mStartupLogPath, (new Date()).toUTCString())
         .catch(() => null)
@@ -316,7 +316,7 @@ class Application {
         .then(() => this.testUserEnvironment())
         .then(() => this.validateFiles())
         .then(() => (args?.startMinimized === true)
-          ? Promise.resolve(undefined)
+          ? Bluebird.resolve(undefined)
           : this.startSplash())
         // start initialization
         .tap(splashIn => (splashIn !== undefined)
@@ -366,7 +366,7 @@ class Application {
         .tap(() => log('debug', 'starting user interface'))
         .then(() => {
           this.setupContextMenu();
-          return Promise.resolve();
+          return Bluebird.resolve();
         })
         .then(() => this.startUi())
         .tap(() => log('debug', 'setting up tray icon'))
@@ -381,7 +381,7 @@ class Application {
           this.connectTrayAndWindow();
           return (splash !== undefined)
             ? splash.fadeOut()
-            : Promise.resolve();
+            : Bluebird.resolve();
         })
         .tapCatch((err) => log('debug', 'quitting with exception', err.message))
         .catch(UserCanceled, () => app.exit())
@@ -444,9 +444,9 @@ class Application {
         .finally(() => fs.removeAsync(this.mStartupLogPath).catch(() => null));
   }
 
-  private isUACEnabled(): Promise<boolean> {
+  private isUACEnabled(): Bluebird<boolean> {
     if (process.platform !== 'win32') {
-      return Promise.resolve(true);
+      return Bluebird.resolve(true);
     }
 
     const getSystemPolicyValue = (key: string) => {
@@ -454,17 +454,17 @@ class Application {
         const res = winapi.RegGetValue('HKEY_LOCAL_MACHINE',
           'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System',
           key);
-        return Promise.resolve({ key, type: res.type, value: res.value});
+        return Bluebird.resolve({ key, type: res.type, value: res.value});
       } catch (err) {
         // We couldn't retrieve the value, log this and resolve positively
         //  as the user might have a version of Windows that does not use
         //  the key we're looking for.
         log('debug', 'failed to check UAC settings', err);
-        return Promise.resolve(undefined);
+        return Bluebird.resolve(undefined);
       }
     };
 
-    return Promise.all([getSystemPolicyValue('ConsentPromptBehaviorAdmin'),
+    return Bluebird.all([getSystemPolicyValue('ConsentPromptBehaviorAdmin'),
                         getSystemPolicyValue('ConsentPromptBehaviorUser')])
       .then(res => {
         res.forEach(value => {
@@ -474,23 +474,23 @@ class Application {
         });
         const adminConsent = res[0];
         return ((adminConsent.type === 'REG_DWORD') && (adminConsent.value === 0))
-          ? Promise.resolve(false)
-          : Promise.resolve(true);
+          ? Bluebird.resolve(false)
+          : Bluebird.resolve(true);
       })
       // Perfectly ok not to have the registry keys.
-      .catch(err => Promise.resolve(true));
+      .catch(err => Bluebird.resolve(true));
   }
 
-  private warnAdmin(): Promise<void> {
+  private warnAdmin(): Bluebird<void> {
     const state: IState = this.mStore.getState();
-    return timeout(Promise.resolve(isAdmin()), 1000)
+    return timeout(Bluebird.resolve(isAdmin()), 1000)
       .then(admin => {
         if ((admin === undefined) || !admin) {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
         log('warn', 'running as administrator');
         if (state.app.warnedAdmin > 0) {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
         return this.isUACEnabled().then(uacEnabled => dialog.showMessageBox(getVisibleWindow(), {
             title: 'Admin rights detected',
@@ -519,27 +519,27 @@ class Application {
               app.quit();
             } else {
               this.mStore.dispatch(setWarnedAdmin(1));
-              return Promise.resolve();
+              return Bluebird.resolve();
             }
           }));
       });
   }
 
-  private checkUpgrade(): Promise<void> {
+  private checkUpgrade(): Bluebird<void> {
     const currentVersion = getApplication().version;
     return this.migrateIfNecessary(currentVersion)
       .then(() => {
         this.mStore.dispatch(setApplicationVersion(currentVersion));
-        return Promise.resolve();
+        return Bluebird.resolve();
       });
   }
 
-  private migrateIfNecessary(currentVersion: string): Promise<void> {
+  private migrateIfNecessary(currentVersion: string): Bluebird<void> {
     const state: IState = this.mStore.getState();
     const lastVersion = state.app.appVersion || '0.0.0';
     if (this.mFirstStart || (currentVersion === '0.0.1')) {
       // don't check version change in development builds or on first start
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
     if (isMajorDowngrade(lastVersion, currentVersion)) {
       if (dialog.showMessageBoxSync(getVisibleWindow(), {
@@ -558,13 +558,13 @@ class Application {
         noLink: true,
       }) === 0) {
         app.quit();
-        return Promise.reject(new UserCanceled());
+        return Bluebird.reject(new UserCanceled());
       }
     } else if (semver.gt(currentVersion, lastVersion)) {
       log('info', 'Vortex was updated, checking for necessary migrations');
       return migrate(this.mStore, getVisibleWindow())
         .then(() => {
-          return Promise.resolve();
+          return Bluebird.resolve();
         })
         .catch(err => !(err instanceof UserCanceled)
                    && !(err instanceof ProcessCanceled), (err: Error) => {
@@ -573,17 +573,17 @@ class Application {
             'The migration from the previous Vortex release failed. '
             + 'Please resolve the errors you got, then try again.');
           app.exit(1);
-          return Promise.reject(new ProcessCanceled('Migration failed'));
+          return Bluebird.reject(new ProcessCanceled('Migration failed'));
         });
     }
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   private splitPath(statePath: string): string[] {
     return statePath.match(/(\\.|[^.])+/g).map(input => input.replace(/\\(.)/g, '$1'));
   }
 
-  private handleGet(getPath: string | boolean, dbpath: string): Promise<void> {
+  private handleGet(getPath: string | boolean, dbpath: string): Bluebird<void> {
     if (typeof(getPath) === 'boolean') {
       fs.writeSync(1, 'Usage: vortex --get <path>\n');
       app.quit();
@@ -602,7 +602,7 @@ class Application {
       .then(keys => {
         const matches = keys
           .filter(key => _.isEqual(key.slice(0, pathArray.length), pathArray));
-        return Promise.map(matches, match => persist.getItem(match)
+        return Bluebird.map(matches, match => persist.getItem(match)
           .then(value => `${match.join('.')} = ${value}`));
       }).then(output => { process.stdout.write(output.join('\n') + '\n'); })
       .catch(err => { process.stderr.write(err.message + '\n'); })
@@ -611,7 +611,7 @@ class Application {
       });
   }
 
-  private handleSet(setParameters: string[], dbpath: string): Promise<void> {
+  private handleSet(setParameters: string[], dbpath: string): Bluebird<void> {
     if (setParameters.length !== 2) {
       process.stdout.write('Usage: vortex --set <path>=<value>\n');
       app.quit();
@@ -645,7 +645,7 @@ class Application {
       });
   }
 
-  private handleDel(delPath: string, dbpath: string): Promise<void> {
+  private handleDel(delPath: string, dbpath: string): Bluebird<void> {
     const pathArray = this.splitPath(delPath);
 
     let persist: LevelPersist;
@@ -675,10 +675,10 @@ class Application {
       });
   }
 
-  private createTray(): Promise<void> {
+  private createTray(): Bluebird<void> {
     const TrayIcon = require('./TrayIcon').default;
     this.mTray = new TrayIcon(this.mExtensions.getApi());
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   private connectTrayAndWindow() {
@@ -709,7 +709,7 @@ class Application {
   }
 
   private createStore(restoreBackup?: string, mergeBackup?: string,
-                      repair?: boolean): Promise<void> {
+                      repair?: boolean): Bluebird<void> {
     const newStore = createVortexStore(this.sanityCheckCB);
     const backupPath = path.join(app.getPath('temp'), STATE_BACKUP_PATH);
     let backups: string[];
@@ -724,7 +724,7 @@ class Application {
         backups = [];
       });
 
-    const deleteBackups = () => Promise.map(backups, backupName =>
+    const deleteBackups = () => Bluebird.map(backups, backupName =>
           fs.removeAsync(path.join(backupPath, backupName))
             .catch(() => undefined))
           .then(() => null);
@@ -751,7 +751,7 @@ class Application {
       .catch(DataInvalid, err => {
         const failedPersistor = this.mLevelPersistors.pop();
         return failedPersistor.close()
-          .then(() => Promise.reject(err));
+          .then(() => Bluebird.reject(err));
       })
       .then(() => {
         let dataPath = app.getPath('userData');
@@ -790,7 +790,7 @@ class Application {
               this.mLevelPersistors.push(levelPersistor);
             });
         } else {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
       })
       .then(() => {
@@ -814,11 +814,11 @@ class Application {
 
           // relaunching the process happens asynchronously but we don't want to any further work
           // before that
-          return new Promise(() => null);
+          return new Bluebird(() => null);
         }
         const reducer = require('../reducers/index').default;
         newStore.replaceReducer(reducer(this.mExtensions.getReducers(), querySanitize));
-        return Promise.mapSeries(allHives(this.mExtensions), hive =>
+        return Bluebird.mapSeries(allHives(this.mExtensions), hive =>
           insertPersistor(hive, new SubPersistor(last(this.mLevelPersistors), hive)));
       })
       .then(() => {
@@ -837,7 +837,7 @@ class Application {
                            payload: oldState,
                          });
                        }) :
-                   Promise.resolve();
+                   Bluebird.resolve();
       })
       .then(() => {
         log('debug', 'updating state backups');
@@ -857,7 +857,7 @@ class Application {
             .then(() => updateBackups())
             .catch(err => {
               if (err instanceof UserCanceled) {
-                return Promise.reject(err);
+                return Bluebird.reject(err);
               }
               terminate({
                 message: 'Failed to restore backup',
@@ -878,7 +878,7 @@ class Application {
             })
             .catch(err => {
               if (err instanceof UserCanceled) {
-                return Promise.reject(err);
+                return Bluebird.reject(err);
               }
               terminate({
                 message: 'Failed to merge backup',
@@ -889,7 +889,7 @@ class Application {
               }, {}, false);
             });
         } else {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
       })
       .then(() => {
@@ -957,10 +957,10 @@ class Application {
         } else if (!repair) {
           // we started without any problems, save this application state
           return createFullStateBackup('startup', this.mStore)
-            .then(() => Promise.resolve())
+            .then(() => Bluebird.resolve())
             .catch(err => log('error', 'Failed to create startup state backup', err.message));
         }
-        return Promise.resolve();
+        return Bluebird.resolve();
       })
       .then(() => this.mExtensions.doOnce());
   }
@@ -970,12 +970,12 @@ class Application {
       'An invalid state change was prevented, this was probably caused by a bug', err);
   }
 
-  private initDevel(): Promise<void> {
+  private initDevel(): Bluebird<void> {
     if (process.env.NODE_ENV === 'development') {
       const {installDevelExtensions} = require('../util/devel') as typeof develT;
       return installDevelExtensions();
     } else {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
   }
 
@@ -1005,7 +1005,7 @@ class Application {
     setWindow(this.mMainWindow.getHandle());
   }
 
-  private testUserEnvironment(): Promise<void> {
+  private testUserEnvironment(): Bluebird<void> {
     // Should be used to test the user's environment for known
     //  issues before starting up Vortex.
     // On Windows:
@@ -1014,19 +1014,19 @@ class Application {
       try {
         const documentsFolder = app.getPath('documents');
         return (documentsFolder !== '')
-          ? Promise.resolve()
-          : Promise.reject(new DocumentsPathMissing());
+          ? Bluebird.resolve()
+          : Bluebird.reject(new DocumentsPathMissing());
       } catch (err) {
-        return Promise.reject(new DocumentsPathMissing());
+        return Bluebird.reject(new DocumentsPathMissing());
       }
     } else {
       // No tests needed.
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
   }
 
-  private validateFiles(): Promise<void> {
-    return Promise.resolve(validateFiles(getVortexPath('assets_unpacked')))
+  private validateFiles(): Bluebird<void> {
+    return Bluebird.resolve(validateFiles(getVortexPath('assets_unpacked')))
       .then(validation => {
         if ((validation.changed.length > 0)
             || (validation.missing.length > 0)) {
@@ -1047,21 +1047,21 @@ class Application {
               app.quit();
             } else {
               disableErrorReport();
-              return Promise.resolve();
+              return Bluebird.resolve();
             }
           });
         } else {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
       });
   }
 
   private applyArguments(args: IParameters) {
     if (args.download || args.install) {
-      const prom: Promise<void> = (this.mMainWindow === undefined)
+      const prom: Bluebird<void> = (this.mMainWindow === undefined)
         // give the main instance a moment to fully start up
-        ? Promise.delay(2000)
-        : Promise.resolve(undefined);
+        ? Bluebird.delay(2000)
+        : Bluebird.resolve(undefined);
 
       prom.then(() => {
         if (this.mMainWindow !== undefined) {

--- a/src/app/MainWindow.ts
+++ b/src/app/MainWindow.ts
@@ -12,7 +12,7 @@ import * as storeHelperT from '../util/storeHelper';
 import { truthy } from '../util/util';
 import { closeAllViews } from '../util/webview';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ipcMain, screen, webContents } from 'electron';
 import * as path from 'path';
 import * as Redux from 'redux';
@@ -88,9 +88,9 @@ class MainWindow {
     }, 500);
   }
 
-  public create(store: ThunkStore<IState>): Promise<Electron.WebContents> {
+  public create(store: ThunkStore<IState>): Bluebird<Electron.WebContents> {
     if (this.mWindow !== null) {
-      return Promise.resolve(undefined);
+      return Bluebird.resolve(undefined);
     }
 
     const BrowserWindow: typeof Electron.BrowserWindow = require('electron').BrowserWindow;
@@ -197,7 +197,7 @@ class MainWindow {
 
     this.initEventHandlers(store);
 
-    return new Promise<Electron.WebContents>((resolve) => {
+    return new Bluebird<Electron.WebContents>((resolve) => {
       this.mWindow.once('ready-to-show', () => {
         if ((resolve !== undefined) && (this.mWindow !== null)) {
           resolve(this.mWindow.webContents);

--- a/src/app/SplashScreen.ts
+++ b/src/app/SplashScreen.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import getVortexPath from '../util/getVortexPath';
@@ -10,14 +10,14 @@ class SplashScreen {
   public fadeOut() {
     // apparently we can't prevent the user from closing the splash with alt-f4...
     if ((this.mWindow === null) || this.mWindow.isDestroyed()) {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
     // ensure the splash screen remains visible
     this.mWindow.setAlwaysOnTop(true);
 
     // don't fade out immediately, otherwise the it looks odd
     // as the main window appears at the same time
-    return Promise.delay(200)
+    return Bluebird.delay(200)
         .then(() => {
           if (!this.mWindow.isDestroyed()) {
             try {
@@ -29,7 +29,7 @@ class SplashScreen {
         })
         // wait for the fade out animation to finish before destroying
         // the window
-        .then(() => Promise.delay(500))
+        .then(() => Bluebird.delay(500))
         .then(() => {
           if (!this.mWindow.isDestroyed()) {
             this.mWindow.close();
@@ -38,10 +38,10 @@ class SplashScreen {
         });
   }
 
-  public create(disableGPU: boolean): Promise<void> {
+  public create(disableGPU: boolean): Bluebird<void> {
     const BrowserWindow: typeof Electron.BrowserWindow = require('electron').BrowserWindow;
 
-    return new Promise<void>((resolve, reject) => {
+    return new Bluebird<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         log('warn', 'splash screen taking awfully long');
         resolve?.();

--- a/src/controls/DraggableList.tsx
+++ b/src/controls/DraggableList.tsx
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import * as React from 'react';
 import { ListGroup } from 'react-bootstrap';
 import {

--- a/src/controls/Dropzone.tsx
+++ b/src/controls/Dropzone.tsx
@@ -7,7 +7,7 @@ import { truthy } from '../util/util';
 
 import Icon from './Icon';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 import * as React from 'react';
 import { WithTranslation } from 'react-i18next';
@@ -34,7 +34,7 @@ interface IConnectedProps {}
 
 interface IActionProps {
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
 }
 
 type DropMode = 'no' | 'url' | 'file' | 'hover' | 'invalid';

--- a/src/controls/Icon.base.tsx
+++ b/src/controls/Icon.base.tsx
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 
 const debugMissingIcons = process.env.NODE_ENV === 'development';
@@ -42,7 +42,7 @@ export interface IIconProps {
    * get access to the specified set. This allows implementations to lazy-load icon sets
    * on demand
    */
-  getSet: (set: string) => Promise<Set<string>>;
+  getSet: (set: string) => Bluebird<Set<string>>;
 
   onContextMenu?: React.MouseEventHandler<any>;
 }

--- a/src/controls/Icon.tsx
+++ b/src/controls/Icon.tsx
@@ -1,7 +1,7 @@
 import { log } from '../util/log';
 import IconBase from './Icon.base';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 // using fs directly because the svg may be bundled inside the asar so
 // we need the electron-fs hook here
 import * as fs from 'fs';
@@ -29,12 +29,12 @@ export interface IIconProps {
   onContextMenu?: React.MouseEventHandler<Icon>;
 }
 
-export function installIconSet(set: string, setPath: string): Promise<Set<string>> {
+export function installIconSet(set: string, setPath: string): Bluebird<Set<string>> {
   const newset = document.createElement('div');
   newset.id = 'iconset-' + set;
   document.getElementById('icon-sets').appendChild(newset);
   log('info', 'read font', setPath);
-  return new Promise((resolve, reject) => {
+  return new Bluebird((resolve, reject) => {
     fs.readFile(setPath, {}, (err, data) => {
       if (err !== null) {
         return reject(err);
@@ -56,7 +56,7 @@ export function installIconSet(set: string, setPath: string): Promise<Set<string
 const loadingIconSets = new Set<string>();
 
 class Icon extends React.Component<IIconProps, { sets: { [setId: string]: Set<string> } }> {
-  private mLoadPromise: Promise<any>;
+  private mLoadPromise: Bluebird<any>;
   private mMounted: boolean = false;
 
   constructor(props: IIconProps) {
@@ -82,7 +82,7 @@ class Icon extends React.Component<IIconProps, { sets: { [setId: string]: Set<st
     return <IconBase {...this.props} getSet={this.loadSet} />;
   }
 
-  private loadSet = (set: string): Promise<Set<string>> => {
+  private loadSet = (set: string): Bluebird<Set<string>> => {
     const { sets } = this.state;
     if ((sets[set] === undefined) && !loadingIconSets.has(set)) {
       { // mark the set as being loaded
@@ -105,7 +105,7 @@ class Icon extends React.Component<IIconProps, { sets: { [setId: string]: Set<st
         newSymbols.forEach(ele => {
           newSet.add(ele.id);
         });
-        this.mLoadPromise = Promise.resolve(newSet);
+        this.mLoadPromise = Bluebird.resolve(newSet);
       } else {
         // make sure that no other icon instance tries to render this icon
         const fontPath = path.resolve(getVortexPath('assets'), 'fonts', set + '.svg');
@@ -125,7 +125,7 @@ class Icon extends React.Component<IIconProps, { sets: { [setId: string]: Set<st
         return newSet;
       });
     } else {
-      return Promise.resolve(sets[set] || null);
+      return Bluebird.resolve(sets[set] || null);
     }
   }
 }

--- a/src/controls/Table.tsx
+++ b/src/controls/Table.tsx
@@ -23,7 +23,7 @@ import TableRow from './table/TableRow';
 import ToolbarIcon from './ToolbarIcon';
 import Usage from './Usage';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import update from 'immutability-helper';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -173,7 +173,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
 
     this.mHeaderUpdateDebouncer = new Debouncer(() => {
       this.updateColumnWidth();
-      return Promise.resolve();
+      return Bluebird.resolve();
     }, 200, false);
 
     this.mUpdateCalculatedDebouncer = new Debouncer(() => {
@@ -1067,7 +1067,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
         smoothScroll(this.mScrollRef, targetPos, SuperTable.SCROLL_DURATION)
           .then((cont: boolean) => cont && (iterations > 0)
             ? this.scrollToItem(item, false, iterations - 1)
-            : Promise.resolve());
+            : Bluebird.resolve());
       } else {
         this.mScrollRef.scrollTop = targetPos;
 
@@ -1132,10 +1132,10 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     this.mHeaderRef = ref;
   }
 
-  private updateCalculatedValues(props: IProps, forceUpdateId?: string): Promise<string[]> {
+  private updateCalculatedValues(props: IProps, forceUpdateId?: string): Bluebird<string[]> {
     this.mNextUpdateState = props;
     if (this.mUpdateInProgress) {
-      return Promise.resolve([]);
+      return Bluebird.resolve([]);
     }
     this.mUpdateInProgress = true;
 
@@ -1149,21 +1149,21 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     let newValues: ILookupCalculated = this.state.calculatedValues || {};
 
     // recalculate each attribute in each row
-    return Promise.map(Object.keys(data), (rowId: string) => {
+    return Bluebird.map(Object.keys(data), (rowId: string) => {
       const delta: any = {};
 
-      return Promise.map(objects, (attribute: ITableAttribute) => {
+      return Bluebird.map(objects, (attribute: ITableAttribute) => {
         // avoid recalculating if the source data hasn't changed. To support
         // isVolatile we still go through each attribute even if the entire row didn't change
         if (!attribute.isVolatile
             && (attribute.id !== forceUpdateId)
             && (oldState.data[rowId] === data[rowId])) {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
         if (attribute.calc === undefined) {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
-        return Promise.resolve(attribute.calc(data[rowId], t))
+        return Bluebird.resolve(attribute.calc(data[rowId], t))
           .then(newValue => {
             if (!_.isEqual(newValue, getSafe(newValues, [rowId, attribute.id], undefined))) {
               changedColumns.add(attribute.id);
@@ -1191,14 +1191,14 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
         }
       });
     })
-    .then(() => Promise.map(Object.keys(oldState.data), rowId => {
+    .then(() => Bluebird.map(Object.keys(oldState.data), rowId => {
       if (data[rowId] === undefined) {
         delete newValues[rowId];
       }
     }))
     .then(() =>
       // once everything is recalculated, update the cache
-      new Promise<void>((resolve, reject) => {
+      new Bluebird<void>((resolve, reject) => {
         this.updateState(update(this.mNextState, {
           calculatedValues: { $set: newValues },
         }), () => resolve());
@@ -1214,12 +1214,12 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
         // another update was queued while this was active
         return this.updateCalculatedValues(this.mNextUpdateState);
       } else {
-        return Promise.resolve(Array.from(changedColumns));
+        return Bluebird.resolve(Array.from(changedColumns));
       }
     })
     .catch(err => {
       this.mUpdateInProgress = false;
-      return Promise.reject(err);
+      return Bluebird.reject(err);
     });
   }
 

--- a/src/extensions/browser/index.ts
+++ b/src/extensions/browser/index.ts
@@ -8,7 +8,7 @@ import BrowserView, { SubscriptionResult } from './views/BrowserView';
 import { closeBrowser, showURL } from './actions';
 import { sessionReducer } from './reducers';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ipcRenderer } from 'electron';
 import { generate as shortid } from 'shortid';
 import * as url from 'url';
@@ -48,7 +48,7 @@ let lastURL: string;
 function doBrowse(api: IExtensionApi, navUrl: string,
                   instructions: string, subscriptionId: string,
                   skippable: boolean) {
-  return new Promise<string>((resolve, reject) => {
+  return new Bluebird<string>((resolve, reject) => {
     lastURL = navUrl;
     subscribe(subscriptionId, 'close', (skip: boolean) => {
       reject(new UserCanceled(skip));

--- a/src/extensions/browser/views/BrowserView.tsx
+++ b/src/extensions/browser/views/BrowserView.tsx
@@ -13,7 +13,7 @@ import Notification from '../../../views/Notification';
 
 import { closeBrowser } from '../actions';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { clipboard } from 'electron';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -89,7 +89,7 @@ class BrowserView extends ComponentEx<IProps, IComponentState> {
       if (loading !== this.state.loading) {
         this.nextState.loading = loading;
       }
-      return Promise.resolve();
+      return Bluebird.resolve();
     }, 100, false);
 
     this.mCallbacks = {

--- a/src/extensions/category_management/util/CategoryFilter.tsx
+++ b/src/extensions/category_management/util/CategoryFilter.tsx
@@ -10,7 +10,7 @@ import { IMod } from '../../mod_management/types/IMod';
 import filterModInfo from '../../mod_management/util/filterModInfo';
 import { activeGameId } from '../../profile_management/selectors';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import update from 'immutability-helper';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -173,7 +173,7 @@ class CategoryFilterComponent extends React.Component<IProps, IComponentState> {
       customOption = { label: customFilter.slice(1), value: customFilter };
     }
 
-    Promise.map(filtered, archiveId =>
+    Bluebird.map(filtered, archiveId =>
       filterModInfo({ download: props.downloads[archiveId] }, undefined)
         .then(info => {
           if (info.category !== undefined) {

--- a/src/extensions/category_management/views/CategoryList.tsx
+++ b/src/extensions/category_management/views/CategoryList.tsx
@@ -21,7 +21,7 @@ import { ICategory, ICategoryDictionary } from '../types/ICategoryDictionary';
 import { ICategoriesTree } from '../types/ITrees';
 import createTreeDataObject from '../util/createTreeDataObject';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import { FormControl } from 'react-bootstrap';
 import * as SortableTreeT from 'react-sortable-tree';
@@ -45,7 +45,7 @@ interface IActionProps {
   onSetCategoryOrder: (gameId: string, categoryIds: string[]) => void;
   onRenameCategory: (activeGameId: string, categoryId: string, newCategory: {}) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
 }
 
 interface IConnectedProps {

--- a/src/extensions/diagnostics_files/util/loadVortexLogs.ts
+++ b/src/extensions/diagnostics_files/util/loadVortexLogs.ts
@@ -3,7 +3,7 @@ import {LogLevel} from '../../../util/log';
 
 import { ILog, ISession } from '../types/ISession';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import getVortexPath from '../../../util/getVortexPath';
 
@@ -23,14 +23,14 @@ function parseLine(line: string, idx: number): ILog {
   }
 }
 
-export function loadVortexLogs(): Promise<ISession[]> {
+export function loadVortexLogs(): Bluebird<ISession[]> {
   const logPath = getVortexPath('userData');
 
-  return Promise.resolve(fs.readdirAsync(logPath))
+  return Bluebird.resolve(fs.readdirAsync(logPath))
     .filter((fileName: string) => fileName.match(/vortex[0-9]?\.log/) !== null)
     .then((logFileNames: string[]) => {
       logFileNames = logFileNames.sort((lhs: string, rhs: string) => rhs.localeCompare(lhs));
-      return Promise.mapSeries(logFileNames, (logFileName: string) =>
+      return Bluebird.mapSeries(logFileNames, (logFileName: string) =>
                               fs.readFileAsync(path.join(logPath, logFileName), 'utf8'));
     })
     .then((data: string[]) => data.join('\n'))

--- a/src/extensions/diagnostics_files/views/DiagnosticsFilesDialog.tsx
+++ b/src/extensions/diagnostics_files/views/DiagnosticsFilesDialog.tsx
@@ -11,7 +11,7 @@ import { ILog, ISession } from '../types/ISession';
 import { loadVortexLogs } from '../util/loadVortexLogs';
 
 import * as RemoteT from '@electron/remote';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import update from 'immutability-helper';
 import * as os from 'os';
 import * as path from 'path';
@@ -267,7 +267,7 @@ class DiagnosticsFilesDialog extends ComponentEx<IProps, IComponentState> {
     );
   }
 
-  private updateLogs(): Promise<void> {
+  private updateLogs(): Bluebird<void> {
     const { onShowError } = this.props;
     return loadVortexLogs()
       .then(sessions => {
@@ -314,7 +314,7 @@ class DiagnosticsFilesDialog extends ComponentEx<IProps, IComponentState> {
 
     this.props.onHide();
     const logPath = path.join(nativeCrashesPath, 'session.log');
-    fs.ensureDirWritableAsync(nativeCrashesPath, () => Promise.resolve())
+    fs.ensureDirWritableAsync(nativeCrashesPath, () => Bluebird.resolve())
       .then(() => fs.writeFileAsync(logPath, fullLog))
       .then(() => {
         this.context.api.events.emit('report-log-error', logPath);

--- a/src/extensions/download_management/FileAssembler.ts
+++ b/src/extensions/download_management/FileAssembler.ts
@@ -4,7 +4,7 @@ import * as fs from '../../util/fs';
 import { log } from '../../util/log';
 import { makeQueue } from '../../util/util';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { dialog as dialogIn } from 'electron';
 import * as fsFast from 'fs-extra';
 import * as path from 'path';
@@ -20,18 +20,18 @@ const dialog = (process.type === 'renderer')
  * @class FileAssembler
  */
 class FileAssembler {
-  public static create(fileName: string): Promise<FileAssembler> {
+  public static create(fileName: string): Bluebird<FileAssembler> {
     let exists = false;
     let size = 0;
     return fs.ensureDirAsync(path.dirname(fileName))
       .then(() => fs.statAsync(fileName))
       .then(stats => {
         if (stats.isDirectory()) {
-          return Promise.reject(new Error('Download target is a directory'));
+          return Bluebird.reject(new Error('Download target is a directory'));
         }
         size = stats.size;
         exists = true;
-        return Promise.resolve();
+        return Bluebird.resolve();
       })
       .catch(() => null)
       .then(() => fs.openAsync(fileName, exists ? 'r+' : 'w'))
@@ -46,7 +46,7 @@ class FileAssembler {
   private mFD: number;
   private mFileName: string;
   private mTotalSize: number;
-  private mQueue: (cb: () => Promise<any>, tryOnly: boolean) => Promise<any>;
+  private mQueue: (cb: () => Bluebird<any>, tryOnly: boolean) => Bluebird<any>;
   private mWritten: number = 0;
   private mLastFlushedTime: number = 0;
   private mLastFlushedSize: number = 0;
@@ -61,7 +61,7 @@ class FileAssembler {
   public setTotalSize(size: number) {
     this.mQueue(() => {
       this.mTotalSize = size;
-      return Promise.resolve();
+      return Bluebird.resolve();
     }, false);
   }
 
@@ -69,9 +69,9 @@ class FileAssembler {
     return this.mFD === undefined;
   }
 
-  public rename(newName: string | Promise<string>) {
+  public rename(newName: string | Bluebird<string>) {
     const closeFD = () => this.isClosed()
-      ? Promise.reject(new ProcessCanceled('File is closed'))
+      ? Bluebird.reject(new ProcessCanceled('File is closed'))
       : fs.closeAsync(this.mFD);
 
     let resolved: string;
@@ -80,20 +80,20 @@ class FileAssembler {
     return this.mQueue(() =>
       closeFD()
       .catch({ code: 'EBADF' }, () => null)
-      .then(() => Promise.resolve(newName).then(nameResolved => resolved = nameResolved))
+      .then(() => Bluebird.resolve(newName).then(nameResolved => resolved = nameResolved))
       .then(() => fs.renameAsync(this.mFileName, resolved))
       .then(() => fs.openAsync(resolved, 'r+'))
       .then(fd => {
         this.mFD = fd;
         this.mFileName = resolved;
-        return Promise.resolve();
+        return Bluebird.resolve();
       })
       .catch(err => {
         if (err instanceof ProcessCanceled) {
           // This would only happen if we have closed the
           //  file in one of the queue's previous iterations.
           log('warn', 'attempt to rename closed file', this.mFileName);
-          return Promise.reject(err);
+          return Bluebird.reject(err);
         }
 
         // in case of error, re-open the original file name so we can continue writing,
@@ -102,16 +102,16 @@ class FileAssembler {
           .then(fd => {
             this.mFD = fd;
           })
-          .then(() => Promise.reject(err));
+          .then(() => Bluebird.reject(err));
       }),
       false);
   }
 
-  public addChunk(offset: number, data: Buffer): Promise<boolean> {
+  public addChunk(offset: number, data: Buffer): Bluebird<boolean> {
     let synced = false;
     return this.mQueue(() =>
       ((this.mFD === undefined)
-        ? Promise.reject(new ProcessCanceled('file already closed'))
+        ? Bluebird.reject(new ProcessCanceled('file already closed'))
         : this.writeAsync(data, offset))
       .then(({ bytesWritten, buffer }) => {
         this.mWritten += bytesWritten;
@@ -127,12 +127,12 @@ class FileAssembler {
             })
             .then(() => bytesWritten);
         } else {
-          return Promise.resolve(bytesWritten);
+          return Bluebird.resolve(bytesWritten);
         }
       })
       .then((bytesWritten: number) => (bytesWritten !== data.length)
-          ? Promise.reject(new Error(`incomplete write ${bytesWritten}/${data.length}`))
-          : Promise.resolve(synced))
+          ? Bluebird.reject(new Error(`incomplete write ${bytesWritten}/${data.length}`))
+          : Bluebird.resolve(synced))
       .catch({ code: 'ENOSPC' }, () => {
         (dialog.showMessageBoxSync(getVisibleWindow(), {
           type: 'warning',
@@ -144,12 +144,12 @@ class FileAssembler {
           noLink: true,
         }) === 1)
           ? this.addChunk(offset, data)
-          : Promise.reject(new UserCanceled());
+          : Bluebird.reject(new UserCanceled());
       })
     , false);
   }
 
-  public close(): Promise<void> {
+  public close(): Bluebird<void> {
     return this.mQueue(() => {
       if (this.mFD !== undefined) {
         const fd = this.mFD;
@@ -158,11 +158,11 @@ class FileAssembler {
           .then(() => fs.closeAsync(fd))
           .catch({ code: 'EBADF' }, () => {
             log('warn', 'failed to sync or close file', this.mFileName);
-            return Promise.resolve();
+            return Bluebird.resolve();
           })
-          .catch({ code: 'ENOENT' }, () => Promise.resolve());
+          .catch({ code: 'ENOENT' }, () => Bluebird.resolve());
       } else {
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
     }, false);
   }
@@ -170,13 +170,13 @@ class FileAssembler {
   private writeAsync(data: Buffer, offset: number) {
     // try to write with the lower-overhead function first. If it fails, retry with
     // our own wrapper that will retry on some errors and provide better backtraces
-    return Promise.resolve(fsFast.write(this.mFD, data, 0, data.length, offset))
+    return Bluebird.resolve(fsFast.write(this.mFD, data, 0, data.length, offset))
       .catch(() => fs.writeAsync(this.mFD, data, 0, data.length, offset))
       .catch(err => {
         if (err.code === 'EBADF') {
           err.message += ` (fd: ${this.mFD ?? 'closed'})`;
         }
-        return Promise.reject(err);
+        return Bluebird.reject(err);
       });
   }
 }

--- a/src/extensions/download_management/downloadAttributes.tsx
+++ b/src/extensions/download_management/downloadAttributes.tsx
@@ -24,7 +24,7 @@ import DownloadProgressFilter from './views/DownloadProgressFilter';
 import { IDownloadViewProps } from './views/DownloadView';
 import FileTime from './views/FileTime';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { TFunction } from 'i18next';
 import * as path from 'path';
 import * as React from 'react';
@@ -132,7 +132,7 @@ function createColumns(
   };
 
   const onSetDownloadGames = (dlId: string, games: string[]) => {
-    return Promise.resolve(setDownloadGames(api, dlId, games, withAddInProgress));
+    return Bluebird.resolve(setDownloadGames(api, dlId, games, withAddInProgress));
   };
 
   return [
@@ -252,7 +252,7 @@ function createColumns(
         .then(stat => {
           const id = Object.keys(downloads).find(key => downloads[key] === attributes);
           onSetAttribute(id, stat.mtimeMs);
-          return Promise.resolve(stat.mtime);
+          return Bluebird.resolve(stat.mtime);
         })
         .catch(() => undefined);
       },

--- a/src/extensions/download_management/types/IChunk.ts
+++ b/src/extensions/download_management/types/IChunk.ts
@@ -1,7 +1,7 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export interface IChunk {
-  url: () => Promise<string>;
+  url: () => Bluebird<string>;
   received: number;
   offset: number;
   size: number;

--- a/src/extensions/download_management/types/IDownloadJob.ts
+++ b/src/extensions/download_management/types/IDownloadJob.ts
@@ -1,7 +1,7 @@
 import { IChunk } from './IChunk';
 import { IDownloadOptions } from './IDownload';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export interface IDownloadJob extends IChunk {
   state: 'init' | 'running' | 'paused' | 'finished';
@@ -12,7 +12,7 @@ export interface IDownloadJob extends IChunk {
   confirmedSize: number;
   extraCookies: string[];
 
-  dataCB?: (offset: number, data) => Promise<boolean>;
+  dataCB?: (offset: number, data) => Bluebird<boolean>;
   completionCB?: () => void;
   errorCB?: (err) => void;
   responseCB?: (size: number, fileName: string, chunkable: boolean) => void;

--- a/src/extensions/download_management/types/ProtocolHandlers.ts
+++ b/src/extensions/download_management/types/ProtocolHandlers.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export interface IResolvedURL {
   urls: string[];
@@ -14,5 +14,5 @@ export interface IResolvedURLs {
 
 export interface IProtocolHandlers {
   [schema: string]: (inputUrl: string, name: string, friendlyName: string)
-    => Promise<IResolvedURL>;
+    => Bluebird<IResolvedURL>;
 }

--- a/src/extensions/download_management/util/queryDLInfo.ts
+++ b/src/extensions/download_management/util/queryDLInfo.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import { Action } from 'redux';
 import { IExtensionApi, ILookupResult } from '../../../types/IExtensionContext';
@@ -14,14 +14,14 @@ import { setDownloadModInfo } from '../actions/state';
 import { downloadPathForGame } from '../selectors';
 
 function queryInfo(api: IExtensionApi, dlIds: string[],
-                   ignoreCache: boolean): Promise<void> {
+                   ignoreCache: boolean): Bluebird<void> {
   const state: IState = api.store.getState();
 
   const actions: Action[] = [];
 
   const knownGames = selectors.knownGames(state);
 
-  return Promise.map(dlIds ?? [], dlId => {
+  return Bluebird.map(dlIds ?? [], dlId => {
     const dl = state.persistent.downloads.files[dlId];
     if (dl === undefined) {
       log('warn', 'download no longer exists', dlId);
@@ -70,7 +70,7 @@ function queryInfo(api: IExtensionApi, dlIds: string[],
           // incorrect data, so ignore all of it
           if ((dlNow?.modInfo?.nexus?.ids?.fileId !== undefined)
               && (dlNow?.modInfo?.nexus?.ids?.fileId !== nxmUrl.fileId)) {
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
 
           setInfo('source', 'nexus');
@@ -87,7 +87,7 @@ function queryInfo(api: IExtensionApi, dlIds: string[],
         }
         return (gameId !== metaGameId)
           ? api.emitAndAwait('set-download-games', dlId, [metaGameId, gameId])
-          : Promise.resolve();
+          : Bluebird.resolve();
       }
     })
     .catch(err => {

--- a/src/extensions/download_management/views/DownloadGameList.tsx
+++ b/src/extensions/download_management/views/DownloadGameList.tsx
@@ -7,7 +7,7 @@ import * as selectors from '../../../util/selectors';
 
 import { SITE_ID } from '../../gamemode_management/constants';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fuzz from 'fuzzball';
 import { TFunction } from 'i18next';
 import * as React from 'react';
@@ -18,7 +18,7 @@ export interface IDownloadGameListProps {
   id: string;
   currentGames: string[];
   games: IGameStored[];
-  onSetDownloadGames: (dlId: string, gameIds: string[]) => Promise<void>;
+  onSetDownloadGames: (dlId: string, gameIds: string[]) => Bluebird<void>;
 }
 
 class DownloadGameList extends PureComponentEx<IDownloadGameListProps, {}> {

--- a/src/extensions/download_management/views/DownloadView.tsx
+++ b/src/extensions/download_management/views/DownloadView.tsx
@@ -34,7 +34,7 @@ import { DownloadIsHTML } from '../DownloadManager';
 
 import DownloadGraph from './DownloadGraph';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { TFunction } from 'i18next';
 import _ from 'lodash';
 import * as path from 'path';
@@ -66,7 +66,7 @@ type DownloadFinishState = 'finished' | 'failed' | 'redirect';
 interface IActionProps {
   onSetAttribute: (id: string, time: number) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
   onShowError: (message: string, details?: string | Error,
                 notificationId?: string, allowReport?: boolean,
                 attachments?: IAttachment[]) => void;

--- a/src/extensions/download_management/views/Settings.tsx
+++ b/src/extensions/download_management/views/Settings.tsx
@@ -33,7 +33,7 @@ import getDownloadPath, {getDownloadPathPattern} from '../util/getDownloadPath';
 
 import getText from '../texts';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import * as process from 'process';
 import * as React from 'react';
@@ -61,7 +61,7 @@ interface IActionProps {
   onSetTransfer: (dest: string) => void;
   onSetMaxDownloads: (value: number) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
   onShowError: (message: string, details: string | Error,
                 allowReport: boolean, isBBCode?: boolean) => void;
   onSetCopyOnIFF: (enabled: boolean) => void;
@@ -443,7 +443,7 @@ class Settings extends ComponentEx<IProps, IComponentState> {
           return this.transferPath()
             .then(() => writeDownloadsTag(this.context.api, newPath));
         } else {
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
       })
       .then(() => {
@@ -463,7 +463,7 @@ class Settings extends ComponentEx<IProps, IComponentState> {
             + 'Clean-up of the old downloads folder has been cancelled.<br /><br />'
             + `Old downloads folder: [url]{{thePath}}[/url]`,
             { replace: { thePath: oldPath } }),
-        }, [ { label: 'Close', action: () => Promise.resolve() } ]);
+        }, [ { label: 'Close', action: () => Bluebird.resolve() } ]);
 
         if (!(err.errorObject instanceof UserCanceled)) {
           this.context.api.showErrorNotification('Clean-up failed', err.errorObject);
@@ -549,7 +549,7 @@ class Settings extends ComponentEx<IProps, IComponentState> {
       }));
   }
 
-  private confirmElevate = (): Promise<void> => {
+  private confirmElevate = (): Bluebird<void> => {
     const { t, onShowDialog } = this.props;
     return onShowDialog('question', 'Access denied', {
       text: 'This directory is not writable to the current windows user account. '
@@ -560,12 +560,12 @@ class Settings extends ComponentEx<IProps, IComponentState> {
       { label: 'Create as Administrator' },
     ])
     .then(result => (result.action === 'Cancel')
-      ? Promise.reject(new UserCanceled())
-      : Promise.resolve());
+      ? Bluebird.reject(new UserCanceled())
+      : Bluebird.resolve());
   }
 
   private checkTargetEmpty(oldDownloadPath: string, newDownloadPath: string) {
-    let queue = Promise.resolve();
+    let queue = Bluebird.resolve();
     let fileCount = 0;
     let hasDownloadTag: boolean = false;
     let tagInstance: string;
@@ -595,7 +595,7 @@ class Settings extends ComponentEx<IProps, IComponentState> {
         ;
     }
     // ensure the destination directories are empty
-    return queue.then(() => new Promise((resolve, reject) => {
+    return queue.then(() => new Bluebird((resolve, reject) => {
       if ((fileCount > 0) && (tagInstance !== this.props.instanceId)) {
         if (tagInstance !== undefined) {
           return this.props.onShowDialog('question', 'Confirm', {
@@ -642,12 +642,12 @@ class Settings extends ComponentEx<IProps, IComponentState> {
         sourceIsMissing = (['ENOENT', 'UNKNOWN'].indexOf(err.code) !== -1);
         log('warn', 'Transfer failed - missing source directory', err);
         return (sourceIsMissing)
-          ? Promise.resolve(undefined)
-          : Promise.reject(err);
+          ? Bluebird.resolve(undefined)
+          : Bluebird.reject(err);
       })
       .then(stats => {
         const queryReset = (stats !== undefined)
-          ? Promise.resolve()
+          ? Bluebird.resolve()
           : onShowDialog('question', 'Missing downloads folder', {
             bbcode: 'Vortex is unable to find your current downloads folder; '
               + 'this can happen when: <br />'
@@ -666,8 +666,8 @@ class Settings extends ComponentEx<IProps, IComponentState> {
               { label: 'Reinitialize' },
             ])
             .then(result => (result.action === 'Cancel')
-              ? Promise.reject(new UserCanceled())
-              : Promise.resolve());
+              ? Bluebird.reject(new UserCanceled())
+              : Bluebird.resolve());
 
         return queryReset
           .then(() => {
@@ -683,8 +683,8 @@ class Settings extends ComponentEx<IProps, IComponentState> {
               }
             })
               .catch(err => (sourceIsMissing && (err.path === oldPath))
-                ? Promise.resolve()
-                : Promise.reject(err));
+                ? Bluebird.resolve()
+                : Bluebird.reject(err));
           });
       });
   }

--- a/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/extensions/extension_manager/ExtensionManager.tsx
@@ -20,7 +20,7 @@ import getTableAttributes from './tableAttributes';
 import { IExtension, IExtensionWithState } from './types';
 
 import { EndorsedStatus } from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import * as path from 'path';
 import * as React from 'react';
@@ -195,14 +195,14 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
     const { downloads } = this.props;
     let success = false;
     log('info', 'installing extension(s) via drag and drop', { extPaths });
-    const prop: Promise<void[]> = (type === 'files')
-      ? Promise.map(extPaths, extPath => installExtension(this.context.api, extPath)
+    const prop: Bluebird<void[]> = (type === 'files')
+      ? Bluebird.map(extPaths, extPath => installExtension(this.context.api, extPath)
           .then(() => { success = true; })
           .catch(err => {
             this.context.api.showErrorNotification('Failed to install extension', err,
                                                    { allowReport: false });
           }))
-      : Promise.map(extPaths, url => new Promise<void>((resolve, reject) => {
+      : Bluebird.map(extPaths, url => new Bluebird<void>((resolve, reject) => {
         this.context.api.events.emit('start-download', [url], undefined,
                                      (error: Error, id: string) => {
           const dlPath = path.join(this.props.downloadPath, downloads[id].localPath);

--- a/src/extensions/extension_manager/installExtension.ts
+++ b/src/extensions/extension_manager/installExtension.ts
@@ -13,7 +13,7 @@ import { countryExists, languageExists } from '../settings_interface/languagemap
 import { ExtensionType, IExtension } from './types';
 import { readExtensionInfo } from './util';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import ZipT = require('node-7z');
 import * as path from 'path';
@@ -22,7 +22,7 @@ import * as vortexRunT from 'vortex-run';
 
 const vortexRun: typeof vortexRunT = lazyRequire(() => require('vortex-run'));
 
-const rimrafAsync: (removePath: string, options: any) => Promise<void> = Promise.promisify(rimraf);
+const rimrafAsync: (removePath: string, options: any) => Bluebird<void> = Bluebird.promisify(rimraf);
 
 class ContextProxyHandler implements ProxyHandler<any> {
   private mDependencies: string[] = [];
@@ -52,7 +52,7 @@ class ContextProxyHandler implements ProxyHandler<any> {
   }
 }
 
-function installExtensionDependencies(api: IExtensionApi, extPath: string): Promise<void> {
+function installExtensionDependencies(api: IExtensionApi, extPath: string): Bluebird<void> {
   const handler = new ContextProxyHandler();
   const context = new Proxy({}, handler);
 
@@ -62,14 +62,14 @@ function installExtensionDependencies(api: IExtensionApi, extPath: string): Prom
 
     const state: IState = api.store.getState();
 
-    return Promise.map(handler.dependencies, depId => {
+    return Bluebird.map(handler.dependencies, depId => {
       const ext = state.session.extensions.available.find(iter =>
         (!iter.type && ((iter.name === depId) || (iter.id === depId))));
 
       if (ext !== undefined) {
         return api.emitAndAwait('install-extension', ext);
       } else {
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
     })
     .then(() => null);
@@ -78,9 +78,9 @@ function installExtensionDependencies(api: IExtensionApi, extPath: string): Prom
     //   and registers actions
     if ((err.name === 'TypeError')
         && (err.message.startsWith('Duplicate action type'))) {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
-    return Promise.reject(err);
+    return Bluebird.reject(err);
   }
 }
 
@@ -94,7 +94,7 @@ function sanitize(input: string): string {
   }
 }
 
-function removeOldVersion(api: IExtensionApi, info: IExtension): Promise<void> {
+function removeOldVersion(api: IExtensionApi, info: IExtension): Bluebird<void> {
   const state: IState = api.store.getState();
   const { installed }  = state.session.extensions;
 
@@ -113,7 +113,7 @@ function removeOldVersion(api: IExtensionApi, info: IExtension): Promise<void> {
   }
 
   previousVersions.forEach(key => api.store.dispatch(removeExtension(key)));
-  return Promise.resolve();
+  return Bluebird.resolve();
 }
 
 /**
@@ -121,26 +121,26 @@ function removeOldVersion(api: IExtensionApi, info: IExtension): Promise<void> {
  * per theme, each is expected to contain at least one of
  * "variables.scss", "style.scss" or "fonts.scss"
  */
-function validateTheme(extPath: string): Promise<void> {
+function validateTheme(extPath: string): Bluebird<void> {
   return fs.readdirAsync(extPath)
     .filter((fileName: string) =>
       fs.statAsync(path.join(extPath, fileName))
         .then(stats => stats.isDirectory()))
     .then(dirNames => {
       if (dirNames.length === 0) {
-        return Promise.reject(
+        return Bluebird.reject(
           new DataInvalid('Expected a subdirectory containing the stylesheets'));
       }
-      return Promise.map(dirNames, dirName =>
+      return Bluebird.map(dirNames, dirName =>
         fs.readdirAsync(path.join(extPath, dirName))
           .then(files => {
             if (!files.includes('variables.scss')
                 && !files.includes('style.scss')
                 && !files.includes('fonts.scss')) {
-              return Promise.reject(
+              return Bluebird.reject(
                 new DataInvalid('Theme not found'));
             } else {
-              return Promise.resolve();
+              return Bluebird.resolve();
             }
           }))
         .then(() => null);
@@ -160,7 +160,7 @@ function isLocaleCode(input: string): boolean {
  * validate a translation extension. Can only contain one iso-code named directory (other
  * directories are ignored) which needs to contain at least one json file
  */
-function validateTranslation(extPath: string): Promise<void> {
+function validateTranslation(extPath: string): Bluebird<void> {
   return fs.readdirAsync(extPath)
     .filter((fileName: string) => isLocaleCode(fileName))
     .filter((fileName: string) =>
@@ -168,7 +168,7 @@ function validateTranslation(extPath: string): Promise<void> {
         .then(stats => stats.isDirectory()))
     .then(dirNames => {
       if (dirNames.length !== 1) {
-        return Promise.reject(
+        return Bluebird.reject(
           new DataInvalid('Expected exactly one language subdirectory'));
       }
       // the check in isLocaleCode is extremely unreliable because it will fall back to
@@ -177,15 +177,15 @@ function validateTranslation(extPath: string): Promise<void> {
       const [language, country] = dirNames[0].split('-');
       if (!languageExists(language)
           || (country !== undefined) && !countryExists(country)) {
-        return Promise.reject(new DataInvalid('Directory isn\'t a language code'));
+        return Bluebird.reject(new DataInvalid('Directory isn\'t a language code'));
       }
       return fs.readdirAsync(path.join(extPath, dirNames[0]))
         .then(files => {
           if (files.find(fileName => path.extname(fileName) === '.json') === undefined) {
-            return Promise.reject(new DataInvalid('No translation files'));
+            return Bluebird.reject(new DataInvalid('No translation files'));
           }
 
-          return Promise.resolve();
+          return Bluebird.resolve();
         });
     });
 }
@@ -193,19 +193,19 @@ function validateTranslation(extPath: string): Promise<void> {
 /**
  * validate an extension. It has to contain an index.js and info.json on the top-level
  */
-function validateExtension(extPath: string): Promise<void> {
-  return Promise.all([
+function validateExtension(extPath: string): Bluebird<void> {
+  return Bluebird.all([
     fs.statAsync(path.join(extPath, 'index.js')),
     fs.statAsync(path.join(extPath, 'info.json')),
   ])
     .then(() => null)
     .catch({ code: 'ENOENT' }, () => {
-      return Promise.reject(
+      return Bluebird.reject(
         new DataInvalid('Extension needs to include index.js and info.json on top-level'));
     });
 }
 
-function validateInstall(extPath: string, info?: IExtension): Promise<ExtensionType> {
+function validateInstall(extPath: string, info?: IExtension): Bluebird<ExtensionType> {
   if (info === undefined) {
     let validAsTheme: boolean = true;
     let validAsTranslation: boolean = true;
@@ -221,34 +221,34 @@ function validateInstall(extPath: string, info?: IExtension): Promise<ExtensionT
       .catch(DataInvalid, () => validAsExtension = false)
       .then(() => {
         if (!validAsExtension && !validAsTheme && !validAsTranslation) {
-          return Promise.reject(
+          return Bluebird.reject(
             new DataInvalid('Doesn\'t seem to contain a correctly packaged extension, '
               + 'theme or translation'));
         }
 
         // at least one type was valid, let's guess what it really is
         if (validAsExtension) {
-          return Promise.resolve(undefined);
+          return Bluebird.resolve(undefined);
         } else if (validAsTranslation) {
           // it's unlikely we would mistake a theme for a translation since it would require
           // it to contain a directory named like a iso language code including json files.
-          return Promise.resolve('translation' as ExtensionType);
+          return Bluebird.resolve('translation' as ExtensionType);
         } else {
-          return Promise.resolve('theme' as ExtensionType);
+          return Bluebird.resolve('theme' as ExtensionType);
         }
       });
   } else if (info.type === 'theme') {
-    return validateTheme(extPath).then(() => Promise.resolve('theme' as ExtensionType));
+    return validateTheme(extPath).then(() => Bluebird.resolve('theme' as ExtensionType));
   } else if (info.type === 'translation') {
-    return validateTranslation(extPath).then(() => Promise.resolve('translation' as ExtensionType));
+    return validateTranslation(extPath).then(() => Bluebird.resolve('translation' as ExtensionType));
   } else {
-    return validateExtension(extPath).then(() => Promise.resolve(undefined));
+    return validateExtension(extPath).then(() => Bluebird.resolve(undefined));
   }
 }
 
 function installExtension(api: IExtensionApi,
                           archivePath: string,
-                          info?: IExtension): Promise<void> {
+                          info?: IExtension): Bluebird<void> {
   const extensionsPath = path.join(getVortexPath('userData'), 'plugins');
   let destPath: string;
   const tempPath = path.join(extensionsPath, path.basename(archivePath)) + '.installing';
@@ -281,11 +281,11 @@ function installExtension(api: IExtensionApi,
         return res;
       })
       .catch({ code: 'ENOENT' }, () => (info !== undefined)
-        ? Promise.resolve({
+        ? Bluebird.resolve({
             id: path.basename(archivePath, path.extname(archivePath)),
             info,
           })
-        : Promise.reject(new Error('not an extension, info.json missing')))
+        : Bluebird.reject(new Error('not an extension, info.json missing')))
       .then(manifestInfo =>
         // update the manifest on disc, in case we had new info from the caller
         fs.writeFileAsync(path.join(tempPath, 'info.json'),
@@ -311,14 +311,14 @@ function installExtension(api: IExtensionApi,
               .then(stat => ({ name: entry, stat })))
             .then(() => null);
         } else if (type === 'theme') {
-          return Promise.resolve();
+          return Bluebird.resolve();
         } else {
           // don't install dependencies for extensions that are already loaded because
           // doing so could cause an exception
           if (api.getLoadedExtensions().find(ext => ext.name === extName) === undefined) {
             return installExtensionDependencies(api, destPath);
           } else {
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
         }
       })
@@ -328,7 +328,7 @@ function installExtension(api: IExtensionApi,
                                               { allowReport: false, message: archivePath })))
       .catch(err =>
         rimrafAsync(tempPath, { glob: false })
-        .then(() => Promise.reject(err)));
+        .then(() => Bluebird.reject(err)));
 }
 
 export default installExtension;

--- a/src/extensions/gamemode_management/types/IModType.ts
+++ b/src/extensions/gamemode_management/types/IModType.ts
@@ -1,13 +1,13 @@
 import {IInstruction, IModTypeOptions} from '../../../types/IExtensionContext';
 import {IGame} from '../../../types/IGame';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export interface IModType {
   typeId: string;
   priority: number;
   isSupported: (gameId: string) => boolean;
   getPath: (game: IGame) => string;
-  test: (installInstructions: IInstruction[]) => Promise<boolean>;
+  test: (installInstructions: IInstruction[]) => Bluebird<boolean>;
   options: IModTypeOptions;
 }

--- a/src/extensions/gamemode_management/util/discovery.ts
+++ b/src/extensions/gamemode_management/util/discovery.ts
@@ -15,7 +15,7 @@ import {IToolStored} from '../types/IToolStored';
 
 import Progress from './Progress';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import turbowalk from 'turbowalk';
@@ -32,14 +32,14 @@ interface IFileEntry {
 export function quickDiscoveryTools(gameId: string,
                                     tools: ITool[],
                                     onDiscoveredTool: DiscoveredToolCB)
-                                    : Promise<void> {
+                                    : Bluebird<void> {
   if (tools === undefined) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
-  return Promise.map(tools, tool => {
+  return Bluebird.map(tools, tool => {
     if (tool.queryPath === undefined) {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
 
     try {
@@ -58,10 +58,10 @@ export function quickDiscoveryTools(gameId: string,
             });
         } else {
           log('debug', 'tool not found', tool.id);
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
       } else {
-        return (toolPath as Promise<string>)
+        return (toolPath as Bluebird<string>)
           .then((resolvedPath) => {
             if (resolvedPath) {
               return autoGenIcon(tool, resolvedPath, gameId)
@@ -75,7 +75,7 @@ export function quickDiscoveryTools(gameId: string,
                   });
                 });
             }
-            return Promise.resolve();
+            return Bluebird.resolve();
           })
           .catch((err) => {
             log('debug', 'tool not found', {id: tool.id, err: err.message});
@@ -83,7 +83,7 @@ export function quickDiscoveryTools(gameId: string,
       }
     } catch (err) {
       log('error', 'failed to determine tool setup', err);
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
   })
   .then(() => null);
@@ -99,8 +99,8 @@ export function quickDiscoveryTools(gameId: string,
 export function quickDiscovery(knownGames: IGame[],
                                discoveredGames: {[id: string]: IDiscoveryResult},
                                onDiscoveredGame: DiscoveredCB,
-                               onDiscoveredTool: DiscoveredToolCB): Promise<string[]> {
-  return Promise.map(knownGames, game => new Promise<string>((resolve, reject) => {
+                               onDiscoveredTool: DiscoveredToolCB): Bluebird<string[]> {
+  return Bluebird.map(knownGames, game => new Bluebird<string>((resolve, reject) => {
     return quickDiscoveryTools(game.id, game.supportedTools, onDiscoveredTool)
       .then(() => {
         if (game.queryPath === undefined) {
@@ -113,7 +113,7 @@ export function quickDiscovery(knownGames: IGame[],
         try {
           const gamePath = game.queryPath();
           const prom = (typeof (gamePath) === 'string')
-            ? Promise.resolve(gamePath)
+            ? Bluebird.resolve(gamePath)
             : gamePath;
 
           let store: string;
@@ -137,16 +137,16 @@ export function quickDiscovery(knownGames: IGame[],
               }
             })
             .then(resolvedPath => resolvedPath === undefined
-              ? Promise.resolve(undefined)
+              ? Bluebird.resolve(undefined)
               : fs.statAsync(resolvedPath)
                 .then(() => resolvedPath)
                 .catch(err => {
                   if (err.code === 'ENOENT') {
                     log('info', 'rejecting game discovery, directory doesn\'t exist',
                         resolvedPath);
-                    return Promise.resolve(undefined);
+                    return Bluebird.resolve(undefined);
                   }
-                  return Promise.reject(err);
+                  return Bluebird.reject(err);
                 }))
             .then(resolvedPath => {
               if (!truthy(resolvedPath)) {
@@ -208,7 +208,7 @@ function walk(searchPath: string,
               matchList: Set<string>,
               resultCB: (path: string) => void,
               progress: Progress,
-              normalize: Normalize): Promise<number> {
+              normalize: Normalize): Bluebird<number> {
   // we can't actually know the progress percentage because for
   // that we'd need to search the disk twice, first to know the number of directories
   // just so we can show progress for the second run.
@@ -272,22 +272,22 @@ function walk(searchPath: string,
     .then(() => seenDirectories);
 }
 
-function verifyToolDir(tool: ITool, testPath: string): Promise<void> {
-  return Promise.mapSeries(tool.requiredFiles,
+function verifyToolDir(tool: ITool, testPath: string): Bluebird<void> {
+  return Bluebird.mapSeries(tool.requiredFiles,
     // our fs overload would try to acquire access to the directory if it's locked, which
     // is not something we want at this point because we don't even know yet if the user
     // wants to manage the game at all.
     (fileName: string) => fsExtra.stat(path.join(testPath, fileName))
       .catch(err => {
-        return Promise.reject(err);
+        return Bluebird.reject(err);
       }))
     .then(() => undefined);
 }
 
 export function assertToolDir(tool: ITool, testPath: string)
-                              : Promise<string> {
+                              : Bluebird<string> {
   if (!truthy(testPath)) {
-    return Promise.resolve(undefined);
+    return Bluebird.resolve(undefined);
   }
 
   return verifyToolDir(tool, testPath)
@@ -303,7 +303,7 @@ export function assertToolDir(tool: ITool, testPath: string)
         log('error', 'failed to verify game directory',
           { testPath, error: err.message });
       }
-      return Promise.reject(err);
+      return Bluebird.reject(err);
     });
 }
 
@@ -312,7 +312,7 @@ const nop = () => undefined;
 export function discoverRelativeTools(game: IGame, gamePath: string,
                                       discoveredGames: {[id: string]: IDiscoveryResult},
                                       onDiscoveredTool: DiscoveredToolCB, normalize: Normalize)
-                               : Promise<void> {
+                               : Bluebird<void> {
   log('info', 'discovering relative tools', gamePath);
   const discoveredTools: { [id: string]: IToolStored } =
     getSafe(discoveredGames[game.id], ['tools'], {});
@@ -322,7 +322,7 @@ export function discoverRelativeTools(game: IGame, gamePath: string,
                  || (discoveredTools[tool.id].executable === undefined));
 
   if (relativeTools.length === 0) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   const files: IFileEntry[] = relativeTools.reduce((prev: IFileEntry[], tool: ITool) => {
@@ -343,14 +343,14 @@ export function discoverRelativeTools(game: IGame, gamePath: string,
   return walk(gamePath, matchList, onFileCB, undefined, normalize).then(() =>  null);
 }
 
-function autoGenIcon(application: ITool, exePath: string, gameId: string): Promise<void> {
+function autoGenIcon(application: ITool, exePath: string, gameId: string): Bluebird<void> {
   const iconPath = StarterInfo.toolIconRW(gameId, application.id);
   return (application.logo === 'auto')
-    ? fs.ensureDirWritableAsync(path.dirname(iconPath), () => Promise.resolve())
+    ? fs.ensureDirWritableAsync(path.dirname(iconPath), () => Bluebird.resolve())
         .then(() => fs.statAsync(iconPath).then(() => null))
         .catch(() => extractExeIcon(exePath, iconPath))
       .catch(err => log('warn', 'failed to fetch exe icon', err.message))
-    : Promise.resolve();
+    : Bluebird.resolve();
 }
 
 function testApplicationDirValid(application: ITool, testPath: string, gameId: string,
@@ -435,18 +435,18 @@ function onFile(filePath: string, files: IFileEntry[], normalize: Normalize,
  * @param {string[]} searchPaths
  * @param {DiscoveredCB} onDiscoveredGame
  * @param {Progress} progressObj
- * @returns {Promise<any[]>}
+ * @returns {Bluebird<any[]>}
  */
 export function searchDiscovery(
     knownGames: IGame[], discoveredGames: {[id: string]: IDiscoveryResult},
     searchPaths: string[], onDiscoveredGame: DiscoveredCB,
     onDiscoveredTool: DiscoveredToolCB,
     onError: (title: string, message: string) => void,
-    progressCB: (idx: number, percent: number, label: string) => void): Promise<any> {
+    progressCB: (idx: number, percent: number, label: string) => void): Bluebird<any> {
 
   let totalRead = 0;
 
-  return Promise.map(
+  return Bluebird.map(
     // windows has separate cwds per drive. If we used c: as the search path it would not actually
     // search in the root of drive c but in whatever is currently the working directory on c, so
     // we have to append a backslash. Damn you windows...
@@ -495,9 +495,9 @@ export function searchDiscovery(
         .catch(err => {
           log('error', 'game search failed', { error: err.message, searchPath });
           return (err.code === 'ENOENT')
-            ? Promise.resolve(
+            ? Bluebird.resolve(
                 onError('A search path doesn\'t exist or is not connected', searchPath))
-            : Promise.resolve(onError(err.message, searchPath));
+            : Bluebird.resolve(onError(err.message, searchPath));
         })
         .then(() => {
           progressObj.completed(searchPath);

--- a/src/extensions/gamemode_management/util/modTypeExtensions.ts
+++ b/src/extensions/gamemode_management/util/modTypeExtensions.ts
@@ -1,7 +1,7 @@
 import { IInstruction, IModTypeOptions } from '../../../types/IExtensionContext';
 import { IGame, IModType } from '../../../types/IGame';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 const modTypeExtensions: IModType[] = [];
 
@@ -24,7 +24,7 @@ export function getModType(id: string): IModType {
 export function registerModType(id: string, priority: number,
                                 isSupported: (gameId: string) => boolean,
                                 getPath: (game: IGame) => string,
-                                test: (instructions: IInstruction[]) => Promise<boolean>,
+                                test: (instructions: IInstruction[]) => Bluebird<boolean>,
                                 options?: IModTypeOptions) {
   modTypeExtensions.push({
     typeId: id,

--- a/src/extensions/gamemode_management/util/queryGameInfo.ts
+++ b/src/extensions/gamemode_management/util/queryGameInfo.ts
@@ -6,11 +6,11 @@ import walk from '../../../util/walk';
 
 import {IDiscoveryResult} from '../types/IDiscoveryResult';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
-function queryGameInfo(game: IGame & IDiscoveryResult): Promise<{ [key: string]: IGameDetail }> {
+function queryGameInfo(game: IGame & IDiscoveryResult): Bluebird<{ [key: string]: IGameDetail }> {
   if (game.path === undefined) {
-    return Promise.resolve({});
+    return Bluebird.resolve({});
   }
   let totalSize = 0;
   let sizeWithoutLinks = 0;
@@ -22,7 +22,7 @@ function queryGameInfo(game: IGame & IDiscoveryResult): Promise<{ [key: string]:
     if (stats.nlink === 1) {
       sizeWithoutLinks += stats.size;
     }
-    return Promise.resolve();
+    return Bluebird.resolve();
   })
   .then(() => {
     return {

--- a/src/extensions/gamemode_management/views/GameInfoPopover.tsx
+++ b/src/extensions/gamemode_management/views/GameInfoPopover.tsx
@@ -7,14 +7,14 @@ import { bytesToString } from '../../../util/util';
 import { IDiscoveryResult } from '../types/IDiscoveryResult';
 import { IGameStored } from '../types/IGameStored';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { TFunction } from 'i18next';
 import * as React from 'react';
 
 export interface IBaseProps {
   t: TFunction;
   game: IGameStored;
-  onRefreshGameInfo: (gameId: string) => Promise<void>;
+  onRefreshGameInfo: (gameId: string) => Bluebird<void>;
   onChange: () => void;
 }
 

--- a/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -29,7 +29,7 @@ import GameThumbnail from './GameThumbnail';
 import ShowHiddenButton from './ShowHiddenButton';
 
 import { IGameListEntry } from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ratio } from 'fuzzball';
 import update from 'immutability-helper';
 import memoizeOne from 'memoize-one';
@@ -59,8 +59,8 @@ function byGameName(lhs: IGameStored, rhs: IGameStored): number {
 }
 
 interface IBaseProps {
-  onRefreshGameInfo: (gameId: string) => Promise<void>;
-  onBrowseGameLocation: (gameId: string) => Promise<void>;
+  onRefreshGameInfo: (gameId: string) => Bluebird<void>;
+  onBrowseGameLocation: (gameId: string) => Bluebird<void>;
   nexusGames: IGameListEntry[];
 }
 

--- a/src/extensions/gamemode_management/views/GameRow.tsx
+++ b/src/extensions/gamemode_management/views/GameRow.tsx
@@ -12,7 +12,7 @@ import { IGameStored } from '../types/IGameStored';
 
 import GameInfoPopover from './GameInfoPopover';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { TFunction } from 'i18next';
 import * as path from 'path';
 import * as React from 'react';
@@ -29,8 +29,8 @@ export interface IProps {
   type: string;
   getBounds: () => ClientRect;
   container: HTMLElement;
-  onRefreshGameInfo: (gameId: string) => Promise<void>;
-  onBrowseGameLocation: (gameId: string) => Promise<void>;
+  onRefreshGameInfo: (gameId: string) => Bluebird<void>;
+  onBrowseGameLocation: (gameId: string) => Bluebird<void>;
 }
 
 /**

--- a/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -12,7 +12,7 @@ import { IGameStored } from '../types/IGameStored';
 
 import GameInfoPopover from './GameInfoPopover';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { TFunction } from 'i18next';
 import * as path from 'path';
 import * as React from 'react';
@@ -25,7 +25,7 @@ export interface IBaseProps {
   game: IGameStored;
   active: boolean;
   discovered?: boolean;
-  onRefreshGameInfo?: (gameId: string) => Promise<void>;
+  onRefreshGameInfo?: (gameId: string) => Bluebird<void>;
   type: string;
   getBounds?: () => ClientRect;
   container?: HTMLElement;

--- a/src/extensions/gamemode_management/views/NoGameDashlet.tsx
+++ b/src/extensions/gamemode_management/views/NoGameDashlet.tsx
@@ -7,7 +7,7 @@ import { IGameStored } from '../types/IGameStored';
 
 import GameThumbnail from './GameThumbnail';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 
 export interface IBaseProps {
@@ -98,7 +98,7 @@ class Dashlet extends ComponentEx<IProps, IComponentState> {
   }
 
   private refreshGameInfo = gameId => {
-    return new Promise<void>((resolve, reject) => {
+    return new Bluebird<void>((resolve, reject) => {
       this.context.api.events.emit('refresh-game-info', gameId, err => {
         if (err !== null) {
           reject(err);

--- a/src/extensions/gamemode_management/views/RecentlyManagedDashlet.tsx
+++ b/src/extensions/gamemode_management/views/RecentlyManagedDashlet.tsx
@@ -11,7 +11,7 @@ import { IGameStored } from '../types/IGameStored';
 
 import GameThumbnail from './GameThumbnail';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 
 export interface IBaseProps {
@@ -88,7 +88,7 @@ class RecentlyManaged extends ComponentEx<IProps, {}> {
   }
 
   private refreshGameInfo = gameId => {
-    return new Promise<void>((resolve, reject) => {
+    return new Bluebird<void>((resolve, reject) => {
       this.context.api.events.emit('refresh-game-info', gameId, err => {
         if (err !== null) {
           reject(err);

--- a/src/extensions/harmony_injector/delegates/Context.ts
+++ b/src/extensions/harmony_injector/delegates/Context.ts
@@ -15,7 +15,7 @@ import { getGame } from '../../gamemode_management/util/getGame';
 
 import DelegateBase from './DelegateBase';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import getVersion from 'exe-version';
 import * as path from 'path';
 import turbowalk, { IEntry } from 'turbowalk';
@@ -154,7 +154,7 @@ export class Context extends DelegateBase {
   private readDir = (rootPath: string,
                      recurse: boolean,
                      filterFunc: (entry: IEntry) => boolean)
-                     : Promise<string[]> => {
+                     : Bluebird<string[]> => {
     let fileList: string[] = [];
 
     return turbowalk(rootPath, entries => {

--- a/src/extensions/harmony_injector/util/netVersion.ts
+++ b/src/extensions/harmony_injector/util/netVersion.ts
@@ -1,6 +1,6 @@
 import * as fs from '../../../util/fs';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import * as winapi from 'winapi-bindings';
 
@@ -63,10 +63,10 @@ export function getNetVersion(): string {
     : undefined;
 }
 
-export function checkAssemblies(): Promise<boolean> {
+export function checkAssemblies(): Bluebird<boolean> {
   const instPath = getRegValue('InstallPath', 'REG_SZ');
   if (instPath === undefined) {
-    return Promise.resolve(false);
+    return Bluebird.resolve(false);
   }
   return fs.readdirAsync(instPath)
     .map((iter: string) => iter.toLowerCase())
@@ -74,6 +74,6 @@ export function checkAssemblies(): Promise<boolean> {
     .then(files => {
       const installed = new Set(files);
       const missing = REQUIRED_ASSEMBLIES.find(name => !installed.has(name));
-      return Promise.resolve(missing === undefined);
+      return Bluebird.resolve(missing === undefined);
     });
 }

--- a/src/extensions/installer_fomod/delegates/Context.ts
+++ b/src/extensions/installer_fomod/delegates/Context.ts
@@ -12,7 +12,7 @@ import {getGame} from '../../gamemode_management/util/getGame';
 
 import DelegateBase from './DelegateBase';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import minimatch from 'minimatch';
 import * as path from 'path';
 import turbowalk, { IEntry } from 'turbowalk';
@@ -141,7 +141,7 @@ export class Context extends DelegateBase {
   private readDir = (rootPath: string,
                      recurse: boolean,
                      filterFunc: (entry: IEntry) => boolean)
-                     : Promise<string[]> => {
+                     : Bluebird<string[]> => {
     let fileList: string[] = [];
 
     return turbowalk(rootPath, entries => {

--- a/src/extensions/installer_fomod/util/netVersion.ts
+++ b/src/extensions/installer_fomod/util/netVersion.ts
@@ -1,6 +1,6 @@
 import * as fs from '../../../util/fs';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import * as winapi from 'winapi-bindings';
 
@@ -63,10 +63,10 @@ export function getNetVersion(): string {
     : undefined;
 }
 
-export function checkAssemblies(): Promise<boolean> {
+export function checkAssemblies(): Bluebird<boolean> {
   const instPath = getRegValue('InstallPath', 'REG_SZ');
   if (instPath === undefined) {
-    return Promise.resolve(false);
+    return Bluebird.resolve(false);
   }
   return fs.readdirAsync(instPath)
     .map((iter: string) => iter.toLowerCase())
@@ -74,6 +74,6 @@ export function checkAssemblies(): Promise<boolean> {
     .then(files => {
       const installed = new Set(files);
       const missing = REQUIRED_ASSEMBLIES.find(name => !installed.has(name));
-      return Promise.resolve(missing === undefined);
+      return Bluebird.resolve(missing === undefined);
     });
 }

--- a/src/extensions/installer_nested_fomod/index.ts
+++ b/src/extensions/installer_nested_fomod/index.ts
@@ -12,11 +12,11 @@ import {
 } from '../../types/IExtensionContext';
 import {log} from '../../util/log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
-function testSupported(files: string[]): Promise<ISupportedResult> {
-  return new Promise((resolve, reject) => {
+function testSupported(files: string[]): Bluebird<ISupportedResult> {
+  return new Bluebird((resolve, reject) => {
     const fomod = files.find((file) => path.extname(file) === '.fomod');
     if (fomod !== undefined) {
       resolve({ supported: true, requiredFiles: [ fomod ] });
@@ -29,8 +29,8 @@ function testSupported(files: string[]): Promise<ISupportedResult> {
 function install(api: IExtensionApi,
                  files: string[], destinationPath: string,
                  gameId: string, choicesIn: any, unattended: boolean,
-                 progress: ProgressDelegate): Promise<any> {
-  return new Promise((resolve, reject) => {
+                 progress: ProgressDelegate): Bluebird<any> {
+  return new Bluebird((resolve, reject) => {
     const fomod = files.find((file) => path.extname(file) === '.fomod');
     const filePath = path.join(destinationPath, fomod);
     log('debug', 'install nested', filePath);

--- a/src/extensions/mod_load_order/types/types.ts
+++ b/src/extensions/mod_load_order/types/types.ts
@@ -1,4 +1,4 @@
-import * as Promise from 'bluebird';
+import * as Bluebird from 'bluebird';
 import { IActionDefinitionEx } from '../../../controls/ActionControl';
 import { IMod } from '../../../types/IState';
 import { ICollection } from '../types/collections';
@@ -154,7 +154,7 @@ export interface IGameLoadOrderEntry {
   //  before we start sorting the mods.
   preSort?: (items: ILoadOrderDisplayItem[],
              sortDir: SortType,
-             updateType?: UpdateType) => Promise<ILoadOrderDisplayItem[]>;
+             updateType?: UpdateType) => Bluebird<ILoadOrderDisplayItem[]>;
 
   // Allow game extensions to run custom filtering logic
   //  and display only mods which need to be sorted.

--- a/src/extensions/mod_load_order/views/DraggableList.tsx
+++ b/src/extensions/mod_load_order/views/DraggableList.tsx
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import { ListGroup } from 'react-bootstrap';
 import { ConnectDragPreview,  ConnectDragSource, ConnectDropTarget, DragSource,
@@ -183,7 +183,7 @@ class DraggableList extends ComponentEx<IProps, IState> {
 
     this.applyDebouncer = new util.Debouncer((list: ILoadOrderDisplayItem[]) => {
       this.props.apply(list);
-      return Promise.resolve() as any;
+      return Bluebird.resolve() as any;
     }, 300, false, true);
 
   }

--- a/src/extensions/mod_management/InstallContext.ts
+++ b/src/extensions/mod_management/InstallContext.ts
@@ -25,7 +25,7 @@ import { IInstallContext, InstallOutcome } from './types/IInstallContext';
 import { IMod, ModState } from './types/IMod';
 import getModName from './util/modName';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
 class InstallContext implements IInstallContext {
@@ -152,7 +152,7 @@ class InstallContext implements IInstallContext {
     this.mDismissNotification('install_' + this.mIndicatorId);
     this.mStopActivity(`installing_${this.mIndicatorId}`);
 
-    Promise.delay(500)
+    Bluebird.delay(500)
     .then(() => {
       if (!this.mDidReportError) {
         this.mDidReportError = true;

--- a/src/extensions/mod_management/listInstaller.tsx
+++ b/src/extensions/mod_management/listInstaller.tsx
@@ -6,12 +6,12 @@ import { ISupportedInstaller } from './types/IModInstaller';
 import { ProgressDelegate } from './types/InstallFunc';
 import { ISupportedResult } from './types/TestSupported';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import { XXHash64 } from 'xxhash-addon';
 
-function testSupported(): Promise<ISupportedResult> {
-  return Promise.resolve({
+function testSupported(): Bluebird<ISupportedResult> {
+  return Bluebird.resolve({
     supported: true,
     requiredFiles: [],
   });
@@ -20,7 +20,7 @@ function testSupported(): Promise<ISupportedResult> {
 function makeXXHash64() {
   // using seed 0
   const xxh64 = new XXHash64();
-  return (filePath: string): Promise<string> => {
+  return (filePath: string): Bluebird<string> => {
     return fs.readFileAsync(filePath)
       .then(data => {
         const buf: Buffer = xxh64.hash(data);
@@ -35,9 +35,9 @@ function makeXXHash64() {
  */
 function makeListInstaller(extractList: IFileListItem[],
                            basePath: string)
-                           : Promise<ISupportedInstaller> {
-  let lookupFunc: (filePath: string) => Promise<string> =
-    (filePath: string) => Promise.resolve(fileMD5(filePath));
+                           : Bluebird<ISupportedInstaller> {
+  let lookupFunc: (filePath: string) => Bluebird<string> =
+    (filePath: string) => Bluebird.resolve(fileMD5(filePath));
 
   let idxId = 'md5';
 
@@ -48,7 +48,7 @@ function makeListInstaller(extractList: IFileListItem[],
     idxId = 'xxh64';
   }
 
-  return Promise.resolve({
+  return Bluebird.resolve({
     installer: {
       id: 'list-installer',
       priority: 0,
@@ -57,7 +57,7 @@ function makeListInstaller(extractList: IFileListItem[],
                 progressDelegate: ProgressDelegate) => {
         let prog = 0;
         // build lookup table of the existing files on disk md5 -> source path
-        return Promise.reduce(files.filter(relPath => !relPath.endsWith(path.sep)),
+        return Bluebird.reduce(files.filter(relPath => !relPath.endsWith(path.sep)),
                               (prev, relPath, idx, length) => {
           return lookupFunc(path.join(basePath, relPath))
             .then(checksum => {

--- a/src/extensions/mod_management/modActivation.ts
+++ b/src/extensions/mod_management/modActivation.ts
@@ -10,11 +10,11 @@ import renderModName from './util/modName';
 
 import { MERGED_PATH } from './modMerging';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import { UserCanceled } from '../../util/api';
 
-function ensureWritable(api: IExtensionApi, modPath: string): Promise<void> {
+function ensureWritable(api: IExtensionApi, modPath: string): Bluebird<void> {
   return fs.ensureDirWritableAsync(modPath, () => api.showDialog('question', 'Access Denied', {
     text: 'The mod folder for this game is not writable to your user account.\n'
       + 'If you have admin rights on this system, Vortex can change the permissions '
@@ -23,8 +23,8 @@ function ensureWritable(api: IExtensionApi, modPath: string): Promise<void> {
       { label: 'Cancel' },
       { label: 'Allow access' },
     ]).then(result => (result.action === 'Cancel')
-      ? Promise.reject(new UserCanceled())
-      : Promise.resolve()));
+      ? Bluebird.reject(new UserCanceled())
+      : Bluebird.resolve()));
 }
 
 /**
@@ -36,7 +36,7 @@ function ensureWritable(api: IExtensionApi, modPath: string): Promise<void> {
  * @param {IMod[]} mods list of mods to activate (sorted from lowest to highest
  * priority)
  * @param {IDeploymentMethod} method the activator to use
- * @returns {Promise<void>}
+ * @returns {Bluebird<void>}
  */
 function deployMods(api: IExtensionApi,
                     gameId: string,
@@ -49,9 +49,9 @@ function deployMods(api: IExtensionApi,
                     skipFiles: Set<string>,
                     subDir: (mod: IMod) => string,
                     progressCB?: (name: string, progress: number) => void,
-                   ): Promise<IDeployedFile[]> {
+                   ): Bluebird<IDeployedFile[]> {
   if (!truthy(destinationPath)) {
-    return Promise.resolve([]);
+    return Bluebird.resolve([]);
   }
 
   log('info', 'deploying', { gameId, typeId, installationPath, destinationPath });
@@ -63,7 +63,7 @@ function deployMods(api: IExtensionApi,
       normalize = norm;
       return method.prepare(destinationPath, true, lastActivation, norm);
     })
-    .then(() => Promise.each(mods, (mod, idx, length) => {
+    .then(() => Bluebird.each(mods, (mod, idx, length) => {
       try {
         if (progressCB !== undefined) {
           progressCB(renderModName(mod), Math.round((idx * 50) / length));

--- a/src/extensions/mod_management/types/IDependency.ts
+++ b/src/extensions/mod_management/types/IDependency.ts
@@ -1,10 +1,10 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import {ILookupResult, IModInfo} from 'modmeta-db';
 import { IFileListItem, IMod, IModReference } from './IMod';
 
 export interface IModInfoEx extends IModInfo {
-  referer?: string | (() => Promise<string>);
-  sourceURI: string | (() => Promise<string>);
+  referer?: string | (() => Bluebird<string>);
+  sourceURI: string | (() => Bluebird<string>);
 }
 
 export interface ILookupResultEx extends ILookupResult {

--- a/src/extensions/mod_management/types/IDeploymentMethod.ts
+++ b/src/extensions/mod_management/types/IDeploymentMethod.ts
@@ -2,7 +2,7 @@ import { IExtensionApi } from '../../../types/IExtensionContext';
 import { Normalize } from '../../../util/getNormalizeFunc';
 import { TFunction } from '../../../util/i18n';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * details about a file change
@@ -87,7 +87,7 @@ export interface IUnavailableReason {
    * if the problem can be fixed automatically, this can be set to a function that takes care
    * of it
    */
-  fixCallback?: (api: IExtensionApi) => Promise<void>;
+  fixCallback?: (api: IExtensionApi) => Bluebird<void>;
   /**
    * When no method is supported, Vortex will offer possible solutions in this order.
    * It should indicate both how much effort the solution is and also a general preference for
@@ -174,13 +174,13 @@ export interface IDeploymentMethod {
    *
    * @memberof IDeploymentMethod
    */
-  userGate: () => Promise<void>;
+  userGate: () => Bluebird<void>;
 
   /**
    * called before the deployment method is selected. Primary use is to show usage instructions
    * the user needs to know before using it
    */
-  onSelected?: (api: IExtensionApi) => Promise<void>;
+  onSelected?: (api: IExtensionApi) => Bluebird<void>;
 
   /**
    * called before any calls to activate/deactivate, in case the
@@ -198,7 +198,7 @@ export interface IDeploymentMethod {
    * @memberOf IDeploymentMethod
    */
   prepare: (dataPath: string, clean: boolean, lastActivation: IDeployedFile[],
-            normalize: Normalize) => Promise<void>;
+            normalize: Normalize) => Bluebird<void>;
 
   /**
    * called after an activate call was made for all active mods,
@@ -218,7 +218,7 @@ export interface IDeploymentMethod {
   finalize: (gameId: string,
              dataPath: string,
              installationPath: string,
-             progressCB?: (files: number, total: number) => void) => Promise<IDeployedFile[]>;
+             progressCB?: (files: number, total: number) => void) => Bluebird<IDeployedFile[]>;
 
   /**
    * if defined, this gets called instead of finalize if an error occurred since prepare was called.
@@ -229,7 +229,7 @@ export interface IDeploymentMethod {
    */
   cancel?: (gameId: string,
             dataPath: string,
-            installationPath: string) => Promise<void>;
+            installationPath: string) => Bluebird<void>;
 
   /**
    * activate the specified mod in the specified location
@@ -242,7 +242,7 @@ export interface IDeploymentMethod {
    * @memberOf IDeploymentMethod
    */
   activate: (sourcePath: string, sourceName: string, deployPath: string,
-             blackList: Set<string>) => Promise<void>;
+             blackList: Set<string>) => Bluebird<void>;
 
   /**
    * deactivate the specified mod, removing all files it has deployed to the destination
@@ -253,7 +253,7 @@ export interface IDeploymentMethod {
    * @todo sorry about the stupid parameter order, sourceName was added after release so to
    *   remain backwards compatible we have to append it
    */
-  deactivate: (sourcePath: string, dataPath: string, sourceName: string) => Promise<void>;
+  deactivate: (sourcePath: string, dataPath: string, sourceName: string) => Bluebird<void>;
 
   /**
    * called before mods are being purged. If multiple mod types are going to be purged,
@@ -261,7 +261,7 @@ export interface IDeploymentMethod {
    * This is primarily useful for optimization, to avoid work being done redundantly
    * for every modtype-purge
    */
-  prePurge: (installPath: string) => Promise<void>;
+  prePurge: (installPath: string) => Bluebird<void>;
 
   /**
    * deactivate all mods at the destination location
@@ -278,14 +278,14 @@ export interface IDeploymentMethod {
    * @memberOf IDeploymentMethod
    */
   purge: (installPath: string, dataPath: string, gameId?: string,
-          onProgress?: (num: number, total: number) => void) => Promise<void>;
+          onProgress?: (num: number, total: number) => void) => Bluebird<void>;
 
   /**
    * called after mods were purged. If multiple mod types wer purged, this is only called
    * after they are all done.
    * Like prePurge, this is intended for optimizations
    */
-  postPurge: () => Promise<void>;
+  postPurge: () => Bluebird<void>;
 
   /**
    * retrieve list of external changes, that is: files that were installed by this
@@ -296,7 +296,7 @@ export interface IDeploymentMethod {
    * @memberOf IDeploymentMethod
    */
   externalChanges: (gameId: string, installPath: string, dataPath: string,
-                    activation: IDeployedFile[]) => Promise<IFileChange[]>;
+                    activation: IDeployedFile[]) => Bluebird<IFileChange[]>;
 
   /**
    * given a file path (relative to a staging path), return the name under which the
@@ -313,5 +313,5 @@ export interface IDeploymentMethod {
    * @param {string} installPath Vortex path where mods are installed from (source)
    * @param {string} dataPath game path where mods are installed to (destination)
    */
-  isDeployed: (installPath: string, dataPath: string, file: IDeployedFile) => Promise<boolean>;
+  isDeployed: (installPath: string, dataPath: string, file: IDeployedFile) => Bluebird<boolean>;
 }

--- a/src/extensions/mod_management/types/InstallFunc.ts
+++ b/src/extensions/mod_management/types/InstallFunc.ts
@@ -1,10 +1,10 @@
 import {IInstallResult} from './IInstallResult';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export type ProgressDelegate = (perc: number) => void;
 
 export type InstallFunc =
     (files: string[], destinationPath: string, gameId: string,
      progressDelegate: ProgressDelegate, choices?: any,
-     unattended?: boolean, archivePath?: string) => Promise<IInstallResult>;
+     unattended?: boolean, archivePath?: string) => Bluebird<IInstallResult>;

--- a/src/extensions/mod_management/types/TestSupported.ts
+++ b/src/extensions/mod_management/types/TestSupported.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export interface ISupportedResult {
   supported: boolean;
@@ -6,4 +6,4 @@ export interface ISupportedResult {
 }
 
 export type TestSupported =
-  (files: string[], gameId: string, archivePath?: string) => Promise<ISupportedResult>;
+  (files: string[], gameId: string, archivePath?: string) => Bluebird<ISupportedResult>;

--- a/src/extensions/mod_management/util/basicInstaller.ts
+++ b/src/extensions/mod_management/util/basicInstaller.ts
@@ -1,17 +1,17 @@
 import {ProgressDelegate} from '../types/InstallFunc';
 import {ISupportedResult} from '../types/TestSupported';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
-export function testSupported(files: string[]): Promise<ISupportedResult> {
+export function testSupported(files: string[]): Bluebird<ISupportedResult> {
   const result: ISupportedResult = { supported: true, requiredFiles: [] };
-  return Promise.resolve(result);
+  return Bluebird.resolve(result);
 }
 
 export function install(files: string[], destinationPath: string,
-                        gameId: string, progress: ProgressDelegate): Promise<any> {
-  return Promise.resolve({
+                        gameId: string, progress: ProgressDelegate): Bluebird<any> {
+  return Bluebird.resolve({
     message: 'Success',
     instructions: files
       .filter((name: string) => !name.endsWith(path.sep))

--- a/src/extensions/mod_management/util/filterModInfo.ts
+++ b/src/extensions/mod_management/util/filterModInfo.ts
@@ -1,6 +1,6 @@
 import { AttributeExtractor } from '../../../types/IExtensionContext';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
 const attributeExtractors: Array<{ priority: number, extractor: AttributeExtractor}> = [];
@@ -13,8 +13,8 @@ function filterUndefined(input: { [key: string]: any }) {
   return _.omitBy(input, val => val === undefined);
 }
 
-function filterModInfo(input: any, modPath: string): Promise<any> {
-  return Promise.map(
+function filterModInfo(input: any, modPath: string): Bluebird<any> {
+  return Bluebird.map(
     attributeExtractors.sort((lhs, rhs) => rhs.priority - lhs.priority),
     extractor => extractor.extractor(input, modPath),
   ).then(infoBlobs => Object.assign({}, ...infoBlobs.map(filterUndefined)));

--- a/src/extensions/mod_management/util/queryGameId.ts
+++ b/src/extensions/mod_management/util/queryGameId.ts
@@ -5,7 +5,7 @@ import { UserCanceled } from '../../../util/CustomErrors';
 import { activeGameId, discoveryByGame, gameName } from '../../../util/selectors';
 import { SITE_ID } from '../../gamemode_management/constants';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * Determine which game to install a download for.
@@ -13,7 +13,7 @@ import Promise from 'bluebird';
  */
 function queryGameId(store: ThunkStore<any>,
                      downloadGameIds: string[],
-                     fileName: string): Promise<string> {
+                     fileName: string): Bluebird<string> {
   const state: IState = store.getState();
   const gameMode = activeGameId(state);
 
@@ -24,16 +24,16 @@ function queryGameId(store: ThunkStore<any>,
   if (gameMode === undefined && downloadGameIds.length === 1) {
     // Surely if there's no active game, and the downloaded game id
     //  array contains a single element, then we can just use that.
-    return Promise.resolve(downloadGameIds[0]);
+    return Bluebird.resolve(downloadGameIds[0]);
   }
 
   if (downloadGameIds.indexOf(gameMode) !== -1) {
     // the managed game is compatible to the archive so use that
-    return Promise.resolve(gameMode);
+    return Bluebird.resolve(gameMode);
   }
 
   if ((downloadGameIds.length === 1) && (downloadGameIds[0] === SITE_ID)) {
-    return Promise.resolve(downloadGameIds[0]);
+    return Bluebird.resolve(downloadGameIds[0]);
   }
 
   const profiles = state.persistent.profiles;
@@ -46,7 +46,7 @@ function queryGameId(store: ThunkStore<any>,
     profileGames.has(gameId) && (discoveryByGame(state, gameId)?.path !== undefined));
 
   // ask the user
-  return new Promise<string>((resolve, reject) => {
+  return new Bluebird<string>((resolve, reject) => {
     const options = [
       { label: 'Cancel', action: () => reject(new UserCanceled()) },
     ];

--- a/src/extensions/mod_management/util/refreshMods.ts
+++ b/src/extensions/mod_management/util/refreshMods.ts
@@ -8,7 +8,7 @@ import { getSafe } from '../../../util/storeHelper';
 import { setModArchiveId } from '../actions/mods';
 import {IMod} from '../types/IMod';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
 /**
@@ -25,7 +25,7 @@ function refreshMods(api: IExtensionApi, gameId: string,
     .then(() => fs.readdirAsync(installPath))
     .filter((modName: string) => fs.statAsync(path.join(installPath, modName))
       .then(stats => stats.isDirectory())
-      .catch(() => Promise.resolve(false)))
+      .catch(() => Bluebird.resolve(false)))
     .then((modNames: string[]) => {
       const filtered = modNames
         .filter(name => !name.startsWith('__'))
@@ -36,7 +36,7 @@ function refreshMods(api: IExtensionApi, gameId: string,
           knownModNames.filter((name: string) => filtered.indexOf(name) === -1);
 
       if ((addedMods.length === 0) && (removedMods.length === 0)) {
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
 
       log('warn', 'manual mod changed', {
@@ -79,7 +79,7 @@ function refreshMods(api: IExtensionApi, gameId: string,
         { label: 'Apply Changes' },
       ]).then(res => {
         if (res.action === 'Apply Changes') {
-          return Promise.map(addedMods, (modName: string) => {
+          return Bluebird.map(addedMods, (modName: string) => {
             const fullPath: string = path.join(installPath, modName);
             return fs.statAsync(fullPath)
               .then((stat: fs.Stats) => {

--- a/src/extensions/mod_management/util/removeMods.ts
+++ b/src/extensions/mod_management/util/removeMods.ts
@@ -1,10 +1,10 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { IExtensionApi } from '../../../types/IExtensionContext';
 import { INotification } from '../../../types/INotification';
 import { toPromise } from '../../../util/util';
 
-export function removeMod(api: IExtensionApi, gameId: string, modId: string): Promise<void> {
-  return new Promise((resolve, reject) => {
+export function removeMod(api: IExtensionApi, gameId: string, modId: string): Bluebird<void> {
+  return new Bluebird((resolve, reject) => {
     api.events.emit('remove-mod', gameId, modId, err => {
       if (err) {
         reject(err);
@@ -15,9 +15,9 @@ export function removeMod(api: IExtensionApi, gameId: string, modId: string): Pr
   });
 }
 
-export function removeMods(api: IExtensionApi, gameId: string, modIds: string[]): Promise<void> {
+export function removeMods(api: IExtensionApi, gameId: string, modIds: string[]): Bluebird<void> {
   if (modIds.length === 0) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   const notiParams: INotification = {

--- a/src/extensions/mod_management/views/DeactivationButton.tsx
+++ b/src/extensions/mod_management/views/DeactivationButton.tsx
@@ -13,7 +13,7 @@ import { getSafe } from '../../../util/storeHelper';
 import { IDeploymentMethod } from '../types/IDeploymentMethod';
 import { NoDeployment } from '../util/exceptions';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import * as Redux from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -27,7 +27,7 @@ interface IConnectedProps {
 interface IActionProps {
   onShowError: (message: string, details?: string | any, allowReport?: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
   onSetConfirmPurge: (enabled: boolean) => void;
   onShowWarning: (message: string, dialogAction: INotificationAction, id: string) => void;
   onSetSettingsPage: (pageId: string) => void;
@@ -58,9 +58,9 @@ class DeactivationButton extends ComponentEx<IProps, {}> {
 
   private activate = () => {
     const { confirmPurge, onShowError } = this.props;
-    const prom = (confirmPurge !== false) ? this.confirmPurge() : Promise.resolve();
+    const prom = (confirmPurge !== false) ? this.confirmPurge() : Bluebird.resolve();
     prom
-      .then(() => new Promise((resolve, reject) => {
+      .then(() => new Bluebird((resolve, reject) => {
         this.context.api.events.emit('purge-mods', false, (err) => {
           if (err !== null) {
             reject(err);
@@ -101,7 +101,7 @@ class DeactivationButton extends ComponentEx<IProps, {}> {
     }, 'select-deployment-method-first');
   }
 
-  private confirmPurge(): Promise<void> {
+  private confirmPurge(): Bluebird<void> {
     const { onSetConfirmPurge, onShowDialog } = this.props;
     return onShowDialog('question', 'Confirm purge', {
       text: 'Purging will remove all links deployed to the game directory.\n'
@@ -116,12 +116,12 @@ class DeactivationButton extends ComponentEx<IProps, {}> {
     ])
     .then(result => {
       if (result.action === 'Cancel') {
-        return Promise.reject(new UserCanceled());
+        return Bluebird.reject(new UserCanceled());
       } else {
         if (result.input.confirm_purge) {
           onSetConfirmPurge(false);
         }
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
     });
   }

--- a/src/extensions/nexus_integration/texts.ts
+++ b/src/extensions/nexus_integration/texts.ts
@@ -1,6 +1,3 @@
-import chromePath from './util/chromePath';
-
-import Promise from 'bluebird';
 import { TFunction } from 'i18next';
 
 function getText(id: string, t: TFunction): string {

--- a/src/extensions/nexus_integration/util/chromeAllowScheme.ts
+++ b/src/extensions/nexus_integration/util/chromeAllowScheme.ts
@@ -5,13 +5,13 @@ import { deBOM } from '../../../util/util';
 
 import chromePath from './chromePath';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * changes the chrome config file to allow for handling of the specified url scheme.
  * This has no effect if chrome is running
  */
-function chromeAllowScheme(scheme: string): Promise<boolean> {
+function chromeAllowScheme(scheme: string): Bluebird<boolean> {
   let changed = false;
 
   return chromePath()
@@ -28,10 +28,10 @@ function chromeAllowScheme(scheme: string): Promise<boolean> {
         .then(() => fs.unlinkAsync(statePath))
         .then(() => fs.renameAsync(statePath + '.temp', statePath));
       } else {
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
     }))
-  .then(() => Promise.resolve(changed));
+  .then(() => Bluebird.resolve(changed));
 }
 
 export default chromeAllowScheme;

--- a/src/extensions/nexus_integration/util/chromePath.ts
+++ b/src/extensions/nexus_integration/util/chromePath.ts
@@ -2,7 +2,7 @@ import * as fs from '../../../util/fs';
 import getVortexPath from '../../../util/getVortexPath';
 import { deBOM, truthy } from '../../../util/util';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
 /**
@@ -10,7 +10,7 @@ import * as path from 'path';
  *
  * @returns
  */
-function chromePath(): Promise<string> {
+function chromePath(): Bluebird<string> {
   const appPath = getVortexPath('appData');
   if (process.platform === 'win32') {
     const userData = process.env.LOCALAPPDATA !== undefined
@@ -23,16 +23,16 @@ function chromePath(): Promise<string> {
           const prof = truthy(dat) && truthy(dat.profile) && truthy(dat.profile.last_used)
             ? dat.profile.last_used
             : 'Default';
-          return Promise.resolve(path.join(userData, prof, 'Preferences'));
+          return Bluebird.resolve(path.join(userData, prof, 'Preferences'));
         } catch (err) {
-          return Promise.reject(err);
+          return Bluebird.reject(err);
         }
       })
       .catch(err => (['ENOENT', 'EBUSY', 'EPERM', 'EISDIR'].indexOf(err.code) !== -1)
-        ? Promise.resolve(path.join(userData, 'Default', 'Preferences'))
-        : Promise.reject(err));
+        ? Bluebird.resolve(path.join(userData, 'Default', 'Preferences'))
+        : Bluebird.reject(err));
   } else {
-    return Promise.resolve((process.platform === 'linux')
+    return Bluebird.resolve((process.platform === 'linux')
       ? path.resolve(appPath, 'google-chrome', 'Local State')
       : path.resolve(appPath, 'Google', 'Chrome', 'Local State'));
   }

--- a/src/extensions/nexus_integration/util/endorseMod.ts
+++ b/src/extensions/nexus_integration/util/endorseMod.ts
@@ -1,5 +1,5 @@
 import NexusT from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * endorse the mod by the server call
@@ -13,7 +13,7 @@ import Promise from 'bluebird';
  */
 
 function endorseMod(nexus: NexusT, gameId: string, nexusModId: number,
-                    version: string, endorseStatus: string): Promise<string> {
+                    version: string, endorseStatus: string): Bluebird<string> {
   endorseStatus = endorseStatus.toLowerCase();
   if (endorseStatus === 'undecided' || endorseStatus === 'abstained' ||
       endorseStatus === '') {
@@ -22,7 +22,7 @@ function endorseMod(nexus: NexusT, gameId: string, nexusModId: number,
     endorseStatus = 'abstain';
   }
 
-  return Promise.resolve(nexus.endorseMod(nexusModId, version, endorseStatus as any, gameId))
+  return Bluebird.resolve(nexus.endorseMod(nexusModId, version, endorseStatus as any, gameId))
       .then(result => result.status);
 }
 
@@ -36,7 +36,7 @@ function endorseCollection(nexus: NexusT, gameId: string, collectionId: number,
     endorseStatus = 'abstain';
   }
 
-  return Promise.resolve(nexus.endorseCollection(collectionId, endorseStatus as any, gameId));
+  return Bluebird.resolve(nexus.endorseCollection(collectionId, endorseStatus as any, gameId));
 }
 
 export { endorseCollection, endorseMod };

--- a/src/extensions/nexus_integration/util/guessModID.ts
+++ b/src/extensions/nexus_integration/util/guessModID.ts
@@ -154,7 +154,7 @@ export function fillNexusIdByMD5(api: IExtensionApi,
                   [info.gameId, ...downloads[mod.archiveId].game]);
               }
             }
-            return Promise.resolve();
+            return Bluebird.resolve();
           })
           .catch(err => api.showErrorNotification('Failed to update mod ids', err));
       } else {

--- a/src/extensions/nexus_integration/util/submitFeedback.ts
+++ b/src/extensions/nexus_integration/util/submitFeedback.ts
@@ -1,18 +1,18 @@
 import * as fs from '../../../util/fs';
 
 import NexusT, { IFeedbackResponse } from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import ZipT = require('node-7z');
 import { tmpName } from 'tmp';
 
-function zipFiles(files: string[]): Promise<string> {
+function zipFiles(files: string[]): Bluebird<string> {
   if (files.length === 0) {
-    return Promise.resolve(undefined);
+    return Bluebird.resolve(undefined);
   }
   const Zip: typeof ZipT = require('node-7z');
   const task: ZipT = new Zip();
 
-  return new Promise<string>((resolve, reject) => {
+  return new Bluebird<string>((resolve, reject) => {
     tmpName({
       postfix: '.7z',
     }, (err, tmpPath: string) => (err !== null)
@@ -25,7 +25,7 @@ function zipFiles(files: string[]): Promise<string> {
 }
 
 function submitFeedback(nexus: NexusT, title: string, message: string, feedbackFiles: string[],
-                        anonymous: boolean, hash: string): Promise<IFeedbackResponse> {
+                        anonymous: boolean, hash: string): Bluebird<IFeedbackResponse> {
   let archive: string;
   return zipFiles(feedbackFiles)
     .then(tmpPath => {

--- a/src/extensions/null_activator/index.ts
+++ b/src/extensions/null_activator/index.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { IDeploymentMethod, IExtensionContext } from '../../types/IExtensionContext';
 import { IGame } from '../../types/IGame';
 import { getGame } from '../gamemode_management/util/getGame';
@@ -31,39 +31,39 @@ class DeploymentMethod implements IDeploymentMethod {
   }
 
   public userGate() {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public prepare(dataPath, clean, lastActivation, normalize) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public finalize(gameId, dataPath, installationPath, progressCB) {
-    return Promise.resolve([]);
+    return Bluebird.resolve([]);
   }
 
   public activate(sourcePath, sourceName, dataPath, blackList) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public deactivate(sourcePath, dataPath, sourceName) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public prePurge(installPath) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public purge(installPath, dataPtah, gameId) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public postPurge() {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   public externalChanges(gameId, installPath, dataPath, activation) {
-    return Promise.resolve([]);
+    return Bluebird.resolve([]);
   }
 
   public getDeployedPath(input) {
@@ -71,7 +71,7 @@ class DeploymentMethod implements IDeploymentMethod {
   }
 
   public isDeployed(installPath, dataPath, file) {
-    return Promise.resolve(true);
+    return Bluebird.resolve(true);
   }
 }
 

--- a/src/extensions/profile_management/sync.ts
+++ b/src/extensions/profile_management/sync.ts
@@ -3,16 +3,16 @@ import * as fs from '../../util/fs';
 import {copyFileAtomic} from '../../util/fsAtomic';
 import {log} from '../../util/log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
 export function syncToProfile(
   profilePath: string, sourceFiles: string[],
-  onError: (error: string, details: string | Error, allowReport?: boolean) => void): Promise<void> {
+  onError: (error: string, details: string | Error, allowReport?: boolean) => void): Bluebird<void> {
   log('debug', 'sync to profile', { profilePath, sourceFiles });
   return fs.ensureDirAsync(profilePath)
     .then(() =>
-      Promise.map(sourceFiles, (filePath: string) => {
+      Bluebird.map(sourceFiles, (filePath: string) => {
         const destPath = path.join(profilePath, path.basename(filePath));
         return copyFileAtomic(filePath, destPath)
           .catch(UserCanceled, () => {
@@ -30,14 +30,14 @@ export function syncToProfile(
     .then(() => {
       log('debug', 'sync to profile complete');
     })
-    .catch(err => Promise.reject(new Error('failed to sync to profile: ' + err.message)));
+    .catch(err => Bluebird.reject(new Error('failed to sync to profile: ' + err.message)));
 }
 
 export function syncFromProfile(
   profilePath: string, sourceFiles: string[],
-  onError: (error: string, details: string | Error, allowReport?: boolean) => void): Promise<void> {
+  onError: (error: string, details: string | Error, allowReport?: boolean) => void): Bluebird<void> {
   log('debug', 'sync from profile', { profilePath, sourceFiles });
-  return Promise.map(sourceFiles, (filePath: string) => {
+  return Bluebird.map(sourceFiles, (filePath: string) => {
     const srcPath = path.join(profilePath, path.basename(filePath));
     return copyFileAtomic(srcPath, filePath)
     .catch(UserCanceled, () => {
@@ -55,5 +55,5 @@ export function syncFromProfile(
     log('debug', 'sync from profile complete');
   })
   .catch(err =>
-    Promise.reject(new Error('failed from sync to profile: ' + err.message)));
+    Bluebird.reject(new Error('failed from sync to profile: ' + err.message)));
 }

--- a/src/extensions/recovery/Workarounds.tsx
+++ b/src/extensions/recovery/Workarounds.tsx
@@ -1,4 +1,4 @@
-import PromiseBB from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 import * as React from 'react';
 import { Button, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
@@ -26,7 +26,7 @@ interface IConnectedProps {
 
 interface IActionProps {
   onShowDialog: (type: DialogType, title: string,
-                 content: IDialogContent, actions: DialogActions) => PromiseBB<IDialogResult>;
+                 content: IDialogContent, actions: DialogActions) => Bluebird<IDialogResult>;
 }
 
 type IProps = IBaseProps & IActionProps & IConnectedProps;

--- a/src/extensions/settings_interface/SettingsInterface.tsx
+++ b/src/extensions/settings_interface/SettingsInterface.tsx
@@ -25,7 +25,7 @@ import { nativeCountryName, nativeLanguageName } from './languagemap';
 import getText from './texts';
 
 import * as remoteT from '@electron/remote';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { app } from 'electron';
 import * as path from 'path';
 import * as React from 'react';
@@ -76,7 +76,7 @@ interface IActionProps {
   onSetProfilesVisible: (visible: boolean) => void;
   onSetAdvancedMode: (advanced: boolean) => void;
   onShowDialog: (type: DialogType, title: string,
-                 content: IDialogContent, actions: DialogActions) => Promise<IDialogResult>;
+                 content: IDialogContent, actions: DialogActions) => Bluebird<IDialogResult>;
   onSetCustomTitlebar: (enable: boolean) => void;
   onSetDesktopNotifications: (enabled: boolean) => void;
   onSetHideTopLevelCategory: (hide: boolean) => void;
@@ -317,10 +317,10 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
     }
     const ext: { modId?: number } = extensions.find(iter => iter.name === extName) || {};
     const { value } = target;
-    const dlProm: Promise<boolean[]> = ext.modId !== undefined
+    const dlProm: Bluebird<boolean[]> = ext.modId !== undefined
       ? this.context.api.emitAndAwait('install-extension', ext)
-        .tap(success => success ? this.props.onReloadLanguages() : Promise.resolve())
-      : Promise.resolve([true]);
+        .tap(success => success ? this.props.onReloadLanguages() : Bluebird.resolve())
+      : Bluebird.resolve([true]);
     dlProm.then((success: boolean[]) => {
       if (success.indexOf(false) === -1) {
         this.props.onSetLanguage(value);
@@ -529,7 +529,7 @@ function isValidLanguageCode(langId: string) {
   }
 }
 
-function readLocales(extensions: IAvailableExtension[]): Promise<ILanguage[]> {
+function readLocales(extensions: IAvailableExtension[]): Bluebird<ILanguage[]> {
   const bundledLanguages = getVortexPath('locales');
   const userLanguages = path.normalize(path.join(getVortexPath('userData'), 'locales'));
 
@@ -537,7 +537,7 @@ function readLocales(extensions: IAvailableExtension[]): Promise<ILanguage[]> {
 
   let local: string[] = [];
 
-  return Promise.join(readExtensibleDir('translation', bundledLanguages, userLanguages)
+  return Bluebird.join(readExtensibleDir('translation', bundledLanguages, userLanguages)
     .map((file: string) => path.basename(file))
     .tap(files => local = files),
     translationExts.map(ext => ext.language))

--- a/src/extensions/starter_dashlet/Tools.tsx
+++ b/src/extensions/starter_dashlet/Tools.tsx
@@ -26,7 +26,7 @@ import { setPrimaryTool, setToolOrder } from './actions';
 
 import ToolEditDialog from './ToolEditDialog';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import { Media } from 'react-bootstrap';
 import * as Redux from 'redux';
@@ -46,7 +46,7 @@ import { useSelector } from 'react-redux';
 import Tool from './Tool';
 
 interface IBaseProps {
-  onGetValidTools: (starters: IStarterInfo[], gameMode: string) => Promise<string[]>;
+  onGetValidTools: (starters: IStarterInfo[], gameMode: string) => Bluebird<string[]>;
 }
 
 interface IConnectedProps {
@@ -92,7 +92,7 @@ interface IActionProps {
   onSetToolVisible: (gameId: string, toolId: string, visible: boolean) => void;
   onShowError: (message: string, details?: any, allowReport?: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
   onSetPrimary: (gameId: string, toolId: string) => void;
   onSetToolOrder: (gameId: string, tools: string[]) => void;
 }

--- a/src/extensions/starter_dashlet/util.ts
+++ b/src/extensions/starter_dashlet/util.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import _ from 'lodash';
 import Debouncer from '../../util/Debouncer';
 import { nativeImage } from 'electron';
@@ -114,7 +114,7 @@ export function toToolDiscovery(tool: IEditStarterInfo): IDiscoveredTool {
   };
 }
 
-function toPNG(inputPath: string, outputPath: string): Promise<void> {
+function toPNG(inputPath: string, outputPath: string): Bluebird<void> {
   return fs.writeFileAsync(outputPath, nativeImage.createFromPath(inputPath).toPNG());
 }
 
@@ -125,18 +125,18 @@ export function updateImage(tool: IStarterInfo, filePath: string, cb: (err?: Err
   updateImageDebouncer.schedule(cb, tool, filePath);
 }
 
-function useImage(tool: IStarterInfo, filePath: string): Promise<void> {
+function useImage(tool: IStarterInfo, filePath: string): Bluebird<void> {
   const destPath = tool.iconOutPath;
 
   if (destPath === filePath) {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 
   return fs.statAsync(filePath)
-    .catch(err => Promise.reject(new ProcessCanceled('invalid file')))
+    .catch(err => Bluebird.reject(new ProcessCanceled('invalid file')))
     .then(stats => stats.isDirectory()
-      ? Promise.reject(new ProcessCanceled('is a directory'))
-      : Promise.resolve())
+      ? Bluebird.reject(new ProcessCanceled('is a directory'))
+      : Bluebird.resolve())
     .then(() => fs.ensureDirAsync(path.dirname(destPath)))
     .then(() => (path.extname(filePath) === '.exe')
       ? extractExeIcon(filePath, destPath)

--- a/src/extensions/symlink_activator_elevate/Settings.tsx
+++ b/src/extensions/symlink_activator_elevate/Settings.tsx
@@ -6,7 +6,7 @@ import { ComponentEx } from '../../util/ComponentEx';
 
 import { enableUserSymlinks } from './actions';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import { Alert, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
 import { withTranslation } from 'react-i18next';
@@ -27,7 +27,7 @@ interface IConnectedProps {
 interface IActionProps {
   onEnableUserSymlinks: (enable: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
 }
 
 type IProps = IBaseProps & IActionProps & IConnectedProps;

--- a/src/extensions/symlink_activator_elevate/walk.ts
+++ b/src/extensions/symlink_activator_elevate/walk.ts
@@ -2,25 +2,25 @@
 
 import * as fs from 'fs-extra';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as path from 'path';
 
 function walk(target: string,
-              callback: (iterPath: string, stats: fs.Stats) => Promise<any>): Promise<any> {
+              callback: (iterPath: string, stats: fs.Stats) => Bluebird<any>): Bluebird<any> {
   let allFileNames: string[];
 
-  return Promise.resolve(fs.readdir(target))
+  return Bluebird.resolve(fs.readdir(target))
     .then((fileNames: string[]) => {
       allFileNames = fileNames;
-      return Promise.mapSeries(fileNames, (statPath: string) => {
+      return Bluebird.mapSeries(fileNames, (statPath: string) => {
         const fullPath: string = path.join(target, statPath);
-        return Promise.resolve(fs.lstat(fullPath)).reflect();
+        return Bluebird.resolve(fs.lstat(fullPath)).reflect();
       });
-    }).then((res: Array<Promise.Inspection<fs.Stats>>) => {
+    }).then((res: Array<Bluebird.Inspection<fs.Stats>>) => {
       // use the stats results to generate a list of paths of the directories
       // in the searched directory
       const subDirs: string[] = [];
-      const cbPromises: Array<Promise<any>> = [];
+      const cbPromises: Array<Bluebird<any>> = [];
       res.forEach((stat, idx) => {
         if (!stat.isFulfilled()) {
           return;
@@ -31,8 +31,8 @@ function walk(target: string,
           subDirs.push(fullPath);
         }
       });
-      return Promise.all(
-        cbPromises.concat(Promise.mapSeries(subDirs, (subDir) => walk(subDir, callback))));
+      return Bluebird.all(
+        cbPromises.concat(Bluebird.mapSeries(subDirs, (subDir) => walk(subDir, callback))));
     }).then(() => null);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import * as fs from './util/fs';
 import { log } from './util/log';
 import * as selectors from './util/selectors';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export * from './controls/api';
 export * from './views/api';
-export { actions, Promise, fs, log, selectors, types, util };
+export { actions, Bluebird, fs, log, selectors, types, util };
 export { ComponentEx, PureComponentEx } from './util/ComponentEx';

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -9,7 +9,7 @@ if (process.env.DEBUG_REACT_RENDERS === 'true') {
     trackAllPureComponents: true,
     trackExtraHooks: [
       [require('react-redux'), 'useSelector']
-    ]   
+    ]
   });
 }
 
@@ -83,7 +83,7 @@ import MainWindow from './views/MainWindow';
 
 import * as remote from '@electron/remote';
 import * as msgpackT from '@msgpack/msgpack';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ipcRenderer, webFrame } from 'electron';
 import { forwardToMain, replayActionRenderer } from 'electron-redux';
 import { EventEmitter } from 'events';
@@ -211,7 +211,7 @@ if (process.platform === 'win32') {
 }
 
 // allow promises to be cancelled.
-Promise.config({
+Bluebird.config({
   cancellation: true,
   // long stack traces would be sooo nice but the performance cost in some places is ridiculous
   longStackTraces: false,
@@ -417,7 +417,7 @@ function init() {
     // if there are outdated extensions
     log('warn', 'outdated extensions discovered in renderer');
     relaunch();
-    return Promise.resolve(null);
+    return Bluebird.resolve(null);
   }
   const extReducers = extensions.getReducers();
 
@@ -468,7 +468,7 @@ function init() {
     lastHeapSize = stat.totalHeapSize;
   }, 5000);
 
-  const startupPromise = new Promise(resolve => (startupFinished = resolve));
+  const startupPromise = new Bluebird(resolve => (startupFinished = resolve));
 
   // tslint:disable-next-line:no-unused-variable
   const globalNotifications = new GlobalNotifications(extensions.getApi());
@@ -522,7 +522,7 @@ function init() {
     const id = args[args.length - 1];
     const cb = (...cbArgs) => {
       const newCBArgs = cbArgs.map(arg => {
-        if (!(arg instanceof Promise)) {
+        if (!(arg instanceof Bluebird)) {
           return arg;
         }
         const promId = shortid();
@@ -572,7 +572,7 @@ function init() {
     }
   });
 
-  return Promise.resolve(extensions);
+  return Bluebird.resolve(extensions);
 }
 
 function renderer(extensions: ExtensionManager) {
@@ -616,7 +616,7 @@ function renderer(extensions: ExtensionManager) {
           path: ext.path,
         }));
 
-      return Promise.map(dynamicExts, ext => {
+      return Bluebird.map(dynamicExts, ext => {
         const filePath = path.join(ext.path, 'language.json');
         return fs.readFile(filePath, { encoding: 'utf-8' })
           .then((fileData: string) => {

--- a/src/types/IExtensionContext.ts
+++ b/src/types/IExtensionContext.ts
@@ -44,7 +44,7 @@ import { IDiscoveryResult, IMod, IState } from './IState';
 import { ITableAttribute } from './ITableAttribute';
 import { ITestResult } from './ITestResult';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { ILookupResult, IModInfo, IReference } from 'modmeta-db';
 import * as React from 'react';
 import * as Redux from 'redux';
@@ -70,7 +70,7 @@ export type PropsCallback = () => any;
  */
 export type PersistingType = 'global' | 'game' | 'profile';
 
-export type CheckFunction = () => Promise<ITestResult>;
+export type CheckFunction = () => Bluebird<ITestResult>;
 
 export type RegisterSettings =
   (title: string,
@@ -186,7 +186,7 @@ export interface IRegisterProtocol {
 export interface IRegisterRepositoryLookup {
   (repositoryId: string,
    preferOverMD5: boolean,
-   callback: (id: IModRepoId) => Promise<IModLookupResult[]>);
+   callback: (id: IModRepoId) => Bluebird<IModLookupResult[]>);
 }
 
 export interface IFileFilter {
@@ -231,12 +231,12 @@ export type PersistorKey = string[];
  * @interface IPersistor
  */
 export interface IPersistor {
-  setResetCallback(cb: () => Promise<void>): void;
-  getItem(key: PersistorKey): Promise<string>;
-  setItem(key: PersistorKey, value: string): Promise<void>;
-  removeItem(key: PersistorKey): Promise<void>;
-  getAllKeys(): Promise<PersistorKey[]>;
-  getAllKVs?(prefix?: string): Promise<Array<{ key: PersistorKey, value: string }>>;
+  setResetCallback(cb: () => Bluebird<void>): void;
+  getItem(key: PersistorKey): Bluebird<string>;
+  setItem(key: PersistorKey, value: string): Bluebird<void>;
+  removeItem(key: PersistorKey): Bluebird<void>;
+  getAllKeys(): Bluebird<PersistorKey[]>;
+  getAllKVs?(prefix?: string): Bluebird<Array<{ key: PersistorKey, value: string }>>;
 }
 
 /**
@@ -263,17 +263,17 @@ export interface IArchiveOptions {
  * @interface IArchiveHandler
  */
 export interface IArchiveHandler {
-  readDir(archPath: string): Promise<string[]>;
+  readDir(archPath: string): Bluebird<string[]>;
   readFile?(filePath: string): NodeJS.ReadableStream;
-  extractFile?(filePath: string, outputPath: string): Promise<void>;
-  extractAll(outputPath: string): Promise<void>;
-  addFile?(filePath: string, sourcePath: string): Promise<void>;
-  create?(sourcePath: string): Promise<void>;
-  write?(): Promise<void>;
+  extractFile?(filePath: string, outputPath: string): Bluebird<void>;
+  extractAll(outputPath: string): Bluebird<void>;
+  addFile?(filePath: string, sourcePath: string): Bluebird<void>;
+  create?(sourcePath: string): Bluebird<void>;
+  write?(): Bluebird<void>;
 }
 
 export type ArchiveHandlerCreator =
-  (fileName: string, options: IArchiveOptions) => Promise<IArchiveHandler>;
+  (fileName: string, options: IArchiveOptions) => Bluebird<IArchiveHandler>;
 
 /**
  * callback used to extract download information into mod info.
@@ -282,7 +282,7 @@ export type ArchiveHandlerCreator =
  * not be accessing the disk or network or do any complex coomputation
  */
 export type AttributeExtractor = (modInfo: any, modPath: string) =>
-  Promise<{ [key: string]: any }>;
+  Bluebird<{ [key: string]: any }>;
 
 export interface IGameDetail {
   title: string;
@@ -321,7 +321,7 @@ export interface IErrorOptions {
  * field that doesn't exist in both IGameStored and IDiscoveryResult, please assume
  * it may be undefined.
  */
-export type GameInfoQuery = (game: any) => Promise<{ [key: string]: IGameDetail }>;
+export type GameInfoQuery = (game: any) => Bluebird<{ [key: string]: IGameDetail }>;
 
 export interface IMergeFilter {
   // files to use as basis for merge, will be copied to the merge
@@ -340,7 +340,7 @@ export type MergeTest = (game: IGame, gameDiscovery: IDiscoveryResult) => IMerge
 /**
  * callback to do the actual merging
  */
-export type MergeFunc = (filePath: string, mergePath: string) => Promise<void>;
+export type MergeFunc = (filePath: string, mergePath: string) => Bluebird<void>;
 
 /**
  * options used when starting an external application through runExecutable
@@ -430,7 +430,7 @@ export interface IExtensionApi {
    * show a dialog
    */
   showDialog?: (type: DialogType, title: string, content: IDialogContent,
-                actions: DialogActions, id?: string) => Promise<IDialogResult>;
+                actions: DialogActions, id?: string) => Bluebird<IDialogResult>;
 
   /**
    * close a dialog
@@ -456,21 +456,21 @@ export interface IExtensionApi {
    *
    * @memberOf IExtensionApi
    */
-  selectFile: (options: IOpenOptions) => Promise<string>;
+  selectFile: (options: IOpenOptions) => Bluebird<string>;
 
   /**
    * show a system dialog to select an executable file
    *
    * @memberOf IExtensionApi
    */
-  selectExecutable: (options: IOpenOptions) => Promise<string>;
+  selectExecutable: (options: IOpenOptions) => Bluebird<string>;
 
   /**
    * show a system dialog to open a single directory
    *
    * @memberOf IExtensionApi
    */
-  selectDir: (options: IOpenOptions) => Promise<string>;
+  selectDir: (options: IOpenOptions) => Bluebird<string>;
 
   /**
    * the redux store containing all application state & data
@@ -578,7 +578,7 @@ export interface IExtensionApi {
    *
    * @memberOf IExtensionApi
    */
-  lookupModReference: (ref: IModReference, options?: ILookupOptions) => Promise<IModLookupResult[]>;
+  lookupModReference: (ref: IModReference, options?: ILookupOptions) => Bluebird<IModLookupResult[]>;
 
   /**
    * add a meta server
@@ -597,20 +597,20 @@ export interface IExtensionApi {
    *
    * @memberOf IExtensionApi
    */
-  lookupModMeta: (details: ILookupDetails, ignoreCache?: boolean) => Promise<ILookupResult[]>;
+  lookupModMeta: (details: ILookupDetails, ignoreCache?: boolean) => Bluebird<ILookupResult[]>;
 
   /**
    * save meta information about a mod
    *
    * @memberOf IExtensionApi
    */
-  saveModMeta: (modInfo: IModInfo) => Promise<void>;
+  saveModMeta: (modInfo: IModInfo) => Bluebird<void>;
 
   /**
    * opens an archive
    */
   openArchive: (archivePath: string, options?: IArchiveOptions,
-                extension?: string) => Promise<Archive>;
+                extension?: string) => Bluebird<Archive>;
 
   /**
    * clear the stylesheet cache to ensure it gets rebuilt even if the list of files hasn't changed
@@ -651,14 +651,14 @@ export interface IExtensionApi {
    * The returned promise is resolved when the started process has run to completion.
    * IRunOptions.onSpawned can be used to react to when the process has been started.
    */
-  runExecutable: (executable: string, args: string[], options: IRunOptions) => Promise<void>;
+  runExecutable: (executable: string, args: string[], options: IRunOptions) => Bluebird<void>;
 
   /**
-   * emit an event and allow every receiver to return a Promise. This call will only return
-   * after all these Promises are resolved.
+   * emit an event and allow every receiver to return a Bluebird. This call will only return
+   * after all these Bluebirds are resolved.
    * If the event handlers return a value, this returns an array of results
    */
-  emitAndAwait: <T = any>(eventName: string, ...args: any[]) => Promise<T>;
+  emitAndAwait: <T = any>(eventName: string, ...args: any[]) => Bluebird<T>;
 
   /**
    * handle an event emitted with emitAndAwait. The listener can return a promise and the emitter
@@ -676,8 +676,8 @@ export interface IExtensionApi {
    * the result of the callback if any (the result is the first argument because the number
    * of arguments may be variable)
    */
-  withPrePost: <T>(eventName: string, callback: (...args: any[]) => Promise<T>)
-    => ((...args: any[]) => Promise<T>);
+  withPrePost: <T>(eventName: string, callback: (...args: any[]) => Bluebird<T>)
+    => ((...args: any[]) => Bluebird<T>);
 
   /**
    * returns true if the running version of Vortex is considered outdated. This is mostly used
@@ -705,7 +705,7 @@ export interface IExtensionApi {
    * displayed but may require the UI to be processed.
    * Specifically events can only be sent once this event has been triggered
    */
-  awaitUI: () => Promise<void>;
+  awaitUI: () => Bluebird<void>;
 
   /**
    * wrapper for api.store.getState() with the benefit that it automatically assigns a type
@@ -1123,7 +1123,7 @@ export interface IExtensionContext {
    *                                          game
    * @param {(game: IGame) => string} getPath given the specified game, return the absolute path to
    *                                          where games of this type should be installed.
-   * @param {(instructions) => Promise<boolean>} test given the list of install instructions,
+   * @param {(instructions) => Bluebird<boolean>} test given the list of install instructions,
    *                                                  determine if the installed mod is of this type
    * @param {IModTypeOptions} options options controlling the mod type
    */
@@ -1131,7 +1131,7 @@ export interface IExtensionContext {
                     priority: number,
                     isSupported: (gameId: string) => boolean,
                     getPath: (game: IGame) => string,
-                    test: (installInstructions: IInstruction[]) => Promise<boolean>,
+                    test: (installInstructions: IInstruction[]) => Bluebird<boolean>,
                     options?: IModTypeOptions) => void;
 
   /**
@@ -1212,7 +1212,7 @@ export interface IExtensionContext {
    * @param {function} hook the hook to be called
    */
   registerStartHook: (priority: number, id: string,
-                      hook: (call: IRunParameters) => Promise<IRunParameters>) => void;
+                      hook: (call: IRunParameters) => Bluebird<IRunParameters>) => void;
 
   /**
    * register a migration step. This migration is always called when the loaded extension has
@@ -1237,7 +1237,7 @@ export interface IExtensionContext {
    *                           As soon as the promise returned from this is resolved, the stored
    *                           version number is updated.
    */
-  registerMigration: (migrate: (oldVersion: string) => Promise<void>) => void;
+  registerMigration: (migrate: (oldVersion: string) => Bluebird<void>) => void;
 
   /**
    * register a file to be stored with the profile. It will always be synchronised with the current
@@ -1288,14 +1288,14 @@ export interface IExtensionContext {
    * show a single file doesn't exist because duh.)
    * This way the most feature rich handler supporting a file type will get picked.
    *
-   * Note: If the viewer supports picking the Promise shall resolve after the
+   * Note: If the viewer supports picking the Bluebird shall resolve after the
    *   choice is made and include the selected entry, if it doesn't it can resolve
    *   as soon as the handler knows whether it supports the file.
    */
   registerPreview?: (
     priority: number,
     handler: (files: IPreviewFile[], allowPick: boolean)
-      => Promise<IPreviewFile>) => void;
+      => Bluebird<IPreviewFile>) => void;
 
   /**
    * register a callback that will introduce additional variables that can be used as part of
@@ -1365,7 +1365,7 @@ export interface IExtensionContext {
    *
    * @memberOf IExtensionContext
    */
-  once: (callback: () => void | Promise<void>) => void;
+  once: (callback: () => void | Bluebird<void>) => void;
 
   /**
    * similar to once but this callback will be run (only) on the electron "main" process.

--- a/src/types/IGame.ts
+++ b/src/types/IGame.ts
@@ -3,7 +3,7 @@ import { IModType } from '../extensions/gamemode_management/types/IModType';
 import { IDiscoveryResult, IMod } from './IState';
 import { ITool } from './ITool';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export { IModType };
 
@@ -63,7 +63,7 @@ export interface IGame extends ITool {
    *
    * Do not implement this in your game extension, the function is added by vortex itself
    */
-  getInstalledVersion?: (discovery: IDiscoveryResult) => Promise<string>;
+  getInstalledVersion?: (discovery: IDiscoveryResult) => Bluebird<string>;
 
   /**
    * Determine whether the game needs to be executed via a launcher, like Steam or EpicGamesLauncher
@@ -87,7 +87,7 @@ export interface IGame extends ITool {
    *
    * @param gamePath path where the game is installed.
    */
-  requiresLauncher?: (gamePath: string) => Promise<{ launcher: string, addInfo?: any }>;
+  requiresLauncher?: (gamePath: string) => Bluebird<{ launcher: string, addInfo?: any }>;
 
   /**
    * returns the mod type extensions applicable to this game (all
@@ -148,7 +148,7 @@ export interface IGame extends ITool {
    * (like creating a directory, changing a registry key, ...) do it here. It will be called
    * every time before the game mode is activated.
    */
-  setup?: (discovery: IDiscoveryResult) => Promise<void>;
+  setup?: (discovery: IDiscoveryResult) => Bluebird<void>;
 
   /**
    * additional details about the game that may be used by extensions. Some extensions may work
@@ -222,5 +222,5 @@ export interface IGame extends ITool {
    * Once the promise resolves the mods as enabled at that time will be deployed, so for example
    * if the user enabled a mod while this promise is pending, that mod will be deployed.
    */
-  deploymentGate?: () => Promise<void>;
+  deploymentGate?: () => Bluebird<void>;
 }

--- a/src/types/IGameStore.ts
+++ b/src/types/IGameStore.ts
@@ -2,7 +2,7 @@ import { IExecInfo } from './IExecInfo';
 import { IExtensionApi } from './IExtensionContext';
 import { IGameStoreEntry } from './IGameStoreEntry';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export type GameLaunchType = 'gamestore' | 'commandline';
 
@@ -53,7 +53,7 @@ export class GameEntryNotFound extends Error {
 // Allows game extensions to pass arguments and attempt to partially
 //  control how the game gets started. Please use the optional addInfo
 //  parameter when returning from IGame::requiresLauncher
-// requiresLauncher?: (gamePath: string) => Promise<{
+// requiresLauncher?: (gamePath: string) => Bluebird<{
 //   launcher: string;
 //   addInfo?: any; <- return a ICustomExecutionInfo object here.
 // }>;
@@ -81,38 +81,38 @@ export interface IGameStore {
    *  resource intensive operation for each game the user attempts to
    *  manage.
    */
-  allGames: () => Promise<IGameStoreEntry[]>;
+  allGames: () => Bluebird<IGameStoreEntry[]>;
 
   /**
    * Attempt to find a game entry using its game store Id/Ids.
    *
    * @param appId of the game entry. This is obviously game store specific.
    */
-  findByAppId: (appId: string | string[]) => Promise<IGameStoreEntry>;
+  findByAppId: (appId: string | string[]) => Bluebird<IGameStoreEntry>;
 
   /**
    * Attempt to find a game store entry using the game's name.
    *
    * @param appName the game name which the game store uses to identify this game.
    */
-  findByName: (appName: string) => Promise<IGameStoreEntry>;
+  findByName: (appName: string) => Bluebird<IGameStoreEntry>;
 
   /**
    * Returns the full path to the launcher's executable.
    *  As of 1.4, this function is no longer optional - gamestores
    *  such as the Xbox app which do not have a stat-able store path
-   *  should return Promise.resolve(undefined) and define the
+   *  should return Bluebird.resolve(undefined) and define the
    *  "isGameStoreInstalled" function so that the game store helper
    *  is able to confirm that the gamestore is installed on the user's PC
    */
-  getGameStorePath: () => Promise<string>;
+  getGameStorePath: () => Bluebird<string>;
 
   /**
    * Launches the game using this game launcher.
    * @param appId whatever the game store uses to identify a game.
    * @param api gives access to API functions if needed.
    */
-  launchGame: (appId: any, api?: IExtensionApi) => Promise<void>;
+  launchGame: (appId: any, api?: IExtensionApi) => Bluebird<void>;
 
   /**
    * Determine whether the game has been installed by this game store launcher.
@@ -120,7 +120,7 @@ export interface IGameStore {
    *
    * @param name of the game we're looking for.
    */
-  isGameInstalled?: (name: string) => Promise<boolean>;
+  isGameInstalled?: (name: string) => Bluebird<boolean>;
 
   /**
    * In most cases the game store helper is fully capable of determining
@@ -130,7 +130,7 @@ export interface IGameStore {
    *  executable path MUST provide this function so that the game store helper
    *  can confirm that the store is installed correctly!
    */
-  isGameStoreInstalled?: () => Promise<boolean>;
+  isGameStoreInstalled?: () => Bluebird<boolean>;
 
   /**
    * Some launchers may support Posix paths when attempting to launch a
@@ -143,7 +143,7 @@ export interface IGameStore {
    *
    * @param name of the game we want the posix path for.
    */
-  getPosixPath?: (name: string) => Promise<string>;
+  getPosixPath?: (name: string) => Bluebird<string>;
 
   /**
    * Game store may support command line arguments when launching the game.
@@ -152,14 +152,14 @@ export interface IGameStore {
    *
    * @param appId - Whatever the game store uses to identify a game.
    */
-  getExecInfo?: (appId: any) => Promise<IExecInfo>;
+  getExecInfo?: (appId: any) => Bluebird<IExecInfo>;
 
   /**
    * Generally the game store helper should be able to launch games directly.
    *  This functor allows game stores to define their own custom start up logic
    *  if needed. e.g. gamestore-xbox
    */
-  launchGameStore?: (api: IExtensionApi, parameters?: string[]) => Promise<void>;
+  launchGameStore?: (api: IExtensionApi, parameters?: string[]) => Bluebird<void>;
 
   /**
    * Allows game stores to provide functionality to reload/refresh their
@@ -169,7 +169,7 @@ export interface IGameStore {
    * The game store helper is configured to call this function for all known
    *  game stores when a discovery scan is initiated.
    */
-  reloadGames?: () => Promise<void>;
+  reloadGames?: () => Bluebird<void>;
 
   /**
    * determine if the specified game is managed by/installed through this store.
@@ -181,5 +181,5 @@ export interface IGameStore {
    * The fallback function can be used to invoke the "default" behavior on top.
    */
   identifyGame?: (gamePath: string,
-                  fallback: (gamePath: string) => PromiseLike<boolean>) => Promise<boolean>;
+                  fallback: (gamePath: string) => PromiseLike<boolean>) => Bluebird<boolean>;
 }

--- a/src/types/ITestResult.ts
+++ b/src/types/ITestResult.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 export type ProblemSeverity = 'warning' | 'error' | 'fatal';
 
@@ -11,6 +11,6 @@ export interface ITestResult {
     context?: any;
   };
   severity: ProblemSeverity;
-  automaticFix?: () => Promise<void>;
-  onRecheck?: () => Promise<void>;
+  automaticFix?: () => Bluebird<void>;
+  onRecheck?: () => Bluebird<void>;
 }

--- a/src/types/ITool.ts
+++ b/src/types/ITool.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { IGameStoreEntry } from './IGameStoreEntry';
 
 /**
@@ -60,7 +60,7 @@ export interface ITool {
    * This may be left undefined but then the tool/game can only be discovered
    * by searching the disk which is slow and only happens manually.
    */
-  queryPath?: () => string | Promise<string | IGameStoreEntry>;
+  queryPath?: () => string | Bluebird<string | IGameStoreEntry>;
 
   /**
    * return the path of the tool executable relative to the tool base path,

--- a/src/util/Debouncer.ts
+++ b/src/util/Debouncer.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 type Callback = (err: Error) => void;
 

--- a/src/util/LevelPersist.ts
+++ b/src/util/LevelPersist.ts
@@ -2,7 +2,7 @@ import {IPersistor} from '../types/IExtensionContext';
 import { DataInvalid } from './CustomErrors';
 import { log } from './log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import encode from 'encoding-down';
 import leveldownT from 'leveldown';
 import * as levelup from 'levelup';
@@ -18,8 +18,8 @@ export class DatabaseLocked extends Error {
   }
 }
 
-function repairDB(dbPath: string): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+function repairDB(dbPath: string): Bluebird<void> {
+  return new Bluebird<void>((resolve, reject) => {
     log('warn', 'repairing database', dbPath);
     const leveldown: typeof leveldownT = require('leveldown');
     leveldown.repair(dbPath, (err: Error) => {
@@ -32,8 +32,8 @@ function repairDB(dbPath: string): Promise<void> {
   });
 }
 
-function openDB(dbPath: string): Promise<levelup.LevelUp> {
-  return new Promise<levelup.LevelUp>((resolve, reject) => {
+function openDB(dbPath: string): Bluebird<levelup.LevelUp> {
+  return new Bluebird<levelup.LevelUp>((resolve, reject) => {
     const leveldown: typeof leveldownT = require('leveldown');
     const db = levelup.default(encode(leveldown(dbPath)),
                      { keyEncoding: 'utf8', valueEncoding: 'utf8' }, (err) => {
@@ -48,19 +48,19 @@ function openDB(dbPath: string): Promise<levelup.LevelUp> {
 class LevelPersist implements IPersistor {
   public static create(persistPath: string,
                        tries: number = 10,
-                       repair: boolean = false): Promise<LevelPersist> {
-    return (repair ? repairDB(persistPath) : Promise.resolve())
+                       repair: boolean = false): Bluebird<LevelPersist> {
+    return (repair ? repairDB(persistPath) : Bluebird.resolve())
       .then(() => openDB(persistPath))
       .then(db => new LevelPersist(db))
       .catch(err => {
         if (err instanceof DataInvalid) {
-          return Promise.reject(err);
+          return Bluebird.reject(err);
         }
         if (tries === 0) {
           log('info', 'failed to open db', err);
-          return Promise.reject(new DatabaseLocked());
+          return Bluebird.reject(new DatabaseLocked());
         } else {
-          return Promise.delay(500)
+          return Bluebird.delay(500)
             .then(() => LevelPersist.create(persistPath, tries - 1, false));
         }
       });
@@ -72,19 +72,19 @@ class LevelPersist implements IPersistor {
     this.mDB = db;
   }
 
-  public close(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+  public close(): Bluebird<void> {
+    return new Bluebird<void>((resolve, reject) => {
       this.mDB.close((err) =>
         !!err ? reject(err) : resolve());
     });
   }
 
-  public setResetCallback(cb: () => Promise<void>): void {
+  public setResetCallback(cb: () => Bluebird<void>): void {
     return undefined;
   }
 
-  public getItem(key: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
+  public getItem(key: string[]): Bluebird<string> {
+    return new Bluebird((resolve, reject) => {
       this.mDB.get(key.join(SEPARATOR), (error, value) => {
         if (error) {
           return reject(error);
@@ -94,8 +94,8 @@ class LevelPersist implements IPersistor {
     });
   }
 
-  public getAllKeys(options?: any): Promise<string[][]> {
-    return new Promise((resolve, reject) => {
+  public getAllKeys(options?: any): Bluebird<string[][]> {
+    return new Bluebird((resolve, reject) => {
       const keys: string[][] = [];
       let resolved = false;
       this.mDB.createKeyStream(options)
@@ -117,8 +117,8 @@ class LevelPersist implements IPersistor {
     });
   }
 
-  public getAllKVs(prefix?: string): Promise<Array<{ key: string[], value: string }>> {
-    return new Promise((resolve, reject) => {
+  public getAllKVs(prefix?: string): Bluebird<Array<{ key: string[], value: string }>> {
+    return new Bluebird((resolve, reject) => {
         const kvs: Array<{ key: string[], value: string }> = [];
 
         const options = (prefix === undefined)
@@ -141,9 +141,9 @@ class LevelPersist implements IPersistor {
       });
   }
 
-  public setItem(statePath: string[], newState: string): Promise<void> {
+  public setItem(statePath: string[], newState: string): Bluebird<void> {
     const stackErr = new Error();
-    return new Promise<void>((resolve, reject) => {
+    return new Bluebird<void>((resolve, reject) => {
       this.mDB.put(statePath.join(SEPARATOR), newState, error => {
         if (error) {
           error.stack = stackErr.stack;
@@ -159,8 +159,8 @@ class LevelPersist implements IPersistor {
     });
   }
 
-  public removeItem(statePath: string[]): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+  public removeItem(statePath: string[]): Bluebird<void> {
+    return new Bluebird<void>((resolve, reject) => {
       this.mDB.del(statePath.join(SEPARATOR), error => {
         if (error) {
           return reject(error);

--- a/src/util/StarterInfo.ts
+++ b/src/util/StarterInfo.ts
@@ -19,7 +19,7 @@ import { MissingDependency, MissingInterpreter,
          ProcessCanceled, UserCanceled } from './CustomErrors';
 import getVortexPath from './getVortexPath';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fs from 'fs';
 import * as path from 'path';
 import { GameEntryNotFound } from '../types/IGameStore';
@@ -76,14 +76,14 @@ class StarterInfo implements IStarterInfo {
 
   public static run(info: IStarterInfo, api: IExtensionApi, onShowError: OnShowErrorFunc) {
     const game: IGame = getGame(info.gameId);
-    const launcherPromise: Promise<{ launcher: string, addInfo?: any }> =
+    const launcherPromise: Bluebird<{ launcher: string, addInfo?: any }> =
       (game.requiresLauncher !== undefined) && info.isGame
       ? game.requiresLauncher(path.dirname(info.exePath))
         .catch(err => {
           onShowError('Failed to determine if launcher is required', err, true);
-          return Promise.resolve(undefined);
+          return Bluebird.resolve(undefined);
         })
-      : Promise.resolve(undefined);
+      : Bluebird.resolve(undefined);
 
     const onSpawned = () => {
       api.store.dispatch(setToolRunning(info.exePath, Date.now(), info.exclusive));
@@ -146,7 +146,7 @@ class StarterInfo implements IStarterInfo {
                              api: IExtensionApi,
                              onShowError: OnShowErrorFunc,
                              onSpawned: () => void,
-                             ): Promise<void> {
+                             ): Bluebird<void> {
     const spawned = () => {
       onSpawned();
       if (['hide', 'hide_recover'].includes(info.onStart)) {
@@ -227,18 +227,18 @@ class StarterInfo implements IStarterInfo {
   private static runThroughLauncher(launcher: string,
                                     info: IStarterInfo,
                                     api: IExtensionApi,
-                                    addInfo: any): Promise<void> {
+                                    addInfo: any): Bluebird<void> {
     let gameLauncher;
     try {
       gameLauncher = GameStoreHelper.getGameStore(launcher);
     } catch (err) {
-      return Promise.reject(err);
+      return Bluebird.reject(err);
     }
     const infoObj = (addInfo !== undefined)
       ? addInfo : path.dirname(info.exePath);
     return (gameLauncher !== undefined)
       ? gameLauncher.launchGame(infoObj, api)
-      : Promise.reject(new Error(`unsupported launcher ${launcher}`));
+      : Bluebird.reject(new Error(`unsupported launcher ${launcher}`));
   }
 
   private static gameIcon(gameId: string, extensionPath: string, logo: string) {

--- a/src/util/SubPersistor.ts
+++ b/src/util/SubPersistor.ts
@@ -1,9 +1,9 @@
 import { IPersistor, PersistorKey } from '../types/IExtensionContext';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 class SubPersistor implements IPersistor {
-  public getAllKVs: () => Promise<Array<{ key: string[], value: string }>> = undefined;
+  public getAllKVs: () => Bluebird<Array<{ key: string[], value: string }>> = undefined;
 
   private mWrapped: IPersistor;
   private mHive: string;
@@ -20,23 +20,23 @@ class SubPersistor implements IPersistor {
     }
   }
 
-  public setResetCallback(cb: () => Promise<void>): void {
+  public setResetCallback(cb: () => Bluebird<void>): void {
     this.mWrapped.setResetCallback(cb);
   }
 
-  public getItem(key: string[]): Promise<string> {
+  public getItem(key: string[]): Bluebird<string> {
     return this.mWrapped.getItem([].concat(this.mHive, key));
   }
 
-  public setItem(key: string[], value: string): Promise<void> {
+  public setItem(key: string[], value: string): Bluebird<void> {
     return this.mWrapped.setItem([].concat(this.mHive, key), value);
   }
 
-  public removeItem(key: string[]): Promise<void> {
+  public removeItem(key: string[]): Bluebird<void> {
     return this.mWrapped.removeItem([].concat(this.mHive, key));
   }
 
-  public getAllKeys(): Promise<string[][]> {
+  public getAllKeys(): Bluebird<string[][]> {
     return this.mWrapped.getAllKeys()
       .then(keys => keys
         .filter(key => key[0] === this.mHive)

--- a/src/util/archives.ts
+++ b/src/util/archives.ts
@@ -1,6 +1,6 @@
 import { IArchiveHandler } from '../types/IExtensionContext';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * wrapper around an format-specific archive handler
@@ -18,7 +18,7 @@ export class Archive {
   /**
    * list files at the specified path
    */
-  public get readDir(): (archivePath: string) => Promise<string[]> {
+  public get readDir(): (archivePath: string) => Bluebird<string[]> {
     return (this.mHandler.readDir !== undefined)
       ? (archivePath: string) => this.mHandler.readDir(archivePath)
       : undefined;
@@ -36,7 +36,7 @@ export class Archive {
   /**
    * extract a single file
    */
-  public get extractFile(): (filePath: string, outputPath: string) => Promise<void> {
+  public get extractFile(): (filePath: string, outputPath: string) => Bluebird<void> {
     return (this.mHandler.extractFile !== undefined)
       ? (filePath: string, outputPath: string) => this.mHandler.extractFile(filePath, outputPath)
       : undefined;
@@ -45,7 +45,7 @@ export class Archive {
   /**
    * extract the entire archive
    */
-  public get extractAll(): (outputPath: string) => Promise<void> {
+  public get extractAll(): (outputPath: string) => Bluebird<void> {
     return (this.mHandler.extractAll !== undefined)
       ? (outputPath: string) => this.mHandler.extractAll(outputPath)
       : undefined;
@@ -54,7 +54,7 @@ export class Archive {
   /**
    * create this archive from the files in sourcePath
    */
-  public get create(): (sourcePath: string) => Promise<void> {
+  public get create(): (sourcePath: string) => Bluebird<void> {
     return (this.mHandler.create !== undefined)
       ? (sourcePath: string) => this.mHandler.create(sourcePath)
       : undefined;
@@ -63,13 +63,13 @@ export class Archive {
   /**
    * add a single file to the archive
    */
-  public get addFile(): (filePath: string, sourcePath: string) => Promise<void> {
+  public get addFile(): (filePath: string, sourcePath: string) => Bluebird<void> {
     return (this.mHandler.addFile !== undefined)
       ? (filePath: string, sourcePath: string) => this.mHandler.addFile(filePath, sourcePath)
       : undefined;
   }
 
-  public get write(): () => Promise<void> {
+  public get write(): () => Bluebird<void> {
     return (this.mHandler.write !== undefined)
       ? () => this.mHandler.write()
       : undefined;

--- a/src/util/asyncRequire.tsx
+++ b/src/util/asyncRequire.tsx
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as React from 'react';
@@ -17,10 +17,10 @@ const Module = require('module');
  * @export
  * @param {string} id
  * @param {string} [basedir]
- * @returns {Promise<any>}
+ * @returns {Bluebird<any>}
  */
-export default function(id: string, basedir?: string): Promise<any> {
-  return new Promise((resolve, reject) => {
+export default function(id: string, basedir?: string): Bluebird<any> {
+  return new Bluebird((resolve, reject) => {
     const options = basedir !== undefined ? { basedir } : undefined;
     reqResolve(id, options, (resErr, filePath) => {
       if (resErr) {

--- a/src/util/copyRecursive.ts
+++ b/src/util/copyRecursive.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -79,8 +79,8 @@ function copyDir(sourcePath: string, destinationPath: string, relPath: string,
  * @param {string} source source path to copy from
  * @param {string} destination destination path to copy to
  */
-function copyRecursive(source: string, destination: string): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+function copyRecursive(source: string, destination: string): Bluebird<void> {
+  return new Bluebird<void>((resolve, reject) => {
     const queue = {
       dir: [],
       file: [],

--- a/src/util/devel.ts
+++ b/src/util/devel.ts
@@ -1,6 +1,6 @@
 import { log } from './log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 /**
  * downloads and installs development extensions that help with redux / react development.
@@ -9,8 +9,8 @@ import Promise from 'bluebird';
  * @export
  * @returns
  */
-export function installDevelExtensions(): Promise<void> {
-  return new Promise<void>((resolved, reject) => {
+export function installDevelExtensions(): Bluebird<void> {
+  return new Bluebird<void>((resolved, reject) => {
     if (process.env.NODE_ENV === 'development') {
       const installExtension = require('electron-devtools-installer').default;
       const {

--- a/src/util/errorHandling.ts
+++ b/src/util/errorHandling.ts
@@ -15,7 +15,7 @@ import { flatten, getAllPropertyNames, spawnSelf, truthy } from './util';
 
 import * as RemoteT from '@electron/remote';
 import NexusT, { IFeedbackResponse } from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import {
   BrowserWindow,
   dialog as dialogIn,
@@ -127,11 +127,11 @@ export function createErrorReport(type: string, error: IError, context: IErrorCo
 
 function nexusReport(hash: string, type: string, error: IError, labels: string[],
                      context: IErrorContext, apiKey: string, reporterProcess: string,
-                     sourceProcess: string, attachment: string): Promise<IFeedbackResponse> {
+                     sourceProcess: string, attachment: string): Bluebird<IFeedbackResponse> {
   const Nexus: typeof NexusT = require('@nexusmods/nexus-api').default;
 
   const referenceId = require('uuid').v4();
-  return Promise.resolve(Nexus.create(apiKey, 'Vortex', getApplication().version, undefined))
+  return Bluebird.resolve(Nexus.create(apiKey, 'Vortex', getApplication().version, undefined))
     .then(nexus => nexus.sendFeedback(
       createTitle(type, error, hash),
       createReport(type, error, context, getApplication().version, reporterProcess, sourceProcess),
@@ -194,9 +194,9 @@ if (ipcRenderer !== undefined) {
   });
 }
 
-export function sendReportFile(fileName: string): Promise<IFeedbackResponse> {
+export function sendReportFile(fileName: string): Bluebird<IFeedbackResponse> {
   let reportInfo: any;
-  return Promise.resolve(fs.readFile(fileName, { encoding: 'utf8' }))
+  return Bluebird.resolve(fs.readFile(fileName, { encoding: 'utf8' }))
     .then(reportData => {
       reportInfo = JSON.parse(reportData.toString());
       const userData = reportInfo['userData'] ?? getVortexPath('userData');
@@ -226,7 +226,7 @@ export function sendReportFile(fileName: string): Promise<IFeedbackResponse> {
 export function sendReport(type: string, error: IError, context: IErrorContext,
                            labels: string[],
                            reporterId: string, reporterProcess: string,
-                           sourceProcess: string, attachment: string): Promise<IFeedbackResponse> {
+                           sourceProcess: string, attachment: string): Bluebird<IFeedbackResponse> {
   const dialog = process.type === 'renderer' ? remote.dialog : dialogIn;
   const hash = genHash(error);
   if (process.env.NODE_ENV === 'development') {
@@ -237,7 +237,7 @@ export function sendReport(type: string, error: IError, context: IErrorContext,
       type, error, labels, context, reporterId, reporterProcess, sourceProcess,
       attachment,
     }, undefined, 2));
-    return Promise.resolve(undefined);
+    return Bluebird.resolve(undefined);
   } else {
     return nexusReport(hash, type, error, labels, context, reporterId || fallbackAPIKey,
                        reporterProcess, sourceProcess, attachment);
@@ -536,7 +536,7 @@ export function clearErrorContext(id: string) {
  * @param value context value
  * @param fun the function to set
  */
-export function withContext(id: string, value: string, fun: () => Promise<any>) {
+export function withContext(id: string, value: string, fun: () => Bluebird<any>) {
   setErrorContext(id, value);
   return fun().finally(() => {
     clearErrorContext(id);

--- a/src/util/fsAtomic.ts
+++ b/src/util/fsAtomic.ts
@@ -2,7 +2,7 @@ import { checksum } from './checksum';
 import * as fs from './fs';
 import { log } from './log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import { createHash } from 'crypto';
 import { file } from 'tmp';
 
@@ -12,7 +12,7 @@ export function writeFileAtomic(filePath: string, input: string | Buffer) {
 
 function writeFileAtomicImpl(filePath: string,
                              input: string | Buffer,
-                             attempts: number): Promise<void> {
+                             attempts: number): Bluebird<void> {
   const stackErr = new Error();
   let cleanup: () => void;
   let tmpPath: string;
@@ -38,8 +38,8 @@ function writeFileAtomicImpl(filePath: string,
     fd = fdIn;
     tmpPath = pathIn;
     return fs.writeAsync(fd, buf, 0, buf.byteLength, 0)
-      .then(() => fs.fsyncAsync(fd).catch(() => Promise.resolve()))
-      .then(() => fs.closeAsync(fd).catch(() => Promise.resolve()));
+      .then(() => fs.fsyncAsync(fd).catch(() => Bluebird.resolve()))
+      .then(() => fs.closeAsync(fd).catch(() => Bluebird.resolve()));
   }, {
     cleanup: false,
     template: `${filePath}.XXXXXX.tmp`,
@@ -50,7 +50,7 @@ function writeFileAtomicImpl(filePath: string,
         filePath,
         fd,
       });
-      return Promise.resolve(undefined);
+      return Bluebird.resolve(undefined);
     })
     .then(data => {
       if ((data === undefined) || (checksum(data) !== hash)) {
@@ -58,7 +58,7 @@ function writeFileAtomicImpl(filePath: string,
         return (attempts > 0)
           // retry
           ? writeFileAtomicImpl(filePath, input, attempts - 1)
-          : Promise.reject(new Error('Write failed, checksums differ'));
+          : Bluebird.reject(new Error('Write failed, checksums differ'));
       } else {
         return fs.renameAsync(tmpPath, filePath)
           .catch({ code: 'EEXIST' }, () =>
@@ -68,7 +68,7 @@ function writeFileAtomicImpl(filePath: string,
     })
     .catch(err => {
       err.stack = err.stack + '\n' + stackErr.stack;
-      return Promise.reject(err);
+      return Bluebird.reject(err);
     })
     .finally(() => {
       callCleanup();
@@ -85,13 +85,13 @@ function writeFileAtomicImpl(filePath: string,
  * @export
  * @param {string} srcPath
  * @param {string} destPath
- * @returns {Promise<void>}
+ * @returns {Bluebird<void>}
  */
 export function copyFileAtomic(srcPath: string,
-                               destPath: string): Promise<void> {
+                               destPath: string): Bluebird<void> {
   let cleanup: () => void;
   let tmpPath: string;
-  return new Promise((resolve, reject) => {
+  return new Bluebird((resolve, reject) => {
            file({template: `${destPath}.XXXXXX.tmp`},
                 (err: any, genPath: string, fd: number,
                  cleanupCB: () => void) => {
@@ -110,18 +110,18 @@ export function copyFileAtomic(srcPath: string,
           // if the file is currently in use, try a second time
           // 100ms later
           log('debug', 'file locked, retrying delete', destPath);
-          return Promise.delay(100).then(() => fs.unlinkAsync(destPath));
+          return Bluebird.delay(100).then(() => fs.unlinkAsync(destPath));
         } else if (err.code === 'ENOENT') {
           // file doesn't exist anyway? no problem
-          return Promise.resolve();
+          return Bluebird.resolve();
         } else {
-          return Promise.reject(err);
+          return Bluebird.reject(err);
         }
       }))
-      .catch(err => err.code === 'ENOENT' ? Promise.resolve() : Promise.reject(err))
+      .catch(err => err.code === 'ENOENT' ? Bluebird.resolve() : Bluebird.reject(err))
       .then(() => (tmpPath !== undefined)
           ? fs.renameAsync(tmpPath, destPath)
-          : Promise.resolve())
+          : Bluebird.resolve())
       .catch(err => {
         log('info', 'failed to copy', {srcPath, destPath, err: err.stack});
         if (cleanup !== undefined) {
@@ -131,6 +131,6 @@ export function copyFileAtomic(srcPath: string,
             log('error', 'failed to clean up temporary file', cleanupErr.message);
           }
         }
-        return Promise.reject(err);
+        return Bluebird.reject(err);
       });
 }

--- a/src/util/getFileList.ts
+++ b/src/util/getFileList.ts
@@ -1,6 +1,6 @@
 import walk from './walk';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fs from 'fs';
 
 export interface IFileEntry {
@@ -8,7 +8,7 @@ export interface IFileEntry {
   stats: fs.Stats;
 }
 
-function getFileList(basePath: string): Promise<IFileEntry[]> {
+function getFileList(basePath: string): Bluebird<IFileEntry[]> {
 
   const result: IFileEntry[] = [];
 
@@ -16,15 +16,15 @@ function getFileList(basePath: string): Promise<IFileEntry[]> {
     if (!filePath.startsWith('__')) {
       result.push({filePath, stats});
     }
-    return Promise.resolve();
+    return Bluebird.resolve();
   })
   .then(() => result)
   .catch(err => {
     if (err.code === 'ENOENT') {
       // if the directory doesn't exist it obviously doesn't contain files, right?
-      return Promise.resolve([]);
+      return Bluebird.resolve([]);
     } else {
-      return Promise.reject(err);
+      return Bluebird.reject(err);
     }
   });
 }

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -4,7 +4,7 @@ import * as fs from './fs';
 import getVortexPath from './getVortexPath';
 import { log } from './log';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import I18next, { i18n, TOptions } from 'i18next';
 import FSBackend from 'i18next-node-fs-backend';
 import * as path from 'path';
@@ -136,7 +136,7 @@ class HighlightPP {
  * @param {string} language
  * @returns {I18next.I18n}
  */
-function init(language: string, translationExts: () => IExtension[]): Promise<IInitResult> {
+function init(language: string, translationExts: () => IExtension[]): Bluebird<IInitResult> {
   // reset to english if the language isn't valid
   try {
     (new Date()).toLocaleString(language);
@@ -154,7 +154,7 @@ function init(language: string, translationExts: () => IExtension[]): Promise<II
     .use(initReactI18next)
     ;
 
-  return Promise.resolve(i18nObj.init(
+  return Bluebird.resolve(i18nObj.init(
     {
       lng: language,
       fallbackLng: 'en',
@@ -199,7 +199,7 @@ function init(language: string, translationExts: () => IExtension[]): Promise<II
       },
     }))
     .tap(tFunc => { actualT = tFunc; })
-    .then(tFunc => Promise.resolve({
+    .then(tFunc => Bluebird.resolve({
       i18n: i18nObj,
       tFunc,
     }))

--- a/src/util/message.ts
+++ b/src/util/message.ts
@@ -18,7 +18,7 @@ import { log } from './log';
 import { flatten, setdefault, truthy } from './util';
 
 import { IFeedbackResponse } from '@nexusmods/nexus-api';
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import ZipT = require('node-7z');
 import * as os from 'os';
 import * as path from 'path';
@@ -155,7 +155,7 @@ function shouldAllowReport(err: string | Error | any, options?: IErrorOptions): 
 }
 
 function dataToFile(id, input: any) {
-  return new Promise<string>((resolve, reject) => {
+  return new Bluebird<string>((resolve, reject) => {
     const data: Buffer = Buffer.from(JSON.stringify(input));
     tmpFile({
       prefix: id,
@@ -178,14 +178,14 @@ function dataToFile(id, input: any) {
   });
 }
 
-function zipFiles(files: string[]): Promise<string> {
+function zipFiles(files: string[]): Bluebird<string> {
   if (files.length === 0) {
-    return Promise.resolve(undefined);
+    return Bluebird.resolve(undefined);
   }
   const Zip: typeof ZipT = require('node-7z');
   const task: ZipT = new Zip();
 
-  return new Promise<string>((resolve, reject) => {
+  return new Bluebird<string>((resolve, reject) => {
     tmpName({
       postfix: '.7z',
     }, (err, tmpPath: string) => (err !== null)
@@ -197,7 +197,7 @@ function zipFiles(files: string[]): Promise<string> {
         .then(() => tmpPath));
 }
 
-function serializeAttachments(input: IAttachment): Promise<string> {
+function serializeAttachments(input: IAttachment): Bluebird<string> {
   if (input.type === 'file') {
     return input.data;
   } else {
@@ -205,14 +205,14 @@ function serializeAttachments(input: IAttachment): Promise<string> {
   }
 }
 
-export function bundleAttachment(options?: IErrorOptions): Promise<string> {
+export function bundleAttachment(options?: IErrorOptions): Bluebird<string> {
   if ((options === undefined)
       || (options.attachments === undefined)
       || (options.attachments.length === 0)) {
-    return Promise.resolve(undefined);
+    return Bluebird.resolve(undefined);
   }
 
-  return Promise.reduce(options.attachments, (accum: string[], iter: IAttachment) => {
+  return Bluebird.reduce(options.attachments, (accum: string[], iter: IAttachment) => {
     if (iter.type === 'file') {
       return fs.statAsync(iter.data)
         .then(() => serializeAttachments(iter))

--- a/src/util/smoothScroll.ts
+++ b/src/util/smoothScroll.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 
 function step(startTime: number, endTime: number, time: number) {
   if (time <= startTime) {
@@ -27,7 +27,7 @@ function smoothScroll(element: HTMLElement, targetPos: number, duration: number)
     scrollJobs[element.id]();
   }
 
-  return new Promise<boolean>((resolve, reject) => {
+  return new Bluebird<boolean>((resolve, reject) => {
     let canceled = false;
     let timer: number;
 

--- a/src/util/storeHelper.ts
+++ b/src/util/storeHelper.ts
@@ -6,7 +6,7 @@ import { IGameStored } from '../extensions/gamemode_management/types/IGameStored
 
 import { activeGameId } from './selectors';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as Redux from 'redux';
 
 function clone<T>(input: T): T {
@@ -331,8 +331,8 @@ export function rehydrate<T extends object>(
     : state;
 }
 
-function waitUntil(predicate: () => boolean, interval: number = 100): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+function waitUntil(predicate: () => boolean, interval: number = 100): Bluebird<void> {
+  return new Bluebird<void>((resolve, reject) => {
     setTimeout(() => {
       if (predicate()) {
         resolve();
@@ -352,15 +352,15 @@ function waitUntil(predicate: () => boolean, interval: number = 100): Promise<vo
  *
  * @export
  * @param {*} state
- * @returns {Promise<IGameStored>}
+ * @returns {Bluebird<IGameStored>}
  */
-export function currentGame(store: Redux.Store<any>): Promise<IGameStored> {
+export function currentGame(store: Redux.Store<any>): Bluebird<IGameStored> {
   const fallback = {id: '__placeholder', name: '<No game>', requiredFiles: []};
   let knownGames = getSafe(store.getState(), ['session', 'gameMode', 'known'], null);
   if ((knownGames !== null) && (knownGames !== undefined)) {
     const gameMode = activeGameId(store.getState());
     const res = knownGames.find((ele: IGameStored) => ele.id === gameMode);
-    return Promise.resolve(res || fallback);
+    return Bluebird.resolve(res || fallback);
   } else {
     return waitUntil(() => {
              knownGames =
@@ -371,7 +371,7 @@ export function currentGame(store: Redux.Store<any>): Promise<IGameStored> {
           const gameMode = activeGameId(store.getState());
 
           const res = knownGames.find((ele: IGameStored) => ele.id === gameMode);
-          return Promise.resolve(res || fallback);
+          return Bluebird.resolve(res || fallback);
         });
   }
 }

--- a/src/util/transferPath.ts
+++ b/src/util/transferPath.ts
@@ -8,7 +8,7 @@ import getNormalizeFunc, { Normalize } from './getNormalizeFunc';
 import { log } from './log';
 import { isChildPath } from './util';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as diskusage from 'diskusage';
 import * as path from 'path';
 import turbowalk, { IEntry } from 'turbowalk';
@@ -26,9 +26,9 @@ const MIN_DISK_SPACE_OFFSET = 512 * 1024 * 1024;
  * @param source The current source folder.
  * @param destination The proposed destination folder.
  */
-export function testPathTransfer(source: string, destination: string): Promise<void> {
+export function testPathTransfer(source: string, destination: string): Bluebird<void> {
   if (process.platform !== 'win32') {
-    return Promise.reject(new UnsupportedOperatingSystem());
+    return Bluebird.reject(new UnsupportedOperatingSystem());
   }
 
   let destinationRoot: string;
@@ -39,21 +39,21 @@ export function testPathTransfer(source: string, destination: string): Promise<v
     //  the only way for this error to be reported at this point is when
     //  the destination path is pointing towards a non-existing partition.
     return (err.systemCode === 2)
-      ? Promise.reject(new NotFound(err.path))
-      : Promise.reject(err);
+      ? Bluebird.reject(new NotFound(err.path))
+      : Bluebird.reject(err);
   }
 
-  const isOnSameVolume = (): Promise<boolean> => {
-    return Promise.all([fs.statAsync(source), fs.statAsync(destinationRoot)])
+  const isOnSameVolume = (): Bluebird<boolean> => {
+    return Bluebird.all([fs.statAsync(source), fs.statAsync(destinationRoot)])
       .then(stats => stats[0].dev === stats[1].dev);
   };
 
-  const calculate = (filePath: string): Promise<number> => {
+  const calculate = (filePath: string): Bluebird<number> => {
     let total = 0;
     return turbowalk(filePath, entries => {
       const files = entries.filter(entry => !entry.isDirectory);
       total += files.reduce((lhs, rhs) => lhs + rhs.size, 0);
-    }, { skipHidden: false }).then(() => Promise.resolve(total));
+    }, { skipHidden: false }).then(() => Bluebird.resolve(total));
   };
 
   let totalNeededBytes = 0;
@@ -65,11 +65,11 @@ export function testPathTransfer(source: string, destination: string): Promise<v
       //  possibly a faulty HDD that was replaced.
       //  For that reason, we're going to skip disk calculations entirely.
       log('warn', 'Transfer disk space test failed - missing source directory', err);
-      return Promise.reject(new ProcessCanceled('Missing source directory'));
+      return Bluebird.reject(new ProcessCanceled('Missing source directory'));
     })
     .then(() => isOnSameVolume())
     .then(res => res
-      ? Promise.reject(new ProcessCanceled('Disk space calculations are unnecessary.'))
+      ? Bluebird.reject(new ProcessCanceled('Disk space calculations are unnecessary.'))
       : calculate(source))
     .then(totalSize => {
       totalNeededBytes = totalSize;
@@ -77,14 +77,14 @@ export function testPathTransfer(source: string, destination: string): Promise<v
         return diskusage.check(destinationRoot);
       } catch (err) {
         // don't report an error just because this check failed
-        return Promise.resolve({ free: Number.MAX_VALUE });
+        return Bluebird.resolve({ free: Number.MAX_VALUE });
       }
     })
     .then(res =>
       (totalNeededBytes < (res.free - MIN_DISK_SPACE_OFFSET))
-        ? Promise.resolve()
-        : Promise.reject(new InsufficientDiskSpace(destinationRoot)))
-    .catch(ProcessCanceled, () => Promise.resolve());
+        ? Bluebird.resolve()
+        : Bluebird.reject(new InsufficientDiskSpace(destinationRoot)))
+    .catch(ProcessCanceled, () => Bluebird.resolve());
 }
 
 export type ProgressCallback = (from: string, to: string, percentage: number) => void;
@@ -99,7 +99,7 @@ export type ProgressCallback = (from: string, to: string, percentage: number) =>
  */
 export function transferPath(source: string,
                              dest: string,
-                             progress: ProgressCallback): Promise<void> {
+                             progress: ProgressCallback): Bluebird<void> {
   let func = fs.copyAsync;
 
   let completed: number = 0;
@@ -107,7 +107,7 @@ export function transferPath(source: string,
   let lastPerc: number = 0;
   let lastProgress: number = 0;
 
-  let copyPromise = Promise.resolve();
+  let copyPromise = Bluebird.resolve();
 
   // Used to keep track of leftover empty directories when
   //  the user moves the directory to a nested one
@@ -130,16 +130,16 @@ export function transferPath(source: string,
     .then(norm => {
       normalize = norm;
       if (norm(dest) === norm(source)) {
-        return Promise.reject(new ProcessCanceled('Source and Destination are the same'));
+        return Bluebird.reject(new ProcessCanceled('Source and Destination are the same'));
       }
       moveDown = isChildPath(dest, source, norm);
     })
-    .then(() => Promise.join(fs.statAsync(source), fs.statAsync(dest),
+    .then(() => Bluebird.join(fs.statAsync(source), fs.statAsync(dest),
       (statOld: fs.Stats, statNew: fs.Stats) =>
-        Promise.resolve(statOld.dev === statNew.dev)))
+        Bluebird.resolve(statOld.dev === statNew.dev)))
     .then((sameVolume: boolean) => {
       func = sameVolume ? linkFile : fs.copyAsync;
-      return Promise.resolve();
+      return Bluebird.resolve();
     })
     .then(() => turbowalk(source, (entries: IEntry[]) => {
       if (moveDown) {
@@ -156,31 +156,31 @@ export function transferPath(source: string,
       count += files.length;
 
       copyPromise = isCancelled
-        ? Promise.resolve()
-        : copyPromise.then(() => Promise.each(directories.sort(longestFirst), entry => {
+        ? Bluebird.resolve()
+        : copyPromise.then(() => Bluebird.each(directories.sort(longestFirst), entry => {
         if (moveDown && isChildPath(dest, entry.filePath)) {
           // this catches the case where we transfer .../mods to .../mods/foo/bar
           // and we come across the path .../mods/foo. Wouldn't want to try to remove
           // that, do we?
-          return Promise.resolve();
+          return Bluebird.resolve();
         }
         removableDirectories.push(entry.filePath);
         const destPath = path.join(dest, path.relative(source, entry.filePath));
         return isCancelled
-          ? Promise.reject(new UserCanceled())
+          ? Bluebird.reject(new UserCanceled())
           : fs.mkdirsAsync(destPath).catch(err => (err.code === 'EEXIST')
-            ? Promise.resolve()
-            : Promise.reject(err));
+            ? Bluebird.resolve()
+            : Bluebird.reject(err));
       })
         .then(() => null))
-        .then(() => Promise.map(files, entry => {
+        .then(() => Bluebird.map(files, entry => {
           const sourcePath = entry.filePath;
           const destPath = path.join(dest, path.relative(source, entry.filePath));
 
           return func(sourcePath, destPath, { showDialogCallback })
             .catch(UserCanceled, () => {
               isCancelled = true;
-              copyPromise = Promise.resolve();
+              copyPromise = Bluebird.resolve();
             })
             .catch(err => {
               // EXDEV implies we tried to rename when source and destination are
@@ -194,9 +194,9 @@ export function transferPath(source: string,
                 func = fs.copyAsync;
                 return func(sourcePath, destPath, { showDialogCallback });
               } else if (err.code === 'ENOENT') {
-                return Promise.resolve();
+                return Bluebird.resolve();
               } else {
-                return Promise.reject(err);
+                return Bluebird.reject(err);
               }
             })
             .then(() => {
@@ -216,8 +216,8 @@ export function transferPath(source: string,
           }));
     }, { details: false, skipHidden: false }))
     .then(() => copyPromise.then(() => (exception !== undefined)
-      ? Promise.reject(exception)
-      : Promise.resolve()))
+      ? Bluebird.reject(exception)
+      : Bluebird.resolve()))
     .then(() => {
       const cleanUp = () => {
         return (moveDown)
@@ -235,7 +235,7 @@ export function transferPath(source: string,
             log('error', 'Failed to remove source directory',
               (err.stack !== undefined) ? err.stack : err);
 
-            return Promise.reject(new CleanupFailedException(err));
+            return Bluebird.reject(new CleanupFailedException(err));
         });
     });
 }
@@ -248,17 +248,17 @@ export function transferPath(source: string,
  *  https://github.com/Nexus-Mods/Vortex/issues/6769
  * @param dirPath
  */
-export function cleanFailedTransfer(dirPath: string): Promise<void> {
+export function cleanFailedTransfer(dirPath: string): Bluebird<void> {
   let files: IEntry[] = [];
   return turbowalk(dirPath, entries => {
     files = files.concat(entries);
   }, { skipHidden: false, skipLinks: false, recurse: true })
   .catch(err => (['ENOENT', 'ENOTFOUND'].includes(err.code))
-    ? Promise.resolve()
-    : Promise.reject(err))
+    ? Bluebird.resolve()
+    : Bluebird.reject(err))
   .then(() => {
     files = files.sort((lhs, rhs) => rhs.filePath.length - lhs.filePath.length);
-    return Promise.each(files, file => fs.removeAsync(file.filePath));
+    return Bluebird.each(files, file => fs.removeAsync(file.filePath));
   })
   .then(() => fs.removeAsync(dirPath));
 }
@@ -266,47 +266,47 @@ export function cleanFailedTransfer(dirPath: string): Promise<void> {
 function removeFolderTags(sourceDir: string) {
   // Attempt to remove the folder tag. (either staging folder or downloads tag)
   //  This should only be called when the folder is moved down a layer.
-  const tagFileExists = (filePath: string): Promise<boolean> => {
+  const tagFileExists = (filePath: string): Bluebird<boolean> => {
     return fs.statAsync(filePath)
       .then(() => true)
       .catch(() => false);
   };
 
-  const removeTag = (filePath: string): Promise<void> => {
+  const removeTag = (filePath: string): Bluebird<void> => {
     return tagFileExists(filePath)
       .then(exists => exists
         ? fs.removeAsync(filePath).catch(err => {
           log('error', 'Unable to remove directory tag', err);
           return (['ENOENT'].indexOf(err.code) !== -1)
             // Tag file is gone ? no problem.
-            ? Promise.resolve()
-            : Promise.reject(err);
+            ? Bluebird.resolve()
+            : Bluebird.reject(err);
         })
-        : Promise.resolve());
+        : Bluebird.resolve());
   };
 
   const stagingFolderTag = path.join(sourceDir, STAGING_DIR_TAG);
   const downloadsTag = path.join(sourceDir, DOWNLOADS_DIR_TAG);
-  return Promise.all([removeTag(stagingFolderTag), removeTag(downloadsTag)]);
+  return Bluebird.all([removeTag(stagingFolderTag), removeTag(downloadsTag)]);
 }
 
-function removeOldDirectories(directories: string[]): Promise<void> {
+function removeOldDirectories(directories: string[]): Bluebird<void> {
   const longestFirst = (lhs, rhs) => rhs.length - lhs.length;
-  return Promise.each(directories.sort(longestFirst), dir => fs.removeAsync(dir)
+  return Bluebird.each(directories.sort(longestFirst), dir => fs.removeAsync(dir)
     .catch(err => (['ENOENT'].indexOf(err.code) !== -1)
       // Directory missing ? odd but lets keep going.
-      ? Promise.resolve()
-      : Promise.reject(err))).then(() => Promise.resolve());
+      ? Bluebird.resolve()
+      : Bluebird.reject(err))).then(() => Bluebird.resolve());
 }
 
 function linkFile(
     source: string, dest: string,
-    options?: fs.ILinkFileOptions): Promise<void> {
+    options?: fs.ILinkFileOptions): Bluebird<void> {
   return fs.ensureDirAsync(path.dirname(dest))
     .then(() => {
       return fs.linkAsync(source, dest, options)
         .catch(err => (err.code !== 'EEXIST')
-          ? Promise.reject(err)
-          : Promise.resolve());
+          ? Bluebird.reject(err)
+          : Bluebird.resolve());
   });
 }

--- a/src/util/vortex-run/lib/elevated.js
+++ b/src/util/vortex-run/lib/elevated.js
@@ -22,7 +22,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const bluebird_1 = __importDefault(require("bluebird"));
+const Bluebird = __importDefault(require("bluebird"));
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const tmp = __importStar(require("tmp"));
@@ -101,7 +101,7 @@ function elevatedMain(moduleRoot, ipcPath, main) {
  *                             out when the process is done (using ipc) it should delete it
  */
 function runElevated(ipcPath, func, args) {
-    return new bluebird_1.default((resolve, reject) => {
+    return new Bluebird.default((resolve, reject) => {
         tmp.file((err, tmpPath, fd, cleanup) => {
             if (err) {
                 return reject(err);

--- a/src/util/vortex-run/lib/thread.d.ts
+++ b/src/util/vortex-run/lib/thread.d.ts
@@ -1,3 +1,3 @@
-import Promise from 'bluebird';
-declare function runThreaded(func: (...args: any[]) => any, moduleBase: string, ...args: any[]): Promise<any>;
+import Bluebird from 'bluebird';
+declare function runThreaded(func: (...args: any[]) => any, moduleBase: string, ...args: any[]): Bluebird<any>;
 export default runThreaded;

--- a/src/util/vortex-run/src/thread.ts
+++ b/src/util/vortex-run/src/thread.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as tmp from 'tmp';
@@ -58,8 +58,8 @@ function writeProgram(func: (...args: any[]) => any, moduleBase: string, args?: 
 }
 
 function runThreaded(func: (...args: any[]) => any,
-                     moduleBase: string, ...args: any[]): Promise<any> {
-  return new Promise((resolve, reject) => {
+                     moduleBase: string, ...args: any[]): Bluebird<any> {
+  return new Bluebird((resolve, reject) => {
     tmp.file((err: any, tmpPath: string, fd: number, cleanup: () => void) => {
       if (err) {
         return reject(err);

--- a/src/views/QuickLauncher.tsx
+++ b/src/views/QuickLauncher.tsx
@@ -19,7 +19,7 @@ import StarterInfo from '../util/StarterInfo';
 import { getSafe } from '../util/storeHelper';
 import { truthy } from '../util/util';
 
-import Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import * as React from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { WithTranslation } from 'react-i18next';
@@ -49,7 +49,7 @@ interface IConnectedProps {
 interface IActionProps {
   onShowError: (message: string, details?: any, allowReport?: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Bluebird<IDialogResult>;
 }
 
 type IProps = IBaseProps & IConnectedProps & IActionProps & WithTranslation;
@@ -62,7 +62,7 @@ interface IComponentState {
 class QuickLauncher extends ComponentEx<IProps, IComponentState> {
   private mCacheDebouncer: Debouncer = new Debouncer(() => {
     this.nextState.gameIconCache = this.genGameIconCache();
-    return Promise.resolve();
+    return Bluebird.resolve();
   }, 100);
 
   constructor(props: IProps) {


### PR DESCRIPTION
This commit refactors all import statements for 'bluebird' to Bluebird.
Some import statements used PromiseBB or Promise previously.
This should help with consistency and further code cleanup.

An unused import statement for 'bluebird' was removed entirely from each of `src/control/DraggableList.tsx` and `src/extensions/nexus_integration/texts.ts`.
An additional unused import statement was also removed from `src/extensions/nexus_integration/texts.ts`.
[It hadn't been used for a while.](https://github.com/Nexus-Mods/Vortex/commit/b7db2f2b61c8f643c1ed638c2fc62bc3dbd08ee0#diff-f71910ff257547dd19dce2ee2027c5c2cf208b0a828c764e5521f61829461b04)