### PR TITLE
Fix Icon component to use imported paths instead of string names

### DIFF
--- a/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -4,21 +4,29 @@ import type {
   CollectionSortField,
   SortDirection,
 } from "@nexusmods/nexus-api";
+
+import {
+  mdiChevronLeft,
+  mdiChevronRight,
+  mdiOpenInNew,
+  mdiRefresh,
+} from "@mdi/js";
 import numeral from "numeral";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+
 import MainPage from "../../../renderer/views/MainPage";
 import Tailwind from "../../../tailwind";
-import { activeGameId, isCollectionModPresent } from "../../../util/selectors";
-import type { IState } from "../../../types/IState";
-import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { UserCanceled } from "../../../util/api";
 import opn from "../../../util/opn";
+import { activeGameId, isCollectionModPresent } from "../../../util/selectors";
+import { CollectionsDownloadClickedEvent } from "../../analytics/mixpanel/MixpanelEvents";
 import { getGame } from "../../gamemode_management/util/getGame";
 import { nexusGameId } from "../../nexus_integration/util/convertGameId";
-import { CollectionsDownloadClickedEvent } from "../../analytics/mixpanel/MixpanelEvents";
-import { UserCanceled } from "../../../util/api";
 
 interface IBrowseNexusPageProps {
   api: IExtensionApi;
@@ -320,17 +328,24 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
           >
             <Tailwind.TabBar className="mb-5">
               <Tailwind.TabButton
-                name={t("collection:browse.tabs.collections")}
                 count={allCollectionsTotal}
+                name={t("collection:browse.tabs.collections")}
               />
+
               <Tailwind.TabButton name={t("collection:browse.tabs.mods")} />
             </Tailwind.TabBar>
 
             <Tailwind.TabPanel name={t("collection:browse.tabs.collections")}>
               {/* Search Bar */}
-              <div className="flex gap-2.5 mb-4 items-start">
+              <div className="mb-4 flex items-start gap-2.5">
                 <Tailwind.Input
+                  errorMessage={searchValidationError || undefined}
+                  fieldClassName="w-64 shrink-0"
+                  hideLabel={true}
+                  label={t("collection:browse.searchPlaceholder")}
+                  placeholder={t("collection:browse.searchPlaceholder")}
                   type="text"
+                  value={searchQuery}
                   onChange={(e) => {
                     setSearchQuery(e.target.value);
                     // Clear validation error when user types
@@ -338,19 +353,13 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                       setSearchValidationError("");
                     }
                   }}
-                  value={searchQuery}
-                  placeholder={t("collection:browse.searchPlaceholder")}
                   onKeyDown={handleKeyDown}
-                  fieldClassName="w-64 shrink-0"
-                  errorMessage={searchValidationError || undefined}
-                  hideLabel={true}
-                  label={t("collection:browse.searchPlaceholder")}
                 />
 
                 <Tailwind.Button
                   buttonType="secondary"
-                  size="md"
                   filled="strong"
+                  size="md"
                   onClick={handleSearch}
                 >
                   {t("common:actions.search")}
@@ -358,10 +367,10 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
 
                 <Tailwind.Button
                   buttonType="tertiary"
-                  size="md"
                   filled="weak"
+                  leftIconPath={mdiRefresh}
+                  size="md"
                   onClick={handleRefresh}
-                  leftIconPath="mdiRefresh"
                 >
                   {t("collection:browse.refresh")}
                 </Tailwind.Button>
@@ -372,8 +381,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 <div className="flex flex-col items-center gap-4 py-8">
                   <div className="text-center">
                     <Tailwind.Typography
-                      typographyType="body-lg"
                       appearance="subdued"
+                      typographyType="body-lg"
                     >
                       {t("collection:browse.loading")}
                     </Tailwind.Typography>
@@ -383,15 +392,16 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 <div className="flex flex-col items-center gap-4 py-8">
                   <div className="text-center">
                     <Tailwind.Typography
-                      typographyType="body-lg"
                       appearance="none"
                       className="mb-2 text-danger-moderate"
+                      typographyType="body-lg"
                     >
                       {t("collection:browse.error")}
                     </Tailwind.Typography>
+
                     <Tailwind.Typography
-                      typographyType="body-md"
                       appearance="subdued"
+                      typographyType="body-md"
                     >
                       {error.message}
                     </Tailwind.Typography>
@@ -401,8 +411,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 <div className="flex flex-col items-center gap-4 py-8">
                   <div className="text-center">
                     <Tailwind.Typography
-                      typographyType="body-lg"
                       appearance="subdued"
+                      typographyType="body-lg"
                     >
                       {t("collection:browse.noCollections")}
                     </Tailwind.Typography>
