### PR TITLE
fomod-installer tests are not designed to be executed through main repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
       "/node_modules/",
       "/dist/",
       "/app/",
-      "/playwright/"
+      "/playwright/",
+      "/extensions/fomod-installer/"
     ],
     "moduleFileExtensions": [
       "js",


### PR DESCRIPTION
Can't update to the latest commit of the submodule until the main repo knows to ignore them.