### PR TITLE
Several improvements to ensure smoother collection installations

### DIFF
--- a/src/extensions/file_based_loadorder/index.ts
+++ b/src/extensions/file_based_loadorder/index.ts
@@ -79,16 +79,17 @@ async function genLoadOrderChange(api: types.IExtensionApi, oldState: any, newSt
     //  Maybe it was changed by an extension ?
     return;
   }
-  if ((state.session.base.activity?.installing_dependencies ?? []).length > 0) {
-    // Don't do anything if we're in the middle of installing deps
-    log('info', 'skipping load order serialization/deserialization');
-    return;
-  }
 
   const gameEntry = findGameEntry(profile.gameId);
   if (gameEntry === undefined) {
     // This game wasn't registered with the LO component. That's fine
     //  probably just a game that doesn't need LO support.
+    return;
+  }
+
+  if ((state.session.base.activity?.installing_dependencies ?? []).length > 0) {
+    // Don't do anything if we're in the middle of installing deps
+    log('info', 'skipping load order serialization/deserialization');
     return;
   }
 

--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -167,7 +167,7 @@ class InstallManager {
   private mDependencyDownloadsLimit: ConcurrencyLimiter =
     new ConcurrencyLimiter(10);
   private mDependencyInstallsLimit: ConcurrencyLimiter =
-    new ConcurrencyLimiter(1);
+    new ConcurrencyLimiter(3);
   private mDependencyQueue = makeQueue<void>();
 
   constructor(api: IExtensionApi, installPath: (gameId: string) => string) {

--- a/src/util/waitForCondition.ts
+++ b/src/util/waitForCondition.ts
@@ -1,0 +1,34 @@
+/* eslint-disable */
+export interface IWaitForConditionOptions {
+  // Only call the callback if the condition is true
+  condition: () => boolean;
+
+  // Do something if the condition is met
+  callback: () => void;
+
+  // Whether the app still needs to call the callback
+  required?: () => boolean;
+
+  // How long to wait before checking the condition again
+  timeoutMS?: number;
+}
+
+export const waitForCondition = (opts: IWaitForConditionOptions) => {
+  const { condition, callback, required = () => true, timeoutMS = 1000 } = opts;
+  const waitForCondition = new Promise<void>((resolve) => {
+    const checkCondition = () => {
+      if (!required() || condition()) {
+        resolve();
+      } else {
+        setTimeout(checkCondition, timeoutMS);
+      }
+    };
+    checkCondition();
+  });
+
+  waitForCondition.then(() => {
+    if (typeof callback === 'function' && required()) {
+      callback();
+    }
+  });
+};


### PR DESCRIPTION
- Will avoid redundant deployment events while installing a collection (collection phases will still deploy)
- Removed unnecessary log spam from the FBLO extension (when managing a game which isn't using FBLO)
- Added utility function waitForCondition to allow us to wait for a specific state change within other state change subscribers.
- Can now run 3 dependency installers concurrently