### PR TITLE
fixed installer choices not preserved as expected

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1334,6 +1334,7 @@ class InstallManager {
             }
           };
           let existingMod: IMod;
+          let installingFileId: number;
           // Start the installation process - the promise will resolve when callback is called
           const dlInfo = archiveId != null
             ? api.getState().persistent.downloads.files[archiveId]
@@ -1634,6 +1635,7 @@ class InstallManager {
                 })
                 .then((modInfo) => {
                   const fileId = modInfo.fileId ?? modInfo.revisionId;
+                  installingFileId = fileId;
                   const isCollection = modInfo.revisionId !== undefined;
 
                   existingMod =
@@ -1701,10 +1703,16 @@ class InstallManager {
                 .then(() => {
                   // If no choices were provided (e.g. manual reinstall), preserve the
                   // existing mod's installerChoices so the user doesn't have to redo them.
-                  if (existingMod !== undefined && fullInfo.choices === undefined) {
-                    const prevChoices = existingMod.attributes?.installerChoices;
-                    if (prevChoices !== undefined) {
-                      fullInfo.choices = prevChoices;
+                  // Only do this when the fileId matches, meaning it's the exact same
+                  // version being reinstalled — a different version (upgrade/downgrade)
+                  // may have different installer steps.
+                  if (fullInfo.choices === undefined) {
+                    const prevFileId = fullInfo.previous?.fileId;
+                    if (prevFileId !== undefined && prevFileId === installingFileId) {
+                      const prevChoices = fullInfo.previous?.installerChoices;
+                      if (prevChoices !== undefined) {
+                        fullInfo.choices = prevChoices;
+                      }
                     }
                   }
 


### PR DESCRIPTION
More robust implementation.
* Same-version reinstall: `fileIds` match → choices restored
* Version upgrade (2.6.3 → 2.6.7): different `fileIds` → choices NOT restored
* Version downgrade (2.6.7 → 2.6.3): different `fileIds` → choices NOT restored

This won't work for fomods that are not sourced/hosted on Nexus Mods unfortunately. There is no unique identifier we can go by except maybe md5 hashes.

fixes https://linear.app/nexus-mods/issue/APP-144/fomod-choices-are-not-preserved-or-shown-correctly fixes https://github.com/Nexus-Mods/Vortex/issues/21864