### PR TITLE
updating libloot to 0.29.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,8 +499,8 @@ catalogs:
       specifier: ^4.17.21
       version: 4.17.23
     loot:
-      specifier: git+https://github.com/Nexus-Mods/node-loot#d8071f95fa9d110099c38adbb67c3c4ec30aaa42
-      version: 6.2.0
+      specifier: git+https://github.com/Nexus-Mods/node-loot#04a77fcae028b0838b5e0c53cfcdc65898c49727
+      version: 6.2.1
     lru-cache:
       specifier: ^11.2.6
       version: 11.2.6
@@ -1639,7 +1639,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/6b8900658d66438fe92ac55bc182a45404e8bf3f
       loot:
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/d8071f95fa9d110099c38adbb67c3c4ec30aaa42
+        version: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727
 
   extensions/gamebryo-savegame-management:
     devDependencies:
@@ -10382,9 +10382,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/d8071f95fa9d110099c38adbb67c3c4ec30aaa42:
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/d8071f95fa9d110099c38adbb67c3c4ec30aaa42}
-    version: 6.2.0
+  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727:
+    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727}
+    version: 6.2.1
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -19857,7 +19857,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/d8071f95fa9d110099c38adbb67c3c4ec30aaa42:
+  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727:
     dependencies:
       autogypi: 0.2.2
       lodash: 4.17.23

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -200,7 +200,7 @@ catalog:
   leveldown: ^5.6.0
   levelup: ^4.4.0
   lodash: ^4.17.21
-  loot: git+https://github.com/Nexus-Mods/node-loot#d8071f95fa9d110099c38adbb67c3c4ec30aaa42
+  loot: git+https://github.com/Nexus-Mods/node-loot#04a77fcae028b0838b5e0c53cfcdc65898c49727
   lru-cache: ^11.2.6
   markdown-ast: ^0.2.1
   memoize-one: ^5.1.1


### PR DESCRIPTION
libloot dropped their hash mismatch functionality - that means that sorting should be faster.