### PR TITLE
bypass file override checks if no instructions were generated

### DIFF
--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -1138,7 +1138,9 @@ class InstallManager {
             unattended,
             archivePath
           );
-
+          if (!installerResult.instructions) {
+            return installerResult;
+          }
           const overrideInstructionsFilePresentInArchive = fileList.some(file =>
             path.basename(file) === VORTEX_OVERRIDE_INSTRUCTIONS_FILENAME);
 


### PR DESCRIPTION
Some installers are intentionally used to block users from installing certain downloads (e.g. Witcher 3 script merger). Under these cases the installer might not produce any instructions at all so there is no point in checking for the existence of an override instructions file.

fixes nexus-mods/vortex#17708