### PR TITLE
fixed file based override instructions not being applied correctly

### DIFF
--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -1490,8 +1490,8 @@ class InstallManager {
       return Bluebird.reject(new ProcessCanceled('Empty archive or no options selected'));
     }
 
-    const isInstallingDependencies = getBatchContext('install-dependencies', '', false) !== undefined;
-    if (isInstallingDependencies) {
+    const batchContext = getBatchContext('install-dependencies', '', false);
+    if (unattended && batchContext.itemCount > 0) {
       // we don't want to override any instructions when installing as part of a collection!
       //  this will just add extra complexity to an already complex process.
       result.overrideInstructions = [];


### PR DESCRIPTION
previously the check for whether the user is actively installing a mod through a dependency was too strict and could cause the override instructions to never apply.

improved overall detection of whether the mod is being installed as a dependency, which intentionally does not allow override instructions