### PR TITLE
Fix Illegal invocation error in Debouncer setTimeout/clearTimeout calls

### DIFF
--- a/src/main/NodeDebouncer.ts
+++ b/src/main/NodeDebouncer.ts
@@ -1,9 +1,13 @@
-import { GenericDebouncer } from "../shared/Debouncer";
+import {
+  GenericDebouncer,
+  SetTimeoutFunc,
+  ClearTimeoutFunc,
+} from "../shared/Debouncer";
 
 export default class Debouncer extends GenericDebouncer<
   NodeJS.Timeout,
-  typeof setTimeout,
-  typeof clearTimeout
+  SetTimeoutFunc<NodeJS.Timeout>,
+  ClearTimeoutFunc<NodeJS.Timeout>
 > {
   constructor(
     func: (...args: any[]) => Error | PromiseLike<void>,
@@ -12,8 +16,8 @@ export default class Debouncer extends GenericDebouncer<
     triggerImmediately: boolean = false,
   ) {
     super(
-      setTimeout,
-      clearTimeout,
+      (callback, delay) => setTimeout(callback, delay),
+      (timeout) => clearTimeout(timeout),
       func,
       debounceMS,
       reset,

--- a/src/util/Debouncer.ts
+++ b/src/util/Debouncer.ts
@@ -1,9 +1,13 @@
-import { GenericDebouncer } from "../shared/Debouncer";
+import {
+  GenericDebouncer,
+  SetTimeoutFunc,
+  ClearTimeoutFunc,
+} from "../shared/Debouncer";
 
 export default class Debouncer extends GenericDebouncer<
   ReturnType<typeof setTimeout>,
-  typeof setTimeout,
-  typeof clearTimeout
+  SetTimeoutFunc<ReturnType<typeof setTimeout>>,
+  ClearTimeoutFunc<ReturnType<typeof setTimeout>>
 > {
   constructor(
     func: (...args: any[]) => Error | PromiseLike<void>,
@@ -12,8 +16,8 @@ export default class Debouncer extends GenericDebouncer<
     triggerImmediately: boolean = false,
   ) {
     super(
-      setTimeout,
-      clearTimeout,
+      (callback, delay) => setTimeout(callback, delay),
+      (timeout) => clearTimeout(timeout),
       func,
       debounceMS,
       reset,


### PR DESCRIPTION
Passing setTimeout/clearTimeout as bare function references to GenericDebouncer loses the window context in the Electron renderer process, causing "TypeError: Illegal invocation" at runtime. Wrap them in arrow functions so they are always called with the correct global context.

Vortex won't start on my machine without this, it crashes during startup. 