### PR TITLE
adding permissions field to queries

### DIFF
--- a/src/extensions/nexus_integration/util.ts
+++ b/src/extensions/nexus_integration/util.ts
@@ -585,6 +585,10 @@ export function getCollectionInfo(nexus: Nexus,
     id: true,
     collection: {
       viewerIsBlocked: true,
+      permissions: {
+        global: true,
+        key: true,
+      },
       category: {
         id: true,
         name: true,
@@ -1189,6 +1193,10 @@ export function checkForCollectionUpdates(store: Redux.Store<any>,
   return BluebirdPromise.all(collectionIds.map(modId => {
     const query: Partial<ICollectionQuery> = {
       viewerIsBlocked: true,
+      permissions: {
+        global: true,
+        key: true,
+      },
       revisions: {
         revisionNumber: true,
         id: true,

--- a/src/extensions/nexus_integration/util/graphQueries.ts
+++ b/src/extensions/nexus_integration/util/graphQueries.ts
@@ -96,6 +96,10 @@ export const FULL_COLLECTION_INFO: ICollectionQuery = {
   overallRating: true,
   overallRatingCount: true,
   viewerIsBlocked: true,
+  permissions: {
+    global: true,
+    key: true,
+  },
   recentRating: true,
   recentRatingCount: true,
 };


### PR DESCRIPTION
closes nexus-mods/vortex#18453

requires:
https://github.com/Nexus-Mods/extension-collections/pull/64

### How to test

Testing should be done using two non-admin accounts as all admin accounts have the ability to edit a collection.

User A creates a collection, publishes it and gives permissions to User B

User B downloads the collection and clones it - after a permissions check, User B will be able to upload an update for the collection.

Functionality-wise, the permissions are asserted upon cloning a collection, you can confirm that it's working as the "Upload Update" button will appear instead of the "Upload New" button which is displayed when the user does not have permissions to edit the collection.

Please note that the myCollections query does not currently return collections where User B has been given permissions for, this is what is used to display uninstalled workshop collections automatically, and we therefore cannot display those in the workshop without User B cloning the collection.