### PR TITLE
fix: workaround Electron >=39.6.1 crash on BrowserView close (v2.0)

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -222,10 +222,18 @@ class Application {
             this.mDeinitCrashDump();
           }
           if (process.platform !== "darwin") {
+            // All windows are already destroyed at this point (via the
+            // destroy() workaround in MainWindow), so app.quit() won't
+            // attempt to close any windows — it just fires the before-quit
+            // / will-quit lifecycle events (needed by the autoupdater) and
+            // then exits cleanly.
             app.quit();
           }
         })
-        .catch((err: unknown) => log("error", "error finalizing write", err));
+        .catch((err: unknown) => {
+          log("error", "error finalizing write", unknownToError(err));
+          app.exit(1);
+        });
     });
 
     app.on("activate", () => {
@@ -233,7 +241,7 @@ class Application {
         this.mMainWindow
           .create()
           .catch((err: unknown) =>
-            log("error", "failed to create main window", err),
+            log("error", "failed to create main window", unknownToError(err)),
           );
       }
     });
@@ -241,7 +249,7 @@ class Application {
     app.on("second-instance", (_event: Event, secondaryArgv: string[]) => {
       log("debug", "getting arguments from second instance", secondaryArgv);
       this.applyArguments(parseCommandline(secondaryArgv, true)).catch(
-        (err: unknown) => log("error", "error applying arguments", err),
+        (err: unknown) => log("error", "error applying arguments", unknownToError(err)),
       );
     });
 
@@ -266,7 +274,7 @@ class Application {
       protocol.registerHttpProtocol("nxm", (request) => {
         const cfgFile: IParameters = { download: request.url };
         this.applyArguments(cfgFile).catch((err: unknown) =>
-          log("error", "error applying arguments", err),
+          log("error", "error applying arguments", unknownToError(err)),
         );
       });
 
@@ -295,7 +303,7 @@ class Application {
     app
       .whenReady()
       .then(onReady)
-      .catch((err: unknown) => log("error", "error starting application", err));
+      .catch((err: unknown) => log("error", "error starting application", unknownToError(err)));
 
     app.on(
       "web-contents-created",

--- a/src/main/src/MainWindow.ts
+++ b/src/main/src/MainWindow.ts
@@ -407,13 +407,18 @@ class MainWindow {
       return;
     }
 
-    this.mWindow.on("close", () => {
+    this.mWindow.on("close", (event) => {
       if (this.mWindow === null) {
         return;
       }
-      // Forward close event to renderer
+      // Work around Electron >=39.6.1 crash on Windows where the normal
+      // WM_CLOSE destruction path triggers an access violation inside
+      // electron.exe (STATUS_FATAL_USER_CALLBACK_EXCEPTION / 0xC000041D).
+      // See: https://github.com/electron/electron/issues/50040
+      event.preventDefault();
       this.mWindow.webContents.send("window:event:close");
       closeAllViews(this.mWindow);
+      this.mWindow.destroy();
     });
     this.mWindow.on("closed", () => {
       this.mWindow = null;


### PR DESCRIPTION
cherry-pick for https://linear.app/nexus-mods/issue/APP-108/fix-incorrect-exit-code-when-closing-via-x-button