### PR TITLE
added protective code to validate potentially invalid download entries

### DIFF
--- a/src/extensions/download_management/reducers/state.ts
+++ b/src/extensions/download_management/reducers/state.ts
@@ -221,6 +221,7 @@ export const stateReducer: IReducerSpec = {
         game: [payload.game],
         localPath: payload.localPath,
         size: payload.fileSize,
+        received: payload.fileSize,
         fileTime: Date.now(),
         urls: [],
         modInfo: {},


### PR DESCRIPTION
will now compare a download's state against the disk state in case Vortex's state is corrupt somehow