### PR TITLE
fixed terrible attempt at preventing default/user-created theme mismatch

### DIFF
--- a/extensions/theme-switcher/src/SettingsDebug.tsx
+++ b/extensions/theme-switcher/src/SettingsDebug.tsx
@@ -424,7 +424,7 @@ class SettingsDebug extends ComponentEx<IProps, IComponentState> {
             {
               id: "name",
               placeholder: "Theme Name",
-              value: themeName !== "__default" ? themeName : "",
+              value: themeName !== "default" ? themeName : "",
             },
           ],
           condition: (content: types.IDialogContent) => {

--- a/extensions/theme-switcher/src/SettingsTheme.tsx
+++ b/extensions/theme-switcher/src/SettingsTheme.tsx
@@ -208,7 +208,7 @@ class SettingsTheme extends ComponentEx<IProps, IComponentState> {
             {
               id: "name",
               placeholder: "Theme Name",
-              value: themeName !== "__default" ? themeName : "",
+              value: themeName !== "default" ? themeName : "",
             },
           ],
           condition: (content: types.IDialogContent) => {

--- a/extensions/theme-switcher/src/operations.ts
+++ b/extensions/theme-switcher/src/operations.ts
@@ -21,7 +21,6 @@ export function themeName(location: string): string {
 }
 
 export function themePath(themeName: string): string | undefined {
-  themeName = themeName.replace(/^__/, "");
   return themes.find((theme) => path.basename(theme) === themeName);
 }
 

--- a/extensions/theme-switcher/src/reducers.ts
+++ b/extensions/theme-switcher/src/reducers.ts
@@ -8,7 +8,7 @@ const settingsReducer: types.IReducerSpec = {
       util.setSafe(state, ["currentTheme"], payload),
   },
   defaults: {
-    currentTheme: "__default",
+    currentTheme: "default",
   },
 };
 


### PR DESCRIPTION
absolutely pointless method to block default/user-created theme mismatches

fixes https://linear.app/nexus-mods/issue/APP-114/upon-new-installation-incorrect-theme-is-shown-in-the-list