### PR TITLE
fixed inability to update/download folon mods through collections

### DIFF
--- a/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/extensions/nexus_integration/eventHandlers.ts
@@ -540,9 +540,8 @@ export function onDownloadUpdate(api: IExtensionApi,
       return Promise.resolve(undefined);
     }
 
-    const game = (gameId === SITE_ID)
-      ? null
-      : gameById(api.store.getState(), gameId);
+    const state = api.getState();
+    const game = (gameId === SITE_ID) ? null : gameById(state, gameId) || currentGame(state);
 
     if (game === undefined) {
       api.sendNotification({


### PR DESCRIPTION
The fallback download for compatible games was not executing as part of updating/downloading mods from a collection - this is now fixed

fixes nexus-mods/vortex#16267