### PR TITLE
Align build docs and Nix flake with current setup

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -118,7 +118,7 @@ sudo pacman -S base-devel python python-setuptools dotnet-sdk-9.0
 - Install toolchain requirements: `volta install node@22 yarn@v1`
 - Install PNPM via Corepack: `npm install --global corepack@latest && corepack install`
 - Setup dependencies: `pnpm run build:fomod && pnpm install`
-- Build: `pnpm run build`
+- Build: `pnpm run build:all`
 - Start: `pnpm run start`
     - Wayland: `pnpm run start -- --ozone-platform-hint=auto`
 
@@ -155,7 +155,7 @@ There is a `flake.nix` that provides all required dependencies: `node`, `pnpm`, 
     - Or if using direnv: `direnv allow` (from now on shell will auto-activate when you `cd` into this folder)
 - Use shell-provided `pnpm` directly (do not run `corepack enable` inside Nix shells)
 - Setup dependencies: `pnpm run build:fomod && pnpm install`
-- Build: `pnpm run build`
+- Build: `pnpm run build:all`
 - Start: `pnpm run start`
 
 Python is included in the dev shell (with `setuptools`) for node-gyp and the Flatpak helper scripts.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Once complete, you can build Vortex:
 ```powershell
 cd C:\vortex\Vortex
 pnpm run build:fomod && pnpm install  # Setup dependencies
-pnpm run build        # Build the application
+pnpm run build:all    # Build the app, assets, and bundled extensions
 ```
 
 ### Support

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             dotnetCorePackages.sdk_9_0
 
             # Electron (wrapped with GTK dependencies)
-            electron_39 # 14 Dec 2025: We're ahead of Vortex which is on 37. Doing this for default Wayland support.
+            electron_39
 
             # GTK dependencies for Electron runtime
             gtk3


### PR DESCRIPTION
## Summary
- update local build docs to use `pnpm run build:all`
- keep the Nix flake documentation in sync with the current Electron setup

## Why
The local development workflow now relies on `pnpm run build:all` as the standard pre-launch build step. Updating the docs and Nix flake notes keeps setup instructions consistent with the current repository state.