### PR TITLE
fixed default blacklist entries being ignored

### DIFF
--- a/src/extensions/mod_management/index.ts
+++ b/src/extensions/mod_management/index.ts
@@ -67,6 +67,7 @@ import {TestSupported} from './types/TestSupported';
 import { fallbackPurge, loadActivation,
         saveActivation, withActivationLock } from './util/activationStore';
 import allTypesSupported from './util/allTypesSupported';
+import BlacklistSet from './util/BlacklistSet';
 import * as basicInstaller from './util/basicInstaller';
 import { genSubDirFunc, purgeMods, purgeModsInPath } from './util/deploy';
 import { getAllActivators, getCurrentActivator, getSelectedActivator,
@@ -91,7 +92,6 @@ import Workarounds from './views/Workarounds';
 
 import { opn } from '../../util/api';
 
-import { DEPLOY_BLACKLIST } from './constants';
 import { onAddMod, onGameModeActivated, onModsChanged, onPathsChanged,
          onRemoveMod, onRemoveMods, onStartInstallDownload } from './eventHandlers';
 import InstallManager from './InstallManager';
@@ -103,7 +103,6 @@ import { findModByRef } from './util/dependencies';
 
 import Promise from 'bluebird';
 import * as _ from 'lodash';
-import minimatch from 'minimatch';
 import * as path from 'path';
 import React from 'react';
 import * as Redux from 'redux';
@@ -129,19 +128,6 @@ interface IInstaller {
 const installers: IInstaller[] = [];
 
 const mergers: IFileMerge[] = [];
-
-class BlacklistSet extends Set<string> {
-  private mPatterns: string[];
-  constructor(blacklist: string[], game: IGame, normalize: Normalize) {
-    super(blacklist.map(iter => normalize(iter)));
-    this.mPatterns = [].concat(DEPLOY_BLACKLIST, game.details?.ignoreDeploy ?? []);
-  }
-
-  public has(value: string): boolean {
-    return super.has(value)
-      || (this.mPatterns.find(pat => minimatch(value, pat, { nocase: true })) !== undefined);
-  }
-}
 
 function registerInstaller(id: string,
                            priority: number,

--- a/src/extensions/mod_management/modActivation.ts
+++ b/src/extensions/mod_management/modActivation.ts
@@ -5,6 +5,7 @@ import getNormalizeFunc, { Normalize } from '../../util/getNormalizeFunc';
 import { log } from '../../util/log';
 import { truthy } from '../../util/util';
 
+import BlacklistSet from './util/BlacklistSet';
 import { IDeployedFile, IDeploymentMethod } from './types/IDeploymentMethod';
 import { IMod } from './types/IMod';
 import renderModName from './util/modName';
@@ -47,7 +48,7 @@ function deployMods(api: IExtensionApi,
                     method: IDeploymentMethod,
                     lastActivation: IDeployedFile[],
                     typeId: string,
-                    skipFiles: Set<string>,
+                    skipFiles: BlacklistSet,
                     subDir: (mod: IMod) => string,
                     progressCB?: (name: string, progress: number) => void,
                    ): Promise<IDeployedFile[]> {
@@ -70,12 +71,11 @@ function deployMods(api: IExtensionApi,
           progressCB(renderModName(mod), Math.round((idx * 50) / length));
         }
         const modPath = path.join(installationPath, mod.installationPath);
-        const overrides = new Set<string>(skipFiles);
         if (mod.fileOverrides !== undefined) {
           mod.fileOverrides.map(file => path.relative(destinationPath, file))
-                           .forEach(file => overrides.add(normalize(file)));
+                           .forEach(file => skipFiles.add(normalize(file)));
         }
-        return method.activate(modPath, mod.installationPath, subDir(mod), overrides);
+        return method.activate(modPath, mod.installationPath, subDir(mod), skipFiles);
       } catch (err) {
         log('error', 'failed to deploy mod', {err: err.message, id: mod.id});
       }

--- a/src/extensions/mod_management/util/BlacklistSet.ts
+++ b/src/extensions/mod_management/util/BlacklistSet.ts
@@ -1,0 +1,17 @@
+import minimatch from 'minimatch';
+import { DEPLOY_BLACKLIST } from '../constants';
+import { Normalize } from '../../../util/getNormalizeFunc';
+import { IGame } from '../../../types/IGame';
+
+export default class BlacklistSet extends Set<string> {
+  private mPatterns: string[];
+  constructor(blacklist: string[], game: IGame, normalize: Normalize) {
+    super(blacklist.map(iter => normalize(iter)));
+    this.mPatterns = [].concat(DEPLOY_BLACKLIST, game.details?.ignoreDeploy ?? []);
+  }
+
+  public has(value: string): boolean {
+    return super.has(value)
+      || (this.mPatterns.find(pat => minimatch(value, pat, { nocase: true })) !== undefined);
+  }
+}


### PR DESCRIPTION
the ignoreDeploy property when defining a game extension alongside all other default ignore patterns weren't being passed to the deployment method correctly. This would cause unnecessary conflicts and actually deploy those files.