### PR TITLE
updates required to support Starfield 0.8.x

### DIFF
--- a/src/extensions/file_based_loadorder/index.ts
+++ b/src/extensions/file_based_loadorder/index.ts
@@ -258,7 +258,7 @@ export default function init(context: IExtensionContext) {
     visible: () => {
       const currentGameId: string = selectors.activeGameId(context.api.store.getState());
       const gameEntry: ILoadOrderGameInfo = findGameEntry(currentGameId);
-      return (gameEntry !== undefined) ? true : false;
+      return (gameEntry?.condition !== undefined) ? gameEntry.condition() : gameEntry !== undefined;
     },
     priority: 120,
     props: () => {

--- a/src/extensions/file_based_loadorder/types/types.ts
+++ b/src/extensions/file_based_loadorder/types/types.ts
@@ -179,6 +179,13 @@ export interface ILoadOrderGameInfo {
    *
    */
   validate: (prev: LoadOrder, current: LoadOrder) => Promise<IValidationResult>;
+
+  /**
+   * Predicate to allow the game extension to decide wheter the load order page should be visible
+   *  (In case the game extension wants to hide or switch between different LO management logic)
+   * @returns true if the load order page should be visible, false otherwise.
+   */
+  condition?: () => boolean;
 }
 
 export interface ILoadOrderGameInfoExt extends ILoadOrderGameInfo {

--- a/src/extensions/ini_prep/gameSupport.ts
+++ b/src/extensions/ini_prep/gameSupport.ts
@@ -78,6 +78,14 @@ const gameSupport = makeOverlayableDictionary<string, IGameSupport>({
     ],
     iniFormat: 'winapi',
   },
+  starfield: {
+    iniFiles: [
+      path.join('{mygames}', 'Starfield', 'Starfield.ini'),
+      path.join('{mygames}', 'Starfield', 'StarfieldPrefs.ini'),
+      path.join('{mygames}', 'Starfield', 'StarfieldCustom.ini'),
+    ],
+    iniFormat: 'winapi',
+  },
   oblivion: {
     iniFiles: [
       path.join('{mygames}', 'Oblivion', 'Oblivion.ini'),

--- a/src/extensions/installer_fomod/delegates/Context.ts
+++ b/src/extensions/installer_fomod/delegates/Context.ts
@@ -29,6 +29,7 @@ function extenderForGame(gameId: string) {
     falloutnv: 'nvse',
     fallout4: 'f4se',
     fallout4vr: 'f4se',
+    starfield: 'sfse',
   }[gameId];
 }
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -547,6 +547,10 @@ function init() {
     startDownloadFromURL(url, fileName, install);
   });
 
+  eventEmitter.on('relaunch-application', (gameId: string, ) => {
+    relaunch(['--game', gameId]);
+  });
+
   ipcRenderer.on(
     'external-url',
     (event, url: string, fileName?: string, install?: boolean) => {


### PR DESCRIPTION
- FBLO game entry registration now allows to hide/display load order page via a provided predicate
- Added event to allow extensions to restart the app if required
- Added Starfield data to the ini_prep extension

part of nexus-mods/vortex#15918