### PR TITLE
Plugin rules editor tweaks

### DIFF
--- a/extensions/gamebryo-plugin-management/src/stylesheets/plugin_management.scss
+++ b/extensions/gamebryo-plugin-management/src/stylesheets/plugin_management.scss
@@ -126,8 +126,22 @@
         overflow-y: auto;
         max-height: 300px;
 
-        .btn {
-            margin-left: 8px;
+        .list-group-item {
+            display: flex;
+
+            .btn {
+                margin-right: 0.5em;
+            }
+
+            .rule-name {
+                color: $text-color;
+            }
+
+            .rule-type {
+                color: $brand-info-lighter;
+                font-style: italic;
+                margin: 0 0.5em;
+            }
         }
     }
 

--- a/extensions/gamebryo-plugin-management/src/views/UserlistEditor.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/UserlistEditor.tsx
@@ -51,7 +51,9 @@ class RuleEntry extends React.Component<IRuleEntryProps, {}> {
           tooltip=""
           onClick={this.click}
         />
-          {pluginId} {this.renderType(type)} {reference}
+        <div className="rule-name">{pluginId}</div>
+        <div className="rule-type">{this.renderType(type)}</div>
+        <div className="rule-name">{reference}</div>
       </ListGroupItem>
     );
   }


### PR DESCRIPTION
This one's very minor but it has bothered me since the beginning.

- Moves button for removing a plugin rule to the left.
  This lets you remove multiple rules in succession without having to move your mouse left/right
- Borrows rules styling from Collections to be more readable.

Current release:
<img width="587" height="241" alt="plugin-rules-old" src="https://github.com/user-attachments/assets/3d3150f9-27aa-4564-8b71-e42a4f7679de" />

This PR:
<img width="597" height="229" alt="plugin-rules-new" src="https://github.com/user-attachments/assets/323b4a1f-a6c4-465c-97a8-989c8dd687a1" />
