### PR TITLE
Support detecting updates for prerelease mod versions

### DIFF
--- a/src/extensions/mod_management/util/versionClean.ts
+++ b/src/extensions/mod_management/util/versionClean.ts
@@ -1,8 +1,9 @@
 import * as semver from 'semver';
 
 function versionClean(input: string): string {
-  let res = semver.valid(semver.parse(input) ?? semver.coerce(input));
-  
+  let res = semver.valid(
+    semver.coerce(input, { includePrerelease: true })
+  );
   if (res !== null) {
     res = semver.clean(res);
   }

--- a/src/extensions/mod_management/util/versionClean.ts
+++ b/src/extensions/mod_management/util/versionClean.ts
@@ -1,7 +1,7 @@
 import * as semver from 'semver';
 
 function versionClean(input: string): string {
-  let res = semver.valid(semver.coerce(input));
+  let res = semver.valid(semver.parse(input));
   if (res !== null) {
     res = semver.clean(res);
   }

--- a/src/extensions/mod_management/util/versionClean.ts
+++ b/src/extensions/mod_management/util/versionClean.ts
@@ -1,7 +1,8 @@
 import * as semver from 'semver';
 
 function versionClean(input: string): string {
-  let res = semver.valid(semver.parse(input));
+  let res = semver.valid(semver.parse(input) ?? semver.coerce(input));
+  
   if (res !== null) {
     res = semver.clean(res);
   }


### PR DESCRIPTION
Use `includePrerelease` option, that has been added since semver 7.6.0, to parse version with prerelease.

Continuation of #15044 after [semver PR](https://github.com/npm/node-semver/pull/671) has been merged

Fixes #15213