### PR TITLE
Fix IPC assertion type for objects

### DIFF
--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -68,15 +68,46 @@ export type Serializable =
   | DataView
   | TypedArray;
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsUnknown<T> =
+  IsAny<T> extends true
+    ? false
+    : unknown extends T
+      ? T extends unknown
+        ? true
+        : false
+      : false;
+
+type HasError<T> = T extends { __error__: string }
+  ? true
+  : T extends object
+    ? { [K in keyof T]: HasError<T[K]> }[keyof T] extends true
+      ? true
+      : false
+    : false;
+
 // NOTE(erri120): If you found this type because you got an error, that means you're trying to pass data across the IPC
 // that can't be serialized. Check the list of supported types above and pick one of them. If you think there is a type missing
 // from the list above, write a small proof and we can discuss it.
-
-// NOTE(erri120): Alternative is using `never` in the fallback but that doesn't produce very nice error messages.
+//
 /** Utility type to assert that the type is serializable */
-export type AssertSerializable<T> = T extends Serializable
-  ? T
-  : { __error__: "Type is not serializable for IPC" };
+export type AssertSerializable<T> =
+  // any
+  IsAny<T> extends true
+    ? { __error__: "any is not serializable for IPC" }
+    : // unknown
+      IsUnknown<T> extends true
+      ? { __error__: "unknown is not serializable for IPC" }
+      : // known serializables
+        T extends Serializable
+        ? T
+        : // objects
+          T extends object
+          ? HasError<{ [K in keyof T]: AssertSerializable<T[K]> }> extends true
+            ? { __error__: "Type is not serializable for IPC" }
+            : T
+          : // everything else
+            { __error__: "Type is not serializable for IPC" };
 
 /** Utility type to check all args are serializable */
 export type SerializableArgs<T extends readonly unknown[]> = {


### PR DESCRIPTION
Using recursive assertion type instead of just relying on the index signature.