### PR TITLE
FBLO will now keep an update set to restore LO entry positions

### DIFF
--- a/src/extensions/file_based_loadorder/UpdateSet.ts
+++ b/src/extensions/file_based_loadorder/UpdateSet.ts
@@ -1,0 +1,160 @@
+/* eslint-disable */
+import {
+  IExtensionApi,
+} from '../../types/IExtensionContext';
+import {getSafe} from '../../util/storeHelper';
+
+import * as _ from 'lodash';
+import { ILoadOrderEntry } from './types/types';
+import { log } from '../../util/log';
+import { activeGameId } from '../profile_management/selectors';
+
+export interface ILoadOrderEntryExt extends ILoadOrderEntry {
+  index: number;
+}
+
+export default class UpdateSet extends Set<number> {
+  private mApi: IExtensionApi;
+  private mModEntries: { [modId: number]: ILoadOrderEntryExt[] } = {};
+  private mInitialized = false;
+  constructor(api: IExtensionApi) {
+    super([]);
+    this.mApi = api;
+  }
+
+  public addNumericModId = (lo: ILoadOrderEntryExt) => {
+    const state = this.mApi.getState();
+    const gameMode = activeGameId(state);
+    const mods = getSafe(state, ['persistent', 'mods', gameMode], {});
+    if (lo.modId === undefined) {
+      // No modId, no restoration
+      return;
+    }
+
+    if (mods[lo.modId]?.attributes?.modId === undefined) {
+      // The numeric id of the mod is the only unique item we can
+      //  use to ascertain if we can recover this entry's index.
+      return;
+    }
+
+    const numericId: number = getSafe(mods[lo.modId], ['attributes', 'modId'], -1);
+    if (numericId !== -1 && (this.mModEntries[numericId] === undefined) || (!this.mModEntries[numericId].some(m => m.name === lo.name))) {
+      this.mModEntries[numericId] = [].concat(this.mModEntries[numericId] || [], lo);
+      super.add(numericId);
+    }
+    return;
+  }
+
+  public init = (modEntries: ILoadOrderEntryExt[]) => {
+    this.reset();
+    this.registerListeners();
+    this.mInitialized = true;
+    modEntries.forEach((iter: ILoadOrderEntryExt) => this.addNumericModId(iter));
+  }
+
+  private registerListeners = () => {
+    this.mApi.events.on('gamemode-activated', this.reset);
+  }
+
+  private removeListeners = () => {
+    this.mApi.events.removeListener('gamemode-activated', this.reset);
+  }
+
+  public destroy = () => {
+    this.reset();
+  }
+
+  private reset = () => {
+    this.removeListeners();
+    super.clear();
+    this.mModEntries = [];
+    this.mInitialized = false;
+  }
+
+  public has = (value: number): boolean => {
+    return super.has(value)
+      || (this.mModEntries[value] !== undefined);
+  }
+
+  public hasEntry = (entry: ILoadOrderEntry): boolean => {
+    return Object.values(this.mModEntries).some(l => l.some(m => m.modId === entry.modId || m.id === entry.id));
+  }
+
+  private tryRemoveNumId = (numId: number, entries: ILoadOrderEntryExt[], nameLookup: string) => {
+    if (entries.length === 1) {
+      // If this is the only entry in the array, we remove all traces
+      //  of this specific numeric mod id, both from the numeric set
+      //  and the mod entries object.
+      super.delete(numId);
+      delete this.mModEntries[numId]; 
+    } else {
+      // Take out the entry from the mod entries object. This will ensure we don't
+      //  attempt to re-arrange it again.
+      this.mModEntries[numId] = entries.filter(l => l.name !== nameLookup);
+    }
+
+    if (super.size === 0) {
+      this.reset();
+    }
+  }
+
+  public restore = (loadOrder: ILoadOrderEntry[]): ILoadOrderEntry[] => {
+    if (Object.keys(this.mModEntries).length === 0) {
+      // Nothing to restore
+      return loadOrder;
+    }
+    const restoredLO: ILoadOrderEntry[] = [...loadOrder];
+    loadOrder.forEach((iter, idx) => {
+      // Check if the updateSet has this modId.
+      const stored: { numId: number, entries: ILoadOrderEntryExt[] } = this.findEntry(iter);
+      if (stored) {
+        // We're only interested in 1 specific entry, keep in mind that there might be multiple lo entries
+        //  that are associated with the same numeric mod id.
+        const entryExt: ILoadOrderEntryExt = stored.entries.find(l => l.name === iter.name);
+        if (entryExt && entryExt.index !== idx) {
+          // The entry is in the wrong position - re-arrange the array.
+          restoredLO.splice(idx, 1);
+          restoredLO.splice(entryExt.index, 0, iter);
+
+          // We only remove the numeric mod id if we confirm that we modified the
+          //  list, otherwise we keep it around as the restoration functionality
+          //  can be called multiple times without modification.
+          this.tryRemoveNumId(stored.numId, stored.entries, iter.name);
+        }
+      }
+    });
+    return restoredLO;
+  }
+
+  public get = (value: number): ILoadOrderEntryExt[] | null => {
+    if (super.has(value) && this.mModEntries[value] !== undefined) {
+      return this.mModEntries[value];
+    }
+    return null;
+  }
+
+  // The modId of the mod we are looking for as stored in Vortex's state.
+  public findEntry = (lookUpEntry: ILoadOrderEntry): { numId: number, entries: ILoadOrderEntryExt[] } | null => {
+    if (!this.hasEntry(lookUpEntry)) {
+      return null;
+    }
+
+    const numericId = Object.entries(this.mModEntries).find(entry => {
+      const [nId, loEntries] = entry;
+      return loEntries.some(l => l.modId === lookUpEntry.modId || l.id === lookUpEntry.id);
+    })?.[0];
+    if (numericId === undefined) {
+      return null;
+    }
+    return { numId: +numericId, entries: this.mModEntries[numericId] };
+  }
+
+  public add = (x: number): this => {
+    log('warn', 'Use addNumericModId', x);    
+    return;
+  }
+
+  public isInitialized = (): boolean => {
+    return this.mInitialized;
+  }
+}

--- a/src/extensions/mod_management/eventHandlers.ts
+++ b/src/extensions/mod_management/eventHandlers.ts
@@ -673,7 +673,7 @@ export function onRemoveMods(api: IExtensionApi,
 
   store.dispatch(startActivity('mods', `removing_${modIds[0]}`));
 
-  api.emitAndAwait('will-remove-mods', gameId, removeMods.map(mod => mod.id))
+  api.emitAndAwait('will-remove-mods', gameId, removeMods.map(mod => mod.id), options)
     .then(() => undeployMods(api, activators, gameId, removeMods))
     .then(() => Promise.mapSeries(removeMods,
         (mod: IMod, idx: number, length: number) => {


### PR DESCRIPTION
- Updating a mod will now keep its LO index.
- Re-installing a mod will also keep LO index.
- Switching between different variants of mods will also keep the index.

closes nexus-mods/vortex#16086