### PR TITLE
fix: load level_pivot from private build to restore snappy compression

### DIFF
--- a/scripts/generate-query-types.ts
+++ b/scripts/generate-query-types.ts
@@ -167,7 +167,7 @@ async function main(): Promise<void> {
   try {
     // Install and load level_pivot
     console.log("Installing level_pivot...");
-    await connection.run("INSTALL level_pivot FROM community");
+    await connection.run("FORCE INSTALL level_pivot FROM 'https://halgari.github.io/duckdb-level-pivot/current_release'");
     await connection.run("LOAD level_pivot");
     const tmpDbPath = path.join(tmpDir, "gen.db");
     await connection.run(

--- a/src/main/src/store/DuckDBSingleton.ts
+++ b/src/main/src/store/DuckDBSingleton.ts
@@ -48,7 +48,7 @@ class DuckDBSingleton {
       const connection = await this.#mDuckDB.connect();
       try {
         log("debug", "duckdb-singleton: installing level_pivot");
-        await connection.run("INSTALL level_pivot FROM community");
+        await connection.run("FORCE INSTALL level_pivot FROM 'https://halgari.github.io/duckdb-level-pivot/current_release'");
         log("debug", "duckdb-singleton: loading level_pivot");
         await connection.run("LOAD level_pivot");
       } finally {


### PR DESCRIPTION
## What was broken

After switching from the private `halgari.github.io/duckdb-level-pivot` build to the DuckDB community extension repository, Vortex failed to load existing user state. The community-hosted `level_pivot` extension is compiled without snappy compression, so it cannot read LevelDB databases that were written with snappy-compressed data, which is the default for LevelDB.

## What we changed

We own the `level_pivot` extension, but getting an updated build published to the DuckDB community repo takes a few days. To get master working again in the meantime, both the runtime extension loader and the build-time type generator now `FORCE INSTALL` from our own build:

```
FORCE INSTALL level_pivot FROM 'https://halgari.github.io/duckdb-level-pivot/current_release'
```

- **`src/main/src/store/DuckDBSingleton.ts`** — runtime, loaded on every Vortex start
- **`scripts/generate-query-types.ts`** — build-time schema introspection

`FORCE INSTALL` is used instead of `INSTALL` to overwrite any previously cached community extension.

The build at `halgari.github.io/duckdb-level-pivot` uses DuckDB-version subfolders (e.g. `current_release/v1.5.1/windows_amd64/`). DuckDB's extension loader appends the version and platform automatically, so the base URL is all that's needed. The `duckdb-level-pivot` repo was also updated to build against DuckDB v1.5.1 to match `@duckdb/node-api 1.5.1-r.1`.