### PR TITLE
fixed incorrect identification of updated fileIds

### DIFF
--- a/src/extensions/file_based_loadorder/index.ts
+++ b/src/extensions/file_based_loadorder/index.ts
@@ -114,8 +114,8 @@ async function genLoadOrderChange(api: types.IExtensionApi, oldState: any, newSt
       return acc;
     }
     const currFileId = util.getSafe(state, ['persistent', 'mods', profile.gameId, lo?.modId, 'attributes', 'fileId'], undefined);
-    const prevFileId = updateSet.findEntry(lo)?.entries?.[0]?.fileId;
-    if (currFileId !== prevFileId) {
+    const prevFileId = updateSet.findEntry(lo)?.entries?.filter(e => e.id === lo.id && e.name === lo.name)?.[0]?.fileId ?? -1;
+    if (!!currFileId && currFileId !== prevFileId) {
       updateSet.shouldRestore = true;
       return acc;
     }


### PR DESCRIPTION
Another instance that could potentially cause FBLO to think it needs to restore the loadorder when in fact it was querying the wrong lo entry.

This is only reproduceable when downloading two or more main files from the same mod page.