### PR TITLE
fixed exception when unmanaging (some) community game extensions

### DIFF
--- a/src/extensions/gamemode_management/util/getGame.ts
+++ b/src/extensions/gamemode_management/util/getGame.ts
@@ -24,7 +24,7 @@ const gameExHandler = {
 
       return gamePath => {
         let defaultPath = target.queryModPath(gamePath);
-        if (defaultPath === undefined) {
+        if (!defaultPath) {
           defaultPath = '.';
         }
         if (!path.isAbsolute(defaultPath)) {


### PR DESCRIPTION
The fallback mod path logic only catered for "undefined" mod paths; any community game extension which would return "null" for whatever reason would cause an exception to be raised

fixes nexus-mods/vortex#16507