### PR TITLE
Bugfix-17465: Fix ToolButton run menu item

### DIFF
--- a/src/extensions/starter_dashlet/ToolButton.tsx
+++ b/src/extensions/starter_dashlet/ToolButton.tsx
@@ -58,7 +58,7 @@ function ToolButton(props: IToolButtonProps) {
     {
       title: 'Run',
       icon: 'launch-simple',
-      action: () => run,
+      action: run,
       condition: () => valid ? true : t('Not configured') as string,
     },
     {


### PR DESCRIPTION
This PR is to fix issue #17465 where the `Run` menu item of the tool button won't start the tool.