### PR TITLE
Download Issues Fixes

### DIFF
--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -2572,7 +2572,8 @@ class DownloadManager {
       // download attempts (e.g., non-chunkable re-downloads that don't truncate on open)
       // Use download.size (from server) when known; download.received can be inflated
       // by chunk retries that re-download and re-count the same bytes
-      const actualSize = ((download.size ?? 0) > 0) ? download.size : (download.received ?? 0);
+      const knownSize = download.size ?? 0;
+      const actualSize = knownSize > 0 ? knownSize : (download.received ?? 0);
       if (actualSize > 0) {
         download.assembler.truncate(actualSize);
       }

--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -452,10 +452,13 @@ class DownloadWorker {
     );
 
     try {
+      // Don't request compressed encoding — Range headers specify byte offsets
+      // of the uncompressed resource, and mixing compression with range requests
+      // causes size mismatches that corrupt chunked downloads
       const headers = {
         Range: `bytes=${job.offset}-${job.offset + job.size - 1}`,
         "User-Agent": this.mUserAgent,
-        "Accept-Encoding": "gzip, deflate",
+        "Accept-Encoding": "identity",
         Cookie: allCookies,
       };
       if (referer !== undefined) {

--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -932,7 +932,7 @@ class DownloadWorker {
 
       let fileSize = chunkSize;
       if (chunkable) {
-        const rangeExp: RegExp = /bytes (\d)*-(\d*)\/(\d*)/i;
+        const rangeExp: RegExp = /bytes (\d+)-(\d+)\/(\d+)/i;
         const sizeMatch: string[] = (
           response.headers["content-range"] as string
         ).match(rangeExp);

--- a/src/extensions/download_management/DownloadManager.ts
+++ b/src/extensions/download_management/DownloadManager.ts
@@ -2564,6 +2564,14 @@ class DownloadManager {
 
     if (activeChunk === undefined) {
       let finalPath = download.tempName;
+      // Truncate file to actual size to remove stale data from previous
+      // download attempts (e.g., non-chunkable re-downloads that don't truncate on open)
+      // Use download.size (from server) when known; download.received can be inflated
+      // by chunk retries that re-download and re-count the same bytes
+      const actualSize = ((download.size ?? 0) > 0) ? download.size : (download.received ?? 0);
+      if (actualSize > 0) {
+        download.assembler.truncate(actualSize);
+      }
       download.assembler
         .close()
         .then(() => {

--- a/src/extensions/download_management/FileAssembler.ts
+++ b/src/extensions/download_management/FileAssembler.ts
@@ -190,6 +190,30 @@ class FileAssembler {
     }, false);
   }
 
+  public truncate(size: number): Promise<void> {
+    if (size <= 0) {
+      return Promise.resolve();
+    }
+    return this.mQueue(
+      () =>
+        this.mFD === undefined
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => {
+              fsFast.ftruncate(this.mFD, size, (err) => {
+                if (err) {
+                  log("warn", "failed to truncate file", {
+                    file: this.mFileName,
+                    size,
+                    error: err.message,
+                  });
+                }
+                resolve();
+              });
+            }),
+      false,
+    );
+  }
+
   private writeAsync(data: Buffer, offset: number) {
     return fs
       .writeAsync(this.mFD, data, 0, data.length, offset)

--- a/src/extensions/download_management/types/IDownloadJob.ts
+++ b/src/extensions/download_management/types/IDownloadJob.ts
@@ -55,6 +55,9 @@ export interface IDownloadJob extends IChunk {
   /** Number of times startJob has failed for this chunk */
   startFailures?: number;
 
+  /** Timestamp (ms) before which this chunk should not be retried (used for empty-response backoff) */
+  retryAfter?: number;
+
   extraCookies: string[];
 
   dataCB?: (offset: number, data) => Promise<boolean>;

--- a/src/extensions/download_management/types/IDownloadJob.ts
+++ b/src/extensions/download_management/types/IDownloadJob.ts
@@ -52,6 +52,9 @@ export interface IDownloadJob extends IChunk {
   /** Number of times this chunk has been requeued after finishing with remaining data */
   requeues?: number;
 
+  /** Number of times startJob has failed for this chunk */
+  startFailures?: number;
+
   extraCookies: string[];
 
   dataCB?: (offset: number, data) => Promise<boolean>;

--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -3599,7 +3599,7 @@ class InstallManager {
     tempPath: string,
     progress: (files: string[], percent: number) => void,
     queryPassword: () => Bluebird<string>,
-    maxRetries: number = 3,
+    maxRetries: number = 10,
     retryDelayMs: number = 1000,
   ): Bluebird<{ code: number; errors: string[] }> {
     const attemptExtract = (


### PR DESCRIPTION
* Truncate file if the size is bigger than expected
* Avoid compressed chunks
* Content-range was only capturing the last digit
* Reset write offset on non chunkable response
* Fixed file used by another process
* Additional validations on file before performing actions
* Retry after pause on empty chunks
* Rotate through our available downland urls on retries