### PR TITLE
fixed "Help centre" button not working

### DIFF
--- a/extensions/documentation/src/index.tsx
+++ b/extensions/documentation/src/index.tsx
@@ -11,19 +11,19 @@ import DocumentationView from "./views/DocumentationView";
 import { types, util } from "vortex-api";
 
 const WIKI_TOPICS = {
-  ["adding-games"]: "users/ui/games#finding-a-game",
-  ["creating-themes"]: "developer/creating-a-theme",
-  ["deployment-methods"]: "users/deployment-methods",
-  ["downloading"]: "users/download-from-nexusmods",
-  ["external-changes"]: "users/External-Changes",
-  ["keyboard-shortcuts"]: "users/keyboard-shortcuts",
-  ["file-conflicts"]: "users/managing-file-conflicts",
-  ["load-order-about"]: "users/vortex-approach-to-load-order",
-  ["load-order"]: "users/managing-your-load-order",
-  ["profiles"]: "users/setting-up-profiles",
+  ["adding-games"]: "MODDINGWIKI-Users-UI-Games-section",
+  ["creating-themes"]: "MODDINGWIKI-Developers-General-Creating-a-theme",
+  ["deployment-methods"]: "MODDINGWIKI-Users-General-Deployment-Methods",
+  ["downloading"]: "MODDINGWIKI-Users-General-Downloading-from-Nexus-Mods",
+  ["external-changes"]: "MODDINGWIKI-Users-General-Managing-External-Changes",
+  ["keyboard-shortcuts"]: "MODDINGWIKI-Users-General-Managing-Keyboard-Shortcuts",
+  ["file-conflicts"]: "MODDINGWIKI-Users-General-Managing-File-Conflicts",
+  ["load-order-about"]: "MODDINGWIKI-Users-General-The-Vortex-Approach-to-Load-Order",
+  ["load-order"]: "MODDINGWIKI-Users-General-Managing-your-Load-Order",
+  ["profiles"]: "MODDINGWIKI-Users-General-Setting-up-Profiles",
 };
 
-const WIKI_URL = "https://modding.wiki/en/vortex";
+const WIKI_URL = "https://github.com/Nexus-Mods/Vortex/wiki";
 
 function generateUrl(wikiId: string) {
   const topicId = WIKI_TOPICS[wikiId] || undefined;
@@ -115,13 +115,20 @@ export default function init(context: types.IExtensionContext) {
       }
     });
 
-    context.api.events.on("open-knowledge-base", (wikiId: string) => {
-      context.api.events.emit("show-main-page", "Knowledge Base");
-      const url = generateUrl(wikiId);
-      if (url !== undefined) {
-        setTimeout(() => {
-          context.api.events.emit("navigate-knowledgebase", url);
-        }, 2000);
+    context.api.events.on("open-knowledge-base", (wikiId?: string) => {
+      const state = context.api.store.getState();
+      const isModernLayout = state.settings?.window?.useModernLayout;
+      if (isModernLayout) {
+        const url = generateUrl(wikiId) ?? WIKI_URL;
+        util.opn(url).catch(() => null);
+      } else {
+        context.api.events.emit("show-main-page", "Knowledge base");
+        const url = generateUrl(wikiId);
+        if (url !== undefined) {
+          setTimeout(() => {
+            context.api.events.emit("navigate-knowledgebase", url);
+          }, 2000);
+        }
       }
     });
   });

--- a/src/renderer/src/views/components/Header/HelpSection.tsx
+++ b/src/renderer/src/views/components/Header/HelpSection.tsx
@@ -27,7 +27,7 @@ export const HelpSection: FC = () => {
   const { t } = useTranslation();
 
   const handleHelpCentre = useCallback(() => {
-    api.events.emit("show-main-page", "Knowledge Base");
+    api.events.emit("open-knowledge-base");
   }, [api]);
 
   const handleDiagnosticFiles = useCallback(() => {


### PR DESCRIPTION
The main page registration in the documentation extension is set to classic only - this means that the page is hidden in UIV2 and therefore the button never actually displays anything as the page is not loaded.

The Help centre button will now open in a browser window when UIV2 is active

fixes https://linear.app/nexus-mods/issue/APP-115/help-centre-is-empty