### PR TITLE
improved api type exports for fblo related types

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,9 +30,16 @@ export { IRegisteredExtension } from '../util/ExtensionManager';
 export { IAvailableExtension, IExtension } from '../extensions/extension_manager/types';
 export {
   LoadOrder,
+  LoadOrder as FBLOLoadOrder,
+  LockedState as FBLOLockState,
   ILoadOrderEntry,
+  ILoadOrderEntry as IFBLOLoadOrderEntry,
   ILoadOrderGameInfo,
+  ILoadOrderGameInfo as IFBLOGameInfo,
   IValidationResult,
+  IValidationResult as IFBLOValidationResult,
+  IInvalidResult as IFBLOInvalidResult,
+  IItemRendererProps as IFBLOItemRendererProps,
 } from '../extensions/file_based_loadorder/types/types';
 export {
   IDeploymentMethod,


### PR DESCRIPTION
The api is still backwards compatible with the older types, so this commit will not affect published extensions that are actively using the FBLO api types