### PR TITLE
fixed game store helper potentially losing data during discovery

### DIFF
--- a/src/util/GameStoreHelper.ts
+++ b/src/util/GameStoreHelper.ts
@@ -413,7 +413,7 @@ class GameStoreHelper {
 
           return Bluebird.resolve(accum);
         })
-        .catch(GameEntryNotFound, () => Bluebird.resolve([])), [])
+        .catch(GameEntryNotFound, () => Bluebird.resolve(accum)), [])
       .then(foundEntries => {
         // TODO: A cool future feature here would be to allow the user to select
         //  the gamestore he wants to use. But for now, we just return the


### PR DESCRIPTION
this fixes an intermittent bug which was causing the game store helper to lose track of previously discovered entries when looping through the game stores

fixes nexus-mods/vortex#17373