### PR TITLE
292 code signing migration

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ on:
           required: false
           type: boolean
           default: false
-        release-draft:
+        release:
           description: "Create a draft release?"
           required: false
           type: boolean
@@ -124,40 +124,18 @@ jobs:
 
       - name: Test
         run: yarn test
-
-      - name: Create Release
-        if: inputs.release-draft == true
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ steps.setOutputs.outputs.tagVersion }}
-          release_name: ${{ steps.setOutputs.outputs.releaseVersion }}
-          draft: true
-          prerelease: true
       
-      - name: Upload Release Asset
-        if: inputs.release-draft == true
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: inputs.release == true
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./dist/${{ steps.setOutputs.outputs.artifactNameInstaller }}
-          asset_name: ${{ steps.setOutputs.outputs.artifactNameInstaller }}
-
-      - name: Upload Release Asset
-        if: inputs.release-draft == true
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./dist/latest.yml
-          asset_name: latest.yml
+          files: |
+            ./dist/${{ steps.setOutputs.outputs.artifactNameInstaller }}
+            ./dist/latest.yml
+          prerelease: true
+          draft: true
+          name: ${{ steps.setOutputs.outputs.rawVersion }}
+          tag_name: ${{ steps.setOutputs.outputs.tagVersion }}
 
       - name: Deploy to Epic
         if: inputs.deploy-epic == true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,7 +57,7 @@ jobs:
           echo "rawVersion=$rawVersion" >> $env:GITHUB_OUTPUT
           echo "artifactNameUnpacked=vortex-setup-$rawVersion-unpacked" >> $env:GITHUB_OUTPUT
           echo "artifactNameInstaller=vortex-setup-$rawVersion-installer" >> $env:GITHUB_OUTPUT
-          echo "epicBuildString=$rawVersion+${GITHUB_RUN_NUMBER}" >> $env:GITHUB_OUTPUT
+          echo "epicBuildString=$rawVersion+$env:GITHUB_RUN_NUMBER" >> $env:GITHUB_OUTPUT
       - name: Get current time
         uses: josStorer/get-current-time@v2
         id: current-time

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ on:
           description: "Deploy to Epic?"
           required: false
           type: boolean
-          default: false
+          default: true
         release:
           description: "Create a draft release?"
           required: false
@@ -141,7 +141,7 @@ jobs:
         if: inputs.deploy-epic == true
         shell: pwsh
         run: |
-          echo "steps.setOutputs.outputs.epicBuildString"
+          echo "${{ steps.setOutputs.outputs.epicBuildString }}"
 
       - name: Upload Unpacked
         uses: actions/upload-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,6 +58,7 @@ jobs:
           echo "artifactNameUnpacked=vortex-setup-$rawVersion-unpacked" >> $env:GITHUB_OUTPUT
           echo "artifactNameInstaller=vortex-setup-$rawVersion-installer" >> $env:GITHUB_OUTPUT
           echo "epicBuildString=$rawVersion+$env:GITHUB_RUN_NUMBER" >> $env:GITHUB_OUTPUT
+          echo "epicBuildString=$rawVersion+$env:GITHUB_RUN_NUMBER"
       - name: Get current time
         uses: josStorer/get-current-time@v2
         id: current-time

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -130,7 +130,7 @@ jobs:
         if: inputs.release == true
         with:
           files: |
-            ./dist/${{ steps.setOutputs.outputs.artifactNameInstaller }}
+            ./dist/vortex-setup-${{ steps.setOutputs.outputs.rawVersion }}.exe
             ./dist/latest.yml
           prerelease: true
           draft: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,16 +48,16 @@ jobs:
         shell: pwsh
         env:
           InputVersion: ${{ inputs.version }}
+          GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}        
         run: |
           $tagVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion : "v" + $env:InputVersion
           $rawVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion.Substring(1) : $env:InputVersion
           $validation = [System.Version]::Parse($rawVersion)
-          $runNumber = ${GITHUB_RUN_NUMBER}
           echo "tagVersion=$tagVersion" >> $env:GITHUB_OUTPUT
           echo "rawVersion=$rawVersion" >> $env:GITHUB_OUTPUT
           echo "artifactNameUnpacked=vortex-setup-$rawVersion-unpacked" >> $env:GITHUB_OUTPUT
           echo "artifactNameInstaller=vortex-setup-$rawVersion-installer" >> $env:GITHUB_OUTPUT
