### PR TITLE
fixed state sanitization repairs not persisted to disk

### DIFF
--- a/src/renderer/src/extensions/download_management/actions/state.ts
+++ b/src/renderer/src/extensions/download_management/actions/state.ts
@@ -1,7 +1,8 @@
 import { createAction } from "redux-act";
+
 import type { IChunk } from "../types/IChunk";
 
-import { log } from "../../../util/log";
+import { log } from "../../../logging";
 
 export interface IDictionary {
   [key: string]: any;

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -119,6 +119,7 @@ import { fetchHydrationState } from "./store/hydration";
 import { persistDiffMiddleware } from "./store/persistDiffMiddleware";
 import { reduxLogger } from "./store/reduxLogger";
 import { reduxSanity, type StateError } from "./store/reduxSanity";
+import { computeStateDiff } from "./store/stateDiff";
 import StyleManager from "./StyleManager";
 import { createRendererTelemetryProvider } from "./telemetry/setup";
 import { GameEntryNotFound } from "./types/IGameStore";
@@ -545,7 +546,7 @@ async function init(): Promise<ExtensionManager | null> {
     return null;
   }
 
-  const extReducers = extensions.getReducers() as IExtensionReducer[];
+  const extReducers = extensions.getReducers();
 
   const reportReducerError = (err) =>
     extensions
@@ -588,6 +589,22 @@ async function init(): Promise<ExtensionManager | null> {
       type: "__hydrate",
       payload: { [hive]: sanitizedState[hive] },
     });
+  }
+
+  // Persist sanitization repairs so they don't recur on next startup.
+  // __hydrate actions skip the persist middleware, so repairs made by
+  // sanitizeHydrationState would otherwise be lost between sessions.
+  if (sanitizedState !== hydratedState && window.api?.persist) {
+    for (const hive of Object.keys(sanitizedState)) {
+      const oldHive = hydratedState[hive];
+      const newHive = sanitizedState[hive];
+      if (oldHive !== newHive) {
+        const ops = computeStateDiff(oldHive, newHive);
+        if (ops.length > 0) {
+          window.api.persist.sendDiff(hive as any, ops);
+        }
+      }
+    }
   }
 
   // Set up window event handlers from main process


### PR DESCRIPTION
After hydration completes, we check if sanitizeHydrationState actually changed anything (sanitizedState !== hydratedState — reference inequality means repairs were made). If so, we loop through each hive, diff the original against the sanitized version, and send those diffs directly to the main process via window.api.persist.sendDiff().

This bypasses the persistDiffMiddleware entirely — we're not dispatching a Redux action, just sending the diff operations straight to LevelDB. So the repairs get written to disk immediately, and on next startup the state is already clean.

fixes https://linear.app/nexus-mods/issue/APP-183/state-sanitization-repairs-not-persisted-to-disk-causing-repeated