### PR TITLE
Node events memory leak fixes

### DIFF
--- a/src/controls/DynDiv.tsx
+++ b/src/controls/DynDiv.tsx
@@ -5,6 +5,8 @@ import { extend } from '../util/ExtensionProvider';
 import * as React from 'react';
 import { IExtensibleProps } from '../types/IExtensionProvider';
 
+import ErrorBoundary from '../controls/ErrorBoundary';
+
 interface IDynDivDefinition {
   component: React.ComponentClass<any>;
   options: IDynDivOptions;
@@ -41,9 +43,11 @@ class DynDiv extends React.Component<IProps, {}> {
     }
 
     return (
-      <div id={group} className={classes.join(' ')}>
-        {visible.map((comp, idx) => this.renderComponent(comp, idx))}
-      </div>
+      <ErrorBoundary key={`dynamic-div-${group}`}>
+        <div id={group} className={classes.join(' ')}>
+          {visible.map((comp, idx) => this.renderComponent(comp, idx))}
+        </div>
+      </ErrorBoundary>
     );
   }
 

--- a/src/controls/ErrorBoundary.tsx
+++ b/src/controls/ErrorBoundary.tsx
@@ -30,6 +30,7 @@ export interface IErrorBoundaryProps extends WithTranslation {
 }
 
 interface IErrorBoundaryState {
+  hasError: boolean;
   error: Error;
   errorInfo?: React.ErrorInfo;
 }
@@ -42,6 +43,7 @@ class ErrorBoundary extends ComponentEx<IErrorBoundaryProps, IErrorBoundaryState
     this.state = {
       error: undefined,
       errorInfo: undefined,
+      hasError: false,
     };
 
     this.mErrContext = {
@@ -57,7 +59,13 @@ class ErrorBoundary extends ComponentEx<IErrorBoundaryProps, IErrorBoundaryState
     };
   }
 
