### PR TITLE
Add Linux Devcontainer

### DIFF
--- a/.devcontainer/linux/devcontainer.json
+++ b/.devcontainer/linux/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  // Linux Dev Container to build Vortex.
+  // Usage is discouraged for peformance and ease of development reasons, prefer building directly on host.
+  // Clone the repo on host machine, start the container using VSCode Restart in Container command.
+  // Inside the container run `yarn install` and `yarn build` to build Vortex.
+  "name": "Vortex Linux Build",
+  "build": {
+    "dockerfile": "../../docker/linux/Dockerfile.devcontainer",
+    "context": "../.."
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "volta install node yarn",
+  "postStartCommand": "git config --global --add safe.directory /workspace",
+  "remoteUser": "root",
+  "containerEnv": {
+    "ELECTRON_DISABLE_GPU": "true",
+    "DISPLAY": "${localEnv:DISPLAY}",
+    "NO_PARALLEL": "true"
+  },
+  "runArgs": [
+    "--init"
+  ],
+  "forwardPorts": [],
+  "portsAttributes": {}
+}

--- a/docker/linux/Dockerfile.devcontainer
+++ b/docker/linux/Dockerfile.devcontainer
@@ -1,0 +1,32 @@
+# Vortex Development Container
+# Based on Ubuntu 24.04 with all build dependencies + Volta for Node.js/Yarn
+# For use with VS Code Dev Containers or GitHub Codespaces
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    libfontconfig1-dev \
+    ca-certificates \
+    xz-utils \
+    python3 \
+    python3-setuptools \
+    build-essential \
+    libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET SDK 9.0 (required for fomod-installer)
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 9.0
+ENV DOTNET_ROOT=/root/.dotnet
+ENV PATH="${PATH}:${DOTNET_ROOT}:${DOTNET_ROOT}/tools"
+
+# Install Volta (Node.js and Yarn installed via postCreateCommand)
+ENV VOLTA_HOME=/root/.volta
+ENV PATH="${VOLTA_HOME}/bin:${PATH}"
+RUN curl https://get.volta.sh | bash -s -- --skip-setup
+
+WORKDIR /workspace


### PR DESCRIPTION
This adds a Linux devcontainer configuration.

I tested this on Windows with Docker Desktop and WSL2 support.
`yarn build` took 90 minutes. I tried without `NO_PARALLEL` but I kept running into issues during `yarn build` without it.

It is not possible to run vortex inside the container at the moment (missing electron runtime dependencies).

If we want to try to get that working it should be investigated by someone with a Linux host as on windows iteration times are prohibitive.