### PR TITLE
fixed mod reference tests not using installer options

### DIFF
--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -2330,7 +2330,7 @@ class InstallManager {
         // adequate to show an error but not as a bug in Vortex
         api.showErrorNotification('Failed to install dependencies',
           err.message, { allowReport: false });
-        return [];
+        return Bluebird.resolve([]);
       })
       .catch(UserCanceled, () => {
         log('info', 'canceled out of dependency install');
@@ -2339,15 +2339,15 @@ class InstallManager {
           type: 'info',
           message: 'Installation of dependencies canceled',
         });
-        return [];
+        return Bluebird.resolve([]);
       })
       .catch(err => {
         api.showErrorNotification('Failed to install dependencies', err);
-        return [];
+        return Bluebird.resolve([]);
       })
       .filter(dep => dep !== undefined);
 
-    return res;
+    return Bluebird.resolve(res);
   }
 
   private doInstallDependencies(api: IExtensionApi,
@@ -2423,11 +2423,11 @@ class InstallManager {
           })));
     };
 
-    const installDownload = (dep: IDependency, downloadId: string)
-        : Bluebird<string> => {
-      return Bluebird.resolve(this.mDependencyInstallsLimit.do(() => {
+    const installDownload = (dep: IDependency, downloadId: string) : Bluebird<string> => {
+      return new Bluebird((resolve, reject) => {
+        this.mDependencyInstallsLimit.do(async () => {
         return abort.signal.aborted
-          ? Bluebird.reject(new UserCanceled(false))
+          ? reject(new UserCanceled(false))
           : this.withInstructions(api,
                               modName(sourceMod),
                               renderModReference(dep.reference),
@@ -2436,14 +2436,14 @@ class InstallManager {
                               recommended, () =>
           this.installModAsync(dep.reference, api, downloadId,
             { choices: dep.installerChoices, patches: dep.patches }, dep.fileList,
-            gameId, silent))
+            gameId, silent)).then(res => resolve(res))
           .catch(err => {
             if (err instanceof UserCanceled) {
               err.skipped = true;
             }
-            return Bluebird.reject(err);
+            return reject(err);
           });
-        }));
+        })});
     };
 
     const doDownload = (dep: IDependency) => {
@@ -2528,20 +2528,18 @@ class InstallManager {
             // being installed having a different tag than the rule
             dep.reference = this.updateModRule(api, gameId, sourceModId, dep, {
               ...dep.reference,
+              fileList: dep.fileList,
+              patches: dep.patches,
+              installerChoices: dep.installerChoices,
               tag: downloads[downloadId].modInfo.referenceTag,
             }, recommended)?.reference;
 
-            // now at this point there may in fact already be a mod for the updated reference tag
-            if ((dep.mod === undefined) && (dep.reference !== undefined)) {
-              dep.mod = findModByRef(
-                dep.reference, api.getState().persistent.mods[gameId]);
-              log('info', 'updated mod', JSON.stringify(dep.mod));
-            }
+            dep.mod = findModByRef(dep.reference, api.getState().persistent.mods[gameId]);
           } else {
             log('info', 'downloaded as dependency', { downloadId });
           }
 
-          let queryWrongMD5 = Bluebird.resolve();
+          let queryWrongMD5 = () => Bluebird.resolve();
           if ((dep.mod === undefined)
               && (dep.reference?.versionMatch !== undefined)
               && !isFuzzyVersion(dep.reference.versionMatch)
@@ -2552,7 +2550,7 @@ class InstallManager {
               expected: dep.lookupResults[0].value.fileMD5,
               got: downloads[downloadId].fileMD5,
             });
-            queryWrongMD5 = api.showDialog('question', 'Unrecognized file {{reference}}', {
+            queryWrongMD5 = () => api.showDialog('question', 'Unrecognized file {{reference}}', {
               text: 'The file "{{fileName}}" that was just downloaded for dependency "{{reference}}" '
                   + 'is not the exact file expected. This might not be an issue if the mod has been '
                   + 'updated or repackaged by the author.\n'
@@ -2573,7 +2571,7 @@ class InstallManager {
           }
 
           return (dep.mod === undefined)
-            ? queryWrongMD5
+            ? queryWrongMD5()
                 .then(() => installDownload(dep, downloadId))
                 .catch(err => {
                   if (dep['reresolveDownloadHint'] === undefined) {
@@ -2629,7 +2627,7 @@ class InstallManager {
       abort.abort();
     };
 
-    return res;
+    return Bluebird.resolve(res);
   }
 
   private updateModRule(api: IExtensionApi, gameId: string, sourceModId: string,
@@ -2696,8 +2694,9 @@ class InstallManager {
         if (dep['error'] !== undefined) {
           prev.error.push(dep as IDependencyError);
         } else {
-          const { mod } = dep as IDependency;
-          if ((mod === undefined) || !(modState[mod.id]?.enabled ?? false) || (!!mods[mod.id] && findModByRef(mod, mods) === undefined)) {
+          const { mod, reference } = dep as IDependency;
+          const modReference: IModReference = { ...(dep as IDependency), ...reference };
+          if ((mod === undefined) || !(modState[mod.id]?.enabled ?? false) || (!!mods[mod.id] && testModReference(mods[mod.id], modReference) !== true)) {
             prev.success.push(dep as IDependency);
           } else {
             prev.existing.push(dep as IDependency);

--- a/src/extensions/mod_management/util/dependencies.ts
+++ b/src/extensions/mod_management/util/dependencies.ts
@@ -319,7 +319,13 @@ function gatherDependenciesGraph(
     log('debug', 'no download found', { ref: JSON.stringify(rule.reference) });
   }
 
-  const mod = findModByRef(rule.reference, state.persistent.mods[gameMode] ?? {});
+  const modReference: IModReference = {
+    ...rule.reference,
+    fileList: rule.fileList,
+    patches: rule.extra?.patches ?? {},
+    installerChoices: rule.installerChoices,
+  }
+  const mod = findModByRef(modReference, state.persistent.mods[gameMode] ?? {});
 
   let lookupResults: ILookupResult[];
 


### PR DESCRIPTION
There were quite a few mod reference tests that were using the basic mod metadata without any installer options. This was causing collections to pause.

hopefully finally fixes nexus-mods/vortex#15396