### PR TITLE
fixed destructive reference update operation for dependencies

### DIFF
--- a/src/extensions/mod_management/util/dependencies.ts
+++ b/src/extensions/mod_management/util/dependencies.ts
@@ -352,6 +352,9 @@ export function findDownloadByRef(
   reference: IReference,
   downloads: { [dlId: string]: IDownload },
 ): string {
+  if (!reference) {
+    return undefined;
+  }
   if (reference["md5Hint"] !== undefined) {
     const result = Object.keys(downloads).find(
       (dlId) => downloads[dlId].fileMD5 === reference["md5Hint"],


### PR DESCRIPTION
Can occur when installing the same archive from different collections (even revisions) which contain a different tag for that mod. (this is potentially the culprit for "A StoryWealth" issues)

fixes nexus-mods/vortex#19697
potentially affects nexus-mods/vortex#19680