### PR TITLE
Fixed deleting custom themes

### DIFF
--- a/extensions/theme-switcher/src/operations.ts
+++ b/extensions/theme-switcher/src/operations.ts
@@ -156,7 +156,7 @@ export function readThemeVariables(
 export function removeTheme(api: types.IExtensionApi, themeName: string) {
   selectTheme(api, "default");
   const currentThemePath = themePath(themeName);
-  this.nextState.themes = themes.filter((iter) => iter !== currentThemePath);
+  themes.splice(themes.indexOf(currentThemePath), 1);
   return fs
     .removeAsync(currentThemePath)
     .then(() => {


### PR DESCRIPTION
Fixes #19324 

this.nextState is undefined. Looks like this might have been a very old (4+ years) way of doing things that was never updated.