### PR TITLE
Modified bug template, tickets with insufficient information get discarded

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,3 +38,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+> **Note:** If your issue is specific to a community extension or a game supported by a community extension, please report it on the extension's page on Nexus Mods instead. This tracker is for Vortex core and officially supported functionality only.


### PR DESCRIPTION


We're seeing an increase in unactionable tickets where users do not provide any useful information when diagnosing bugs.

Added a section that informs them that unactionable tickets may get closed without a response.