### PR TITLE
chore: refactor icon component

### DIFF
--- a/src/stylesheets/tailwind-v4.css
+++ b/src/stylesheets/tailwind-v4.css
@@ -24,15 +24,5 @@
 @import "./shared/theme";
 @import "./shared/elements";
 
-:root {
-    /* Icon sizes for consistent icon sizing, don't think this is needed anymore should be able to use `size-[x]` */
-    --icon-size-xs: 12px;
-    --icon-size-sm: 16px;
-    --icon-size-md: 20px;
-    --icon-size-lg: 24px;
-    --icon-size-xl: 32px;
-    --icon-size-2xl: 48px;
-}
-
 /* Make `dark:` respond to a `.dark` class on <html> or parent element */
 @variant dark (.dark &);

--- a/src/tailwind/components/next/button/Button.tsx
+++ b/src/tailwind/components/next/button/Button.tsx
@@ -6,19 +6,19 @@
  * Uses shared CSS classes from button.css (nxm-button-*) for styling.
  */
 
-import * as React from "react";
-import type {
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
-  ComponentProps,
-  MutableRefObject,
-  ReactNode,
-  Ref,
+import React, {
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ComponentProps,
+  type MutableRefObject,
+  type ReactNode,
+  type Ref,
 } from "react";
 
 import { Icon } from "../icon";
 import { Link } from "../link";
 import { type XOr, joinClasses } from "../utils";
+import { mdiCircleOutline, mdiLoading } from "@mdi/js";
 
 export type ButtonType =
   | "primary"
@@ -134,8 +134,8 @@ const ButtonIcon = ({
   if (isLoading) {
     return (
       <span className="nxm-button-icon animate-spin relative">
-        <Icon className="opacity-40" path="mdiCircleOutline" size="none" />
-        <Icon className="absolute inset-0" path="mdiLoading" size="none" />
+        <Icon className="opacity-40" path={mdiCircleOutline} size="none" />
+        <Icon className="absolute inset-0" path={mdiLoading} size="none" />
       </span>
     );
   }

--- a/src/tailwind/components/next/button/ButtonDemo.tsx
+++ b/src/tailwind/components/next/button/ButtonDemo.tsx
@@ -6,6 +6,7 @@
 import * as React from "react";
 import { Button } from "./Button";
 import { Typography } from "../typography/Typography";
+import { mdiCheck, mdiChevronRight, mdiCog, mdiDownload } from "@mdi/js";
 
 export const ButtonDemo: React.ComponentType = () => {
   const [loadingStates, setLoadingStates] = React.useState<
@@ -270,20 +271,20 @@ export const ButtonDemo: React.ComponentType = () => {
         </Typography>
 
         <div className="flex gap-4 flex-wrap items-center">
-          <Button buttonType="primary" size="md" leftIconPath="mdiDownload">
+          <Button buttonType="primary" size="md" leftIconPath={mdiDownload}>
             Download
           </Button>
           <Button
             buttonType="secondary"
             size="md"
-            rightIconPath="mdiChevronRight"
+            rightIconPath={mdiChevronRight}
           >
             Next
           </Button>
-          <Button buttonType="success" size="sm" leftIconPath="mdiCheck">
+          <Button buttonType="success" size="sm" leftIconPath={mdiCheck}>
             Confirm
           </Button>
-          <Button buttonType="tertiary" size="md" leftIconPath="mdiCog">
+          <Button buttonType="tertiary" size="md" leftIconPath={mdiCog}>
             Settings
           </Button>
         </div>

--- a/src/tailwind/components/next/collectiontile/CollectionTile.tsx
+++ b/src/tailwind/components/next/collectiontile/CollectionTile.tsx
@@ -4,7 +4,13 @@
  * Adapted from Figma design for collection browsing
  */
 
-import * as React from "react";
+import React, {
+  type ComponentType,
+  Fragment,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { Button } from "../button/Button";
 import { Typography } from "../typography/Typography";
 import { Icon } from "../icon";
@@ -14,6 +20,7 @@ import type { IExtensionApi } from "../../../../types/IExtensionContext";
 import { isCollectionModPresent } from "../../../../util/selectors";
 import Debouncer from "../../../../util/Debouncer";
 import { delayed } from "../../../../util/util";
+import { mdiOpenInNew, mdiStar, mdiThumbUp } from "@mdi/js";
 
 const debouncer = new Debouncer(
   (func: () => void) => {
@@ -67,7 +74,7 @@ export interface CollectionTileProps {
   className?: string;
 }
 
-export const CollectionTile: React.ComponentType<
+export const CollectionTile: ComponentType<
   CollectionTileProps & { api: IExtensionApi }
 > = ({
   api,
@@ -83,10 +90,10 @@ export const CollectionTile: React.ComponentType<
   onViewPage,
   className,
 }) => {
-  const [isHovered, setIsHovered] = React.useState(false);
-  const [canBeAdded, setCanBeAdded] = React.useState(true);
-  const [tooltip, setTooltip] = React.useState<string>("Add this collection");
-  const [pending, setPending] = React.useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [canBeAdded, setCanBeAdded] = useState(true);
+  const [tooltip, setTooltip] = useState<string>("Add this collection");
+  const [pending, setPending] = useState(false);
   // Helper to extract tag text from string or object
   const getTagText = (tag: any): string => {
     if (typeof tag === "string") {
@@ -107,7 +114,7 @@ export const CollectionTile: React.ComponentType<
     );
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const state = api?.getState?.();
     if (!state) {
       // No state available means we're likely in demo mode, so skip checks.
@@ -125,7 +132,7 @@ export const CollectionTile: React.ComponentType<
   }, [api, slug, pending, isHovered]);
 
   // Refresh user info when user hovers on the tile, debounced to once per 5 seconds
-  React.useEffect(() => {
+  useEffect(() => {
     if (isHovered && api?.events) {
       userInfoDebouncer.schedule(undefined, () => {
         api.events.emit("refresh-user-info");
@@ -135,16 +142,16 @@ export const CollectionTile: React.ComponentType<
 
   // Take max 2 tags
   const displayTags = tags.slice(0, 2);
-  const addCollection = React.useCallback(() => {
+  const addCollection = useCallback(() => {
     if (!pending && canBeAdded) {
       setPending(true);
       addCollectionDebounced();
     }
   }, [onAddCollection, canBeAdded, pending]);
-  const mouseEnter = React.useCallback(() => {
+  const mouseEnter = useCallback(() => {
     setIsHovered(true);
   }, []);
-  const mouseLeave = React.useCallback(() => {
+  const mouseLeave = useCallback(() => {
     setIsHovered(false);
   }, []);
 
@@ -180,7 +187,7 @@ export const CollectionTile: React.ComponentType<
                     appearance="none"
                     className="flex items-center gap-x-0.5 px-1.5 py-0.5 bg-info-weak text-info-50"
                   >
-                    <Icon path="mdiStar" size="xs" />
+                    <Icon path={mdiStar} size="xs" />
                     <span
                       className="px-0.5 leading-5"
                       title={easyInstallBadge.description}
@@ -235,7 +242,7 @@ export const CollectionTile: React.ComponentType<
                   {displayTags.map((tag, index) => {
                     const tagText = getTagText(tag);
                     return (
-                      <React.Fragment key={index}>
+                      <Fragment key={index}>
                         <Typography
                           as="div"
                           typographyType="body-sm"
@@ -251,7 +258,7 @@ export const CollectionTile: React.ComponentType<
                         {index < displayTags.length - 1 && (
                           <div className="w-1 h-1 rotate-45 bg-neutral-subdued" />
                         )}
-                      </React.Fragment>
+                      </Fragment>
                     );
                   })}
                 </div>
@@ -263,7 +270,7 @@ export const CollectionTile: React.ComponentType<
               <div className="flex-1 py-1.5 border-b border-stroke-weak flex justify-start items-center gap-5">
                 {/* Endorsements */}
                 <div className="flex justify-start items-center gap-1 overflow-hidden">
-                  <Icon path="mdiThumbUp" size="sm" />
+                  <Icon path={mdiThumbUp} size="sm" />
                   <Typography
                     as="div"
                     typographyType="body-sm"
@@ -333,7 +340,7 @@ export const CollectionTile: React.ComponentType<
           buttonType="tertiary"
           size="sm"
           onClick={onViewPage}
-          leftIconPath="mdiOpenInNew"
+          leftIconPath={mdiOpenInNew}
         >
           View page
         </Button>

--- a/src/tailwind/components/next/icon/Icon.tsx
+++ b/src/tailwind/components/next/icon/Icon.tsx
@@ -1,146 +1,37 @@
-/**
- * Icon Component
- * Adapted from web team's "next" project for Vortex
- *
- * Renders icons using SVG path data from multiple sources:
- * - Material Design Icons (@mdi/js) - e.g., 'mdiAccount'
- * - Nexus Mods custom icons - e.g., 'nxmVortex', 'nxmCollection'
- * - Direct SVG path data
- *
- * Size System:
- * - xs: 0.75rem (12px) - Extra small icons
- * - sm: 1rem (16px) - Small icons
- * - md: 1.25rem (20px) - Medium icons (DEFAULT)
- * - lg: 1.5rem (24px) - Large icons
- * - xl: 2rem (32px) - Extra large icons
- * - 2xl: 3rem (48px) - 2X extra large icons
- * - none: Size controlled via className
- */
-
-import * as React from "react";
-import * as mdi from "@mdi/js";
-import * as nxm from "../../../lib/icon-paths";
-import type { XOr } from "../utils";
+import React, { type SVGAttributes } from "react";
+import { joinClasses } from "../utils";
 
 export type IconSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "none";
 
-/* eslint-disable sort-keys */
 const sizeMap: { [key in IconSize]: string | undefined } = {
   none: undefined,
-  xs: "var(--icon-size-xs)",
-  sm: "var(--icon-size-sm)",
-  md: "var(--icon-size-md)",
-  lg: "var(--icon-size-lg)",
-  xl: "var(--icon-size-xl)",
-  "2xl": "var(--icon-size-2xl)",
+  xs: "size-3",
+  sm: "size-4",
+  md: "size-5",
+  lg: "size-6",
+  xl: "size-8",
+  "2xl": "size-12",
 };
-/* eslint-enable sort-keys */
 
-export type IconProps = Omit<React.SVGProps<SVGSVGElement>, "size" | "path"> & {
-  /**
-   * Icon path or name (REQUIRED):
-   * - MDI icon name: 'mdiAccount', 'mdiDownload', etc.
-   * - Nexus icon name: 'nxmVortex', 'nxmCollection', etc.
-   * - Direct SVG path data string
-   * Icon names are automatically resolved from @mdi/js or Nexus icon paths
-   */
-  path: string;
-  /**
-   * Icon title for accessibility (optional)
-   */
-  title?: string;
-} & XOr<
-    {
-      /**
-       * Named size from design system (default: 'md')
-       * Cannot be used with sizeOverride
-       */
-      size?: IconSize;
-    },
-    {
-      /**
-       * Custom size override (e.g., '1.5rem', '24px', 'var(--custom-size)')
-       * Cannot be used with size
-       */
-      sizeOverride?: string;
-    }
-  >;
-
-/**
- * Icon component that renders icons from multiple sources
- *
- * Usage:
- * - With MDI icon name: <Icon path="mdiAccount" size="md" />
- * - With Nexus icon name: <Icon path="nxmVortex" size="lg" />
- * - With direct path: <Icon path={mdiAccount} size="sm" />
- * - With className sizing: <Icon path="mdiAccount" size="none" className="size-5" />
- * - With custom size: <Icon path="mdiDownload" sizeOverride="1.75rem" />
- */
 export const Icon = ({
   path,
   size = "md",
-  sizeOverride,
-  className = "",
+  className,
   title,
-  ...rest
-}: IconProps) => {
-  // Resolve path - if it's a string like 'mdiAccount' or 'nxmVortex', look it up
-  let svgPath: string | undefined;
+  ...props
+}: Omit<SVGAttributes<SVGSVGElement>, "size" | "path"> & {
+  path: string;
+  size?: IconSize;
+  title?: string;
+}) => (
+  <svg
+    viewBox="0 0 24 24"
+    className={joinClasses([sizeMap[size], className])}
+    role={title ? "img" : "presentation"}
+    {...props}
+  >
+    {title && <title>{title}</title>}
 
-  if (typeof path === "string") {
-    // Check if it's an icon name or already an SVG path
-    if (path.startsWith("mdi") && path.length > 3) {
-      // It's a Material Design Icon name like 'mdiAccount' - look it up in @mdi/js
-      svgPath = (mdi as any)[path];
-
-      if (!svgPath) {
-        console.warn(
-          `Icon: Unknown MDI icon name "${path}". Check @mdi/js exports.`,
-        );
-        return null;
-      }
-    } else if (path.startsWith("nxm") && path.length > 3) {
-      // It's a Nexus Mods icon name like 'nxmVortex' - look it up in our icon paths
-      svgPath = (nxm as any)[path];
-
-      if (!svgPath) {
-        console.warn(
-          `Icon: Unknown Nexus icon name "${path}". Check available nxm* icons.`,
-        );
-        return null;
-      }
-    } else if (path.startsWith("M") || path.startsWith("m")) {
-      // It's already an SVG path data string
-      svgPath = path;
-    } else {
-      console.warn(
-        `Icon: Invalid path "${path}". Expected MDI icon name (mdi*), Nexus icon name (nxm*), or SVG path data.`,
-      );
-      return null;
-    }
-  } else {
-    console.warn(`Icon: path prop must be a string. Received: ${typeof path}`);
-    return null;
-  }
-
-  if (!svgPath) {
-    return null;
-  }
-
-  // Determine size - use sizeOverride if provided, otherwise use size from map
-  const sizeValue = sizeOverride ?? sizeMap[size ?? "md"];
-
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      style={{ width: sizeValue, height: sizeValue }}
-      className={className}
-      role={title ? "img" : "presentation"}
-      aria-label={title}
-      {...rest}
-    >
-      {title && <title>{title}</title>}
-      <path d={svgPath} fill="currentColor" />
-    </svg>
-  );
-};
+    <path d={path} fill="currentColor" />
+  </svg>
+);

--- a/src/tailwind/components/next/icon/index.ts
+++ b/src/tailwind/components/next/icon/index.ts
@@ -1,4 +1,1 @@
-/**
- * Icon Component - Exports
- */
-export * from "./Icon";
+export { Icon, type IconSize } from "./Icon";

--- a/src/tailwind/index.ts
+++ b/src/tailwind/index.ts
@@ -81,11 +81,7 @@ export type {
   ButtonType,
 } from "./components/next/button/Button";
 
-export type {
-  // Icon types
-  IconProps,
-  IconSize,
-} from "./components/next/icon/Icon";
+export type { IconSize } from "./components/next/icon/Icon";
 
 export type {
   // CollectionTile types


### PR DESCRIPTION
## Summary

The Icon component previously accepted string values that mapped to MDI/NXM icon names or raw icon paths.

This PR removes support for string-based icons in favour of always importing icon paths directly. This simplifies the Icon component and significantly improves developer experience by providing proper type safety. Imported icons are now type-checked at compile time, whereas string values offered no guarantees and were prone to runtime errors.

## Changes

- Removed string-based icon support in favour of imported icon paths
- Updated all existing string icon usages to use the correct MDI imports
- Migrated icon sizing to Tailwind utility classes instead of custom CSS variables
- Removed unnecessary React. prefixing from related components

## Benefits

- Cleaner, simpler Icon API
- Stronger type safety for icons
- More consistent styling via Tailwind
- Reduced surface area for runtime errors