### PR TITLE
Pin Node.js version in .npmrc for reliable native builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+use-node-version=22.14.0
 disturl=https://electronjs.org/headers
 target=39.8.0
 runtime=electron


### PR DESCRIPTION
## Summary

- Adds `use-node-version=22.14.0` to `.npmrc` so pnpm automatically downloads and uses the correct Node.js version for all operations

## Problem

On Windows, PATH ordering issues can cause the wrong `node.exe` or `npm.cmd` to be resolved during `pnpm install`. This is especially common when multiple Node.js version managers (Volta, fnm, nvm-windows) coexist alongside system installs.

Without a pinned version, native module lifecycle scripts (node-gyp) may:
- Compile against mismatched Node.js headers, causing `NODE_MODULE_VERSION` ABI errors at runtime
- Fail to find `npm`/`npx` during install hooks (e.g., `'npm' is not recognized`)
- Download the wrong version of node headers for the Electron target

## How this helps

When `use-node-version` is set in `.npmrc`, pnpm downloads the specified Node.js version to its store and uses it for all commands — including lifecycle scripts that compile native modules like `winapi-bindings`, `bsdiff-node`, `loot`, etc. This bypasses whatever is on the system PATH, eliminating an entire class of "works on my machine" toolchain issues.
