### PR TITLE
fixed inability to update mods that are tagged as compatibleDownloads

### DIFF
--- a/src/extensions/gamemode_management/types/IGameStored.ts
+++ b/src/extensions/gamemode_management/types/IGameStored.ts
@@ -25,3 +25,7 @@ export interface IGameStored {
   contributed?: string;
   final?: boolean;
 }
+
+export interface IGameStoredExt extends IGameStored {
+  downloadGameId?: string;
+}

--- a/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/extensions/nexus_integration/eventHandlers.ts
@@ -1,7 +1,8 @@
+/* eslint-disable */
 import { setDownloadModInfo } from '../../actions';
 import { IExtensionApi, StateChangeCallback } from '../../types/IExtensionContext';
 import { IDownload, IModTable, IState } from '../../types/IState';
-import { ArgumentInvalid, DataInvalid, ProcessCanceled, UserCanceled } from '../../util/CustomErrors';
+import { DataInvalid, ProcessCanceled, UserCanceled } from '../../util/CustomErrors';
 import Debouncer from '../../util/Debouncer';
 import * as fs from '../../util/fs';
 import { log } from '../../util/log';
@@ -15,7 +16,7 @@ import { toPromise, truthy } from '../../util/util';
 import { resolveCategoryName } from '../category_management';
 import { AlreadyDownloaded, DownloadIsHTML } from '../download_management/DownloadManager';
 import { SITE_ID } from '../gamemode_management/constants';
-import {IGameStored} from '../gamemode_management/types/IGameStored';
+import { IGameStoredExt } from '../gamemode_management/types/IGameStored';
 import { setUpdatingMods } from '../mod_management/actions/session';
 import { IModListItem } from '../news_dashlet/types';
 
@@ -223,7 +224,7 @@ function getFileId(download: IDownload): number {
 }
 
 function downloadFile(api: IExtensionApi, nexus: Nexus,
-                      game: IGameStored, modId: number, fileId: number,
+                      game: IGameStoredExt, modId: number, fileId: number,
                       fileName?: string,
                       allowInstall?: boolean): Promise<string> {
     const state: IState = api.getState();
@@ -279,7 +280,8 @@ export function onModUpdate(api: IExtensionApi, nexus: Nexus) {
       return;
     }
 
-    downloadFile(api, nexus, game, modId, fileId, undefined, false)
+    const downloadGameId = (game !== undefined) && (game.id !== gameId) ? gameId : game.id;
+    downloadFile(api, nexus, { ...game, downloadGameId }, modId, fileId, undefined, false)
       .catch(AlreadyDownloaded, err => {
         const state = api.getState();
         const downloads = state.persistent.downloads.files;

--- a/src/extensions/nexus_integration/util/checkModsVersion.ts
+++ b/src/extensions/nexus_integration/util/checkModsVersion.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { IExtensionApi } from '../../../types/IExtensionContext';
 import { log } from '../../../util/log';
 import { getSafe } from '../../../util/storeHelper';
@@ -104,7 +105,7 @@ export function checkModVersion(store: Redux.Store<any>, nexus: NexusT,
   const gameId = getSafe(mod.attributes, ['downloadGame'], undefined) || gameMode;
   const game = gameById(store.getState(), gameId);
   const fallBackGameId = gameId === 'site'
-    ? 'site' : undefined;
+    ? 'site' : gameId;
 
   return Promise.resolve(nexus.getModFiles(nexusModId, nexusGameId(game, fallBackGameId)))
       .then(result => updateFileAttributes(store.dispatch, gameMode, mod, result))

--- a/src/extensions/nexus_integration/util/convertGameId.ts
+++ b/src/extensions/nexus_integration/util/convertGameId.ts
@@ -1,9 +1,9 @@
 import { inspect } from 'util';
 import { IGame } from '../../../types/IGame';
-import { IGameStored } from '../../../types/IState';
 import { log } from '../../../util/log';
 import { truthy } from '../../../util/util';
 import { SITE_ID } from '../../gamemode_management/constants';
+import { IGameStored, IGameStoredExt } from '../../gamemode_management/types/IGameStored';
 
 /**
  * get the nexus page id for a game
@@ -88,7 +88,7 @@ export function convertNXMIdReverse(knownGames: IGameStored[], input: string): s
 /**
  * get the nxm link id for a game
  */
-export function toNXMId(game: IGameStored, gameId: string): string {
+export function toNXMId(game: IGameStoredExt, gameId: string): string {
   // this is a bit of a workaround since "site" isn't and shouldn't be an
   // entry in the list of games (here or on the site)
   if (game === null) {
@@ -100,7 +100,7 @@ export function toNXMId(game: IGameStored, gameId: string): string {
     } else if (game.details.nexusPageId !== undefined) {
       return game.details.nexusPageId;
     }
-    gameId = game.id;
+    gameId = game.downloadGameId || game.id;
   }
   const gameIdL = gameId.toLowerCase();
   if (gameIdL === 'skyrimse') {


### PR DESCRIPTION
FO4 for example, provides the ability to download FOLON mods.

The update check mechanism was attempting to check for an update using the FO4 domain name regardless of the domain name used when the mod was initially downloaded.

This would obviously result in Vortex installing a different mod as an update..

closes nexus-mods/vortex#16231