### PR TITLE
fixed loss of 'this' binding when ascertaining critical errors

### DIFF
--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -1074,7 +1074,7 @@ class InstallManager {
             code,
             errors: errors.join("; "),
           });
-          const critical = errors.find(this.isCritical);
+          const critical = errors.find(err => this.isCritical(err));
           if (critical !== undefined) {
             return Bluebird.reject(
               new ArchiveBrokenError(path.basename(archivePath), critical),
@@ -3612,7 +3612,7 @@ class InstallManager {
             code,
             errors: errors.join("; "),
           });
-          const critical = errors.find(this.isCritical);
+          const critical = errors.find(err => this.isCritical(err));
           if (critical !== undefined) {
             throw new ArchiveBrokenError(path.basename(archivePath), critical);
           }


### PR DESCRIPTION
fixes nexus-mods/vortex#19102
fixes nexus-mods/vortex#19221
fixes nexus-mods/vortex#19148
fixes nexus-mods/vortex#19146
fixes nexus-mods/vortex#19136
fixes nexus-mods/vortex#19133
fixes nexus-mods/vortex#19130
fixes nexus-mods/vortex#19126
fixes nexus-mods/vortex#19123
fixes nexus-mods/vortex#19122