### PR TITLE
fixed crash when attempting to untrack (untracked) mods

### DIFF
--- a/src/extensions/nexus_integration/util/tracking.tsx
+++ b/src/extensions/nexus_integration/util/tracking.tsx
@@ -238,7 +238,7 @@ class Tracking {
           // user isn't actually tracking the mod
           log('warn', 'mod tracking state out of sync between server and Vortex',
             { game: nexusId, modId: nexusModId });
-          this.mTrackedMods[nexusId].delete(nexusModId);
+          this.mTrackedMods[nexusId]?.delete?.(nexusModId);
           this.mOnChanged?.();
         } else {
           this.mApi.showErrorNotification('Failed to track/untrack mod', err);


### PR DESCRIPTION
It's perfectly possible for mods to become untracked when the user mashes the tracking button multiple times.

fixes nexus-mods/vortex#15801