### PR TITLE
fixed intermittent erroneous version identification for downloads

### DIFF
--- a/src/extensions/download_management/index.ts
+++ b/src/extensions/download_management/index.ts
@@ -137,7 +137,7 @@ function attributeExtractor(input: any) {
     fileMD5: getSafe(input, ['download', 'fileMD5'], undefined),
     fileSize: getSafe(input, ['download', 'size'], undefined),
     source: getSafe(input, ['download', 'modInfo', 'source'], undefined),
-    version: getSafe(input, ['download', 'modInfo', 'version'], undefined),
+    version: getSafe(input, ['download', 'modInfo', 'version'], undefined) ?? getSafe(input, ['download', 'modInfo', 'meta', 'fileVersion'], undefined),
     logicalFileName,
     modId: getSafe(input, ['download', 'modInfo', 'ids', 'modId'], undefined),
     fileId: getSafe(input, ['download', 'modInfo', 'ids', 'fileId'], undefined),

--- a/src/extensions/mod_management/util/filterModInfo.ts
+++ b/src/extensions/mod_management/util/filterModInfo.ts
@@ -21,9 +21,10 @@ function filterNullish(input: { [key: string]: any }) {
 function extractorOrSkip(extractor: AttributeExtractor, input: any, modPath: string): Promise<any> {
   return Promise.race([
     extractor(input, modPath),
-    new Promise((_, reject) => setTimeout(() => reject(new Error('Extractor timed out')), 1000))
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Extractor timed out')), 2000))
   ]).catch(err => {
-    log('error', `Extractor skipped: "${extractor.name ?? extractor.toString()}" - ${err.message}`);
+    const extractorName = extractor.name || extractor.constructor?.name || '[anonymous extractor]';
+    log('error', `Extractor skipped: "${extractorName}" (modPath: "${modPath}") - ${err.message}`);
     return {};
   });
 }


### PR DESCRIPTION
This would cause collections to fail to recognize when certain mod versions are already installed as the extractor would file to resolve the file version.

Also increased the extractor timeout to 2 seconds