### PR TITLE
Added sanity check to the setLoadOrder action

### DIFF
--- a/src/extensions/file_based_loadorder/index.ts
+++ b/src/extensions/file_based_loadorder/index.ts
@@ -367,6 +367,15 @@ export default function init(context: IExtensionContext) {
     Interface,
   );
 
+  context.registerActionCheck('SET_FB_LOAD_ORDER', (state, action: any) => {
+      const { profileId, loadOrder } = action.payload;
+      const profile = selectors.profileById(state, profileId);
+      if (updateSet && profile !== undefined) {
+        updateSet.init(profile.gameId, loadOrder.map((lo, idx) => ({ ...lo, index: idx })));
+      }
+      return undefined;
+    });
+
   context.once(() => {
     updateSet = new UpdateSet(context.api, (gameId: string) => {
       const gameEntry: ILoadOrderGameInfo = findGameEntry(gameId);

--- a/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
+++ b/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
@@ -2,7 +2,7 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { Panel } from 'react-bootstrap';
-import { WithTranslation, withTranslation } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import * as actions from '../../../actions/index';


### PR DESCRIPTION
- This will ensure that the updateSet is initialized correctly even when extension developers are forcefully setting the load order (during load order import from an external file for example)
For more info please see:
https://forums.nexusmods.com/topic/13506039-vortex-bg3-bug-with-latest-update-cannot-import-load-order-from-file/#comment-130486697