### PR TITLE
Spine and Menu UI improvements

### DIFF
--- a/src/renderer/src/views/components/Header/IconButton.tsx
+++ b/src/renderer/src/views/components/Header/IconButton.tsx
@@ -6,16 +6,28 @@ import { joinClasses } from "../../../ui/utils/joinClasses";
 
 interface IconButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  appearance?: 'primary' | 'secondary';
   className?: string;
   iconPath: string;
   itemCount?: number;
 }
 
+const appearanceMap: Record<IconButtonProps["appearance"], string> = {
+  primary:
+    "text-neutral-moderate hover:text-neutral-strong aria-expanded:text-neutral-strong",
+  secondary:
+    "text-neutral-subdued hover:text-neutral-moderate aria-expanded:text-neutral-moderate",
+};
+
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ className, iconPath, itemCount, ...props }, ref) => (
+  (
+    { appearance = "primary", className, iconPath, itemCount, ...props },
+    ref,
+  ) => (
     <button
       className={joinClasses([
-        "group/icon-button relative flex size-7 items-center justify-center rounded-sm text-neutral-moderate transition-colors hover:bg-surface-translucent-mid hover:text-neutral-strong aria-expanded:bg-surface-translucent-mid aria-expanded:text-neutral-strong",
+        "group/icon-button relative flex size-7 items-center justify-center rounded-sm transition-colors hover:bg-surface-translucent-mid aria-expanded:bg-surface-translucent-mid",
+        appearanceMap[appearance],
         className,
       ])}
       ref={ref}

--- a/src/renderer/src/views/components/Header/index.tsx
+++ b/src/renderer/src/views/components/Header/index.tsx
@@ -61,6 +61,7 @@ export const Header: FC = () => {
         style={{ WebkitAppRegion: "no-drag" }}
       >
         <IconButton
+          appearance="secondary"
           iconPath={menuIsCollapsed ? nxmPanelOpen : nxmPanelClose}
           title={menuIsCollapsed ? "Open menu" : "Collapse menu"}
           onClick={handleToggleMenu}

--- a/src/renderer/src/views/components/Menu/MenuButton.tsx
+++ b/src/renderer/src/views/components/Menu/MenuButton.tsx
@@ -23,6 +23,7 @@ export const MenuButton: FC<MenuButtonProps> = ({
     <button
       className={joinClasses([
         "flex h-10 items-center gap-x-3 rounded-lg px-3 transition-colors hover:bg-surface-mid hover:text-neutral-moderate",
+        "focus-visible:z-1",
         isActive
           ? "bg-surface-low text-neutral-moderate"
           : "text-neutral-subdued",

--- a/src/renderer/src/views/components/Spine/GameButton.tsx
+++ b/src/renderer/src/views/components/Spine/GameButton.tsx
@@ -68,7 +68,10 @@ export const GameButton: FC<GameButtonProps> = ({
 
   return (
     <button
-      className="group relative size-12 shrink-0 overflow-hidden rounded-lg"
+      className={joinClasses(
+        "group relative size-12 shrink-0 overflow-hidden rounded-lg",
+        { "outline-2 outline-offset-2 outline-neutral-strong focus-within:outline-info-subdued": isActive },
+      )}
       title={title}
       {...props}
     >
@@ -92,12 +95,13 @@ export const GameButton: FC<GameButtonProps> = ({
       )}
 
       <span
-        className={joinClasses([
+        className={joinClasses(
           "absolute inset-0 z-1 rounded-lg transition-colors",
-          isActive
-            ? "border-neutral-strong border-2"
-            : "border-stroke-weak group-hover:border-neutral-strong border group-hover:border-2",
-        ])}
+          {
+            "border border-stroke-weak group-hover:border-2 group-hover:border-neutral-strong":
+              !isActive,
+          },
+        )}
       />
 
       {/* TODO: Re-enable store icon


### PR DESCRIPTION
- **IconButton** with the menu toggle button using the new secondary style (more subdued colors).
- **GameButton** active state: Simplified the active game button border styling —  active buttons now show a solid outline instead of a thicker border, with a  focus-within ring for accessibility.
- **MenuButton** focus styling: Added focus-visible:z-1 to ensure focused menu buttons render above siblings. 