### PR TITLE
Support updating mods with pre-release versions

### DIFF
--- a/src/extensions/mod_management/util/versionClean.ts
+++ b/src/extensions/mod_management/util/versionClean.ts
@@ -1,7 +1,7 @@
 import * as semver from 'semver';
 
 function versionClean(input: string): string {
-  let res = semver.valid(semver.coerce(input));
+  let res = semver.valid(semver.parse(input));
   if (res !== null) {
     res = semver.clean(res);
   }


### PR DESCRIPTION
Let's say we have mod with current version `1.0.0-pre1` and newest `1.0.0-pre2`. Coercing would convert both versions to 1.0.0 and update notification won't occur