### PR TITLE
Logging Corrections

### DIFF
--- a/src/extensions/diagnostics_files/util/loadVortexLogs.ts
+++ b/src/extensions/diagnostics_files/util/loadVortexLogs.ts
@@ -7,10 +7,31 @@ import PromiseBB from "bluebird";
 import * as path from "path";
 import getVortexPath from "../../../util/getVortexPath";
 
-const lineRE = /^(\S+) \[([A-Z]*)\] (.*)\r?/;
+// New format: timestamp [LEVEL] [PROCESS] message
+const lineRE = /^(\S+) \[([A-Z]*)\] \[([A-Z]*)\] (.*)\r?/;
+// Legacy format: timestamp [LEVEL] message
+const lineRE_Legacy = /^(\S+) \[([A-Z]*)\] (.*)\r?/;
+// ANSI color code regex (constructed to avoid ESLint error)
+// eslint-disable-next-line no-control-regex
+const ansiRegex = /\x1b\[[0-9;]*m/g;
 
 function parseLine(line: string, idx: number): ILog {
-  const match = line.match(lineRE);
+  // Strip ANSI color codes from the line
+  const cleanLine = line.replace(ansiRegex, "");
+
+  // Try new format first (with [PROCESS])
+  let match = cleanLine.match(lineRE);
+  if (match !== null && match.length === 5) {
+    return {
+      lineno: idx,
+      time: match[1],
+      type: match[2].toLowerCase() as LogLevel,
+      text: match[4], // Skip the process name in match[3], use the message in match[4]
+    };
+  }
+
+  // Fall back to legacy format (without [PROCESS])
+  match = cleanLine.match(lineRE_Legacy);
   if (match !== null && match.length === 4) {
     return {
       lineno: idx,
@@ -18,9 +39,9 @@ function parseLine(line: string, idx: number): ILog {
       type: match[2].toLowerCase() as LogLevel,
       text: match[3],
     };
-  } else {
-    return undefined;
   }
+
+  return undefined;
 }
 
 export function loadVortexLogs(): PromiseBB<ISession[]> {

--- a/src/main/logging.ts
+++ b/src/main/logging.ts
@@ -26,9 +26,9 @@ function customFormatter(options: FormatOptions, forConsole: boolean): string {
   // https://github.com/winstonjs/winston/blob/b8baf4c6797d652f882e61a8a3bd8d00875e5596/lib/winston/config.js#L21
   const logLevel = forConsole
     ? winston.config.colorize(
-      options.level as unknown as number,
-      formattedLogLevel,
-    )
+        options.level as unknown as number,
+        formattedLogLevel,
+      )
     : formattedLogLevel;
 
   const message = options.message ?? "";
@@ -54,7 +54,9 @@ function formatLogLevel(level: string): string {
 }
 
 const timestamp = () => new Date().toISOString();
-const formatter = (options: unknown) =>
+const fileFormatter = (options: unknown) =>
+  customFormatter(options as FormatOptions, false);
+const consoleFormatter = (options: unknown) =>
   customFormatter(options as FormatOptions, true);
 
 function createFileTransport(basePath: string): winston.FileTransportInstance {
@@ -66,7 +68,7 @@ function createFileTransport(basePath: string): winston.FileTransportInstance {
     maxFiles: 5,
     tailable: true,
     timestamp: timestamp,
-    formatter: formatter,
+    formatter: fileFormatter,
   });
 }
 
@@ -78,10 +80,10 @@ function setupLogger(
 
   const consoleTransport = useConsole
     ? new winston.transports.Console({
-      level: "debug",
-      timestamp: timestamp,
-      formatter: formatter,
-    })
+        level: "debug",
+        timestamp: timestamp,
+        formatter: consoleFormatter,
+      })
     : undefined;
 
   const transports: winston.TransportInstance[] = [fileTransport];


### PR DESCRIPTION
* Do not persist color codes in the logs file
* handle color codes in the file (keep for now since we already have logs like this)
* handle new [RENDERER] and [MAIN] additions in the UI