### PR TITLE
fixed error when attempting to untrack mods

### DIFF
--- a/src/extensions/nexus_integration/util/tracking.tsx
+++ b/src/extensions/nexus_integration/util/tracking.tsx
@@ -230,7 +230,7 @@ class Tracking {
     return this.mNexus
       .untrackMod(nexusModId, nexusId)
       .then(() => {
-        this.mTrackedMods[nexusId].delete(nexusModId);
+        this.mTrackedMods[nexusId]?.delete?.(nexusModId);
         this.mOnChanged?.();
       })
       .catch((err: Error) => {


### PR DESCRIPTION
It's possible to click the untrack icon multiple times in succession and for the tracking id to have been removed from the set by the time the second action is called

fixes nexus-mods/vortex#15935