### PR TITLE
adding api extension to wrap download observer event calls

### DIFF
--- a/src/extensions/download_management/DownloadObserver.ts
+++ b/src/extensions/download_management/DownloadObserver.ts
@@ -28,6 +28,7 @@ import { IChunk } from './types/IChunk';
 import { IDownload, IDownloadOptions } from './types/IDownload';
 import { IDownloadResult } from './types/IDownloadResult';
 import { ProgressCallback } from './types/ProgressCallback';
+import { IStartDownloadOptions } from './types/IStartDownloadOptions';
 import { IDownloadRemoveOptions } from './types/IDownloadRemoveOptions';
 import { ensureDownloadsDirectory } from './util/downloadDirectory';
 import getDownloadGames from './util/getDownloadGames';
@@ -42,7 +43,6 @@ import { generate as shortid } from 'shortid';
 import { getGames } from '../gamemode_management/util/getGame';
 import { util } from '../..';
 import { ModsDownloadCompletedEvent, ModsDownloadFailedEvent, ModsDownloadCancelledEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadCancelledEvent, CollectionsDownloadFailedEvent } from '../analytics/mixpanel/MixpanelEvents';
-import { isArray } from 'lodash';
 import { nexusIdsFromDownloadId } from '../nexus_integration/selectors';
 import { makeModAndFileUIDs } from '../nexus_integration/util/UIDs';
 
@@ -71,14 +71,6 @@ function progressUpdate(store: Redux.Store<any>, dlId: string, received: number,
   if (updates.length > 0) {
     util.batchDispatch(store.dispatch, updates);
   }
-}
-
-export interface IStartDownloadOptions {
-  // whether the download may be auto-installed if the user has that set up for mods (default: true)
-  // if set to 'force', the download will be installed independent of the user config
-  allowInstall?: boolean | 'force';
-  // whether the url should be opened in the embedded browser if it's html (default: true)
-  allowOpenHTML?: boolean;
 }
 
 /**

--- a/src/extensions/download_management/index.ts
+++ b/src/extensions/download_management/index.ts
@@ -61,6 +61,7 @@ import { ensureLoggedIn } from '../nexus_integration/util';
 import NXMUrl from '../nexus_integration/NXMUrl';
 import { knownGames } from '../../util/selectors';
 import { convertNXMIdReverse, convertGameIdReverse } from '../nexus_integration/util/convertGameId';
+import extendAPI from './util/extendApi';
 
 const remote = lazyRequire<typeof RemoteT>(() => require('@electron/remote'));
 
@@ -969,6 +970,7 @@ function init(context: IExtensionContextExt): boolean {
     () => checkPendingTransfer(context.api));
 
   context.once(() => {
+    Object.assign(context.api.ext, extendAPI(context.api));
     const DownloadManagerImpl: typeof DownloadManager = require('./DownloadManager').default;
     const observeImpl: typeof observe = require('./DownloadObserver').default;
 

--- a/src/extensions/download_management/types/IDownloadsAPIExtension.ts
+++ b/src/extensions/download_management/types/IDownloadsAPIExtension.ts
@@ -1,0 +1,20 @@
+import { IDownloadRemoveOptions } from '../types/IDownloadRemoveOptions';
+import { IDownloadResult } from './IDownloadResult';
+import { IStartDownloadOptions } from '../types/IStartDownloadOptions';
+import { RedownloadMode } from '../DownloadManager';
+
+export interface IDownloadsAPIExtension {
+  removeDownload?: (downloadId: string, options?: IDownloadRemoveOptions) => Promise<void>;
+
+  pauseDownload?: (downloadId: string) => Promise<void>;
+
+  resumeDownload?: (downloadId: string, options?: IStartDownloadOptions) => Promise<void>;
+
+  startDownload?: (
+    urls: string[],
+    modInfo: any,
+    fileName: string,
+    redownload?: RedownloadMode,
+    options?: IStartDownloadOptions
+  ) => Promise<IDownloadResult>;
+}

--- a/src/extensions/download_management/types/IStartDownloadOptions.ts
+++ b/src/extensions/download_management/types/IStartDownloadOptions.ts
@@ -1,0 +1,7 @@
+export interface IStartDownloadOptions {
+  // whether the download may be auto-installed if the user has that set up for mods (default: true)
+  // if set to 'force', the download will be installed independent of the user config
+  allowInstall?: boolean | 'force';
+  // whether the url should be opened in the embedded browser if it's html (default: true)
+  allowOpenHTML?: boolean;
+}

--- a/src/extensions/download_management/util/extendApi.ts
+++ b/src/extensions/download_management/util/extendApi.ts
@@ -1,0 +1,63 @@
+import { IExtensionApi } from '../../../types/IExtensionContext';
+import { IDownloadsAPIExtension } from '../types/IDownloadsAPIExtension';
+import { IDownloadRemoveOptions } from '../types/IDownloadRemoveOptions';
+import { IDownloadResult } from '../types/IDownloadResult';
+import { RedownloadMode } from '../DownloadManager';
+import { IStartDownloadOptions } from '../types/IStartDownloadOptions';
+
+function extendAPI(api: IExtensionApi): IDownloadsAPIExtension {
+  return {
+    removeDownload: async (downloadId: string, options?: IDownloadRemoveOptions): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        api.events.emit('remove-download', downloadId, (err: Error) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        }, options);
+      });
+    },
+    pauseDownload: async (downloadId: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        api.events.emit('pause-download', downloadId, (err: Error) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+    resumeDownload: async (downloadId: string, options?: IStartDownloadOptions): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        api.events.emit('resume-download', downloadId, (err: Error) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        }, options);
+      });
+    },
+    startDownload: async (
+      urls: string[],
+      modInfo: any,
+      fileName: string,
+      redownload?: RedownloadMode,
+      options?: IStartDownloadOptions
+    ): Promise<IDownloadResult> => {
+      return new Promise((resolve, reject) => {
+        api.events.emit('start-download', urls, modInfo, fileName, (err: Error, result: IDownloadResult) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result);
+          }
+        }, redownload, options);
+      });
+    }
+  };
+}
+
+export default extendAPI;

--- a/src/types/IExtensionContext.ts
+++ b/src/types/IExtensionContext.ts
@@ -52,6 +52,7 @@ import { ComplexActionCreator } from 'redux-act';
 import { ThunkDispatch } from 'redux-thunk';
 import { INexusAPIExtension } from '../extensions/nexus_integration/types/INexusAPIExtension';
 import { IModsAPIExtension } from '../extensions/mod_management/types/IModsAPIExtension';
+import { IDownloadsAPIExtension } from '../extensions/download_management/types/IDownloadsAPIExtension';
 
 export { TestSupported, IInstallResult, IInstruction, IDeployedFile, IDeploymentMethod,
          IFileChange, ILookupResult, IModInfo, IQuery, InstructionType, IReference, InstallFunc,
@@ -404,7 +405,7 @@ export interface IApiFuncOptions {
   minArguments?: number;
 }
 
-export interface IExtensionApiExtension extends INexusAPIExtension, IModsAPIExtension {
+export interface IExtensionApiExtension extends INexusAPIExtension, IModsAPIExtension, IDownloadsAPIExtension {
   ensureLoggedIn?: () => Promise<void>;
   awaitProfileSwitch?: () => Promise<string>;
   showOverlay?: (id: string, title: string,


### PR DESCRIPTION
Simplifies download observer related calls like startDownload, resumeDownload, etc.