### PR TITLE
Added ability to disable support for the move activator in game extensions

### DIFF
--- a/src/extensions/move_activator/index.ts
+++ b/src/extensions/move_activator/index.ts
@@ -71,6 +71,11 @@ class DeploymentMethod extends LinkingDeployment {
     const game: IGame = getGame(gameId);
     const modPaths = game.getModPaths(discovery.path);
 
+    if ((game.details?.supportsMoveActivator === false)
+      || (game.compatible?.moveActivator === false)) {
+    return { description: t => t('Game doesn\'t support the move deployment method') };
+  }
+
     try {
       fs.accessSync(modPaths[typeId], fs.constants.W_OK);
     } catch (err) {


### PR DESCRIPTION
Deprecating the move activator might be complicated as some users might already have a working modding setup (at least temporarily)

Deprecating this deployment method will require an incremental process.

First lets ensure that the game extensions themselves are able to disable the move activator, similar to how we do it in the symlink one.

#16200 