### PR TITLE
added defensive code to group filter change handler

### DIFF
--- a/extensions/gamebryo-plugin-management/src/util/GroupFilter.tsx
+++ b/extensions/gamebryo-plugin-management/src/util/GroupFilter.tsx
@@ -39,7 +39,7 @@ class GroupFilterComponent extends React.Component<IProps, {}> {
     const { attributeId, onSetFilter } = this.props;
     onSetFilter(
       attributeId,
-      value.map((val) => val.value),
+      (value ?? []).map((val) => val.value),
     );
   };
 }


### PR DESCRIPTION
react-select can pass null when clearing a value. We didn't handle that correctly.

fixes nexus-mods/vortex#19588