### PR TITLE
Added nexus mods id section to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Your Nexus Mods id**
+**Your Nexus Mods username**
 Will help us debug your issue.
 
 **Describe the bug**


### PR DESCRIPTION
This will assist us to verify the user's membership status and view their download lists in attempts to reproduce/diagnose their modding environment