### PR TITLE
fixed recursive folder creation during staging path transfer

### DIFF
--- a/__tests__/util.transferpath.test.js
+++ b/__tests__/util.transferpath.test.js
@@ -84,6 +84,10 @@ jest.mock('../src/util/fs', () => {
         size: 0,
       });
     },
+    ensureDirWritableAsync: jest.fn((dirPath) => {
+      insert(dirPath, { });
+      return Promise.resolve();
+    }),
     mkdirsAsync: jest.fn(dirPath => {
       insert(dirPath, { });
       return Promise.resolve();

--- a/src/util/transferPath.ts
+++ b/src/util/transferPath.ts
@@ -168,7 +168,7 @@ export function transferPath(source: string,
         const destPath = path.join(dest, path.relative(source, entry.filePath));
         return isCancelled
           ? Promise.reject(new UserCanceled())
-          : fs.mkdirsAsync(destPath).catch(err => (err.code === 'EEXIST')
+          : fs.ensureDirWritableAsync(destPath).catch(err => (err.code === 'EEXIST')
             ? Promise.resolve()
             : Promise.reject(err));
       })


### PR DESCRIPTION
fs-extra's recursive directory creation is not reliable; now using fs.ensureDirWritableAsync which is "battle" tested.

(Will apply to downloads too)

fixes nexus-mods/vortex#16710