### PR TITLE
fixed stall timer not getting cleared on download cancellation

### DIFF
--- a/src/renderer/src/extensions/download_management/DownloadManager.ts
+++ b/src/renderer/src/extensions/download_management/DownloadManager.ts
@@ -774,6 +774,7 @@ class DownloadWorker {
       this.mURLResolve = undefined;
     }
     this.mOnAbort?.();
+    clearTimeout(this.mStallTimer);
     if (this.mEnded) {
       return false;
     }


### PR DESCRIPTION
this could potentially trigger Vortex to re-download a cancelled download (couldn't reproduce, but the code suggests it could happen)

fixes https://linear.app/nexus-mods/issue/APP-103/download-graph-shows-activity-even-when-there-are-no-active-downloads