### PR TITLE
fixed premature fileName reference comparison failure

### DIFF
--- a/src/extensions/mod_management/util/testModReference.ts
+++ b/src/extensions/mod_management/util/testModReference.ts
@@ -211,10 +211,10 @@ function testRef(mod: IModLookupInfo, modId: string, ref: IModReference,
   if (ref.logicalFileName !== undefined) {
     if (mod.additionalLogicalFileNames !== undefined) {
       if (!mod.additionalLogicalFileNames.includes(ref.logicalFileName)
-          && (ref.logicalFileName !== mod.logicalFileName)) {
+          && (![mod.logicalFileName, mod.customFileName].includes(ref.logicalFileName) && ref.fileExpression === undefined)) {
         return false;
       }
-    } else if (ref.logicalFileName !== mod.logicalFileName) {
+    } else if (![mod.logicalFileName, mod.customFileName].includes(ref.logicalFileName) && ref.fileExpression === undefined) {
       return false;
     }
   }


### PR DESCRIPTION
Filename comparisons when attempting to ascertain if a mod reference matches one of the installed mods would end prematurely without running the fileExpression comparisons. This would block Vortex from matching mods to their respective mods whenever the mod author changes the name of the mod.