### PR TITLE
fixed profile mod sanitization causing long profile switches

### DIFF
--- a/src/extensions/profile_management/index.ts
+++ b/src/extensions/profile_management/index.ts
@@ -33,7 +33,7 @@ import onceCB from '../../util/onceCB';
 import presetManager from '../../util/PresetManager';
 import { discoveryByGame, gameById, installPathForGame, needToDeployForGame } from '../../util/selectors';
 import { getSafe } from '../../util/storeHelper';
-import { truthy } from '../../util/util';
+import { batchDispatch, truthy } from '../../util/util';
 
 import { IExtension } from '../extension_manager/types';
 import { readExtensions } from '../extension_manager/util';
@@ -77,15 +77,17 @@ function checkProfile(store: Redux.Store<any>, currentProfile: IProfile): Promis
 
 function sanitizeProfile(store: Redux.Store<any>, profile: IProfile): void {
   const state: IState = store.getState();
+  const batched = [];
   Object.keys(profile.modState || {}).forEach(modId => {
     if (getSafe(state.persistent.mods, [profile.gameId, modId], undefined) === undefined) {
       log('debug', 'removing info of missing mod from profile', {
         profile: profile.id,
         game: profile.gameId,
         modId });
-      store.dispatch(forgetMod(profile.id, modId));
+      batched.push(forgetMod(profile.id, modId));
     }
   });
+  batchDispatch(store, batched);
 }
 
 function refreshProfile(store: Redux.Store<any>, profile: IProfile,


### PR DESCRIPTION
Previously the profile sanitization functionality would remove mods at a rate of 1 mod per second which would cause incredibly long wait times if the user re-installed Vortex and the previous profile had missing mods.

This is now far faster as we batch state cleanup

fixes nexus-mods/vortex#18073