### PR TITLE
fixed inconsistent rule checks between unsolved notif and rules dialogs

### DIFF
--- a/extensions/mod-dependency-manager/src/unsolvedConflictsCheck.ts
+++ b/extensions/mod-dependency-manager/src/unsolvedConflictsCheck.ts
@@ -2,7 +2,7 @@ import Promise from 'bluebird';
 import { selectors, types, util } from 'vortex-api';
 import { IBiDirRule } from './types/IBiDirRule';
 import { IConflict } from './types/IConflict';
-import { IModLookupInfo } from './types/IModLookupInfo';
+import { findRuleBiDir } from './util/findRule';
 import showUnsolvedConflictsDialog from './util/showUnsolvedConflicts';
 
 function unsolvedConflictsCheck(api: types.IExtensionApi,
@@ -11,21 +11,23 @@ function unsolvedConflictsCheck(api: types.IExtensionApi,
   const state = api.store.getState();
   const t = api.translate;
 
-  const findRule = (source: types.IMod, ref: IModLookupInfo): IBiDirRule => {
-    return modRules.find(rule =>
-      util.testModReference(source, rule.source)
-      && util.testModReference(ref, rule.reference));
-  };
-
   const gameMode = selectors.activeGameId(state);
   const mods = util.getSafe(state, ['persistent', 'mods', gameMode], {});
   const conflicts: { [modId: string]: IConflict[] } =
     util.getSafe(state, ['session', 'dependencies', 'conflicts'], {}) || {};
 
   // find the first conflict that has no rule associated
+  const encountered = new Set<string>();
+  const mapEnc = (lhs: string, rhs: string) => [lhs, rhs].sort().join(':');
   const firstConflict = Object.keys(conflicts).find(modId =>
-    conflicts[modId].find(conflict =>
-      findRule(mods[modId], conflict.otherMod) === undefined) !== undefined);
+    conflicts[modId].find(conflict => {
+      const encKey = mapEnc(modId, conflict.otherMod.id);
+      if (encountered.has(encKey)) {
+        return false;
+      }
+      encountered.add(encKey);
+      return findRuleBiDir(modRules, mods[modId], conflict.otherMod) === undefined;
+    }) !== undefined);
   if (firstConflict !== undefined) {
     return api.showDialog('error', t('Unresolved Conflict'), {
       bbcode: t('You have unresolved file conflicts {{more}}. '

--- a/extensions/mod-dependency-manager/src/util/DependenciesFilter.tsx
+++ b/extensions/mod-dependency-manager/src/util/DependenciesFilter.tsx
@@ -123,8 +123,10 @@ class DependenciesFilter implements types.ITableFilter {
 
   private findRule(source: types.IMod, ref: IModLookupInfo): IBiDirRule {
     return this.mLocalState.modRules.find(rule =>
-      util.testModReference(source, rule.source)
-      && util.testModReference(ref, rule.reference));
+      (util.testModReference(source, rule.source)
+        && util.testModReference(ref, rule.reference))
+      || (util.testModReference(ref, rule.source)
+        && util.testModReference(source, rule.reference)));
   }
 
   private getDependencyRulesImpl(modId: string) {

--- a/extensions/mod-dependency-manager/src/util/findRule.ts
+++ b/extensions/mod-dependency-manager/src/util/findRule.ts
@@ -8,4 +8,17 @@ function findRule(modRules: IBiDirRule[], source: types.IMod, ref: IModLookupInf
     && util.testModReference(ref, rule.reference));
 }
 
+/**
+ * Like findRule but checks both directions: a rule from source→ref OR ref→source.
+ * Use this when checking if a conflict pair has been resolved in either direction.
+ */
+export function findRuleBiDir(modRules: IBiDirRule[], source: types.IMod,
+                              ref: IModLookupInfo): IBiDirRule {
+  return modRules.find(rule =>
+    (((source === undefined) || util.testModReference(source, rule.source))
+      && util.testModReference(ref, rule.reference))
+    || (util.testModReference(ref, rule.source)
+      && ((source === undefined) || util.testModReference(source, rule.reference))));
+}
+
 export default findRule;

--- a/extensions/mod-dependency-manager/src/util/showUnsolvedConflicts.ts
+++ b/extensions/mod-dependency-manager/src/util/showUnsolvedConflicts.ts
@@ -1,7 +1,7 @@
 import { selectors, types, util } from 'vortex-api';
 import { setConflictDialog } from '../actions';
 import { IBiDirRule } from '../types/IBiDirRule';
-import findRule from './findRule';
+import { findRuleBiDir } from './findRule';
 
 function showUnsolvedConflictsDialog(api: types.IExtensionApi,
                                      modRules: IBiDirRule[],
@@ -28,11 +28,18 @@ function showUnsolvedConflictsDialog(api: types.IExtensionApi,
   let modsToShow = Object.keys(conflicts);
 
   if (!showAll) {
+    const encountered = new Set<string>();
+    const mapEnc = (lhs: string, rhs: string) => [lhs, rhs].sort().join(':');
     modsToShow = modsToShow.filter(modId => conflicts[modId].find(conflict => {
       if (conflict.otherMod === undefined) {
         return false;
       }
-      const rule = findRule(modRules, mods[modId], conflict.otherMod);
+      const encKey = mapEnc(modId, conflict.otherMod.id);
+      if (encountered.has(encKey)) {
+        return false;
+      }
+      encountered.add(encKey);
+      const rule = findRuleBiDir(modRules, mods[modId], conflict.otherMod);
       return rule === undefined;
     }) !== undefined);
   }

--- a/extensions/mod-dependency-manager/src/views/DependencyIcon.tsx
+++ b/extensions/mod-dependency-manager/src/views/DependencyIcon.tsx
@@ -496,7 +496,10 @@ class DependencyIcon extends ComponentEx<IProps, IComponentState> {
   }
 
   private findRule(ref: IModLookupInfo): IBiDirRule {
-    return this.state.modRules.find(rule => util.testModReference(ref, rule.reference));
+    const { mod } = this.props;
+    return this.state.modRules.find(rule =>
+      (util.testModReference(mod, rule.source) && util.testModReference(ref, rule.reference))
+      || (util.testModReference(ref, rule.source) && util.testModReference(mod, rule.reference)));
   }
 
   private renderOverrideIcon(mod: types.IMod) {


### PR DESCRIPTION
conflict rules are bidirectional, the dialog rule lookups were unidirectional and could potentially not display b->a conflicts.

additionally we had a duplication issue where a conflict pair could potentially pass through the filter twice (once from each side) and show up as two separate unsolved entries (when they were actually solved)

fixes nexus-mods/vortex#19746

Funny fact - this bug was in there since before 1.15.2, not sure why it's popping its head now.