### PR TITLE
fixed last few instances of app.quit causing application crash

### DIFF
--- a/src/main/src/TrayIcon.ts
+++ b/src/main/src/TrayIcon.ts
@@ -1,6 +1,4 @@
-import type { BrowserWindow } from "electron";
-
-import { app, Menu, Tray } from "electron";
+import { BrowserWindow, Menu, Tray } from "electron";
 import path from "node:path";
 
 import { getVortexPath } from "./getVortexPath";
@@ -80,7 +78,11 @@ class TrayIcon {
     this.mTrayIcon.setContextMenu(
       Menu.buildFromTemplate([
         { label: "Start Game", click: () => this.startGame() },
-        { label: "Quit", click: () => app.quit() },
+        { label: "Quit", click: () => {
+          for (const win of BrowserWindow.getAllWindows()) {
+            win.close();
+          }
+        } },
       ]),
     );
 

--- a/src/main/src/cli.ts
+++ b/src/main/src/cli.ts
@@ -1,7 +1,7 @@
 import type { IParameters, ISetItem } from "@vortex/shared/cli";
 
 import program from "commander";
-import { app } from "electron";
+import { app, BrowserWindow } from "electron";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -290,5 +290,11 @@ export function parseCommandline(
 
 export function relaunch(args?: string[]) {
   app.relaunch({ args: [...filterArgs(process.argv), ...(args || [])] });
-  app.quit();
+  // Don't call app.quit() — it sets internal quitting state before closing
+  // windows, which causes an access violation in Electron's native
+  // destruction path. Instead, close all windows normally; the
+  // window-all-closed handler will call app.quit() after cleanup.
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.close();
+  }
 }


### PR DESCRIPTION
We handled Electron's native window destructor issue (APP-108) for when closing the app; but we didn't handle other instances such as:
- Re-launching the app with cli arguments would still call app.quit() and could potentially crash.
- Closing the application through Vortex tray icon was also broken

fixes https://linear.app/nexus-mods/issue/APP-216/alpha3-crashes-while-adding-cp2077-extension-for-the-first-time