### PR TITLE
added login status check to browse collections page

### DIFF
--- a/src/renderer/src/controls/CopyClipboardInput.tsx
+++ b/src/renderer/src/controls/CopyClipboardInput.tsx
@@ -35,7 +35,7 @@ function CopyClipboardInput(props: ICopyClipboardInputProps) {
   return (
     <FormGroup>
       <InputGroup>
-        <FormControl type="text" value={props.inputValue} readOnly />
+        <FormControl type="text" value={props.inputValue ?? ""} readOnly />
         <InputGroup.Addon>
           <IconButton
             className="btn-embed"

--- a/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -92,6 +92,12 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
   const gameId = useSelector((state: IState) => activeGameId(state));
   const gameDomainName = nexusGameId(getGame(gameId), gameId);
 
+  const isLoggedIn = useSelector(
+    (state: IState) => {
+      const nexus = state.confidential?.account?.["nexus"];
+      return !!(nexus?.APIKey || nexus?.OAuthCredentials);
+    },
+  );
   const adultContentFilter = useSelector(
     (state: IState) => state.persistent["nexus"]?.userInfo?.adult,
   );
@@ -355,6 +361,7 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                   <CollectionTile
                     api={api}
                     collection={collection}
+                    isLoggedIn={isLoggedIn}
                     key={collection.id}
                     onAddCollection={() => handleAddCollection(collection)}
                     onViewPage={() =>

--- a/src/renderer/src/extensions/nexus_integration/views/DashboardBanner.tsx
+++ b/src/renderer/src/extensions/nexus_integration/views/DashboardBanner.tsx
@@ -8,6 +8,7 @@ import getVortexPath from "../../../util/getVortexPath";
 import opn from "../../../util/opn";
 import { truthy } from "../../../util/util";
 import { clearOAuthCredentials, setUserAPIKey } from "../actions/account";
+import { setUserInfo } from "../actions/persistent";
 import type { IValidateKeyData } from "../types/IValidateKeyData";
 
 import { FALLBACK_AVATAR, NEXUS_BASE_URL } from "../constants";
@@ -28,6 +29,7 @@ interface IConnectedProps {
 interface IActionProps {
   onSetAPIKey: (APIKey?: string) => void;
   onClearOAuthCredentials: () => void;
+  onClearUserInfo: () => void;
   onSetDialogVisible: (id: string) => void;
 }
 
@@ -143,9 +145,10 @@ class DashboardBanner extends ComponentEx<IProps, { requested: boolean }> {
   };
 
   private logout = () => {
-    const { onClearOAuthCredentials, onSetAPIKey } = this.props;
+    const { onClearOAuthCredentials, onClearUserInfo, onSetAPIKey } = this.props;
     onSetAPIKey(undefined);
     onClearOAuthCredentials();
+    onClearUserInfo();
   };
 }
 
@@ -162,6 +165,7 @@ function mapDispatchToProps(
   return {
     onSetAPIKey: (APIKey?: string) => dispatch(setUserAPIKey(APIKey)),
     onClearOAuthCredentials: () => dispatch(clearOAuthCredentials(null)),
+    onClearUserInfo: () => dispatch(setUserInfo(undefined)),
     onSetDialogVisible: (id: string) => dispatch(setDialogVisible(id)),
   };
 }

--- a/src/renderer/src/extensions/nexus_integration/views/LoginIcon.tsx
+++ b/src/renderer/src/extensions/nexus_integration/views/LoginIcon.tsx
@@ -9,6 +9,7 @@ import opn from "../../../util/opn";
 import { truthy } from "../../../util/util";
 
 import { clearOAuthCredentials, setUserAPIKey } from "../actions/account";
+import { setUserInfo } from "../actions/persistent";
 import type { IValidateKeyDataV2 } from "../types/IValidateKeyData";
 
 import { FALLBACK_AVATAR, NEXUS_BASE_URL, OAUTH_URL } from "../constants";
@@ -38,6 +39,7 @@ interface IConnectedProps {
 interface IActionProps {
   onSetAPIKey: (APIKey: string) => void;
   onClearOAuthCredentials: () => void;
+  onClearUserInfo: () => void;
   onShowDialog: () => void;
   onShowError: (title: string, err: Error) => void;
 }
@@ -66,9 +68,10 @@ class LoginIcon extends ComponentEx<IProps, {}> {
   }
 
   private logOut = () => {
-    const { onClearOAuthCredentials, onSetAPIKey } = this.props;
+    const { onClearOAuthCredentials, onSetAPIKey, onClearUserInfo } = this.props;
     onSetAPIKey(undefined);
     onClearOAuthCredentials();
+    onClearUserInfo();
   };
 
   private getMembershipText(userInfo: IValidateKeyDataV2): string {
@@ -207,6 +210,7 @@ function mapDispatchToProps(
   return {
     onSetAPIKey: (APIKey: string) => dispatch(setUserAPIKey(APIKey)),
     onClearOAuthCredentials: () => dispatch(clearOAuthCredentials(null)),
+    onClearUserInfo: () => dispatch(setUserInfo(undefined)),
     onShowDialog: () => dispatch(setDialogVisible("login-dialog")),
     onShowError: (title: string, err: Error) =>
       showError(dispatch, title, err, { allowReport: false }),

--- a/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
@@ -49,6 +49,7 @@ const userInfoDebouncer = new Debouncer(
 export interface CollectionTileProps {
   api: IExtensionApi;
   collection: ICollection;
+  isLoggedIn?: boolean;
   onAddCollection?: () => void;
   onViewPage?: () => void;
   className?: string;
@@ -70,6 +71,7 @@ const Stat = ({
 export const CollectionTile: ComponentType<CollectionTileProps> = ({
   api,
   collection,
+  isLoggedIn = true,
   onAddCollection,
   onViewPage,
   className,
@@ -99,8 +101,8 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
       state,
       collection.slug,
     );
-    setCanBeAdded(!collectionModInstalled);
-  }, [api, collection.slug, pending, isHovered]);
+    setCanBeAdded(!collectionModInstalled && isLoggedIn);
+  }, [api, collection.slug, pending, isHovered, isLoggedIn]);
 
   // Refresh user info when user hovers on the tile, debounced to once per 5 seconds
   useEffect(() => {
@@ -112,11 +114,11 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
   }, [isHovered]);
 
   const addCollection = useCallback(() => {
-    if (!pending && canBeAdded) {
+    if (!pending && canBeAdded && isLoggedIn) {
       setPending(true);
       addCollectionDebounced();
     }
-  }, [onAddCollection, canBeAdded, pending]);
+  }, [onAddCollection, canBeAdded, pending, isLoggedIn]);
 
   // Find the "Easy install" badge (if it exists)
   const easyInstallBadge = collection.badges?.find(
@@ -235,10 +237,11 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
           <Button
             buttonType="tertiary"
             disabled={true}
-            leftIconPath={mdiCheck}
+            leftIconPath={!isLoggedIn ? undefined : mdiCheck}
             size="xs"
+            title={!isLoggedIn ? "Log in to add collections" : undefined}
           >
-            Added
+            {!isLoggedIn ? "Log in to add" : "Added"}
           </Button>
         ) : (
           <Button size="xs" onClick={addCollection}>


### PR DESCRIPTION
- "Add Collection" button is now disabled unless logged in
- fixed instances where logging out could potentially leave userInfo traces behind.

fixes https://linear.app/nexus-mods/issue/APP-126/user-not-asked-to-log-in-when-attempting-to-download-a-collection