### PR TITLE
Added timeout to permission elevation attempts when writing files

### DIFF
--- a/src/renderer/extensions/file_based_loadorder/index.ts
+++ b/src/renderer/extensions/file_based_loadorder/index.ts
@@ -433,7 +433,7 @@ export default function init(context: IExtensionContext) {
           });
           if (loPath) {
             try {
-              await fs.ensureDirWritableAsync(path.basename(loPath));
+              await fs.ensureDirWritableAsync(path.dirname(loPath));
               await fs.writeFileAsync(loPath, data);
               api.sendNotification({
                 type: "success",

--- a/src/renderer/util/fs.ts
+++ b/src/renderer/util/fs.ts
@@ -1020,6 +1020,8 @@ function readlinkInt(
   );
 }
 
+const ELEVATED_TIMEOUT_MS = 30000;
+
 function elevated(
   func: (ipc, req: NodeRequireFunction) => Promise<void>,
   parameters: any,
@@ -1028,21 +1030,28 @@ function elevated(
   return new PromiseBB<void>((resolve, reject) => {
     const id = shortid();
     let resolved = false;
+    let elevatedError: string | undefined;
 
     const ipcPath = `__fs_elevated_${id}`;
 
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        reject(new Error("Elevated process did not connect within the expected time. "
+          + "This usually indicates it crashed or failed to start."));
+      }
+    }, ELEVATED_TIMEOUT_MS);
+
     server = net
       .createServer((connRaw) => {
+        clearTimeout(timeout);
         const conn = new JsonSocket(connRaw);
 
         conn
           .on("message", (data) => {
             if (data.error !== undefined) {
-              if (data.error.startsWith("InvalidScriptError")) {
-                reject(new Error(data.error));
-              } else {
-                log("error", "elevated process failed", data.error);
-              }
+              log("error", "elevated process failed", data.error);
+              elevatedError = data.error;
             } else {
               log("warn", "got unexpected ipc message", JSON.stringify(data));
             }
@@ -1050,7 +1059,11 @@ function elevated(
           .on("end", () => {
             if (!resolved) {
               resolved = true;
-              resolve();
+              if (elevatedError !== undefined) {
+                reject(new Error(elevatedError));
+              } else {
+                resolve();
+              }
             }
           })
           .on("error", (err) => {
@@ -1063,6 +1076,7 @@ function elevated(
       })
       .listen(path.join("\\\\?\\pipe", ipcPath));
     runElevated(ipcPath, func, parameters).catch((err: unknown) => {
+      clearTimeout(timeout);
       const nativeCode = getErrorNativeCode(err);
       const error = unknownToError(err);
       if (


### PR DESCRIPTION
- All errors except InvalidScriptError were entirely ignored, potentially resolving as if succeeded.
- elevated() could potentially wait indefinitely if elevated child process failed for any reason (module resolution, crash, etc) added a timeout period of 30 seconds to cater for this instance.
- really stupid bug in exportList, calling ensureDirWritable on a file instead of the target directory.

fixes https://linear.app/nexus-mods/issue/APP-72/load-order-export-does-not-export