### PR TITLE
fixed packery shenanigans on dashboard

### DIFF
--- a/src/renderer/extensions/dashboard/views/Dashboard.tsx
+++ b/src/renderer/extensions/dashboard/views/Dashboard.tsx
@@ -133,6 +133,11 @@ class Dashboard extends ComponentEx<IProps, IComponentState> {
       {},
     );
 
+    // Dashlets not in the layout (e.g. just re-enabled) are appended after
+    // all existing items so Packery places them in the first available gap
+    // instead of overlapping with items that already claimed their old position.
+    const layoutSize = layout.length;
+
     const sorted = dashlets
       .filter(
         (dash: IDashletProps) =>
@@ -142,8 +147,8 @@ class Dashboard extends ComponentEx<IProps, IComponentState> {
       )
       .sort(
         (lhs: IDashletProps, rhs: IDashletProps) =>
-          (layoutMap[lhs.title] || lhs.position) -
-          (layoutMap[rhs.title] || rhs.position),
+          (layoutMap[lhs.title] ?? layoutSize + lhs.position) -
+          (layoutMap[rhs.title] ?? layoutSize + rhs.position),
       );
     const { fixed, dynamic } = sorted.reduce(
       (prev, dash) => {


### PR DESCRIPTION
Places re-enabled dashlets at the end of the layout list instead of overlapping them when enabled/disabled in quick succession.

fixes https://linear.app/nexus-mods/issue/APP-58/dashlets-can-overlap-when-toggled-off-and-back-on-before-returning-to