### PR TITLE
fixed manual deployment actions not recognized correctly

### DIFF
--- a/src/extensions/mod_management/index.ts
+++ b/src/extensions/mod_management/index.ts
@@ -13,6 +13,7 @@ import { INotification } from '../../types/INotification';
 import {IDiscoveryResult, IState} from '../../types/IState';
 import { ITableAttribute } from '../../types/ITableAttribute';
 import {ITestResult} from '../../types/ITestResult';
+import { IDeployOptions } from './types/IDeployOptions';
 import { ProcessCanceled, TemporaryError, UserCanceled } from '../../util/CustomErrors';
 import Debouncer from '../../util/Debouncer';
 import * as fs from '../../util/fs';
@@ -1112,9 +1113,14 @@ function once(api: IExtensionApi) {
         updateModDeployment(api, manual, profileId, progressCB), 2000);
 
   api.events.on('deploy-mods', (callback: (err: Error) => void, profileId?: string,
-                                progressCB?: (text: string, percent: number) => void) => {
+                                progressCB?: (text: string, percent: number) => void,
+                                deployOptions?: IDeployOptions) => { // Can't believe that 7+ years in, we still didn't have deployment options defined.
     if (!(callback as any).called) {
-      deploymentTimer.runNow(callback, true, profileId, progressCB);
+      if (deployOptions?.manual === true) {
+        deploymentTimer.runNow(callback, true, profileId, progressCB);
+      } else {
+        deploymentTimer.runNow(callback, false, profileId, progressCB);
+      }
     }
   });
 

--- a/src/extensions/mod_management/types/IDeployOptions.ts
+++ b/src/extensions/mod_management/types/IDeployOptions.ts
@@ -1,0 +1,4 @@
+export interface IDeployOptions {
+  manual?: boolean;
+  profileId?: string;
+}

--- a/src/extensions/mod_management/views/ActivationButton.tsx
+++ b/src/extensions/mod_management/views/ActivationButton.tsx
@@ -20,6 +20,7 @@ import { ThunkDispatch } from 'redux-thunk';
 interface IConnectedProps {
   activator: IDeploymentMethod;
   needToDeploy: boolean;
+  profileId: string;
 }
 
 interface IActionProps {
@@ -78,18 +79,20 @@ class ActivationButton extends ComponentEx<IProps, {}> {
           this.props.onShowError('Failed to activate mods', err);
         }
       }
-    }));
+    }), this.props.profileId, undefined, { manual: true });
   }
 }
 
 function mapStateToProps(state: IState, ownProps: IProps): IConnectedProps {
   const gameId = selectors.activeGameId(state);
   const activatorId = getSafe(state, ['settings', 'mods', 'activator', gameId], undefined);
+  const profileId = selectors.lastActiveProfileForGame(state, gameId);
   let activator: IDeploymentMethod;
   if (activatorId !== undefined) {
     activator = ownProps.getActivators().find((act: IDeploymentMethod) => act.id === activatorId);
   }
   return {
+    profileId,
     activator,
     needToDeploy: selectors.needToDeploy(state),
   };


### PR DESCRIPTION
This commit has three main operations:

- Clicking on the activation/deploy mods button will now be recognized as a manual interaction which will force Vortex to deploy immediately regardless of activator/deployment method "UserGate" restrictions. This will primarily be evident when using the Symlink deployment method as it will bypass the archaic "elevation required" notification and will immediately raise the UAC dialog.

- Adds the deployment options object which can be used to control the deployment event and better inform the activators of user interactions.

- Ensures that the deployment event executes for the profile of the currently managed game. It was previously possible to switch between gameModes and run the deployment event for the wrong game.