### PR TITLE
Improved metadata lookup for locally imported downloads

### DIFF
--- a/src/extensions/nexus_integration/util/guessModID.ts
+++ b/src/extensions/nexus_integration/util/guessModID.ts
@@ -129,7 +129,7 @@ export function fillNexusIdByMD5(api: IExtensionApi,
   }, true)
     .then(lookupResults => {
       const applicable = lookupResults.reduce((acc, iter) => {
-        const hasUri = !!iter.value.sourceURI;
+        const hasUri = truthy(iter.value.sourceURI);
         const hasMd5Match = iter.value.fileMD5 === mod?.attributes?.fileMD5;
         if (!hasUri && hasMd5Match && hasValidIds) {
           // We know this is the mod; we just don't have the URI for it.
@@ -139,7 +139,7 @@ export function fillNexusIdByMD5(api: IExtensionApi,
           }
           const url = `nxm://${toNXMId(game, iter.value.gameId)}/mods/${mod.attributes.modId}/files/${mod.attributes.fileId}`;
           acc.push({ ...iter, value: { ...iter.value, sourceURI: url } });
-        } else if (iter.value.sourceURI) {
+        } else if (hasUri) {
           acc.push(iter);
         }
         return acc;

--- a/src/extensions/nexus_integration/util/guessModID.ts
+++ b/src/extensions/nexus_integration/util/guessModID.ts
@@ -169,7 +169,7 @@ export function fillNexusIdByMD5(api: IExtensionApi,
                 ];
                 // The only way for us to correctly assume the mod's version at this
                 //  point, is if we managed to confirm that the installed mod is the latest fileId.
-                if (!isNewestVersion) {
+                if (isNewestVersion) {
                   batched.push(setModAttribute(gameId, mod.id, 'version', mod.attributes.newestVersion));
                 } else {
                   // Let's try to guess the version from the filename and ask the user if it's correct.

--- a/src/extensions/nexus_integration/util/guessModID.ts
+++ b/src/extensions/nexus_integration/util/guessModID.ts
@@ -121,6 +121,8 @@ export function fillNexusIdByMD5(api: IExtensionApi,
                                  : Bluebird<void> {
   const hasValidIds = truthy(mod?.attributes?.modId) && truthy(mod?.attributes?.fileId);
   const isNewestVersion = hasValidIds && (mod?.attributes?.newestFileId === mod?.attributes?.fileId);
+  // We're not using the gameId in the query intentionally as we can't
+  //  determine the game based on fileNames of locally imported archives.
   return api.lookupModMeta({
     fileMD5: mod.attributes?.fileMD5,
     fileName,


### PR DESCRIPTION
- Fixed inability to resolve NXM uri when multiple files with the same version exist.
- Added ability to resolve the mod version based on the fileName (the user will have to indicate whether it's correct or not)
- Added automatic version resolution for when we confirm that the currently locally imported download is the latest file available on the website

This issue is a fix for ids resolution raised by SP3CNAZ on Discord