@@ -411,11 +421,11 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
               ) : (
                 <>
                   {/* Results count and sort */}
-                  <div className="flex justify-between items-center mb-5">
+                  <div className="mb-5 flex items-center justify-between">
                     <Tailwind.Typography
-                      typographyType="body-md"
                       appearance="moderate"
-                      isTranslucent
+                      isTranslucent={true}
+                      typographyType="body-md"
                     >
                       {t("collection:browse.resultsCount", {
                         total: numeral(totalCount).format("0,0"),
@@ -423,14 +433,14 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                     </Tailwind.Typography>
 
                     <Tailwind.Select
+                      className="flex max-w-64 items-center gap-2.5"
+                      hideLabel={true}
                       id="sort-select"
                       label={t("collection:browse.sortBy")}
-                      hideLabel={true}
                       value={SORT_OPTIONS.indexOf(sortBy)}
                       onChange={(e) =>
                         setSortBy(SORT_OPTIONS[parseInt(e.target.value, 10)])
                       }
-                      className="flex items-center gap-2.5 max-w-64"
                     >
                       {SORT_OPTIONS.map((option, index) => (
                         <option key={option.field} value={index}>
@@ -460,34 +470,34 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
 
                       return (
                         <Tailwind.CollectionTile
-                          key={collection.id}
                           api={api}
-                          slug={collection.slug}
-                          gameId={gameId}
-                          id={collection.id.toString()}
-                          title={collection.name}
                           author={{
                             name: collection.user?.name || "Unknown",
                             avatar: collection.user?.avatar,
                           }}
+                          badges={(collection as any).badges}
+                          className="max-w-none"
                           coverImage={tileImage}
-                          tags={tags}
+                          description={
+                            (collection as any).summary ||
+                            "No description available."
+                          }
+                          gameId={gameId}
+                          id={collection.id.toString()}
+                          key={collection.id}
+                          slug={collection.slug}
                           stats={{
                             modCount: latestRevision?.modCount || 0,
                             size: latestRevision?.totalSize || 0,
                             endorsements: collection.endorsements || 0,
                           }}
-                          description={
-                            (collection as any).summary ||
-                            "No description available."
-                          }
+                          tags={tags}
+                          title={collection.name}
                           version={latestRevision?.revisionNumber?.toString()}
-                          badges={(collection as any).badges}
                           onAddCollection={() =>
                             handleAddCollection(collection)
                           }
                           onViewPage={() => handleViewOnNexus(collection)}
-                          className="max-w-none"
                         />
                       );
                     })}
@@ -495,15 +505,15 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
 
                   {/* Pagination Controls */}
                   {totalPages > 1 && (
-                    <div className="flex items-center justify-start gap-2.5 mt-8 pb-5">
+                    <div className="mt-8 flex items-center justify-start gap-2.5 pb-5">
                       {/* Previous Button */}
                       <Tailwind.Button
                         buttonType="tertiary"
+                        className=""
+                        disabled={currentPage === 1}
+                        leftIconPath={mdiChevronLeft}
                         size="md"
                         onClick={handlePreviousPage}
-                        disabled={currentPage === 1}
-                        leftIconPath="mdiChevronLeft"
-                        className=""
                       />
 
                       {/* Page Numbers */}
@@ -533,14 +543,15 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                                     ...
                                   </span>
                                 )}
+
                                 <Tailwind.Button
                                   buttonType="tertiary"
-                                  size="md"
+                                  className=""
                                   filled={
                                     page === currentPage ? "weak" : undefined
                                   }
+                                  size="md"
                                   onClick={() => handlePageClick(page)}
-                                  className=""
                                 >
                                   {page.toString()}
                                 </Tailwind.Button>
@@ -552,37 +563,39 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                       {/* Next Button */}
                       <Tailwind.Button
                         buttonType="tertiary"
+                        className=""
+                        disabled={currentPage === totalPages}
+                        leftIconPath={mdiChevronRight}
                         size="md"
                         onClick={handleNextPage}
-                        disabled={currentPage === totalPages}
-                        leftIconPath="mdiChevronRight"
-                        className=""
                       />
 
                       {/* Direct Page Input */}
-                      <div className="flex items-center gap-1 ml-5">
+                      <div className="ml-5 flex items-center gap-1">
                         <Tailwind.Typography
-                          typographyType="body-md"
                           appearance="subdued"
+                          typographyType="body-md"
                         >
                           {t("collection:pagination.goTo")}
                         </Tailwind.Typography>
+
                         <Tailwind.Input
+                          className="min-w-10 text-center"
+                          hideLabel={true}
+                          id="page-input"
+                          label={t("collection:pagination.pageNumber")}
+                          max={totalPages}
+                          min={1}
                           type="number"
                           value={pageInput}
                           onChange={(e) => setPageInput(e.target.value)}
                           onKeyDown={handlePageInputKeyDown}
-                          className="min-w-10 text-center"
-                          id="page-input"
-                          label={t("collection:pagination.pageNumber")}
-                          hideLabel={true}
-                          min={1}
-                          max={totalPages}
                         />
+
                         <Tailwind.Button
                           buttonType="secondary"
-                          size="md"
                           filled="weak"
+                          size="md"
                           onClick={handleGoToPage}
                         >
                           {t("collection:pagination.go")}
@@ -598,25 +611,25 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
               <div className="flex flex-col items-center gap-4 py-16">
                 {/* Icon */}
                 <Tailwind.Icon
+                  className="size-9 text-neutral-subdued"
                   path="mdiClockOutline"
                   size="xl"
-                  className="w-9 h-9 text-neutral-subdued"
                 />
 
                 {/* Heading */}
                 <Tailwind.Typography
-                  typographyType="body-xl"
                   appearance="subdued"
                   className="font-semibold"
+                  typographyType="body-xl"
                 >
                   {t("collection:browse.modsComingSoon.title")}
                 </Tailwind.Typography>
 
                 {/* Description */}
                 <Tailwind.Typography
-                  typographyType="body-lg"
                   appearance="subdued"
                   className="text-center"
+                  typographyType="body-lg"
                 >
                   {t("collection:browse.modsComingSoon.description")}
                 </Tailwind.Typography>
@@ -624,9 +637,9 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 {/* Button */}
                 <Tailwind.Button
                   buttonType="tertiary"
-                  size="sm"
                   filled="weak"
-                  leftIconPath="mdiOpenInNew"
+                  leftIconPath={mdiOpenInNew}
+                  size="sm"
                   onClick={() => {
                     const game = getGame(gameId);
                     const domainName = nexusGameId(game, gameId);

--- a/src/tailwind/components/next/README.md
+++ b/src/tailwind/components/next/README.md
@@ -354,62 +354,36 @@ import { Button } from '../../../tailwind/next/button';
 **Demo:** See `ButtonDemo` component
 
 **Icon Support:**
-Icons are fully supported using Material Design Icons from `@mdi/js`:
+Icons are supported using Material Design Icons from `@mdi/js` and custom Nexus icons from `tailwind/lib/icon-paths`. The `path` prop accepts a full SVG path string, so you must import the icon path first:
 
 ```tsx
-// With icon name (automatically looks up in @mdi/js)
-<Button buttonType="primary" leftIconPath="mdiDownload">
+import { mdiDownload, mdiChevronRight, mdiCog, mdiChevronDown } from "@mdi/js";
+import { nxmVortex, nxmCollection, nxmInstall } from "../../../tailwind/lib/icon-paths";
+
+// With left icon
+<Button buttonType="primary" leftIconPath={mdiDownload}>
   Download
 </Button>
 
 // With right icon
-<Button buttonType="secondary" rightIconPath="mdiChevronRight">
+<Button buttonType="secondary" rightIconPath={mdiChevronRight}>
   Next
 </Button>
 
 // With both icons
-<Button buttonType="tertiary" leftIconPath="mdiCog" rightIconPath="mdiChevronDown">
+<Button buttonType="tertiary" leftIconPath={mdiCog} rightIconPath={mdiChevronDown}>
   Settings
 </Button>
-```
 
-Available icon names can be found at: https://pictogrammers.com/library/mdi/
-
-**Nexus Mods Custom Icons:**
-In addition to Material Design Icons, the Icon component supports 34 custom Nexus Mods icons:
-
-```tsx
-// Using Nexus Mods custom icons
-<Button buttonType="primary" leftIconPath="nxmVortex">
+// With Nexus Mods custom icons
+<Button buttonType="primary" leftIconPath={nxmVortex}>
   Launch Vortex
 </Button>
-
-<Button buttonType="secondary" leftIconPath="nxmCollection">
-  Collections
-</Button>
-
-<Button buttonType="tertiary" leftIconPath="nxmInstall">
-  Install Mod
-</Button>
 ```
 
-**Available Nexus Icons:**
+Available MDI icons can be found at: https://pictogrammers.com/library/mdi/
 
-- **Brand/App**: `nxmVortex`, `nxmMod`, `nxmModOutline`, `nxmCollection`, `nxmCollections`
-- **Actions**: `nxmInstall`, `nxmDataCheck`, `nxmClipboard`, `nxmUnblock`
-- **Stats/Display**: `nxmUniqueDownloads`, `nxmFileSize`, `nxmHandHeartOutline` (endorsement), `nxmRosette` (featured), `nxmStar`
-- **Social/Publishers**: `nxmDiscord`, `nxmTikTok`, `nxmTwitch`, `nxmX`, `nxmElectronicArts`, `nxmEpicGames`, `nxmPayPal`
-- **UI/Navigation**: `nxmBackArrow`, `nxmGridStandard`, `nxmGridCompact`, `nxmGridList`
-- **Support**: `nxmBug`, `nxmShieldQuestion`, `nxmShieldCross`, `nxmTrackingCentre`
-- **Gaming**: `nxmJoystick`
-
-All Nexus icons are located in `src/tailwind/lib/icon-paths/` and can be imported directly:
-
-```tsx
-import { nxmVortex, nxmCollection } from "../../../tailwind/lib/icon-paths";
-// or
-import { nxmVortex, nxmCollection } from "tailwind";
-```
+Nexus icons are located in `src/tailwind/lib/icon-paths/` and include icons for brand, actions, stats, social, navigation, and more.
 
 ### Icon
 
@@ -422,14 +396,9 @@ Located in `icon/`
 
 **Features:**
 
-- Supports Material Design Icons from `@mdi/js` (5000+ icons)
-- Supports 34 custom Nexus Mods icons
-- Auto-resolution of icon names to SVG paths
+- Accepts full SVG path strings (import from `@mdi/js` or `tailwind/lib/icon-paths`)
 - Named size system matching web team (xs, sm, md, lg, xl, 2xl, none)
-- Custom size override with rem units
-- Type-safe XOr constraint prevents conflicting size props
 - Accessibility support with title attribute
-- Direct SVG path data support
 
 **Size System:**
 
@@ -445,43 +414,20 @@ Located in `icon/`
 
 ```tsx
 import { Icon } from '../../../tailwind/components/next/icon';
+import { mdiAccount, mdiDownload } from "@mdi/js";
+import { nxmVortex } from "../../../tailwind/lib/icon-paths";
 
 // Material Design Icon with named size
-<Icon path="mdiAccount" size="md" />
+<Icon path={mdiAccount} size="md" />
 
 // Nexus Mods Icon with named size
-<Icon path="nxmVortex" size="lg" />
+<Icon path={nxmVortex} size="lg" />
 
 // Custom size with className (use size="none")
-<Icon path="mdiDownload" size="none" className="tw:size-6" />
-
-// Custom rem size with sizeOverride
-<Icon path="mdiAccount" sizeOverride="1.75rem" />
-
-// Direct SVG path
-<Icon path="M12 2L2 7L12 12L22 7L12 2Z" size="sm" />
+<Icon path={mdiDownload} size="none" className="tw:size-6" />
 
 // With accessibility
-<Icon path="mdiAccount" size="md" title="User Account" />
-```
-
-**Icon Resolution:**
-The Icon component automatically resolves icon names:
-
-1. Icons starting with `mdi` are looked up in `@mdi/js`
-2. Icons starting with `nxm` are looked up in custom Nexus icon paths
-3. Strings starting with `M` or `m` are treated as direct SVG path data
-
-**Type Safety:**
-The component uses an XOr type constraint - you can use either `size` OR `sizeOverride`, but not both:
-
-```tsx
-// ✅ Valid
-<Icon path="mdiAccount" size="md" />
-<Icon path="mdiAccount" sizeOverride="1.5rem" />
-
-// ❌ TypeScript error - cannot use both
-<Icon path="mdiAccount" size="md" sizeOverride="1.5rem" />
+<Icon path={mdiAccount} size="md" title="User Account" />
 ```
 
 ### Link

--- a/src/tailwind/lib/icon-paths/icon-paths.ts
+++ b/src/tailwind/lib/icon-paths/icon-paths.ts
@@ -5,9 +5,9 @@
  * Adapted from the web team's "next" project for use in Vortex.
  *
  * Usage:
- * - In Icon component: <Icon path="nxmVortex" />
- * - In Button component: <Button leftIconPath="nxmVortex">...</Button>
- * - Direct import: import { nxmVortex } from 'tailwind/lib/icon-paths';
+ * - import { nxmVortex } from 'tailwind/lib/icon-paths';
+ * - In Icon component: <Icon path={nxmVortex} />
+ * - In Button component: <Button leftIconPath={nxmVortex}>...</Button>
  *
  * All icons are designed for a 24x24 viewBox.
  */


### PR DESCRIPTION
## Summary
- Updated `BrowseNexusPage` to import icon paths from `@mdi/js` and pass them as expressions (e.g. `leftIconPath={mdiRefresh}`) instead of string names (`leftIconPath="mdiRefresh"`)
- Fixed documentation in `README.md` and `icon-paths.ts` comments that incorrectly described auto-resolution of icon name strings — the Icon component only accepts full SVG path data