### PR TITLE
fixed potential attempts to start downloads that have already started

### DIFF
--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -1147,6 +1147,10 @@ class DownloadManager {
     this.mSpeedCalculator.initCounter(workerId);
 
     const job: IDownloadJob = download.chunks.find(ele => ele.state === 'init');
+    if (!job) {
+      // No init chunks? no problem.
+      return Bluebird.resolve();
+    }
     job.state = 'running';
     job.workerId = workerId;
 


### PR DESCRIPTION
When using multiple download threads, it is posssible for a previously available chunk to have been picked up by another worker while trying to start a download

fixes nexus-mods/vortex#17713