### PR TITLE
WIP Dockerfiles for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,82 @@
+stages:
+  - build
+
+variables:
+  NO_PARALLEL: "true"
+  GIT_SUBMODULE_STRATEGY: recursive
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "web"
+
+# Prevent duplicate pipelines for merge requests
+.default_rules:
+  interruptible: true
+
+.build_template:
+  stage: build
+  interruptible: true
+  script:
+    - yarn --frozen-lockfile --network-timeout 600000 install
+    - yarn build
+
+build:linux:
+  extends: .build_template
+  tags:
+    - nexus_runner
+    # TODO: use our dockerfile image instead, don't install dependencies.
+  image: ubuntu:24.04
+  before_script:
+    - |
+      apt-get update && apt-get install -y curl git libfontconfig1-dev ca-certificates xz-utils python3 python3-setuptools build-essential libicu-dev
+
+      # Install .NET SDK 9.0
+      curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 9.0
+      export DOTNET_ROOT="$HOME/.dotnet"
+      export PATH="$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools"
+
+      # Install Volta and Node.js/Yarn
+      export VOLTA_HOME="$HOME/.volta"
+      export PATH="$VOLTA_HOME/bin:$PATH"
+      curl https://get.volta.sh | bash -s -- --skip-setup
+      volta install node yarn
+
+      # Print environment information
+      echo "=== Environment Version Information ==="
+      git --version
+      node --version
+      yarn --version
+      echo "=== End Environment Info ==="
+  script:
+    - yarn --frozen-lockfile --network-timeout 600000 install
+    - yarn build
+
+build:windows:
+  extends: .build_template
+  tags:
+    - windows
+  # Custom image with VS Build Tools 2022, Git, Python 3.10, .NET SDK 9
+  # Built from: docker/windows/Dockerfile
+  # TODO: Push to registry and update this reference
+  # image: vortex-ci-windows:ltsc2022
+  variables:
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "core.longpaths"
+    GIT_CONFIG_VALUE_0: "true"
+    NO_PARALLEL: "true"
+  before_script:
+    # Install Node and Yarn via Volta (reads versions from package.json)
+    - volta install node yarn
+
+    # Configure node-gyp to use VS 2022
+    - $env:npm_config_msvs_version = "2022"
+    - $env:GYP_MSVS_VERSION = "2022"
+
+    # Mark directory as safe for Git
+    - git config --global --add safe.directory $CI_PROJECT_DIR
+  script:
+    - yarn --frozen-lockfile --network-timeout 600000 install
+    - yarn build
+    - yarn test

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,0 +1,52 @@
+# Vortex CI Linux Build Image
+# Based on Ubuntu 24.04 with all build dependencies
+# Includes Volta for Node.js/Yarn version management
+
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies for Vortex build
+# - curl: For downloading scripts and packages
+# - git: Version control
+# - libfontconfig1-dev: Font configuration (required for Electron)
+# - ca-certificates: SSL certificates
+# - xz-utils: Compression utilities
+# - python3, python3-setuptools: Python for node-gyp
+# - build-essential: GCC, make, etc. for native module compilation
+# - libicu-dev: Unicode support library
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    libfontconfig1-dev \
+    ca-certificates \
+    xz-utils \
+    python3 \
+    python3-setuptools \
+    build-essential \
+    libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET SDK 9.0 (required for fomod-installer)
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 9.0
+
+# Set up .NET environment variables
+ENV DOTNET_ROOT=/root/.dotnet
+ENV PATH="${PATH}:${DOTNET_ROOT}:${DOTNET_ROOT}/tools"
+
+# Install Volta (JavaScript tool manager for Node.js and Yarn)
+ENV VOLTA_HOME=/root/.volta
+ENV PATH="${VOLTA_HOME}/bin:${PATH}"
+RUN curl https://get.volta.sh | bash -s -- --skip-setup
+
+# Default working directory
+WORKDIR /src
+
+# Verify installations
+RUN echo "=== Build Image Info ===" && \
+    git --version && \
+    python3 --version && \
+    dotnet --version && \
+    volta --version && \
+    echo "=== End Info ==="

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -1,0 +1,46 @@
+# escape=`
+# Vortex CI Windows Build Image
+# Based on .NET 9.0 SKD on Windows Server 2022 LTSC
+# Uses node-gyp recommended setup: https://github.com/nodejs/node-gyp#on-windows
+
+ARG BASE_IMAGE=dotnet/sdk
+ARG DOTNET_VERSION=9.0
+ARG WIN_VER=ltsc2022
+FROM mcr.microsoft.com/${BASE_IMAGE}:${DOTNET_VERSION}-windowsservercore-${WIN_VER}
+
+# Install Chocolatey
+SHELL ["powershell", "-Command"]
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
+    iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')); `
+    Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+
+# Install all build tools using node-gyp recommended approach
+# visualstudio2022-workload-vctools: Installs VS Build Tools with C++ workload
+# python: Python 3 for node-gyp
+# git.install: Git with Unix tools on PATH
+# volta: Node.js version manager (reads versions from package.json)
+# Note: vswhere may return empty, but node-gyp uses VCINSTALLDIR (set by VsDevCmd.bat) as primary detection
+RUN choco install -y python310 --no-progress; `
+    choco install -y visualstudio2022-workload-vctools --no-progress; `
+    choco install -y git.install --params "'/GitAndUnixToolsOnPath /NoGitLfs /NoCredentialManager /NoGuiHereIntegration'" --no-progress; `
+    choco install -y volta --no-progress
+
+# Add ATL component required for winapi-bindings (atlbase.h)
+# Must use VS installer directly since Chocolatey won't modify existing installation
+RUN & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify `
+    --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools' `
+    --add Microsoft.VisualStudio.Component.VC.ATL `
+    --quiet --norestart --wait; `
+    Remove-Item -Recurse -Force 'C:\ProgramData\Package Cache\*' -ErrorAction SilentlyContinue; `
+    Remove-Item -Recurse -Force 'C:\Users\ContainerAdministrator\AppData\Local\Temp\*' -ErrorAction SilentlyContinue; `
+    Remove-Item -Recurse -Force 'C:\Windows\Temp\*' -ErrorAction SilentlyContinue; `
+    Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey\logs\*' -ErrorAction SilentlyContinue; `
+    Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey\.chocolatey\*' -ErrorAction SilentlyContinue
+
+# Default working directory
+WORKDIR C:\src
+
+# Entry point - Initialize VS Developer environment (x64) and launch PowerShell
+# VsDevCmd.bat sets up PATH, LIB, INCLUDE for the MSVC toolchain (cl.exe, link.exe, etc.)
+# -arch=amd64 ensures 64-bit tools are used for NativeAOT compilation
+ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=amd64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]


### PR DESCRIPTION
This adds a windows and linux dockerfiles to create CI environments with necessary dependencies.

Both images require more testing before being viable.

Windows image should be tested from a windows host running docker desktop configured for windows containers 
- (right click on docker system tray icon to switch to windows containers)

After building the image, run the container and try to run the ci commands (volta install, yarn install, yarn build).

The latest issue I was having on windows was Volta failing to download the specified yarn version for some reason.

The linux worked at some point, but I made some changes for Volta and needs to be tested again.

When the docker images are finalized and vetted to be working, we should talk with platform to have them pushed to our hosted docker hub registry. 
Platform also needs to setup a windows runner with GitLab runner and docker setup 
- https://docs.gitlab.com/runner/install/windows/
- https://docs.gitlab.com/runner/executors/
The gitlab ci script will then need to be updated to reference the pushed images.
