### PR TITLE
Added an option to "fix" the detected path for a game store

### DIFF
--- a/src/util/GameStoreHelper.ts
+++ b/src/util/GameStoreHelper.ts
@@ -23,6 +23,7 @@ export interface IStoreQuery {
     id?: string;
     name?: string;
     prefer?: number;
+    modifyPath?: (detectedPath: string) => string;
   }>;
 }
 
@@ -136,6 +137,7 @@ class GameStoreHelper {
           }
         }
         if (result !== undefined) {
+          if (storeQuery.modifyPath) result.gamePath = storeQuery.modifyPath(result.gamePath);
           result.priority = storeQuery.prefer
             ?? this.mStoresDict[result.gameStoreId]?.priority
             ?? 100;


### PR DESCRIPTION
Some games (Fallout 3, Oblivion, Morrowind) include multiple copies of the game at the top level so the path we detect will not be correct. Added an optional modifyPath option that will allow game extensions to fix the path this feature finds.