### PR TITLE
fixed "icon missing" log entries

### DIFF
--- a/extensions/collections/src/views/CollectionPageEdit/InstallModeRenderer.tsx
+++ b/extensions/collections/src/views/CollectionPageEdit/InstallModeRenderer.tsx
@@ -52,6 +52,7 @@ class InstallModeRenderer extends ComponentEx<IProps, {}> {
       <FlexLayout.Fixed style={{ marginLeft: "5px", marginTop: "3px" }}>
         <tooltip.Icon
           name="options"
+          set="collections"
           tooltip={t("This mod has installer options")}
         />
       </FlexLayout.Fixed>

--- a/extensions/collections/src/views/CollectionPageEdit/index.tsx
+++ b/extensions/collections/src/views/CollectionPageEdit/index.tsx
@@ -204,6 +204,7 @@ class CollectionEdit extends ComponentEx<
             </tooltip.IconButton>
             <tooltip.IconButton
               icon="collection-export"
+              set="collections"
               tooltip={uploadDisabled ?? t("Upload to Nexus Mods")}
               onClick={this.upload}
               disabled={uploadDisabled !== undefined}

--- a/extensions/collections/src/views/CollectionPageView/HealthIndicator.tsx
+++ b/extensions/collections/src/views/CollectionPageView/HealthIndicator.tsx
@@ -84,7 +84,7 @@ function HealthIndicator(props: IHealthIndicatorProps) {
     <FlexLayout type="column" className="collection-health-indicator">
       <div className="collection-health-header">
         <div className="collection-health-header-title">
-          <Icon name="revision" />
+          <Icon set="collections" name="revision" />
           {t("Revision {{number}}", { replace: { number: revisionNumber } })}
         </div>
         <div className="collection-health-header-gameversion">

--- a/extensions/collections/src/views/CollectionPageView/SlideshowControls.tsx
+++ b/extensions/collections/src/views/CollectionPageView/SlideshowControls.tsx
@@ -60,6 +60,7 @@ function SlideshowControls(props: ISlideshowControlsProps) {
     <div className="slideshow-controls">
       <tooltip.IconButton
         icon="collection-previous"
+        set="collections"
         tooltip={t("Show previous mod")}
         disabled={idx === 0}
         onClick={prev}
@@ -69,6 +70,7 @@ function SlideshowControls(props: ISlideshowControlsProps) {
       })}
       <tooltip.IconButton
         icon="collection-next"
+        set="collections"
         tooltip={t("Show next mod")}
         disabled={idx === numItems - 1}
         onClick={next}

--- a/extensions/collections/src/views/CollectionTile/RemoteTile.tsx
+++ b/extensions/collections/src/views/CollectionTile/RemoteTile.tsx
@@ -118,7 +118,7 @@ function RemoteTile(props: IRemoteTileProps) {
               })}
             </div>
             <div className={classes.join(" ")}>
-              <Icon name="health" />
+              <Icon set="collections" name="health" />
               {t("{{rating}}%", {
                 replace: { rating: revision.rating.average },
               })}

--- a/extensions/collections/src/views/CollectionTile/SuccessRating.tsx
+++ b/extensions/collections/src/views/CollectionTile/SuccessRating.tsx
@@ -59,7 +59,7 @@ export function SuccessRating(props: ISuccessRatingProps) {
 
   return (
     <div className={classes.join(" ")}>
-      <Icon name="health" />
+      <Icon set="collections" name="health" />
       {rating === undefined
         ? t("Awaiting")
         : t("{{rating}}%", { replace: { rating } })}

--- a/src/renderer/src/controls/Icon.tsx
+++ b/src/renderer/src/controls/Icon.tsx
@@ -105,10 +105,18 @@ const getOrLoadIconSet = (set: string): Promise<Set<string>> => {
 
 const checkMissingIcon = (set: string, name: string): void => {
   if (!debugMissingIcons || debugReported.has(name)) return;
+  const prefixed = "icon-" + name;
   void getOrLoadIconSet(set).then((symbols) => {
-    if (symbols !== null && !symbols.has("icon-" + name)) {
-      console.trace("icon missing", name);
-      debugReported.add(name);
+    if (symbols !== null && !symbols.has(prefixed)) {
+      // Icon not in requested set — check all loaded sets before reporting
+      const promises = getIconSetPromises();
+      void Promise.all(Array.from(promises.values())).then((allSets) => {
+        const found = allSets.some((s) => s !== null && s.has(prefixed));
+        if (!found) {
+          console.trace("icon missing", name);
+        }
+        debugReported.add(name);
+      });
     }
   });
 };


### PR DESCRIPTION
SVG <use> element resolves symbols globally from the DOM regardless of which set they belong to so these "icon missing" log entries are just pointless noise. (this only happens on dev environments btw)

Updated the `checkMissingIcon` function to search for the symbol across all icon sets before reporting it as missing

fixes https://linear.app/nexus-mods/issue/APP-26/fix-missing-icons