### PR TITLE
fixed inability to switch back from shared to per-user

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -888,7 +888,7 @@ class Application {
           try {
             const sharedSub = new SubPersistor(tempPersistor, "user");
             const val = await sharedSub.getItem(["multiUser"]);
-            if (!Boolean(JSON.parse(val))) {
+            if (!JSON.parse(val)) {
               // User toggled back to per-user while in shared mode
               log("info",
                 "shared database has multiUser disabled, reverting to per-user");


### PR DESCRIPTION
## Summary
- Fix settings dropdown showing "Per-User" while running in shared mode
- Fix inability to switch from shared back to per-user mode
- Ensure re-enabling shared mode works after a previous disable

## Problem

The `multiUser` flag is read from the per-user DB at startup to decide which storage path to use, but once in shared mode all persistence writes go to the shared DB. This caused two issues:

1. The shared DB never received `multiUser = true`, so the Redux store hydrated with the default (`false`) and the dropdown showed "Per-User"
2. Toggling back to "Per-User" wrote `false` to the shared DB only — the per-user DB kept `true`, so every restart re-entered shared mode

## What changed

**Before any side-effects** (path changes, log redirection, new DB connections), we now peek at the shared DB when the per-user DB says `multiUser = true`:

- **Shared DB has `false`** — user toggled back. We sync `false` to the per-user DB, remove the stale key from the shared DB, and proceed as per-user. Single restart, no revert logic needed.
- **Shared DB has no key** (`NotFoundError`) — first launch in shared mode. After the shared DB is set up as the active persistor, we seed `multiUser = true` so hydration gives the UI the correct value.
- **Shared DB has `true`** — steady state, proceed normally.

The temp connection used for the peek is always closed before the main code path creates its own.

fixes https://linear.app/nexus-mods/issue/APP-182/multi-user-mode-toggle-is-broken-cannot-switch-back-from-shared-to-per