### PR TITLE
Adding ability to update all nexus sourced mods in one go

### DIFF
--- a/src/extensions/nexus_integration/index.tsx
+++ b/src/extensions/nexus_integration/index.tsx
@@ -1039,6 +1039,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
   api.events.on('endorse-mod', eh.onEndorseMod(api, nexus));
   api.events.on('submit-feedback', eh.onSubmitFeedback(nexus));
   api.events.on('submit-collection', eh.onSubmitCollection(nexus));
+  api.events.on('mods-update', eh.onModsUpdate(api, nexus));
   api.events.on('mod-update', eh.onModUpdate(api, nexus));
   api.events.on('open-collection-page', eh.onOpenCollectionPage(api));
   api.events.on('open-mod-page', eh.onOpenModPage(api));


### PR DESCRIPTION
- The check for updates drop down menu now has a new "Apply All Updates" entry which will run a full update check and install those updates in sequence.
- Other update check entries will raise a notification with an "Update All" button once the check completes.

Closes #17381 