### PR TITLE
added handling for transient EBUSY errors when starting loot

### DIFF
--- a/extensions/gamebryo-plugin-management/src/autosort.ts
+++ b/extensions/gamebryo-plugin-management/src/autosort.ts
@@ -911,15 +911,28 @@ class LootInterface {
   });
 
   private fork = (modulePath: string, args: string[]) => {
-    (this.mExtensionApi as any)
-      .runExecutable(process.execPath, [modulePath].concat(args || []), {
-        detach: false,
-        suggestDeploy: false,
-        expectSuccess: true,
-        env: {
-          ELECTRON_RUN_AS_NODE: "1",
-        },
-      })
+    const attempt = (retries: number): Bluebird<void> => {
+      return (this.mExtensionApi as any)
+        .runExecutable(process.execPath, [modulePath].concat(args || []), {
+          detach: false,
+          suggestDeploy: false,
+          expectSuccess: true,
+          env: {
+            ELECTRON_RUN_AS_NODE: "1",
+          },
+        })
+        .catch((err: Error) => {
+          if ((err as any).code === "EBUSY" && retries > 0) {
+            log("debug", "LOOT fork got EBUSY, retrying", {
+              retriesLeft: retries,
+            });
+            return Bluebird.delay(500).then(() => attempt(retries - 1));
+          }
+          return Bluebird.reject(err);
+        });
+    };
+
+    attempt(5)
       .catch(util.UserCanceled, () => null)
       .catch(util.ProcessCanceled, () => null)
       .catch((err) => {


### PR DESCRIPTION
AV's are scanning the app on first start and causing libloot to fail to spawn with EBUSY errors - hopefully this retry logic sorts it out.

fixes nexus-mods/vortex#19609