### PR TITLE
fixed infinite metadata loop

### DIFF
--- a/extensions/gamebryo-plugin-management/package.json
+++ b/extensions/gamebryo-plugin-management/package.json
@@ -39,7 +39,7 @@
     "immutability-helper": "^3.1.1",
     "js-yaml": "^4.1.0",
     "json-loader": "^0.5.7",
-    "loot": "Nexus-Mods/node-loot#18811-truncated-messages",
+    "loot": "Nexus-Mods/node-loot",
     "markdown-ast": "^0.2.1",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",

--- a/extensions/gamebryo-plugin-management/yarn.lock
+++ b/extensions/gamebryo-plugin-management/yarn.lock
@@ -1599,9 +1599,9 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loot@Nexus-Mods/node-loot#18811-truncated-messages:
+loot@Nexus-Mods/node-loot:
   version "6.1.1"
-  resolved "https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/108bb32ed37479a9acdf9d9343b32017a88640c5"
+  resolved "https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/4d5b5d1fff12f8a0ba02562b0a16066b3ea9312b"
   dependencies:
     autogypi "^0.2.2"
     lodash "^4.17.21"


### PR DESCRIPTION
FO4 mods with BA2 archives will contain a shit ton of duplicate references, libloot will warn about these duplicates and can easily go over 64KB over the IPC. Windows pipes are limited to 64KB, whenever this limit is breached, the message gets fragmented across multiple data events - we weren't catering for this scenario.

P.S. we no longer hide duplicate reference messages from the user.

closes nexus-mods/vortex#18811