### PR TITLE
added defensive code for when raising toasts

### DIFF
--- a/src/util/ExtensionManager.ts
+++ b/src/util/ExtensionManager.ts
@@ -1125,17 +1125,25 @@ class ExtensionManager {
         noti.id = shortid();
       }
       if (this.canBeToast(noti)) {
-        let toastFunc = noti.type === "error" ? toast.error : toast.success;
-        const toastOptions: ToastOptions = {
-          id: noti.id,
-          duration: noti.displayMS,
-        };
-        const message =
-          noti.title !== undefined
-            ? `${noti.title}:\n${noti.message}`
-            : noti.message;
-        toastFunc(message, toastOptions);
-        return noti.id;
+        try {
+          const toastFunc = noti.type === "error" ? toast.error : toast.success;
+          const toastOptions: ToastOptions = {
+            id: noti.id,
+            duration: noti.displayMS,
+          };
+          const message =
+            noti.title !== undefined
+              ? `${noti.title}:\n${noti.message ?? ""}`
+              : (noti.message ?? "");
+          if (message.length > 0) {
+            toastFunc(message, toastOptions);
+            return noti.id;
+          }
+        } catch (err) {
+          // Toast rendering failed (e.g., goober styling error during race condition)
+          // Fall through to standard notification
+          log("warn", "Failed to show toast notification", err.message);
+        }
       }
       if (notification.type === "warning") {
         log("warn", "warning notification", {


### PR DESCRIPTION
AFAIK the version of react-hot-toast we're using is supposed to set up goober on its own - supposedly this is a theme-ing issue where goober isn't setup correctly.

Perhaps this is tied to our themes? no idea, but we need to ensure the app doesn't crash.

fixes nexus-mods/vortex#18910