### PR TITLE
added error details sanitization to prevent crashpad issues

### DIFF
--- a/src/util/ExtensionManager.ts
+++ b/src/util/ExtensionManager.ts
@@ -1976,8 +1976,14 @@ class ExtensionManager {
                         ? lines[lines.length - 1]
                         : lines.join('\n');
                     }
+
+                    // Sanitize the error message to prevent crashpad issues
+                    const sanitizedExecutable = executable.replace(/[^\x20-\x7E]/g, '?');
+                    const sanitizedLastLine = lastLine.replace(/[^\x20-\x7E]/g, '?').substring(0, 500);
+                    const exitCodeHex = code.toString(16);
+
                     const err: any = new Error(
-                      `Failed to run "${executable}": "${lastLine} (${code.toString(16)})"`);
+                      `Failed to run "${sanitizedExecutable}": "${sanitizedLastLine} (${exitCodeHex})"`);
                     err.exitCode = code;
                     return reject(err);
                   }


### PR DESCRIPTION
- only keep printable ASCII characters
- truncated error message just in case
- pre-computing hex conversion to avoid potential issues during error creation

Please note: the actual issue we want to fix is the LOOT process failing to start, but the error reports are incomplete due to the crash pad and we therefore cannot debug/check why the process dies.

We should be able to get the actual error message in future releases.

fixes nexus-mods/vortex#18251
fixes nexus-mods/vortex#18250