### PR TITLE
Sanitize logs

### DIFF
--- a/src/main/MainWindow.ts
+++ b/src/main/MainWindow.ts
@@ -1,28 +1,30 @@
+import type * as Redux from "redux";
+
+import PromiseBB from "bluebird";
+import { ipcMain, screen, webContents } from "electron";
+import * as path from "path";
+import { pathToFileURL } from "url";
+
+import type { ThunkStore } from "../types/IExtensionContext";
+import type { IState, IWindow } from "../types/IState";
+import type * as storeHelperT from "../util/storeHelper";
+import type TrayIcon from "./TrayIcon";
+
 import { addNotification } from "../actions/notifications";
 import {
   setMaximized,
   setWindowPosition,
   setWindowSize,
 } from "../actions/window";
-import type { ThunkStore } from "../types/IExtensionContext";
-import type { IState, IWindow } from "../types/IState";
+import { getErrorMessageOrDefault } from "../shared/errors";
 import Debouncer from "../util/Debouncer";
 import { terminate } from "../util/errorHandling";
 import getVortexPath from "../util/getVortexPath";
-import { log } from "../util/log";
 import opn from "../util/opn";
 import { downloadPath } from "../util/selectors";
-import type * as storeHelperT from "../util/storeHelper";
 import { parseBool } from "../util/util";
 import { closeAllViews } from "../util/webview";
-
-import PromiseBB from "bluebird";
-import { ipcMain, screen, webContents } from "electron";
-import * as path from "path";
-import type * as Redux from "redux";
-import { pathToFileURL } from "url";
-import type TrayIcon from "./TrayIcon";
-import { getErrorMessageOrDefault } from "../shared/errors";
+import { log } from "./logging";
 
 const MIN_HEIGHT = 700;
 const REQUEST_HEADER_FILTER = {

--- a/src/main/logging.ts
+++ b/src/main/logging.ts
@@ -135,9 +135,14 @@ export function changeLogPath(newBasePath: string): void {
   logger.add(fileTransport);
 }
 
+function sanitize(message: string): string {
+  return message.replaceAll("%", "%%");
+}
+
 export function log(level: Level, message: string, metadata?: unknown): void {
   const meta = metadata === undefined ? undefined : JSON.stringify(metadata);
-  LoggerSingleton.log(level, message, {
+  const sanitized = sanitize(message);
+  LoggerSingleton.log(level, sanitized, {
     process: "main",
     extra: meta,
   } satisfies Metadata);


### PR DESCRIPTION
We'd forward console logs including `%s` to our winston logger which would try and use `%s` with string interpolation...