### PR TITLE
fixed blacklist blocking deployment when file overrides defined

### DIFF
--- a/src/extensions/mod_management/modActivation.ts
+++ b/src/extensions/mod_management/modActivation.ts
@@ -72,8 +72,12 @@ function deployMods(api: IExtensionApi,
         }
         const modPath = path.join(installationPath, mod.installationPath);
         if (mod.fileOverrides !== undefined) {
-          mod.fileOverrides.map(file => path.relative(destinationPath, file))
-                           .forEach(file => skipFiles.add(normalize(file)));
+          mod.fileOverrides.map(file => {
+            const relPath = path.relative(destinationPath, file);
+            const relPathWithSource = path.join(mod.installationPath, relPath);
+            const normRelPathWithSource = normalize(relPathWithSource);
+            return normRelPathWithSource;
+          }).forEach(file => skipFiles.add(file));
         }
         return method.activate(modPath, mod.installationPath, subDir(mod), skipFiles);
       } catch (err) {


### PR DESCRIPTION
Reproducing this requires the user to define a set of file level conflict overrides. The blacklist would then wrongly stop all instances of that specific file from being deployed.