### PR TITLE
fixed lo being automatically restored upon validation error

### DIFF
--- a/src/extensions/file_based_loadorder/UpdateSet.ts
+++ b/src/extensions/file_based_loadorder/UpdateSet.ts
@@ -1,17 +1,11 @@
 /* eslint-disable */
-import {
-  IExtensionApi,
-} from '../../types/IExtensionContext';
-import {getSafe} from '../../util/storeHelper';
+import { IExtensionApi, IMod } from '../../types/api';
+import { getSafe } from '../../util/storeHelper';
 
 import * as _ from 'lodash';
-import { ILoadOrderEntry } from './types/types';
+import { ILoadOrderEntry, ILoadOrderEntryExt } from './types/types';
 import { log } from '../../util/log';
 import { activeGameId, lastActiveProfileForGame } from '../profile_management/selectors';
-
-export interface ILoadOrderEntryExt extends ILoadOrderEntry {
-  index: number;
-}
 
 export default class UpdateSet extends Set<number> {
   private mApi: IExtensionApi;
@@ -53,7 +47,7 @@ export default class UpdateSet extends Set<number> {
       return;
     }
     this.mInitialized = true;
-    modEntries = !!modEntries && Array.isArray(modEntries) ? modEntries : this.genExtendedItemsFromState();
+    modEntries = (!!modEntries && Array.isArray(modEntries)) ? modEntries : this.genExtendedItemsFromState();
     modEntries.forEach((iter: ILoadOrderEntryExt) => this.addNumericModId(iter));
   }
 
@@ -71,8 +65,11 @@ export default class UpdateSet extends Set<number> {
     if (!loadOrder || !Array.isArray(loadOrder)) {
       return [];
     }
+
+    const mods: { [modId: string]: IMod } = getSafe(state, ['persistent', 'mods', gameMode], {});
     const filtered = loadOrder.reduce((acc, lo, idx) => {
-      acc.push({ ...lo, index: idx });
+      const fileId = getSafe(mods[lo.modId], ['attributes', 'fileId'], undefined);
+      acc.push({ ...lo, index: idx, fileId });
       return acc;
     }, []);
     return filtered;

--- a/src/extensions/file_based_loadorder/collections/loadOrder.ts
+++ b/src/extensions/file_based_loadorder/collections/loadOrder.ts
@@ -9,10 +9,10 @@ import {
   ICollectionLoadOrder, IGameSpecificInterfaceProps,
 } from '../types/collections';
 
-import { ILoadOrderGameInfoExt, IValidationResult, LoadOrderValidationError } from '../types/types';
+import { ILoadOrderGameInfoExt } from '../types/types';
 
 import { findGameEntry } from '../gameSupport';
-import { genCollectionLoadOrder } from '../util';
+import { genCollectionLoadOrder, toExtendedLoadOrderEntry } from '../util';
 
 import LoadOrderCollections from '../views/LoadOrderCollections';
 import UpdateSet from '../UpdateSet';
@@ -59,7 +59,7 @@ export async function parser(api: types.IExtensionApi,
     return Promise.reject(new CollectionParseError(collection, 'Invalid profile id'));
   }
 
-  updateSet.init(gameId, (collection.loadOrder ?? []).map((lo, index) => ({ ...lo, index })));
+  updateSet.init(gameId, (collection.loadOrder ?? []).map(toExtendedLoadOrderEntry(api)));
   api.store.dispatch(setFBLoadOrder(profileId, collection.loadOrder));
   return Promise.resolve(undefined);
 }

--- a/src/extensions/file_based_loadorder/types/types.ts
+++ b/src/extensions/file_based_loadorder/types/types.ts
@@ -18,6 +18,20 @@ export interface IItemRendererProps {
   setRef?: (ref: any) => void;
 }
 
+// Used by the update set to restore the order of the load order entries after
+//  a mod update/re-install.
+export interface ILoadOrderEntryExt extends ILoadOrderEntry {
+  // The known index of this entry.
+  index: number;
+
+  // The fileId of the mod to which this LO entry belongs.
+  //  There's currently no reliable way to determine the version of the mod
+  //  due to BE data - the fileId is the only unique identifier we can use
+  //  to detect a version change. (this is optional as some load order entries
+  //  may be managed externally and not have a fileId)
+  fileId?: number | undefined;
+}
+
 export interface ILoadOrderEntry<T = any> {
   // An arbitrary unique id for the load order item
   id: string;

--- a/src/extensions/file_based_loadorder/util.ts
+++ b/src/extensions/file_based_loadorder/util.ts
@@ -1,12 +1,22 @@
 /* eslint-disable */
 import * as types from '../../types/api';
 import * as util from '../../util/api';
-import { lastActiveProfileForGame } from '../profile_management/selectors';
+import { activeGameId, lastActiveProfileForGame } from '../profile_management/selectors';
 import { findGameEntry } from './gameSupport';
 import { ILoadOrderGameInfoExt, IValidationResult, LoadOrder,
-  LoadOrderSerializationError, LoadOrderValidationError } from './types/types';
+  LoadOrderSerializationError, LoadOrderValidationError, ILoadOrderEntryExt } from './types/types';
 
 import { setValidationResult } from './actions/session'
+
+export const toExtendedLoadOrderEntry = (api: types.IExtensionApi) => {
+  return (entry: types.ILoadOrderEntry, index: number) => {
+    const state = api.getState();
+    const gameMode = activeGameId(state);
+    const mods = util.getSafe(state, ['persistent', 'mods', gameMode], {});
+    const fileId = mods[entry?.modId]?.attributes?.fileId;
+    return { ...entry, index, fileId } as ILoadOrderEntryExt;
+  };
+}
 
 export function isModInCollection(collection: types.IMod, mod: types.IMod) {
   if (collection.rules === undefined) {

--- a/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
+++ b/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
@@ -270,7 +270,7 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
           <Panel>
             <PanelX.Body>
               <FilterBox currentFilterValue={this.state.filterText} setFilter={this.onFilter} />
-              <DNDContainer style={{ height: '100%' }}>
+              <DNDContainer style={{ height: '95%' }}>
                 <FlexLayout type='row' className='file-based-load-order-container'>
                   <FlexLayout.Flex className={listClasses.join(' ')}>
                     {draggableList()}


### PR DESCRIPTION
UpdateSet was being too overzealous, restoring the LO to the last known working setup whenever it would encounter a validation error, erasing the console contents and providing no feedback regarding what went wrong.

fixes nexus-mods/vortex#17249