### PR TITLE
fixed elevation script being closed prematurely for collections

### DIFF
--- a/src/renderer/src/extensions/symlink_activator_elevate/index.ts
+++ b/src/renderer/src/extensions/symlink_activator_elevate/index.ts
@@ -641,11 +641,21 @@ class DeploymentMethod extends LinkingDeployment {
     });
   }
 
+  private hasActiveCollectionSession(): boolean {
+      const state = this.api.store.getState() as IState;
+      return state.session?.collections?.activeSession != null;
+  }
+
   private finish() {
     log("debug", "finished");
     if (this.mQuitTimer !== undefined) {
       clearTimeout(this.mQuitTimer);
     }
+
+    // During collection installation, keep the elevated process alive longer to avoid
+    // repeated UAC prompts between deployment phases.
+    const timeoutMs = this.hasActiveCollectionSession() ? 5 * 60 * 1000 : 5000;
+
     this.mQuitTimer = setTimeout(() => {
       log("debug", "closing symlink process");
       this.emit("quit", {});
@@ -653,7 +663,7 @@ class DeploymentMethod extends LinkingDeployment {
 
       this.mElevatedClient = null;
       this.mQuitTimer = undefined;
-    }, 5000);
+    }, timeoutMs);
 
     if (this.mTmpFilePath !== undefined) {
       try {


### PR DESCRIPTION
I chose not to poll the collection status here intentionally, 5 minutes should be plenty of time for the elevation timer to get reset if needed during collection installation. (was previously 5 seconds)

fixes https://linear.app/nexus-mods/issue/APP-192/prolong-elevation-script-lifetime-during-collection-installation