### PR TITLE
restored drag-drop support for non-archives on mods page

### DIFF
--- a/src/renderer/src/extensions/download_management/index.ts
+++ b/src/renderer/src/extensions/download_management/index.ts
@@ -80,22 +80,7 @@ let updateDebouncer: Debouncer;
 
 const protocolHandlers: IProtocolHandlers = {};
 
-const archiveExtLookup = new Set<string>([
-  ".zip",
-  ".z01",
-  ".7z",
-  ".rar",
-  ".r00",
-  ".001",
-  ".bz2",
-  ".bzip2",
-  ".gz",
-  ".gzip",
-  ".xz",
-  ".z",
-  ".fomod",
-  ".dazip",
-]);
+import { knownArchiveExt } from "../../util/archives";
 
 const addLocalInProgress = new Set<string>();
 
@@ -107,13 +92,6 @@ function withAddInProgress(
   return PromiseBB.resolve(cb()).finally(() => {
     addLocalInProgress.delete(fileName);
   });
-}
-
-function knownArchiveExt(filePath: string): boolean {
-  if (!truthy(filePath)) {
-    return false;
-  }
-  return archiveExtLookup.has(path.extname(filePath).toLowerCase());
 }
 
 function refreshDownloads(

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -321,22 +321,6 @@ export const INSTALL_ACTION = "Update current profile";
 export const REPLACE_ACTION = "Update all profiles";
 export const VARIANT_ACTION = "Add Variant";
 
-const archiveExtLookup = new Set<string>([
-  ".zip",
-  ".z01",
-  ".7z",
-  ".rar",
-  ".r00",
-  ".001",
-  ".bz2",
-  ".bzip2",
-  ".gz",
-  ".gzip",
-  ".xz",
-  ".z",
-  ".lzh",
-]);
-
 // file types supported by 7z but we don't want to extract
 // I was tempted to put .exe in here but there may actually be cases where the
 // exe is a self-extracting archive and we would be able to handle it

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -2199,6 +2199,67 @@ function init(context: IExtensionContext): boolean {
     (activity: string[]) => activity !== undefined && activity.length > 0,
   );
 
+  const onDropNonArchiveFiles = async (filePaths: string[]) => {
+    const api = context.api;
+    const state: IState = api.getState();
+    const gameMode = activeGameId(state);
+    if (gameMode === undefined) {
+      return;
+    }
+
+    const fileNames = filePaths.map((fp) => path.basename(fp)).join("\n");
+
+    const result = await api.showDialog(
+      "question",
+      "Not an archive",
+      {
+        text:
+          "The following files are not archives and can't be installed directly. " +
+          "Would you like to create a mod containing these files instead?",
+        message: fileNames,
+      },
+      [{ label: "Cancel" }, { label: "Create Mod" }],
+    );
+
+    if (result.action !== "Create Mod") {
+      return;
+    }
+
+    const modId = shortid();
+    const mod: IMod = {
+      id: modId,
+      state: "installed",
+      type: "",
+      installationPath: modId,
+      attributes: {
+        name: filePaths.length === 1
+          ? path.basename(filePaths[0], path.extname(filePaths[0]))
+          : "New Mod",
+        installTime: new Date(),
+      },
+    };
+
+    const modInstallPath = installPathForGame(state, gameMode);
+    const modPath = path.join(modInstallPath, modId);
+
+    api.events.emit("create-mod", gameMode, mod, async (err: Error) => {
+      if (err !== null) {
+        api.showErrorNotification("Failed to create mod", err);
+        return;
+      }
+      try {
+        for (const filePath of filePaths) {
+          await fs.copyAsync(
+            filePath,
+            path.join(modPath, path.basename(filePath)),
+          );
+        }
+      } catch (copyErr) {
+        api.showErrorNotification("Failed to copy files to mod", copyErr);
+      }
+    });
+  };
+
   context.registerMainPage(
     "mods",
     "Mods",
@@ -2209,7 +2270,10 @@ function init(context: IExtensionContext): boolean {
       group: "per-game",
       visible: () => activeGameId(context.api.store.getState()) !== undefined,
       activity: modsActivity,
-      props: () => ({ modSources: getModSources() }),
+      props: () => ({
+        modSources: getModSources(),
+        onDropNonArchiveFiles,
+      }),
       mdi: nxmMod,
     },
   );

--- a/src/renderer/src/extensions/mod_management/views/ModList.tsx
+++ b/src/renderer/src/extensions/mod_management/views/ModList.tsx
@@ -51,6 +51,7 @@ import type { IInstallOptions } from "../types/IInstallOptions";
 import type { IMod } from "../types/IMod";
 import type { IModProps } from "../types/IModProps";
 import type { IModSource } from "../types/IModSource";
+import { knownArchiveExt } from "../../../util/archives";
 import combineMods from "../util/combine";
 import filterModInfo from "../util/filterModInfo";
 import groupMods from "../util/modGrouping";
@@ -125,6 +126,7 @@ class VersionOption extends React.PureComponent<IVersionOptionProps, {}> {
 interface IBaseProps {
   globalOverlay: JSX.Element;
   modSources: IModSource[];
+  onDropNonArchiveFiles: (filePaths: string[]) => void;
 }
 
 interface IConnectedProps extends IModProps {
@@ -1816,18 +1818,35 @@ class ModList extends ComponentEx<IProps, IComponentState> {
   };
 
   private dropMod = (type: DropType, values: string[]) => {
-    const { autoInstall } = this.props;
-    this.context.api.events.emit(
-      "import-downloads",
-      values,
-      (dlIds: string[]) => {
-        if (autoInstall) {
-          dlIds.forEach((dlId) => {
-            this.context.api.events.emit("start-install-download", dlId);
-          });
-        }
-      },
-    );
+    const { autoInstall, onDropNonArchiveFiles } = this.props;
+
+    const archives: string[] = [];
+    const nonArchives: string[] = [];
+    for (const filePath of values) {
+      if (knownArchiveExt(filePath)) {
+        archives.push(filePath);
+      } else {
+        nonArchives.push(filePath);
+      }
+    }
+
+    if (archives.length > 0) {
+      this.context.api.events.emit(
+        "import-downloads",
+        archives,
+        (dlIds: string[]) => {
+          if (autoInstall) {
+            dlIds.forEach((dlId) => {
+              this.context.api.events.emit("start-install-download", dlId);
+            });
+          }
+        },
+      );
+    }
+
+    if (nonArchives.length > 0) {
+      onDropNonArchiveFiles(nonArchives);
+    }
   };
 
   private conditionNotInstalled = (instanceId: string | string[]) => {

--- a/src/renderer/src/util/archives.ts
+++ b/src/renderer/src/util/archives.ts
@@ -1,6 +1,45 @@
+import type PromiseBB from "bluebird";
+
+import * as path from "path";
+
 import type { IArchiveHandler } from "../types/IExtensionContext";
 
-import type PromiseBB from "bluebird";
+const archiveExtLookup = new Set<string>([
+  // Standard archive formats
+  ".zip",
+  ".7z",
+  ".rar",
+  ".tar",
+  ".gz",
+  ".gzip",
+  ".tgz",
+  ".bz2",
+  ".bzip2",
+  ".tbz2",
+  ".xz",
+  ".txz",
+  ".lzma",
+  ".lzh",
+  ".z",
+  ".zst",
+  ".zstd",
+  ".cab",
+  ".arj",
+  // Split archive parts
+  ".z01",
+  ".r00",
+  ".001",
+  // Mod-specific archive formats
+  ".fomod",
+  ".dazip",
+]);
+
+export function knownArchiveExt(filePath: string): boolean {
+  if (filePath == null || filePath.length === 0) {
+    return false;
+  }
+  return archiveExtLookup.has(path.extname(filePath).toLowerCase());
+}
 
 /**
  * wrapper around an format-specific archive handler
@@ -33,7 +72,7 @@ export class Archive {
     | ((filePath: string) => NodeJS.ReadableStream)
     | undefined {
     return this.mHandler.readFile
-      ? (filePath: string) => this.mHandler.readFile!(filePath)
+      ? (filePath: string) => this.mHandler.readFile(filePath)
       : undefined;
   }
 
@@ -45,7 +84,7 @@ export class Archive {
     | undefined {
     return this.mHandler.extractFile
       ? (filePath: string, outputPath: string) =>
-          this.mHandler.extractFile!(filePath, outputPath)
+          this.mHandler.extractFile(filePath, outputPath)
       : undefined;
   }
 
@@ -65,7 +104,7 @@ export class Archive {
    */
   public get create(): ((sourcePath: string) => PromiseBB<void>) | undefined {
     return this.mHandler.create
-      ? (sourcePath: string) => this.mHandler.create!(sourcePath)
+      ? (sourcePath: string) => this.mHandler.create(sourcePath)
       : undefined;
   }
 
@@ -77,11 +116,11 @@ export class Archive {
     | undefined {
     return this.mHandler.addFile
       ? (filePath: string, sourcePath: string) =>
-          this.mHandler.addFile!(filePath, sourcePath)
+          this.mHandler.addFile(filePath, sourcePath)
       : undefined;
   }
 
   public get write(): (() => PromiseBB<void>) | undefined {
-    return this.mHandler.write ? () => this.mHandler.write!() : undefined;
+    return this.mHandler.write ? () => this.mHandler.write() : undefined;
   }
 }


### PR DESCRIPTION
closes https://linear.app/nexus-mods/issue/APP-181/restore-drag-and-drop-support-for-non-archive-files-on-the-mods-page fixes https://github.com/Nexus-Mods/Vortex/issues/20146

probably other tickets too but I'm too lazy to search for them