### PR TITLE
fixed external changes still being raised incorrectly (v1.16 edition)

### DIFF
--- a/src/extensions/mod_management/InstallManager.ts
+++ b/src/extensions/mod_management/InstallManager.ts
@@ -934,7 +934,41 @@ class InstallManager {
    * Get count of active installations
    */
   public getActiveInstallationCount(): number {
-    return this.mActiveInstalls.size;
+    const state = this.mApi.getState();
+    const currentGameId = activeGameId(state);
+    let count = 0;
+    for (const install of this.mActiveInstalls.values()) {
+      const gameId = install.gameId || currentGameId;
+      const mods = state.persistent.mods[gameId] ?? {};
+      if (mods[install.modId]?.type !== "collection") {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Returns a promise that resolves once there are no active or pending
+   * installations. Resolves immediately if already idle.
+   */
+  public waitForIdle(): Promise<void> {
+    const shouldResolve = () =>
+      this.getActiveInstallationCount() === 0 ||
+      getCollectionActiveSession(this.mApi.getState()) !== undefined;
+
+    if (shouldResolve()) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const check = () => {
+        if (shouldResolve()) {
+          resolve();
+        } else {
+          setTimeout(check, 500);
+        }
+      };
+      setTimeout(check, 500);
+    });
   }
 
   /**

--- a/src/extensions/mod_management/index.ts
+++ b/src/extensions/mod_management/index.ts
@@ -85,7 +85,7 @@ import {
 } from "./types/IDeploymentMethod";
 import { IFileMerge } from "./types/IFileMerge";
 import { IInstallOptions } from "./types/IInstallOptions";
-import { IMod, IModReference } from "./types/IMod";
+import { IMod, IModReference, InstallType } from "./types/IMod";
 import { InstallFunc } from "./types/InstallFunc";
 import { IRemoveModOptions } from "./types/IRemoveModOptions";
 import { IResolvedMerger } from "./types/IResolvedMerger";
@@ -683,7 +683,7 @@ function deployableModTypes(modPaths: { [typeId: string]: string }) {
   return Object.keys(modPaths).filter((typeId) => truthy(modPaths[typeId]));
 }
 
-function genUpdateModDeployment() {
+function genUpdateModDeployment(installManager: InstallManager) {
   return (
     api: IExtensionApi,
     manual: boolean,
@@ -706,11 +706,9 @@ function genUpdateModDeployment() {
       }
       api.store.dispatch(updateNotification(notification.id, percent, text));
     };
-    const state = api.store.getState();
+    const state: IState = api.store.getState();
     let profile: IProfile =
-      profileId !== undefined
-        ? getSafe(state, ["persistent", "profiles", profileId], undefined)
-        : activeProfile(state);
+      state.persistent.profiles?.[profileId] ?? activeProfile(state);
 
     if (
       Object.keys(getSafe(state, ["session", "base", "toolsRunning"], {}))
@@ -733,11 +731,7 @@ function genUpdateModDeployment() {
       return Bluebird.resolve();
     }
     const gameId = profile.gameId;
-    const gameDiscovery = getSafe(
-      state,
-      ["settings", "gameMode", "discovered", gameId],
-      undefined,
-    );
+    const gameDiscovery = state.settings.gameMode.discovered?.[gameId];
     const game = getGame(gameId);
     if (game === undefined || gameDiscovery?.path === undefined) {
       const err = new Error("Game no longer available");
@@ -819,100 +813,106 @@ function genUpdateModDeployment() {
             method: activator.name,
           });
 
-          let mergeResult: { [modType: string]: IMergeResultByType };
-          const lastDeployment: { [typeId: string]: IDeployedFile[] } = {};
-          const mods = state.persistent.mods[profile.gameId] || {};
-          notification.message = t("Deploying mods");
-          api.sendNotification(notification);
-          api.store.dispatch(startActivity("mods", "deployment"));
-          progress(t("Loading deployment manifest"), 0);
+          return Bluebird.resolve(installManager.waitForIdle()).then(() => {
+            let mergeResult: { [modType: string]: IMergeResultByType };
+            const lastDeployment: { [typeId: string]: IDeployedFile[] } = {};
+            const mods = state.persistent.mods[profile.gameId] || {};
+            notification.message = t("Deploying mods");
+            api.sendNotification(notification);
+            api.store.dispatch(startActivity("mods", "deployment"));
+            progress(t("Loading deployment manifest"), 0);
 
-          return Bluebird.each(deployableModTypes(modPaths), (typeId) =>
-            loadActivation(
-              api,
-              gameId,
-              typeId,
-              modPaths[typeId],
-              stagingPath,
-              activator,
-            ).then((deployedFiles) => (lastDeployment[typeId] = deployedFiles)),
-          )
-            .tap(() => progress(t("Running pre-deployment events"), 2))
-            .then(() =>
-              api.emitAndAwait(
-                "will-deploy",
-                profile.id,
-                lastDeployment,
-                deployOptions,
-              ),
-            )
-            .then(() => {
-              // need to update the profile so that if a will-deploy handler disables a mod, that
-              // actually has an affect on this deployment
-              const updatedState = api.getState();
-              const updatedProfile =
-                updatedState.persistent.profiles[profile.id];
-              if (updatedProfile !== undefined) {
-                profile = updatedProfile;
-              } else {
-                // I don't think this can happen
-                log("warn", "profile no longer found?", profileId);
-              }
-            })
-            .tap(() => progress(t("Checking for external changes"), 5))
-            .then(() =>
-              dealWithExternalChanges(
+            return Bluebird.each(deployableModTypes(modPaths), (typeId) =>
+              loadActivation(
                 api,
+                gameId,
+                typeId,
+                modPaths[typeId],
+                stagingPath,
                 activator,
-                profileId,
-                stagingPath,
-                modPaths,
-                lastDeployment,
+              ).then(
+                (deployedFiles) => (lastDeployment[typeId] = deployedFiles),
               ),
             )
-            .tap(() => progress(t("Checking for mod incompatibilities"), 25))
-            .then(() => checkIncompatibilities(api, profile, mods))
-            .tap(() => progress(t("Sorting mods"), 30))
-            .then(() =>
-              doSortMods(api, profile, mods).then((sortedModListIn: IMod[]) => {
-                sortedModList = sortedModListIn;
-              }),
-            )
-            .tap(() => progress(t("Merging mods"), 35))
-            .then(() =>
-              doMergeMods(
-                api,
-                game,
-                gameDiscovery,
-                stagingPath,
-                sortedModList,
-                modPaths,
-                lastDeployment,
-              ).then((mergeResultIn) => (mergeResult = mergeResultIn)),
-            )
-            .tap(() => progress(t("Starting deployment"), 35))
-            .then(() => {
-              const deployProgress = (name, percent) =>
-                progress(t("Deploying: ") + name, 50 + percent / 2);
-
-              const undiscovered = Object.keys(modPaths).filter(
-                (typeId) => !truthy(modPaths[typeId]),
-              );
-              return validateDeploymentTarget(api, undiscovered).then(() =>
-                deployAllModTypes(
+              .tap(() => progress(t("Running pre-deployment events"), 2))
+              .then(() =>
+                api.emitAndAwait(
+                  "will-deploy",
+                  profile.id,
+                  lastDeployment,
+                  deployOptions,
+                ),
+              )
+              .then(() => {
+                // need to update the profile so that if a will-deploy handler disables a mod, that
+                // actually has an affect on this deployment
+                const updatedState = api.getState();
+                const updatedProfile =
+                  updatedState.persistent.profiles[profile.id];
+                if (updatedProfile !== undefined) {
+                  profile = updatedProfile;
+                } else {
+                  // I don't think this can happen
+                  log("warn", "profile no longer found?", profileId);
+                }
+              })
+              .tap(() => progress(t("Checking for external changes"), 5))
+              .then(() =>
+                dealWithExternalChanges(
                   api,
                   activator,
-                  profile,
-                  sortedModList,
+                  profileId,
                   stagingPath,
-                  mergeResult,
                   modPaths,
                   lastDeployment,
-                  newDeployment,
-                  deployProgress,
                 ),
-              );
-            });
+              )
+              .tap(() => progress(t("Checking for mod incompatibilities"), 25))
+              .then(() => checkIncompatibilities(api, profile, mods))
+              .tap(() => progress(t("Sorting mods"), 30))
+              .then(() =>
+                doSortMods(api, profile, mods).then(
+                  (sortedModListIn: IMod[]) => {
+                    sortedModList = sortedModListIn;
+                  },
+                ),
+              )
+              .tap(() => progress(t("Merging mods"), 35))
+              .then(() =>
+                doMergeMods(
+                  api,
+                  game,
+                  gameDiscovery,
+                  stagingPath,
+                  sortedModList,
+                  modPaths,
+                  lastDeployment,
+                ).then((mergeResultIn) => (mergeResult = mergeResultIn)),
+              )
+              .tap(() => progress(t("Starting deployment"), 35))
+              .then(() => {
+                const deployProgress = (name, percent) =>
+                  progress(t("Deploying: ") + name, 50 + percent / 2);
+
+                const undiscovered = Object.keys(modPaths).filter(
+                  (typeId) => !truthy(modPaths[typeId]),
+                );
+                return validateDeploymentTarget(api, undiscovered).then(() =>
+                  deployAllModTypes(
+                    api,
+                    activator,
+                    profile,
+                    sortedModList,
+                    stagingPath,
+                    mergeResult,
+                    modPaths,
+                    lastDeployment,
+                    newDeployment,
+                    deployProgress,
+                  ),
+                );
+              });
+          });
         })
           // at this point the deployment lock gets released so another deployment
           // can be started during post-deployment
@@ -1237,8 +1237,22 @@ function attributeExtractor(input: any) {
   });
 }
 
+function deriveInstallType(input: any): InstallType {
+  if (input.previous === undefined) {
+    return "fresh";
+  }
+  const isNexus = input.previous.source === "nexus";
+  if (isNexus) {
+    return input.previous.fileId === input.download?.modInfo?.nexus?.ids?.fileId
+      ? "reinstall" : "update";
+  }
+  return input.previous.fileMD5 === input.download?.fileMD5
+    ? "reinstall" : "update";
+}
+
 function upgradeExtractor(input: any) {
   return Bluebird.resolve({
+    installType: deriveInstallType(input),
     category: getSafe(input.previous, ["category"], undefined),
     customFileName: getSafe(input.previous, ["customFileName"], undefined),
     variant: getSafe(input.previous, ["variant"], undefined),
@@ -1510,7 +1524,7 @@ function onNeedToDeploy(api: IExtensionApi, current: any) {
 }
 
 function once(api: IExtensionApi) {
-  const store: Redux.Store<any> = api.store;
+  const store: Redux.Store<IState> = api.store;
 
   if (installManager === undefined) {
     installManager = new InstallManager(api, (gameId: string) =>
@@ -1526,7 +1540,7 @@ function once(api: IExtensionApi) {
     });
   }
 
-  const updateModDeployment = genUpdateModDeployment();
+  const updateModDeployment = genUpdateModDeployment(installManager);
   const deploymentTimer = new Debouncer(
     (
       manual: boolean,

--- a/src/extensions/mod_management/types/IMod.ts
+++ b/src/extensions/mod_management/types/IMod.ts
@@ -8,6 +8,8 @@ export type ModState =
   | "installing"
   | "installed";
 
+export type InstallType = "fresh" | "reinstall" | "update";
+
 /**
  * Attributes specific to Nexus Mods Collections (when IMod.type === "collection")
  */
@@ -74,6 +76,7 @@ export interface ICommonModAttributes {
 
   // Installation tracking
   installTime?: string;
+  installType?: InstallType;
   installedAsDependency?: boolean;
   referenceTag?: string;
 

--- a/src/extensions/mod_management/util/externalChanges.ts
+++ b/src/extensions/mod_management/util/externalChanges.ts
@@ -203,12 +203,11 @@ export function changeToEntry(
   };
 }
 
-function defaultCollectionAction(
-  typeId: string,
-  input: IFileChange,
-): IFileEntry {
+function defaultInternalAction(typeId: string, input: IFileChange): IFileEntry {
+  // Internal changes are from mod updates/reinstalls — always drop the old
+  // deployed file so deployment recreates it from the updated staging files.
   const action: FileAction = {
-    refchange: "newest",
+    refchange: "drop",
     valchange: "nop",
     deleted: "restore",
     srcdeleted: "drop",
@@ -284,6 +283,7 @@ export function dealWithExternalChanges(
   stagingPath: string,
   modPaths: { [typeId: string]: string },
   lastDeployment: { [typeId: string]: IDeployedFile[] },
+  autoResolveAll?: boolean,
 ) {
   return checkForExternalChanges(
     api,
@@ -295,10 +295,17 @@ export function dealWithExternalChanges(
   )
     .then((changes: { [typeId: string]: IFileChange[] }) => {
       const automaticActions: IFileEntry[] = [];
+      const state = api.store.getState();
       const isInstallingCollection =
-        getCollectionActiveSession(api.store.getState()) !== undefined;
+        getCollectionActiveSession(state) !== undefined;
+      const shouldAutoResolve = isInstallingCollection || autoResolveAll;
+      const profile =
+        profileId !== undefined
+          ? profileById(state, profileId)
+          : activeProfile(state);
+      const mods = state.persistent.mods[profile?.gameId] ?? {};
       const userChanges = Object.keys(changes).reduce((prev, typeId) => {
-        const { merged, rest, collection } = changes[typeId].reduce(
+        const { merged, rest, autoResolved } = changes[typeId].reduce(
           (prevInner, change) => {
             const isMerged = path
               .basename(change.source)
@@ -307,8 +314,16 @@ export function dealWithExternalChanges(
               prevInner.merged.push(change);
               return prevInner;
             }
-            if (isInstallingCollection) {
-              prevInner.collection.push(change);
+            if (shouldAutoResolve) {
+              prevInner.autoResolved.push(change);
+              return prevInner;
+            }
+
+            // Auto-resolve changes for mods that were reinstalled or updated
+            // by Vortex — these are expected staging changes, not external.
+            const installType = mods[change.source]?.attributes?.installType;
+            if (installType === "reinstall" || installType === "update") {
+              prevInner.autoResolved.push(change);
               return prevInner;
             }
 
@@ -316,7 +331,7 @@ export function dealWithExternalChanges(
 
             return prevInner;
           },
-          { merged: [], rest: [], collection: [] },
+          { merged: [], rest: [], autoResolved: [] },
         );
 
         if (merged.length > 0) {
@@ -325,9 +340,9 @@ export function dealWithExternalChanges(
           );
         }
 
-        if (isInstallingCollection && collection.length > 0) {
-          collection.forEach((change) =>
-            automaticActions.push(defaultCollectionAction(typeId, change)),
+        if (autoResolved.length > 0) {
+          autoResolved.forEach((change) =>
+            automaticActions.push(defaultInternalAction(typeId, change)),
           );
         }
 


### PR DESCRIPTION
This is difficult to reproduce, but usually you have to batch re-install/update multiple mods.

Previously we would fully rely on the InstallManager to confirm that deployment can be started (no active installations). This is generally sufficient if the `deploy-mods` event has been emitted while installations are still executing, but did not cover cases where Vortex managed to re-install/update all mods before `deploy-mods` was called.

A new `IMod` attribute was introduced `installType` to help the external changes dialog identify how the mod was installed (`fresh`/ `reinstall`/`update`) it will handle changes automatically if `reinstall` or `update`.