### PR TITLE
added protective code to avoid forwarding nullish values to minimatch during deployment

### DIFF
--- a/src/extensions/mod_management/util/BlacklistSet.ts
+++ b/src/extensions/mod_management/util/BlacklistSet.ts
@@ -1,23 +1,27 @@
 import minimatch from "minimatch";
 import { DEPLOY_BLACKLIST } from "../constants";
-import { Normalize } from "../../../util/getNormalizeFunc";
+import type { Normalize } from "../../../util/getNormalizeFunc";
 import { IGame } from "../../../types/IGame";
 
 export default class BlacklistSet extends Set<string> {
   private mPatterns: string[];
   constructor(blacklist: string[], game: IGame, normalize: Normalize) {
-    super(blacklist.map((iter) => normalize(iter)));
-    this.mPatterns = [].concat(
-      DEPLOY_BLACKLIST,
-      game.details?.ignoreDeploy ?? [],
-    );
+    super(blacklist.filter((x) => !!x).map((iter) => normalize(iter)));
+    const patterns = DEPLOY_BLACKLIST.concat(game.details?.ignoreDeploy ?? []);
+    this.mPatterns = patterns.filter((x) => !!x).map((iter) => normalize(iter));
   }
 
   public has(value: string): boolean {
-    return (
-      super.has(value) ||
-      this.mPatterns.find((pat) => minimatch(value, pat, { nocase: true })) !==
-        undefined
-    );
+    if (!value) {
+      return false;
+    }
+    try {
+      return (
+        super.has(value) ||
+        this.mPatterns.some((pat) => minimatch(value, pat, { nocase: true }))
+      );
+    } catch {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
not sure how this is possible but at least we shouldn't crash.

fixes nexus-mods/vortex#20424