### PR TITLE
fixed several issues that would cause collection installations to stall

### DIFF
--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -23,6 +23,7 @@ import makeThrottle from "./util/throttle";
 
 import FileAssembler from "./FileAssembler";
 import SpeedCalculator from "./SpeedCalculator";
+import { setDownloadFilePath } from "./actions/state";
 
 import Bluebird from "bluebird";
 import * as contentDisposition from "content-disposition";
@@ -2177,23 +2178,68 @@ class DownloadManager {
       download.finalName = newName;
       newName
         .then((resolvedName) => {
+          const oldTempName = download.tempName;
+          download.tempName = resolvedName;
+
           if (!download.assembler.isClosed()) {
-            const oldTempName = download.tempName;
-            download.tempName = resolvedName;
             return download.assembler
               .rename(resolvedName)
               .then(() => {
                 download.finalName = newName;
               })
               .catch((err) => {
-                // if we failed to rename we will try to continue writing to the original file
-                // so reset to the original name and remove the temporary one that got reserved
-                // for the rename
+                // If file is closed, fall back to fs.renameAsync
+                if (
+                  err instanceof ProcessCanceled &&
+                  err.message === "File is closed"
+                ) {
+                  return fs
+                    .renameAsync(oldTempName, resolvedName)
+                    .then(() => {
+                      download.finalName = newName;
+                      // Update Redux state with the new file path
+                      const newFileName = path.basename(resolvedName);
+                      this.mApi.store.dispatch(
+                        setDownloadFilePath(download.id, newFileName),
+                      );
+                    })
+                    .catch((fsErr) => {
+                      // Reset to original name
+                      download.tempName = oldTempName;
+                      return fs
+                        .removeAsync(resolvedName)
+                        .catch(() => null)
+                        .then(() => Bluebird.reject(fsErr));
+                    });
+                }
+                // For other errors, reset to original name and reject
                 download.tempName = oldTempName;
                 return fs
                   .removeAsync(resolvedName)
                   .catch(() => null)
                   .then(() => Bluebird.reject(err));
+              });
+          } else {
+            // File is already closed (download finished), rename directly using fs
+            return fs
+              .renameAsync(oldTempName, resolvedName)
+              .then(() => {
+                download.finalName = newName;
+                // Update Redux state with the new file path
+                const newFileName = path.basename(resolvedName);
+                this.mApi.store.dispatch(
+                  setDownloadFilePath(download.id, newFileName),
+                );
+              })
+              .catch((err) => {
+                // Don't reject - just log the error
+                log("warn", "failed to rename closed download file", {
+                  error: err.message,
+                  from: oldTempName,
+                  to: resolvedName,
+                });
+                // Reset to original name
+                download.tempName = oldTempName;
               });
           }
         })


### PR DESCRIPTION
Fixed:
- skipped external downloads not registering as skipped/ignored correctly (This would cause the collection to fail to realize that installation had completed successfully)
- fixed bundled mod status potentially reverting back to "downloading" state (This would cause the installation to stall as Vortex was waiting for a bundled mod to download which would never happen)
- fixed incorrect/failed download lookups in collections extension causing the UI to fail to realize that the download is complete.
- fixed collectionsInstallWhileDownloading toggle not being adhered to.
- fixed downloads getting erased incorrectly during collection installation upon failure to rename them (added error handling for that use case which should guarantee it never happens again)
- fixed UI slowdown when installing recommended/optional mods (we were testing references for the entire collection not just the optional mods)

fixes nexus-mods/vortex#19313
fixes nexus-mods/vortex#19314
fixes nexus-mods/vortex#19315
fixes nexus-mods/vortex#19316
fixes nexus-mods/vortex#19317
fixes nexus-mods/vortex#19318