### PR TITLE
fixed unhandled processcanceled errors causing app to crash

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -110,7 +110,7 @@ function last(array: any[]): any {
 
 class Application {
   public static shouldIgnoreError(error: any, promise?: any): boolean {
-    if (error instanceof UserCanceled) {
+    if (error instanceof UserCanceled || error instanceof ProcessCanceled) {
       return true;
     }
 


### PR DESCRIPTION
Similar to UserCanceled, ProcessCanceled errors are being thrown all over the place, including in 3rd party extensions - unfortunately these are not handled correctly in some external extensions and will cause the app to crash pointlessly - this commit fixes that.