### PR TITLE
fixed overrides ignored when deploying single mods

### DIFF
--- a/src/extensions/mod_management/index.ts
+++ b/src/extensions/mod_management/index.ts
@@ -1003,7 +1003,7 @@ function onDeploySingleMod(api: IExtensionApi) {
       .then(() => (mod !== undefined)
         ? (enable !== false)
           ? activator.activate(modPath, mod.installationPath, subdir(mod),
-                               new BlacklistSet([], game, normalize))
+                               new BlacklistSet(mod.fileOverrides ?? [], game, normalize))
           : activator.deactivate(modPath, subdir(mod), mod.installationPath)
         : Promise.resolve())
       .tapCatch(() => {


### PR DESCRIPTION
Currently only affects the script-extender extension.