### PR TITLE
fixed incorrect detection of removed mods on startup

### DIFF
--- a/src/extensions/mod_management/util/refreshMods.ts
+++ b/src/extensions/mod_management/util/refreshMods.ts
@@ -28,7 +28,7 @@ function refreshMods(api: IExtensionApi, gameId: string,
       .catch(() => Promise.resolve(false)))
     .then((modNames: string[]) => {
       const filtered = modNames
-        .filter(name => !name.startsWith('__'))
+        .filter(name => !name.toLowerCase().startsWith('__vortex'))
         .map(name => name.replace(/.installing$/, ''));
       const addedMods =
           filtered.filter((name: string) => knownModNames.indexOf(name) === -1);


### PR DESCRIPTION
We're now less restrictive with the mods we install. The previous detection mechanism was too restrictive when attempting to avoid using the vortex staging tag, which was causing mods with  the '__' prefix being ignored during mod installation status detection.

fixes nexus-mods/vortex#15334