### PR TITLE
Fix Linux Steam game detection

### DIFF
--- a/src/util/GameStoreHelper.ts
+++ b/src/util/GameStoreHelper.ts
@@ -170,16 +170,14 @@ class GameStoreHelper {
               });
             }
           }
-          if (
-            result &&
-            result.gameStoreId !== undefined &&
-            result.priority !== undefined
-          ) {
+          if (result !== undefined) {
             result.priority =
               storeQuery.prefer ??
-              this.mStoresDict[result.gameStoreId]?.priority ??
+              (result.gameStoreId !== undefined
+                ? this.mStoresDict[result.gameStoreId]?.priority
+                : undefined) ??
               defaultPriority;
-            result.priority! += prioOffset++ / 1000;
+            result.priority += prioOffset++ / 1000;
             results.push(result);
           }
         }

--- a/src/util/linux/steamPaths.ts
+++ b/src/util/linux/steamPaths.ts
@@ -1,13 +1,13 @@
 import * as path from "path";
 import * as fs from "fs";
-import getVortexPath from "../getVortexPath";
+import * as os from "os";
 
 /**
  * Default Steam installation paths for Linux systems
  * Ordered by likelihood (most common first)
  */
 export function getLinuxSteamPaths(): string[] {
-  const home = getVortexPath("home");
+  const home = os.homedir();
   return [
     path.join(home, ".local", "share", "Steam"), // XDG standard (native)
     path.join(home, ".steam", "debian-installation"), // Debian/Ubuntu symlink


### PR DESCRIPTION
## Summary

Vortex cannot discover Steam games on Linux due to two independent bugs:

1. **Steam path detection uses `getVortexPath("home")` instead of `os.homedir()`** — prevents the Steam base directory from being found at all.
2. **`GameStoreHelper.find()` regression** — a `strictNullChecks` refactor broke all `queryArgs`-based game discovery.

## Bug 1: Wrong home directory from Electron initialization dependency

`getLinuxSteamPaths()` called `getVortexPath("home")` to build paths like `~/.local/share/Steam`. Under the hood, `getVortexPath("home")` resolves through a multi-layered system that depends on Electron's initialization state:

- **Main process**: delegates to `electron.app.getPath("home")` via `cachedAppPath()`, which requires the Electron `app` object to be fully initialized. If `app` is `undefined` (e.g. the call happens before Electron is ready, or in a forked child process that didn't receive the env vars), it falls back to `os.tmpdir()` — returning something like `/tmp` instead of the user's home directory.
- **Renderer process**: reads from `ApplicationData.vortexPaths`, a cache populated over IPC from the main process during startup. If the cache hasn't been populated yet (timing-dependent), the path lookup can fail or return stale/incorrect values.
- **Forked child processes**: read from environment variables (`ELECTRON_HOME`) that are set when the process is spawned. If game discovery runs in a context where these env vars weren't propagated, the home path is wrong.

All of these indirections are unnecessary here. The home directory is a simple OS-level fact — `os.homedir()` returns it directly from Node.js without any dependency on Electron's lifecycle, IPC state, or environment variable propagation. The fix replaces `getVortexPath("home")` with `os.homedir()`.

## Bug 2: `GameStoreHelper.find()` always discards results

Commit f4d9f06d5 (a `strictNullChecks` refactor) changed the guard in `find()` from:

```typescript
if (result !== undefined)
```

to:

```typescript
if (result && result.gameStoreId !== undefined && result.priority !== undefined)
```

The `result.priority !== undefined` check is the problem: `priority` is not a field that game stores set on their entries — it's **assigned** inside this very block. The old code checked `result !== undefined`, then assigned priority. The refactored code checks priority as a precondition, which always fails, so every result is silently discarded. This breaks all `queryArgs`-based discovery (the primary mechanism game extensions use to find installed games).

The fix restores the guard to `if (result !== undefined)` and keeps strict null safety by wrapping the `mStoresDict` lookup in a ternary to handle entries where `gameStoreId` is undefined (registry entries).

## Test plan

- [x] `yarn build` compiles without errors in modified files
- [x] `yarn test` — no test regressions from these changes
- [x] Manual: start Vortex on Linux, verify Steam games are automatically discovered