+  static getDerivedStateFromError(error) {
+    // Called before the render
+    return { hasError: true, error };
+  }
+
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // Called after the render
     if (this.props.canDisplayError === false) {
       this.context.api.sendNotification({
         type: 'error',
@@ -88,9 +96,9 @@ class ErrorBoundary extends ComponentEx<IErrorBoundaryProps, IErrorBoundaryState
 
   public render(): React.ReactNode {
     const { t, className, canDisplayError, onHide, visible } = this.props;
-    const { error } = this.state;
+    const { hasError } = this.state;
 
-    if (error === undefined) {
+    if (!hasError) {
       return (
         <ErrorContext.Provider value={this.mErrContext}>
           {React.Children.only(this.props.children)}
@@ -153,7 +161,7 @@ class ErrorBoundary extends ComponentEx<IErrorBoundaryProps, IErrorBoundaryState
   }
 
   private retryRender = () => {
-    this.setState({ error: undefined, errorInfo: undefined });
+    this.setState({ hasError: false, error: undefined, errorInfo: undefined });
   }
 }
 

--- a/src/extensions/mod_management/util/deploy.ts
+++ b/src/extensions/mod_management/util/deploy.ts
@@ -1,7 +1,6 @@
 import { startActivity, stopActivity } from '../../../actions/session';
 import { IDeployedFile, IDeploymentMethod, IExtensionApi } from '../../../types/IExtensionContext';
 import { IGame } from '../../../types/IGame';
-import { INotification } from '../../../types/INotification';
 import { IProfile } from '../../../types/IState';
 import { ProcessCanceled, TemporaryError } from '../../../util/CustomErrors';
 import { log } from '../../../util/log';
@@ -10,7 +9,7 @@ import { getSafe } from '../../../util/storeHelper';
 import { truthy } from '../../../util/util';
 import { IModType } from '../../gamemode_management/types/IModType';
 import { getGame } from '../../gamemode_management/util/getGame';
-import { installPath, installPathForGame } from '../selectors';
+import { installPathForGame } from '../selectors';
 import { IMod } from '../types/IMod';
 import { fallbackPurgeType, getManifest, loadActivation, saveActivation, withActivationLock } from './activationStore';
 import { getActivator, getCurrentActivator } from './deploymentMethods';

--- a/src/extensions/mod_management/views/ExternalChangeDialog.tsx
+++ b/src/extensions/mod_management/views/ExternalChangeDialog.tsx
@@ -232,14 +232,14 @@ class ExternalChangeDialog extends ComponentEx<IProps, IComponentState> {
       <div style={{ flex: '1 1 0', display: 'flex', flexDirection: 'column' }}>
         {text}
         <p>{actions.map(action => (
-          <>
-          <a
-            key={action.key}
-            onClick={this.setAll[type]}
-            href={'#' + action.key}
-          >{t(action.allText)}
-          </a><span className='link-action-seperator'>&nbsp; | &nbsp;</span>
-          </>
+          <div key={action.key}>
+            <a
+              key={action.key}
+              onClick={this.setAll[type]}
+              href={'#' + action.key}
+            >{t(action.allText)}
+            </a><span className='link-action-seperator'>&nbsp; | &nbsp;</span>
+          </div>
         ))
         }</p>
         <div style={{ overflowY: 'auto', flex: '1 1 0' }}>

--- a/src/extensions/mod_management/views/ExternalChangeDialog.tsx
+++ b/src/extensions/mod_management/views/ExternalChangeDialog.tsx
@@ -231,7 +231,7 @@ class ExternalChangeDialog extends ComponentEx<IProps, IComponentState> {
     return (
       <div style={{ flex: '1 1 0', display: 'flex', flexDirection: 'column' }}>
         {text}
-        <p>{actions.map(action => (
+        <div>{actions.map(action => (
           <div key={action.key}>
             <a
               key={action.key}
@@ -241,7 +241,7 @@ class ExternalChangeDialog extends ComponentEx<IProps, IComponentState> {
             </a><span className='link-action-seperator'>&nbsp; | &nbsp;</span>
           </div>
         ))
-        }</p>
+        }</div>
         <div style={{ overflowY: 'auto', flex: '1 1 0' }}>
           <Table
             tableId={`external-change-${type}`}

--- a/src/extensions/mod_management/views/ModList.tsx
+++ b/src/extensions/mod_management/views/ModList.tsx
@@ -1076,7 +1076,13 @@ class ModList extends ComponentEx<IProps, IComponentState> {
   }
 
   private updateModGrouping(modsWithState) {
-    const modList = Object.keys(modsWithState).map(key => modsWithState[key]);
+    const modList = Object.keys(modsWithState).reduce((accum, key) => {
+      const mod = modsWithState[key];
+      if (mod) {
+        accum.push(mod);
+      }
+      return accum;
+    }, []);
     const grouped = groupMods(modList, { groupBy: 'file', multipleEnabled: false });
 
     const groupedMods = grouped.reduce((prev: { [id: string]: IModWithState[] }, value) => {

--- a/src/extensions/starter_dashlet/Tools.tsx
+++ b/src/extensions/starter_dashlet/Tools.tsx
@@ -44,6 +44,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import Tool from './Tool';
+import ErrorBoundary from '../../controls/ErrorBoundary';
 
 interface IBaseProps {
   onGetValidTools: (starters: IStarterInfo[], gameMode: string) => Promise<string[]>;
@@ -92,7 +93,7 @@ interface IActionProps {
   onSetToolVisible: (gameId: string, toolId: string, visible: boolean) => void;
   onShowError: (message: string, details?: any, allowReport?: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-                 actions: DialogActions) => Promise<IDialogResult>;
+    actions: DialogActions) => Promise<IDialogResult>;
   onSetPrimary: (gameId: string, toolId: string) => void;
   onSetToolOrder: (gameId: string, tools: string[]) => void;
 }
@@ -209,7 +210,7 @@ export default function Tools(props: IStarterProps) {
         onClose={closeEditDialog}
       />
     ) : null
-  , [state.editTool, closeEditDialog]);
+    , [state.editTool, closeEditDialog]);
   if (gameMode === undefined) {
     content = (
       <EmptyPlaceholder
@@ -225,7 +226,11 @@ export default function Tools(props: IStarterProps) {
       <Media id='starter-dashlet'>
         <FlexLayout type='row' className='starter-dashlet-tools-header'>
           <div className='dashlet-title'>{t('Tools')}</div>
-          <DynDiv group='starter-dashlet-tools-controls' />
+          <ErrorBoundary
+            key={`dyndiv-tools-${gameMode}`}
+          >
+            <DynDiv group='starter-dashlet-tools-controls' />
+          </ErrorBoundary>
         </FlexLayout>
         <Media.Body>
           <FlexLayout type='column'>
@@ -409,7 +414,7 @@ function mapStateToProps(state: any): IConnectedProps {
 
   const keys = Object.keys(res);
   if ((lastConnected === undefined)
-      || (keys.find(key => res[key] !== lastConnected[key]) !== undefined)) {
+    || (keys.find(key => res[key] !== lastConnected[key]) !== undefined)) {
     lastConnected = res;
   }
   return lastConnected;

--- a/src/extensions/starter_dashlet/Tools.tsx
+++ b/src/extensions/starter_dashlet/Tools.tsx
@@ -44,7 +44,6 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import Tool from './Tool';
-import ErrorBoundary from '../../controls/ErrorBoundary';
 
 interface IBaseProps {
   onGetValidTools: (starters: IStarterInfo[], gameMode: string) => Promise<string[]>;
@@ -93,7 +92,7 @@ interface IActionProps {
   onSetToolVisible: (gameId: string, toolId: string, visible: boolean) => void;
   onShowError: (message: string, details?: any, allowReport?: boolean) => void;
   onShowDialog: (type: DialogType, title: string, content: IDialogContent,
-    actions: DialogActions) => Promise<IDialogResult>;
+                 actions: DialogActions) => Promise<IDialogResult>;
   onSetPrimary: (gameId: string, toolId: string) => void;
   onSetToolOrder: (gameId: string, tools: string[]) => void;
 }
@@ -210,7 +209,7 @@ export default function Tools(props: IStarterProps) {
         onClose={closeEditDialog}
       />
     ) : null
-    , [state.editTool, closeEditDialog]);
+  , [state.editTool, closeEditDialog]);
   if (gameMode === undefined) {
     content = (
       <EmptyPlaceholder
@@ -226,11 +225,7 @@ export default function Tools(props: IStarterProps) {
       <Media id='starter-dashlet'>
         <FlexLayout type='row' className='starter-dashlet-tools-header'>
           <div className='dashlet-title'>{t('Tools')}</div>
-          <ErrorBoundary
-            key={`dyndiv-tools-${gameMode}`}
-          >
-            <DynDiv group='starter-dashlet-tools-controls' />
-          </ErrorBoundary>
+          <DynDiv group='starter-dashlet-tools-controls' />
         </FlexLayout>
         <Media.Body>
           <FlexLayout type='column'>
@@ -414,7 +409,7 @@ function mapStateToProps(state: any): IConnectedProps {
 
   const keys = Object.keys(res);
   if ((lastConnected === undefined)
-    || (keys.find(key => res[key] !== lastConnected[key]) !== undefined)) {
+      || (keys.find(key => res[key] !== lastConnected[key]) !== undefined)) {
     lastConnected = res;
   }
   return lastConnected;

--- a/src/views/MainWindow.tsx
+++ b/src/views/MainWindow.tsx
@@ -150,20 +150,6 @@ export class MainWindow extends React.Component<IProps, IMainWindowState> {
     };
 
     this.applicationButtons = [];
-
-    this.props.api.events.on('show-main-page', pageId => {
-      this.setMainPage(pageId, false);
-    });
-
-    this.props.api.events.on('refresh-main-page', () => {
-      this.forceUpdate();
-    });
-
-    this.props.api.events.on('show-modal', id => {
-      this.updateState({
-        showLayer: { $set: id },
-      });
-    });
   }
 
   public getChildContext(): IComponentContext {
@@ -183,6 +169,20 @@ export class MainWindow extends React.Component<IProps, IMainWindowState> {
 
     this.updateSize();
 
+    this.props.api.events.on('show-main-page', pageId => {
+      this.setMainPage(pageId, false);
+    });
+
+    this.props.api.events.on('refresh-main-page', () => {
+      this.forceUpdate();
+    });
+
+    this.props.api.events.on('show-modal', id => {
+      this.updateState({
+        showLayer: { $set: id },
+      });
+    });
+
     window.addEventListener('resize', this.updateSize);
     window.addEventListener('keydown', this.updateModifiers);
     window.addEventListener('keyup', this.updateModifiers);
@@ -191,6 +191,9 @@ export class MainWindow extends React.Component<IProps, IMainWindowState> {
   }
 
   public componentWillUnmount() {
+    this.props.api.events.removeAllListeners('show-main-page');
+    this.props.api.events.removeAllListeners('refresh-main-page');
+    this.props.api.events.removeAllListeners('show-modal');
     window.removeEventListener('resize', this.updateSize);
     window.removeEventListener('keydown', this.updateModifiers);
     window.removeEventListener('keyup', this.updateModifiers);
@@ -436,7 +439,7 @@ export class MainWindow extends React.Component<IProps, IMainWindowState> {
     const state = this.props.api.getState();
     const profile = profileById(state, this.props.activeProfileId);
     const game = profile !== undefined ? getGame(profile.gameId) : undefined;
-    const gameName = game?.name || 'Mods';
+    const gameName = game?.shortName || game?.name || 'Mods';
     const pageGroups = [
       { title: undefined, key: 'dashboard' },
       { title: 'General', key: 'global' },

--- a/src/views/QuickLauncher.tsx
+++ b/src/views/QuickLauncher.tsx
@@ -60,10 +60,12 @@ interface IComponentState {
 }
 
 class QuickLauncher extends ComponentEx<IProps, IComponentState> {
+  private mMounted = false;
   private mCacheDebouncer: Debouncer = new Debouncer(() => {
+    if (!this.mMounted) { return Promise.resolve(); }
     this.nextState.gameIconCache = this.genGameIconCache();
     return Promise.resolve();
-  }, 100);
+  }, 250);
 
   constructor(props: IProps) {
     super(props);
@@ -71,11 +73,14 @@ class QuickLauncher extends ComponentEx<IProps, IComponentState> {
   }
 
   public componentDidMount() {
+    this.mMounted = true;
     this.context.api.events.on('quick-launch', this.start);
   }
 
   public componentWillUnmount() {
+    this.mMounted = false;
     this.context.api.events.removeListener('quick-launch', this.start);
+    this.mCacheDebouncer.clear();
   }
 
   public UNSAFE_componentWillReceiveProps(nextProps: IProps) {


### PR DESCRIPTION
The rest of the leaks are within the collections extension; still trying to figure out how to deal with that without rocking the boat too much.

The functionality for the main app is still solid though.

- Ensures that the symlink activator is no longer "stuck" behind the elevation notification.
- Better error handling throughout the application, React errors will no longer block the entire page view when something fails to render, it will block the specific component that failed to render (which can indeed be a whole page in some cases)
- Dynamic divs are now wrapped in an ErrorBoundary and will provide a way for users to report any rendering issues that occur.
- General improvements to the DOM's consistency (removed anti-patterns) - this might screw up the stylesheets a bit (specifically for ECD)
- Ensured that we add and remove listeners correctly in the QuickLauncher and MainWindow components.


Please ignore until 1.13.x is worked on