### PR TITLE
Improved error handling for history revert events

### DIFF
--- a/src/extensions/history_management/index.ts
+++ b/src/extensions/history_management/index.ts
@@ -45,7 +45,7 @@ function makeAddToHistory(api: IExtensionApi) {
 }
 
 function onErrorImpl(api: IExtensionApi, err: Error, evt: IHistoryEvent, stackId: string) {
-  const allowReport = !(err instanceof ProcessCanceled || err instanceof UserCanceled);
+  const allowReport = !(err instanceof ProcessCanceled || err instanceof UserCanceled || ['EPERM', 'EINVAL', 'ENOENT'].includes(err?.['code']));
   api.showErrorNotification('Failed to revert event', err, { allowReport });
   if (evt.reverted) {
     api.store.dispatch(setHistoryEvent(stackId, { ...evt, reverted: false }));


### PR DESCRIPTION
Suppressed ability to report history revert events when Vortex encounters a file system error (permissions/missing file/etc)

fixes nexus-mods/vortex#16694