### PR TITLE
fixed inability to update site domain tools

### DIFF
--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -47,7 +47,6 @@ import GoPremiumDashlet from './views/GoPremiumDashlet';
 import LoginDialog from './views/LoginDialog';
 import LoginIcon from './views/LoginIcon';
 import { } from './views/Settings';
-import * as semver from 'semver';
 
 import {
   genCollectionIdAttribute,

--- a/src/extensions/nexus_integration/util/convertGameId.ts
+++ b/src/extensions/nexus_integration/util/convertGameId.ts
@@ -102,6 +102,9 @@ export function toNXMId(game: IGameStoredExt, gameId: string): string {
   if (game === null) {
     return SITE_ID;
   }
+  if (!!game.downloadGameId && game.downloadGameId !== game.id) {
+    return game.downloadGameId;
+  }
   if (game?.details !== undefined) {
     if (game.details.nxmLinkId !== undefined) {
       return game.details.nxmLinkId;


### PR DESCRIPTION
- This was caused by use of the legacy property "nexusPageId" which used to completely override the domain for generated download links

fixes nexus-mods/vortex#16480