### PR TITLE
fixed crash if category data is corrupted

### DIFF
--- a/src/extensions/category_management/util/CategoryFilter.tsx
+++ b/src/extensions/category_management/util/CategoryFilter.tsx
@@ -230,7 +230,7 @@ class CategoryFilter implements ITableFilter {
     if ((patterns.length > 0) && (value !== undefined)) {
       const gameId = activeGameId(state);
       const catName = state.persistent.categories[gameId]?.[value];
-      if ((catName !== undefined)
+      if ((catName?.name != null)
           && (patterns.find(pat => catName.name.toLowerCase().includes(pat)) !== undefined)) {
         return true;
       }


### PR DESCRIPTION
fixes nexus-mods/vortex#18283

We have a validator defined in the state reducer which will set the category data to default values upon app restart