### PR TITLE
fixed login session refresh breaking collection installation

### DIFF
--- a/extensions/collections/src/index.ts
+++ b/extensions/collections/src/index.ts
@@ -24,10 +24,7 @@ import {
   InstallStartDialog,
 } from "./views/InstallDialog";
 
-import {
-  isInstallationActive,
-  getActiveInstallSession,
-} from "./util/selectors";
+import { getActiveInstallSession } from "./util/selectors";
 
 import { IPathTools } from "./views/CollectionPageEdit/FileOverrides";
 
@@ -351,7 +348,18 @@ async function pauseCollection(
   }
 
   (collection?.rules ?? []).forEach((rule) => {
-    const dlId = util.findDownloadByRef(rule.reference, downloads);
+    // findDownloadByRef has been modified to omit these fields as well, BUT, the vortex-api
+    //  types don't reflect that change currently. The API submodule needs a complete cleanup
+    //  before we can update the dependency and given the massive changes we've been making
+    //  to the codebase recently + the imminent 1.16 stable release - updating the API submodule
+    //  is not worth the risk at this moment, so will just omit the fields here as well.
+    // TODO: update the vortex-api types and remove the omit when we update the dependency.
+    const cleanReference = _.omit(rule.reference, [
+      "installerChoices",
+      "fileList",
+      "patches",
+    ]);
+    const dlId = util.findDownloadByRef(cleanReference, downloads);
     if (dlId !== undefined) {
       api.events.emit("pause-download", dlId);
     }
@@ -1395,6 +1403,39 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
       );
     }
   });
+
+  // Pause collection installation if user becomes unauthenticated
+  api.onStateChange(
+    ["persistent", "nexus", "userInfo"],
+    (oldValue, newValue) => {
+      // Only pause if user logged out (userInfo became undefined), not during re-login
+      if (oldValue !== undefined && newValue === undefined) {
+        if (!driver.installDone && driver.collection !== undefined) {
+          const gameId =
+            driver.profile?.gameId ?? selectors.activeGameId(api.getState());
+          const modId = driver.collection.id;
+          log("info", "User logged out during collection install, pausing", {
+            modId,
+          });
+          pauseCollection(api, gameId, modId, true)
+            .then(() => {
+              api.sendNotification({
+                type: "warning",
+                title: "Collection paused",
+                message: "You have been logged out. Please log in and resume.",
+                displayMS: 5000,
+              });
+            })
+            .catch((err) => {
+              log("error", "Failed to pause collection after logout", {
+                modId,
+                error: err.message,
+              });
+            });
+        }
+      }
+    },
+  );
 
   const doCheckVoteRequest = () => {
     checkVoteRequest(api).then((nextCheck: number) => {

--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -2145,11 +2145,14 @@ class DownloadManager {
     }
 
     // For single-chunk downloads, update confirmedSize only if download hasn't started yet
+    // AND it starts from the beginning of the file. Partial chunks (from resumed multi-chunk
+    // downloads or 416 recovery) should keep their original confirmedSize.
     // Once download has started (confirmedReceived > 0), confirmedSize is immutable
     // Note: confirmedSize may have already been updated by the worker in handleResponse
     if (
       download.chunks.length === 1 &&
-      download.chunks[0].confirmedReceived === 0
+      download.chunks[0].confirmedReceived === 0 &&
+      download.chunks[0].confirmedOffset === 0
     ) {
       download.chunks[0].confirmedSize = size;
       // Recalculate derived size field
@@ -2346,11 +2349,14 @@ class DownloadManager {
       });
     } else {
       // Single chunk download - update confirmedSize only if download hasn't started yet
+      // AND it starts from the beginning of the file. Partial chunks (from resumed multi-chunk
+      // downloads or 416 recovery) should keep their original confirmedSize.
       // Once download has started (confirmedReceived > 0), confirmedSize is immutable
       // Note: confirmedSize may have already been updated by the worker in handleResponse
       if (
         download.chunks.length === 1 &&
-        download.chunks[0].confirmedReceived === 0
+        download.chunks[0].confirmedReceived === 0 &&
+        download.chunks[0].confirmedOffset === 0
       ) {
         download.chunks[0].confirmedSize = fileSize;
         // Recalculate derived size field

--- a/src/extensions/download_management/DownloadObserver.ts
+++ b/src/extensions/download_management/DownloadObserver.ts
@@ -152,20 +152,22 @@ export class DownloadObserver {
     });
 
     api.onStateChange(["persistent", "nexus", "userInfo"], (old, newValue) => {
-      if (old?.isPremium !== newValue?.isPremium) {
-        // User's premium status has changed
-        // Clear the download queue by pausing all active downloads
+      // Pause active downloads only on actual premium status change (not login/logout).
+      // When user logs out, other handlers (e.g., collections) deal with pausing.
+      if (
+        old !== undefined &&
+        newValue !== undefined &&
+        old.isPremium !== newValue.isPremium
+      ) {
         const state = api.getState();
         const activeDownloadsList = selectors.queueClearingDownloads(state);
         Object.keys(activeDownloadsList).forEach((dlId) => {
-          this.handleRemoveDownload(dlId, undefined, { silent: true });
+          this.handlePauseDownload(dlId);
         });
-        if (newValue?.isPremium === true) {
-          manager.setMaxConcurrentDownloads(10);
-        } else {
-          manager.setMaxConcurrentDownloads(1);
-        }
       }
+
+      // Always adjust concurrent downloads limit based on current premium status
+      manager.setMaxConcurrentDownloads(newValue?.isPremium === true ? 10 : 1);
     });
   }
 

--- a/src/extensions/mod_management/util/dependencies.ts
+++ b/src/extensions/mod_management/util/dependencies.ts
@@ -370,6 +370,10 @@ export function findDownloadByRef(
     reference = _.omit(reference, ["fileMD5"]);
   }
 
+  // Downloads don't contain patch/fileList/installerChoices info, so exclude
+  // these from matching to avoid false negatives
+  reference = _.omit(reference, ["patches", "fileList", "installerChoices"]);
+
   try {
     const fuzzy = isFuzzyVersion(reference.versionMatch);
     const fileExpression =


### PR DESCRIPTION
Added better error handling for when/if the login session times out during collection installation (collection will pause). Theoretically this should also cover network hiccups as long as Vortex realises that it no longer has an internet connection.

Also fixes a use case where Vortex could potentially delete its running downloads on authentication status change.

fixes nexus-mods/vortex#19553