### PR TITLE
re-adding download stall restart

### DIFF
--- a/src/util/CustomErrors.ts
+++ b/src/util/CustomErrors.ts
@@ -185,8 +185,8 @@ export class NotFound extends Error {
 }
 
 export class StalledError extends Error {
-  constructor() {
-    super('Operation stalled');
+  constructor(msg: string) {
+    super(msg);
     this.name = this.constructor.name;
   }
 }


### PR DESCRIPTION
we're encountering download workers stalls again where the backend isn't sending us data for over 15 seconds. Re-added the stall timeout but with a better restart mechanism

closes nexus-mods/vortex#18933