### PR TITLE
fixed race condition causing file not found errors

### DIFF
--- a/src/extensions/download_management/util/postprocessDownload.ts
+++ b/src/extensions/download_management/util/postprocessDownload.ts
@@ -38,7 +38,7 @@ export function finalizeDownload(api: IExtensionApi, id: string,
     })
     .then(() => {
       api.store.dispatch(finishDownload(id, 'finished', undefined));
-      queryInfo(api, [id], false);
+      return queryInfo(api, [id], false);
     })
     .finally(() => {
       // still storing the download as successful even if we didn't manage to calculate its


### PR DESCRIPTION
Upon successful download of a mod/archive, Vortex checks the archive's md5 to retrieve metadata information, this will sometimes cause the archive to be moved to a new location (e.g. BepInEx moved to 'site' domain or some other domain which has an md5 match)

Post processing the download will now ensure that the installation of the mod occurrs from the right path. (Unfortunately we cannot currently control which domain provides the md5 match very well)

This is part of nexus-mods/vortex#17799
And also a better fix for nexus-mods/vortex#17808