### PR TITLE
Collection Name character length set to 64

### DIFF
--- a/extensions/collections/src/constants.ts
+++ b/extensions/collections/src/constants.ts
@@ -32,7 +32,7 @@ export const INSTALLING_NOTIFICATION_ID = "installing-collection-";
 
 // limits
 export const MIN_COLLECTION_NAME_LENGTH = 3;
-export const MAX_COLLECTION_NAME_LENGTH = 36;
+export const MAX_COLLECTION_NAME_LENGTH = 64;
 
 export const INI_TWEAKS_PATH = "Ini Tweaks";
 


### PR DESCRIPTION
Changed MAX_COLLECTION_NAME_LENGTH from 36 to 64
Making it easier to fit a name that might list a few features. As shown need here.
<img width="236" height="235" alt="Stim1" src="https://github.com/user-attachments/assets/5b75d669-7f45-4e33-b524-7a6642d96bd8" />
64 gives enough room to write Fidelity instead of Fix even :O
If there's a larger number that the devs want to use, feel free to make the change before merging! This is just all the character length I've found necessary so far.