-          echo "epicBuildString=$rawVersion+$runNumber" >> $env:GITHUB_OUTPUT
+          echo "epicBuildString=$rawVersion+${GITHUB_RUN_NUMBER}" >> $env:GITHUB_OUTPUT
       - name: Get current time
         uses: josStorer/get-current-time@v2
         id: current-time

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,26 +17,26 @@ on:
           required: true
           type: boolean
           default: true
-        draft:
-          description: "Create a draft release? (not used)"
+        deploy-epic:
+          description: "Deploy to Epic?"
+          required: false
+          type: boolean
+          default: false
+        release-draft:
+          description: "Create a draft release?"
           required: false
           type: boolean
           default: true
-        prerelease:
-          description: "Create a prerelease? (not used)"
-          required: false
-          type: boolean
-          default: true
-        
-env:    
-  SigningCertificate: cert.pfx
 
 jobs:      
   build:
     runs-on: windows-latest
     env:
+      ES_USERNAME: ${{ secrets.ES_USERNAME }}
+      ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+      ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
+      ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true # Allows AddPAth and SetEnv commands
-      CERT_PATH: Release
       
     strategy:
       matrix:
@@ -52,10 +52,12 @@ jobs:
           $tagVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion : "v" + $env:InputVersion
           $rawVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion.Substring(1) : $env:InputVersion
           $validation = [System.Version]::Parse($rawVersion)
+          $runNumber = ${GITHUB_RUN_NUMBER}
           echo "tagVersion=$tagVersion" >> $env:GITHUB_OUTPUT
           echo "rawVersion=$rawVersion" >> $env:GITHUB_OUTPUT
           echo "artifactNameUnpacked=vortex-setup-$rawVersion-unpacked" >> $env:GITHUB_OUTPUT
           echo "artifactNameInstaller=vortex-setup-$rawVersion-installer" >> $env:GITHUB_OUTPUT
+          echo "epicBuildString=$rawVersion+$runNumber" >> $env:GITHUB_OUTPUT
       - name: Get current time
         uses: josStorer/get-current-time@v2
         id: current-time
@@ -79,6 +81,11 @@ jobs:
         run: |
           $vcredist = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
           Invoke-WebRequest $vcredist -OutFile build\VC_redist.x64.exe
+
+      - name: Download CodeSignTool
+        id: codesign
+        shell: pwsh
+        run: .\download-codesigntool.ps1
           
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -91,18 +98,6 @@ jobs:
 
       - name: Print debug info
         run: dotnet --info
-        
-      - name: Decode PFX
-        shell: pwsh        
-        id: decode-pfx
-        run: |
-          $certBytes = [System.Convert]::FromBase64String("${{ secrets.PFX_BASE64 }}")
-          $certPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath $env:SigningCertificate
-          
-          [IO.File]::WriteAllBytes("$certPath", $certBytes)
-
-      #- name: Update Licenses
-      #  run: yarn update_aboutpage
 
       - name: Build API
         run: yarn --non-interactive build_api
@@ -118,21 +113,11 @@ jobs:
         
       - name: Webpack
         run: yarn build_dist
-        
-      - name: Sign
-        shell: pwsh      
-        run: |        
-          $signtool = "C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe"
-          $timestamp = "http://timestamp.digicert.com"
-          $certPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath $env:SigningCertificate
-          & $signtool sign /f $certPath /p "${{ secrets.PFX_KEY }}" /td sha256 /fd sha256 /tr $timestamp "app\node_modules\winapi-bindings\build\Release\winapi.node"
           
       - name: Package
         run: yarn package
         env:
           DEBUG: electron-builder
-          CSC_LINK: ${{ secrets.PFX_BASE64 }} # works directly with base64 string and not a path
-          CSC_KEY_PASSWORD: ${{ secrets.PFX_KEY }}
 
       - name: Extract Sourcemaps
         run: yarn extract_sourcemaps
@@ -140,11 +125,45 @@ jobs:
       - name: Test
         run: yarn test
 
-      - name: Remove PFX
+      - name: Create Release
+        if: inputs.release-draft == true
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.setOutputs.outputs.tagVersion }}
+          release_name: ${{ steps.setOutputs.outputs.releaseVersion }}
+          draft: true
+          prerelease: true
+      
+      - name: Upload Release Asset
+        if: inputs.release-draft == true
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./dist/${{ steps.setOutputs.outputs.artifactNameInstaller }}
+          asset_name: ${{ steps.setOutputs.outputs.artifactNameInstaller }}
+
+      - name: Upload Release Asset
+        if: inputs.release-draft == true
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./dist/latest.yml
+          asset_name: latest.yml
+
+      - name: Deploy to Epic
+        if: inputs.deploy-epic == true
         shell: pwsh
         run: |
