### PR TITLE
fixed app metadata initialization issues + cli args not persisting

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -198,10 +198,6 @@ class Application {
     }
 
     log("debug", "window created");
-
-    // Send app initialization metadata to renderer
-    // Renderer will dispatch Redux actions based on this
-    webContents.send("app:init", this.mAppMetadata);
   }
 
   private async startSplash(): Promise<SplashScreen> {
@@ -840,6 +836,10 @@ class Application {
     this.mAppMetadata = {
       commandLine: this.mArgs as unknown as Record<string, unknown>,
     };
+
+    // Register handler so renderer can request metadata via invoke (avoids
+    // race conditions with the fire-and-forget app:init send pattern)
+    ipcMain.handle("app:getInitMetadata", () => this.mAppMetadata);
 
     // 1. Create LevelPersist for the base path
     const levelPersistor = await LevelPersist.create(

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -97,8 +97,8 @@ try {
     },
     app: {
       relaunch: (args) => betterIpcRenderer.send("app:relaunch", args),
-      onInit: (callback: (metadata: AppInitMetadata) => void) =>
-        betterIpcRenderer.on("app:init", (_, metadata) => callback(metadata)),
+      getInitMetadata: (): Promise<AppInitMetadata> =>
+        betterIpcRenderer.invoke("app:getInitMetadata"),
       setProtocolClient: (protocol: string, udPath: string) =>
         betterIpcRenderer.invoke("app:setProtocolClient", protocol, udPath),
       isProtocolClient: (protocol: string, udPath: string) =>

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -326,6 +326,20 @@ function genUpdateInstalledExtensions(api: IExtensionApi) {
         if (!initial && !_.isEqual(state.session.extensions.installed, ext)) {
           if (!localState.reloadNecessary) {
             localState.reloadNecessary = true;
+
+            // Identify newly installed game extensions so we can pass --game
+            // on restart, allowing the profile manager to offer to manage it
+            const oldInstalled = state.session.extensions.installed;
+            const newGameExt = Object.entries(ext).find(
+              ([id, info]) =>
+                oldInstalled[id] === undefined &&
+                info.name?.startsWith("Game:"),
+            );
+            const relaunchArgs =
+              newGameExt !== undefined
+                ? ["--game", newGameExt[1].name]
+                : undefined;
+
             api.sendNotification({
               id: "extension-updates",
               type: "success",
@@ -334,7 +348,7 @@ function genUpdateInstalledExtensions(api: IExtensionApi) {
                 {
                   title: "Restart now",
                   action: () => {
-                    relaunch();
+                    relaunch(relaunchArgs);
                   },
                 },
               ],

--- a/src/renderer/src/extensions/gamemode_management/index.ts
+++ b/src/renderer/src/extensions/gamemode_management/index.ts
@@ -1305,10 +1305,14 @@ function init(context: IExtensionContext): boolean {
           getGame(gameMode) !== undefined
         ) {
           changeGameMode(undefined, gameMode, profile.id).then(() => null);
-        } else {
-          // if the game is no longer discovered we can't keep this profile as active
+        } else if (getGame(gameMode) !== undefined) {
+          // Game extension is loaded but the game is no longer discovered
+          // (e.g. uninstalled) — clear the active profile
           store.dispatch(setNextProfile(undefined));
         }
+        // If getGame returns undefined the extension may not be installed yet
+        // (e.g. community extension pending install). Don't clear the profile —
+        // removeDisappearedGames/stubs will handle offering to install it.
       }
     }
   });

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -44,6 +44,7 @@ import {
   setProgress,
   setUIBlocker,
 } from "../../actions/session";
+import { log } from "../../logging";
 import { relaunch } from "../../util/commandLine";
 import {
   ProcessCanceled,
@@ -55,7 +56,6 @@ import {
 import { withTrackedActivity } from "../../util/errorHandling";
 import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
-import { log } from "../../util/log";
 import { showError } from "../../util/message";
 import onceCB from "../../util/onceCB";
 import {
@@ -1174,68 +1174,66 @@ function init(context: IExtensionContext): boolean {
       },
     );
 
-    let first = true;
-    context.api.onStateChange(
-      ["session", "gameMode", "known"],
-      (prev: IGameStored[], current: IGameStored[]) => {
-        // known games should only be set once but better safe than sorry
-        if (!first) {
-          return;
-        }
-        first = false;
-        const state: IState = store.getState();
-        const { commandLine } = state.session.base;
-        if (commandLine.profile !== undefined) {
-          const profile: IProfile = getSafe(
-            state,
-            ["persistent", "profiles", commandLine.profile],
-            undefined,
-          );
+    // Handle --profile and --game command line arguments.
+    // This runs directly in once() rather than via onStateChange because
+    // gamemode_management's once() (which dispatches setKnownGames) runs
+    // before profile_management's once(), so the state change would be missed.
+    // But the data we need from the state (the known games and the command line arguments)
+    // Should be available by the time this runs.
+    {
+      const state: IState = store.getState();
+      const { commandLine } = state.session.base;
+      const known: IGameStored[] = state.session.gameMode.known;
+      if (commandLine.profile !== undefined) {
+        const profile: IProfile = getSafe(
+          state,
+          ["persistent", "profiles", commandLine.profile],
+          undefined,
+        );
 
-          if (profile !== undefined) {
-            context.api.store.dispatch(setNextProfile(profile.id));
-          } else {
-            log(
-              "warn",
-              "profile cmdline argument detected - but profile is missing",
-              commandLine.profile,
+        if (profile !== undefined) {
+          context.api.store.dispatch(setNextProfile(profile.id));
+        } else {
+          log(
+            "warn",
+            "profile cmdline argument detected - but profile is missing",
+            commandLine.profile,
+          );
+        }
+      } else if (commandLine.game !== undefined && known.length > 0) {
+        // the game specified on the command line may be a game id or an extension
+        // name, because at the time we download an extension we don't actually know
+        // the game id yet.
+
+        readExtensions(false).then(
+          (extensions: { [extId: string]: IExtension }) => {
+            const extPathLookup = Object.values(extensions).reduce(
+              (prevExt, ext) => {
+                if (ext.path !== undefined) {
+                  prevExt[ext.path] = ext.name;
+                }
+                return prevExt;
+              },
+              {},
             );
-          }
-        } else if (commandLine.game !== undefined) {
-          // the game specified on the command line may be a game id or an extension
-          // name, because at the time we download an extension we don't actually know
-          // the game id yet.
 
-          readExtensions(false).then(
-            (extensions: { [extId: string]: IExtension }) => {
-              const extPathLookup = Object.values(extensions).reduce(
-                (prevExt, ext) => {
-                  if (ext.path !== undefined) {
-                    prevExt[ext.path] = ext.name;
-                  }
-                  return prevExt;
-                },
-                {},
-              );
+            const game = known.find(
+              (iter) =>
+                iter.id === commandLine.game ||
+                extPathLookup[iter.extensionPath] === commandLine.game,
+            );
 
-              const game = current.find(
-                (iter) =>
-                  iter.id === commandLine.game ||
-                  extPathLookup[iter.extensionPath] === commandLine.game,
-              );
-
-              if (game !== undefined) {
-                manageGame(context.api, game.id);
-              } else {
-                log("warn", "game specified on command line not found", {
-                  game: commandLine.game,
-                });
-              }
-            },
-          );
-        }
-      },
-    );
+            if (game !== undefined) {
+              manageGame(context.api, game.id);
+            } else {
+              log("warn", "game specified on command line not found", {
+                game: commandLine.game,
+              });
+            }
+          },
+        );
+      }
+    }
 
     context.api.onStateChange(
       ["persistent", "profiles"],

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -56,12 +56,17 @@ if (SetProcessPreferredUILanguages !== undefined) {
   SetProcessPreferredUILanguages(["en-US"]);
 }
 
+import type { IParameters } from "@vortex/shared/cli";
 import type { AppInitMetadata } from "@vortex/shared/ipc";
 import type crashDumpT from "crash-dump";
 
 import "./util/application.electron";
 
-import { getErrorCode, getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
+import {
+  getErrorCode,
+  getErrorMessageOrDefault,
+  unknownToError,
+} from "@vortex/shared";
 import Bluebird from "bluebird";
 import { ipcRenderer, webFrame } from "electron";
 import { EventEmitter } from "events";
@@ -84,7 +89,7 @@ import type { IExtensionReducer } from './types/extensions';
 import type { ThunkStore } from "./types/IExtensionContext";
 import type { IState } from "./types/IState";
 
-import { setLanguage, setNetworkConnected } from "./actions";
+import { setCommandLine, setLanguage, setNetworkConnected } from "./actions";
 import {
   setApplicationVersion,
   setInstallType,
@@ -119,7 +124,12 @@ import { createRendererTelemetryProvider } from "./telemetry/setup";
 import { GameEntryNotFound } from "./types/IGameStore";
 import { relaunch } from "./util/commandLine";
 import { ProcessCanceled, UserCanceled } from "./util/CustomErrors";
-import { recordErrorSpan, setOutdated, terminate, toError } from "./util/errorHandling";
+import {
+  recordErrorSpan,
+  setOutdated,
+  terminate,
+  toError,
+} from "./util/errorHandling";
 import {} from "./util/extensionRequire";
 import { setTFunction } from "./util/fs";
 import GlobalNotifications from "./util/GlobalNotifications";
@@ -228,9 +238,14 @@ function errorHandler(evt: any) {
     });
 
     if (store !== undefined) {
-      showError(store.dispatch, "The game extension's discovery mechanism failed to find the game installation on your device", error, {
-        allowReport: false,
-      });
+      showError(
+        store.dispatch,
+        "The game extension's discovery mechanism failed to find the game installation on your device",
+        error,
+        {
+          allowReport: false,
+        },
+      );
     }
     return;
   }
@@ -348,9 +363,13 @@ function errorHandler(evt: any) {
         name: extName,
         error: error.stack,
       });
-      recordErrorSpan("Unhandled exception in extension", unknownToError(error), {
-        "extension.name": extName,
-      });
+      recordErrorSpan(
+        "Unhandled exception in extension",
+        unknownToError(error),
+        {
+          "extension.name": extName,
+        },
+      );
       extensions
         ?.getApi()
         ?.showErrorNotification?.("Unhandled exception in extension", error, {
@@ -470,6 +489,9 @@ async function initGlobals(): Promise<void> {
 }
 
 function applyAppMetadata(metadata: AppInitMetadata): void {
+  if (metadata.commandLine) {
+    store.dispatch(setCommandLine(metadata.commandLine as IParameters));
+  }
   if (metadata.version) {
     store.dispatch(setApplicationVersion(metadata.version));
   }
@@ -489,20 +511,18 @@ async function init(): Promise<ExtensionManager | null> {
 
   await StyleManager.renderDefault();
 
-  // Register app:init listener BEFORE async hydration to avoid race condition.
-  // Main process sends app:init immediately after window creation, which can
-  // arrive before hydration completes. Buffer the metadata and apply it after
-  // the store is created.
-  let bufferedAppMetadata: AppInitMetadata | null = null;
-  if (window.api?.app) {
-    window.api.app.onInit((metadata) => {
-      log("debug", "received app:init metadata from main", metadata);
-      if (store !== undefined) {
-        applyAppMetadata(metadata);
-      } else {
-        bufferedAppMetadata = metadata;
-      }
-    });
+  // Fetch app init metadata (commandLine, version, etc.) from main process.
+  // Uses invoke (request/response) to avoid race conditions with the old
+  // fire-and-forget app:init send pattern — commandLine must be in the store
+  // before doOnce() runs.
+  let appInitMetadata: AppInitMetadata | null = null;
+  if (window.api?.app?.getInitMetadata) {
+    try {
+      appInitMetadata = await window.api.app.getInitMetadata();
+      log("debug", "received app init metadata from main", appInitMetadata);
+    } catch (err) {
+      log("warn", "failed to fetch app init metadata", { error: err });
+    }
   }
 
   // Fetch hydration data from main process (persisted state)
@@ -583,10 +603,10 @@ async function init(): Promise<ExtensionManager | null> {
     });
   }
 
-  // Apply any buffered app:init metadata that arrived during hydration
-  if (bufferedAppMetadata !== null) {
-    applyAppMetadata(bufferedAppMetadata);
-    bufferedAppMetadata = null;
+  // Apply app init metadata (commandLine, version, etc.) before extensions
+  // interact with the store — extensions depend on commandLine state
+  if (appInitMetadata !== null) {
+    applyAppMetadata(appInitMetadata);
   }
 
   extensions.setStore(store);

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -139,9 +139,6 @@ export interface MainChannels {
   // Persistence: Send hydration data to renderer on startup
   "persist:hydrate": (hive: PersistedHive, data: Serializable) => void;
 
-  // App initialization: Main sends all startup metadata to renderer in one message
-  "app:init": (metadata: AppInitMetadata) => void;
-
   // Extensions: Response from main process after initializing an extension
   "extensions:init-main-response": (response: {
     extensionName: string;
@@ -206,6 +203,7 @@ export interface InvokeChannels {
   ) => Promise<void>;
   "app:exit": (exitCode?: number) => Promise<void>;
   "app:getName": () => Promise<string>;
+  "app:getInitMetadata": () => Promise<AppInitMetadata>;
 
   // App path channels
   "app:getPath": (name: keyof VortexPaths) => Promise<string>;

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -121,11 +121,8 @@ export interface App {
   /** Relaunches the application with the given arguments */
   relaunch(args?: string[]): void;
 
-  /**
-   * Register a callback for app initialization metadata from main.
-   * Called once during startup with all app metadata.
-   */
-  onInit(callback: (metadata: AppInitMetadata) => void): void;
+  /** Request app initialization metadata from main (request/response) */
+  getInitMetadata(): Promise<AppInitMetadata>;
 
   /** Set as default protocol client */
   setProtocolClient(protocol: string, udPath: string): Promise<void>;


### PR DESCRIPTION
The old onInit metadata dispatcher was affected by race conditions which would fail to properly forward cli parameters to other extensions (such as profile_management), new getAppMetadata call is cleaner and more efficient.

This fixes the bug where the profile_management extension wouldn't attempt to manage a newly downloaded/installed community extension upon application restart.

fixes https://linear.app/nexus-mods/issue/APP-109/fix-vortex-not-auto-managing-on-restart