### PR TITLE
fixed instruction overlay's inability to render react components

### DIFF
--- a/src/extensions/instructions_overlay/actions.ts
+++ b/src/extensions/instructions_overlay/actions.ts
@@ -3,8 +3,8 @@ import safeCreateAction from '../../actions/safeCreateAction';
 import { IOverlayOptions, IPosition } from '../../types/api';
 
 export const showOverlay = safeCreateAction('SHOW_INSTRUCTIONS',
-  (id: string, title: string, content: string | React.ComponentType<any>, pos: IPosition, options: IOverlayOptions) =>
-    ({ id, title, content, pos, options }));
+  (id: string, title: string, content: string, componentId: string, pos: IPosition, options: IOverlayOptions) =>
+    ({ id, title, content, componentId, pos, options }));
 
 export const dismissOverlay = safeCreateAction('DISMISS_INSTRUCTIONS',
   (id: string) => id);

--- a/src/extensions/instructions_overlay/reducer.ts
+++ b/src/extensions/instructions_overlay/reducer.ts
@@ -7,7 +7,7 @@ const sessionReducer: IReducerSpec<IOverlaysState> = {
   reducers: {
     ...addReducer(actions.showOverlay, (state, payload) =>
       setSafe(state, ['overlays', payload.id],
-        { title: payload.title, content: payload.content, position: payload.pos, options: payload.options })),
+        { title: payload.title, content: payload.content, componentId: payload.componentId, position: payload.pos, options: payload.options })),
     ...addReducer(actions.dismissOverlay, (state, payload) =>
       deleteOrNop(state, ['overlays', payload])),
   },

--- a/src/extensions/onboarding_dashlet/index.ts
+++ b/src/extensions/onboarding_dashlet/index.ts
@@ -26,17 +26,20 @@ function init(context: IExtensionContext): boolean {
           context.api.store.dispatch(dismissOverlay(x));
         });
 
+        const props = {
+          desc,
+          url: video,
+          id,
+          isCompleted: context.api.store.getState().settings.onboardingsteps?.steps[id],
+          closeOverlay: () => context.api.ext.dismissOverlay(id),
+        };
+
         context.api.ext.showOverlay(id, undefined, Overlay, pos, {
           containerTitle: title,
           showIcon: false,
           className: 'overlay-onboarding',
           disableCollapse: true,
-          props: () => ({
-            desc,
-            url: video,
-            id,
-            isCompleted: context.api.store.getState().settings.onboardingsteps?.steps[id],
-          }),
+          props,
         });
       },
       getMoreMods: () => {

--- a/src/types/IState.ts
+++ b/src/types/IState.ts
@@ -316,7 +316,8 @@ export interface IModTable {
 
 export interface IOverlay {
   title: string;
-  content: string | React.ComponentType<any>;
+  content?: string; // Text/markdown content
+  componentId?: string; // Registry ID for React components
   position: IPosition;
   options?: IOverlayOptions;
 }


### PR DESCRIPTION
Please never use the redux store to store entire components. The signature will never match when used somewhere else in the application.

fixes nexus-mods/vortex#18410