-          $certPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath $env:SigningCertificate
-          Remove-Item -Path $certPath
+          echo "steps.setOutputs.outputs.epicBuildString"
 
       - name: Upload Unpacked
         uses: actions/upload-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,7 +48,7 @@ jobs:
         shell: pwsh
         env:
           InputVersion: ${{ inputs.version }}
-          GITHUB_RUN_NUMBER: ${{ GITHUB_RUN_NUMBER }}        
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}        
         run: |
           $tagVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion : "v" + $env:InputVersion
           $rawVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion.Substring(1) : $env:InputVersion

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,7 +48,7 @@ jobs:
         shell: pwsh
         env:
           InputVersion: ${{ inputs.version }}
-          GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}        
+          GITHUB_RUN_NUMBER: ${{ GITHUB_RUN_NUMBER }}        
         run: |
           $tagVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion : "v" + $env:InputVersion
           $rawVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion.Substring(1) : $env:InputVersion

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ app/bundledPlugins
 attachments
 sourcemaps
 *.env
+CodeSignTool*
 
 # User-specific files
 *.suo

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vortex",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "productName": "Vortex",
   "description": "Vortex",
   "author": "Black Tree Gaming Ltd.",

--- a/download-codesigntool.ps1
+++ b/download-codesigntool.ps1
@@ -1,0 +1,63 @@
+param (
+  [switch] $Sandbox
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = "Stop"
+$ProgressPreference = 'SilentlyContinue' #'Continue
+
+Write-Host "Sandbox = $Sandbox"
+        
+$rootDir = Resolve-Path "."
+$downloadUrl = "https://www.ssl.com/download/codesigntool-for-windows/"
+$downloadedFile = Join-Path $rootDir "CodeSignTool.zip"
+$extractFolder = Join-Path $rootDir "CodeSignTool"
+$configPath = "/conf/code_sign_tool.properties"
+
+Write-Host "rootDir $rootDir"
+Write-Host "downloadedFile $downloadedFile"
+Write-Host "extractFolder $extractFolder"
+
+# Remove extracted folder if exists, just in case (mainly used locally)
+if(Test-Path $extractFolder) {
+    Remove-Item -Path $extractFolder -Recurse -Force
+}
+
+# Download (if it doesn't exist)
+if(!(Test-Path $downloadedFile -PathType Leaf)) {
+    Invoke-WebRequest -OutFile $downloadedFile $downloadUrl
+}
+        
+# Extract
+Expand-Archive -Path $downloadedFile -DestinationPath $extractFolder -Force
+  
+# need to check for a nested single folder as 1.2.7 was packaged without this, all previous versions were not.
+
+$folderCount = @(Get-ChildItem $extractFolder -Directory ).Count;
+
+#if we have a single folder, then assume we have a nested folder that we need to fix
+If ($folderCount -eq 1) {
+
+    # get nested folder path, there is only 1 at this point
+    $nestedFolderPath = (Get-ChildItem $extractFolder -Directory | Select-Object FullName)[0].FullName
+
+    Write-Host "nestedFolderPath $nestedFolderPath"
+
+    # move all child items from this nested folder to it's parent
+    Get-ChildItem -Path $nestedFolderPath -Recurse | Move-Item -Destination $extractFolder
+
+    # remove nested folder to keep it clean
+    Remove-Item -Path $nestedFolderPath -Force
+}
+
+# Set config to sandbox (only while testing)
+if($Sandbox -eq $true) {
+ 
+    $codeSignToolPropertiesFile = Join-Path $extractFolder $configPath
+
+    $null = New-Item -Path $codeSignToolPropertiesFile -ItemType File -Force
+    Add-Content -Path $codeSignToolPropertiesFile -Value "CLIENT_ID=qOUeZCCzSqgA93acB3LYq6lBNjgZdiOxQc-KayC3UMw"
+    Add-Content -Path $codeSignToolPropertiesFile -Value "OAUTH2_ENDPOINT=https://oauth-sandbox.ssl.com/oauth2/token"
+    Add-Content -Path $codeSignToolPropertiesFile -Value "CSC_API_ENDPOINT=https://cs-try.ssl.com"
+    Add-Content -Path $codeSignToolPropertiesFile -Value "TSA_URL=http://ts.ssl.com"
+}

--- a/electron-builder-config.json
+++ b/electron-builder-config.json
@@ -21,6 +21,10 @@
   "includeSubNodeModules": true,
   "win": {
     "target": "nsis",
+    "signingHashAlgorithms": [
+      "sha256"
+    ],
+    "sign": "./sign.js",
     "publish": [
       {
         "provider": "github",

--- a/sign.js
+++ b/sign.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const fs = require('fs');
+const childProcess = require('child_process');
+require('dotenv').config();
+
+const TEMP_DIR = path.join(__dirname, 'release', 'temp');
+
+if (!fs.existsSync(TEMP_DIR)) {
+    fs.mkdirSync(TEMP_DIR, { recursive: true });
+  }
+
+async function sign(configuration) {
+    
+  // credentials from ssl.com
+  const ES_USERNAME = process.env.ES_USERNAME;
+  const ES_PASSWORD = process.env.ES_PASSWORD;
+  const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
+  const ES_TOTP_SECRET = process.env.ES_TOTP_SECRET;
+
+  if (ES_USERNAME && ES_PASSWORD && ES_TOTP_SECRET && ES_CREDENTIAL_ID) {
+
+    console.log(`Signing ${configuration.path}`);
+
+    const { base, dir } = path.parse(configuration.path);
+    const tempFile = path.join(TEMP_DIR, base);
+
+    // CodeSignTool can't sign in place without verifying the overwrite with a
+    // y/m interaction so we are creating a new file in a temp directory and
+    // then replacing the original file with the signed file.
+
+    const setDir = `cd ./CodeSignTool`;
+    const signFile = `CodeSignTool sign -input_file_path="${configuration.path}" -output_dir_path="${TEMP_DIR}" -credential_id="${ES_CREDENTIAL_ID}" -username="${ES_USERNAME}" -password="${ES_PASSWORD}" -totp_secret="${ES_TOTP_SECRET}"`;
+    const moveFile = `move "${tempFile}" "${dir}"`; 
+
+    childProcess.execSync(`${setDir} && ${signFile} && ${moveFile}`, { stdio: 'inherit' });
+  
+} else {
+
+    console.warn(`sign.js - Can't sign file ${configuration.path}, missing value for:
+        ${ES_USERNAME ? '' : 'ES_USERNAME'}
+        ${ES_PASSWORD ? '' : 'ES_PASSWORD'}
+        ${ES_CREDENTIAL_ID ? '' : 'ES_CREDENTIAL_ID'}
+        ${ES_TOTP_SECRET ? '' : 'ES_TOTP_SECRET'}
+        `);
+
+    process.exit(1);
+
+  }
+}
+
+exports.default = sign;

--- a/sign.js
+++ b/sign.js
@@ -7,7 +7,7 @@ const TEMP_DIR = path.join(__dirname, 'temp');
 
 // these were being incorrectly flagged by esigner as malware 
 // make sure these are lowercase
-const ignoreFileList = ['arctool.exe', '7z.exe']
+const ignoreFileList = ['arctool.exe']
 
 if (!fs.existsSync(TEMP_DIR)) {
     fs.mkdirSync(TEMP_DIR, { recursive: true });

--- a/sign.js
+++ b/sign.js
@@ -3,7 +3,11 @@ const fs = require('fs');
 const childProcess = require('child_process');
 require('dotenv').config();
 
-const TEMP_DIR = path.join(__dirname, 'release', 'temp');
+const TEMP_DIR = path.join(__dirname, 'temp');
+
+// these were being incorrectly flagged by esigner as malware 
+// make sure these are lowercase
+const ignoreFileList = ['arctool.exe', '7z.exe']
 
 if (!fs.existsSync(TEMP_DIR)) {
     fs.mkdirSync(TEMP_DIR, { recursive: true });
@@ -16,6 +20,11 @@ async function sign(configuration) {
   const ES_PASSWORD = process.env.ES_PASSWORD;
   const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
   const ES_TOTP_SECRET = process.env.ES_TOTP_SECRET;
+
+  if (ignoreFileList.includes(path.basename(configuration.path.toLowerCase()))) {
+    console.log(`Ignoring ${configuration.path} as the file is in the ignore list`);
+    return;
+  }
 
   if (ES_USERNAME && ES_PASSWORD && ES_TOTP_SECRET && ES_CREDENTIAL_ID) {
 


### PR DESCRIPTION
Tweaks for using our new code signing certificate, mainly github action and electron-building configs. Version bump as well so we can start testing the new certificate on the beta.