### PR TITLE
second attempt at fixing dashboard/packery overlap issue

### DIFF
--- a/src/renderer/src/extensions/dashboard/reducer.ts
+++ b/src/renderer/src/extensions/dashboard/reducer.ts
@@ -10,12 +10,27 @@ const settingsReducer: IReducerSpec = {
   reducers: {
     [actions.setLayout as any]: (state, payload) =>
       setSafe(state, ["dashboardLayout"], payload),
-    [actions.setDashletEnabled as any]: (state, payload) =>
-      setSafe(
+    [actions.setDashletEnabled as any]: (state, payload) => {
+      let newState = setSafe(
         state,
         ["dashletSettings", payload.widgetId, "enabled"],
         payload.enabled,
-      ),
+      );
+      // When disabling, eagerly remove from layout so a re-enabled dashlet
+      // appends to the end instead of reclaiming a position now occupied by
+      // another dashlet.
+      if (!payload.enabled) {
+        const layout: string[] = newState.dashboardLayout ?? [];
+        if (layout.includes(payload.widgetId)) {
+          newState = setSafe(
+            newState,
+            ["dashboardLayout"],
+            layout.filter((id) => id !== payload.widgetId),
+          );
+        }
+      }
+      return newState;
+    },
     [actions.setDashletWidth as any]: (state, payload) =>
       setSafe(
         state,

--- a/src/renderer/src/extensions/dashboard/views/Dashboard.tsx
+++ b/src/renderer/src/extensions/dashboard/views/Dashboard.tsx
@@ -247,6 +247,11 @@ class Dashboard extends ComponentEx<IProps, IComponentState> {
     const { dashletSettings } = this.props;
     const dashId = evt.currentTarget.getAttribute("data-id");
     const old = dashletSettings[dashId]?.enabled !== false;
+    if (old) {
+      // Clear pending layout save so it can't restore a stale position
+      // for this dashlet after the reducer has already removed it.
+      this.mLayoutDebouncer.clear();
+    }
     this.props.onSetDashletEnabled(dashId, !old);
   };
 
@@ -344,6 +349,7 @@ class Dashboard extends ComponentEx<IProps, IComponentState> {
   };
 
   private dismissDashlet = (dashletId: string) => {
+    this.mLayoutDebouncer.clear();
     this.props.onSetDashletEnabled(dashletId, false);
   };
 }

--- a/src/renderer/src/extensions/dashboard/views/PackeryGrid.tsx
+++ b/src/renderer/src/extensions/dashboard/views/PackeryGrid.tsx
@@ -187,6 +187,13 @@ class Packery extends React.Component<IProps, {}> {
     if (this.mRefreshTimer !== undefined) {
       clearTimeout(this.mRefreshTimer);
     }
+    // Cancel pending layout — the refresh will schedule its own layout
+    // after reloading items. Running layout before reload causes Packery
+    // to position items based on a stale item list, leading to overlap.
+    if (this.mLayoutTimer !== undefined) {
+      clearTimeout(this.mLayoutTimer);
+      this.mLayoutTimer = undefined;
+    }
     this.mRefreshTimer = setTimeout(() => {
       this.mRefreshTimer = undefined;
       if (this.mPackery !== undefined) {


### PR DESCRIPTION
fixes https://linear.app/nexus-mods/issue/APP-58/dashlets-can-overlap-when-toggled-off-and-back-on-before-returning-to