### PR TITLE
added protective code when rendering groups

### DIFF
--- a/extensions/gamebryo-plugin-management/src/util/GroupFilter.tsx
+++ b/extensions/gamebryo-plugin-management/src/util/GroupFilter.tsx
@@ -19,7 +19,7 @@ class GroupFilterComponent extends React.Component<IProps, {}> {
     const { filter, masterlist, userlist } = this.props;
 
     const options = Array.from(new Set(
-          [].concat(masterlist.groups, userlist.groups)
+          [].concat(masterlist.groups || [], userlist.groups || [])
             .map(iter => iter.name)))
       .map(iter => ({ label: iter, value: iter }));
 

--- a/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
@@ -150,7 +150,7 @@ class GroupSelect extends React.PureComponent<IGroupSelectProps, IGroupSelectSta
     }
 
     const existingOptions = Array.from(new Set([]
-        .concat(masterlist.groups, userlist.groups)
+        .concat(masterlist.groups || [], userlist.groups || [])
         .filter(iter => iter !== undefined)
         .map(iter => iter.name)))
       .map(iter => ({ label: iter, value: iter }));
@@ -1133,8 +1133,8 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
   private setGroup = (plugin: string, group: string) => {
     const { onAddGroup, onAddGroupRule, onSetGroup, masterlist, userlist } = this.props;
     if ((group !== undefined)
-      && (masterlist.groups.find(iter => iter.name === group) === undefined)
-      && (userlist.groups.find(iter => iter.name === group) === undefined)) {
+      && ((masterlist.groups || []).find(iter => iter.name === group) === undefined)
+      && ((userlist.groups || []).find(iter => iter.name === group) === undefined)) {
       onAddGroup(group);
       onAddGroupRule(group, 'default');
     }


### PR DESCRIPTION
When LOOT data is loaded, masterlist.groups or userlist.groups can be null/undefined instead of an array. The code concatenates and .map()s over them without null guards, so selecting any group category in Plugins -> Group -> Select crashes the renderer.

fixes nexus-mods/vortex#20436