### PR TITLE
Add workflow for PR maintenance

### DIFF
--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -1,0 +1,44 @@
+name: "PR Maintenance"
+
+on:
+  push:
+    branches: [master]
+  pull_request_target:
+    branches: [master]
+    types: [synchronize]
+  workflow_dispatch:
+  schedule:
+    - cron: "8 10 * * *" # every day at 10:08 UTC
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-dirty:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Check if PRs are dirty"
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "PR: needs rebase"
+          removeOnDirtyLabel: "PR: ready"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: "This PR has conflicts. You need to rebase the PR before it can be merged."
+          commentOnClean: "This PR doesn't have conflicts anymore. It can be merged after all status checks have passed and it has been reviewed."
+
+  check-stale:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # ignore issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          days-before-pr-stale: 7
+          days-before-pr-close: -1 # don't auto-close stale PRs
+          stale-pr-message: "This PR has been marked as stale due to inactivity."
+          stale-pr-label: "PR: stale"


### PR DESCRIPTION
Mirrors what we had on the app repo:

- marks PRs as dirty and adds a comment if they require a rebase
- marks PRs as stale and adds a comment if they haven't been updated in a week