### PR TITLE
adding coreceVersion as an API utility function

### DIFF
--- a/src/extensions/mod_management/util/modReference.ts
+++ b/src/extensions/mod_management/util/modReference.ts
@@ -1,8 +1,6 @@
-import * as path from 'path';
-import * as semver from 'semver';
 import { truthy } from '../../../util/util';
 import { IMod, IReference } from '../types/IMod';
-import { sanitizeExpression } from './testModReference';
+import { sanitizeExpression, coerceToSemver } from './testModReference';
 
 export function makeModReference(mod: IMod): IReference {
   if (!truthy(mod.attributes['fileMD5'])
@@ -21,7 +19,7 @@ export function makeModReference(mod: IMod): IReference {
       ? sanitizeExpression(fileName)
       : undefined,
     fileMD5: mod.attributes['fileMD5'],
-    versionMatch: semver.coerce(mod.attributes['version'])?.version ?? mod.attributes['version'],
+    versionMatch: coerceToSemver(mod.attributes['version']) ?? mod.attributes['version'],
     logicalFileName: mod.attributes['logicalFileName'],
   };
 }

--- a/src/extensions/mod_management/util/testModReference.ts
+++ b/src/extensions/mod_management/util/testModReference.ts
@@ -67,7 +67,7 @@ export function safeCoerce(input: string): string {
 
 export function coerceToSemver(version: string): string {
   if (!version) {
-    return version;
+    return undefined;
   }
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
   if (match) {
@@ -85,7 +85,10 @@ export function coerceToSemver(version: string): string {
       return `${major}.${minor}.${patch}`;
     }
   } else {
-    return semver.coerce(version).version ?? version;
+    if (coerceableRE.test(version)) {
+      return semver.coerce(version).version ?? version; 
+    }
+    return version;
   }
 }
 

--- a/src/extensions/mod_management/util/testModReference.ts
+++ b/src/extensions/mod_management/util/testModReference.ts
@@ -59,13 +59,16 @@ const fuzzyVersionCache: { [input: string]: boolean } = {};
 
 const coerceableRE = /^v?[0-9.]+$/;
 
-function safeCoerce(input: string): string {
+export function safeCoerce(input: string): string {
   return coerceableRE.test(input)
     ? coerceToSemver(input) ?? input
     : input;
 }
 
 export function coerceToSemver(version: string): string {
+  if (!version) {
+    return version;
+  }
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
   if (match) {
     const major = match[1];
@@ -82,7 +85,7 @@ export function coerceToSemver(version: string): string {
       return `${major}.${minor}.${patch}`;
     }
   } else {
-    return version;
+    return semver.coerce(version).version ?? version;
   }
 }
 

--- a/src/extensions/mod_management/util/testModReference.ts
+++ b/src/extensions/mod_management/util/testModReference.ts
@@ -61,8 +61,29 @@ const coerceableRE = /^v?[0-9.]+$/;
 
 function safeCoerce(input: string): string {
   return coerceableRE.test(input)
-    ? semver.coerce(input)?.raw ?? input
+    ? coerceToSemver(input) ?? input
     : input;
+}
+
+export function coerceToSemver(version: string): string {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
+  if (match) {
+    const major = match[1];
+    const minor = match[2];
+    const patch = match[3];
+    let preRelease = match[4].trim();
+
+    // If there's something after the first three segments, treat it as pre-release
+    if (preRelease) {
+      // Remove leading punctuation from the pre-release part
+      preRelease = preRelease.replace(/^[\.\-\+]/, '');
+      return `${major}.${minor}.${patch}-${preRelease}`;
+    } else {
+      return `${major}.${minor}.${patch}`;
+    }
+  } else {
+    return version;
+  }
 }
 
 export function isFuzzyVersion(input: string) {
@@ -211,11 +232,11 @@ function testRef(mod: IModLookupInfo, modId: string, ref: IModReference,
       && truthy(mod.version)) {
     const versionMatch = ref.versionMatch.split('+')[0];
     const doesMatch = (mod.version === ref.versionMatch)
-                    || (mod.version === safeCoerce(versionMatch));
+                    || (safeCoerce(mod.version) === safeCoerce(versionMatch)) || ref.fileMD5 === mod.fileMD5;
     if (!doesMatch) {
-      const versionCoerced = semver.coerce(mod.version);
+      const versionCoerced = safeCoerce(mod.version);
       if (semver.valid(versionCoerced)) {
-        if (!semver.satisfies(versionCoerced, versionMatch, true)) {
+        if (!semver.satisfies(versionCoerced, versionMatch, { loose: true, includePrerelease: true })) {
           return false;
         } // the version is a valid semantic version and does match
       } else {

--- a/src/extensions/mod_management/util/testModReference.ts
+++ b/src/extensions/mod_management/util/testModReference.ts
@@ -86,9 +86,12 @@ export function coerceToSemver(version: string): string {
     }
   } else {
     if (coerceableRE.test(version)) {
-      return semver.coerce(version).version ?? version; 
+      const coerced = semver.coerce(version);
+      if (coerced) {
+        return coerced.version
+      }
+      return version;
     }
-    return version;
   }
 }
 

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -23,7 +23,7 @@ import { makeModReference } from '../extensions/mod_management/util/modReference
 import { getModSource, getModSources } from '../extensions/mod_management/util/modSource';
 import { removeMods } from '../extensions/mod_management/util/removeMods';
 import sortMods, { CycleError } from '../extensions/mod_management/util/sort';
-import testModReference from '../extensions/mod_management/util/testModReference';
+import testModReference, { coerceToSemver } from '../extensions/mod_management/util/testModReference';
 import { convertGameIdReverse, nexusGameId } from '../extensions/nexus_integration/util/convertGameId';
 import GameStoreHelper from '../util/GameStoreHelper';
 import { getApplication } from './application';
@@ -125,6 +125,7 @@ export {
   local,
   lookupFromDownload,
   makeModReference,
+  coerceToSemver,
   makeNormalizingDict,
   makeOverlayableDictionary,
   makeQueue,


### PR DESCRIPTION
This function will attempt to pull out the first 3 digits of the mod's version. Any surplus characters/digits will be added at the end as a hotfix. e.g. `1.2.5.1.beta`  will be converted to `1.2.5-1.beta` ensuring that the version is semantic and rules can be applied to those mods correctly.