### PR TITLE
fixed startup crash when dialogs shown before main window exists

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -121,7 +121,8 @@ class Application {
   private mBasePath: string;
   private mLevelPersistors: LevelPersist[] = [];
   private mArgs: IParameters;
-  private mMainWindow: MainWindow;
+  private mMainWindow: MainWindow | undefined;
+  private mMainWindowReady: Promise<Electron.WebContents | undefined> | undefined;
   private mTray: TrayIcon;
   private mAppMetadata: AppInitMetadata;
   private mFirstStart: boolean = false;
@@ -185,8 +186,7 @@ class Application {
     });
   }
 
-  private async startUi(): Promise<void> {
-    // Read window settings from persistence before creating window
+  private async initMainWindow(): Promise<void> {
     const windowSettings = await readPersistedValue<IWindow>("settings", [
       "window",
     ]);
@@ -194,12 +194,29 @@ class Application {
     this.mMainWindow = new MainWindow(this.mArgs.inspector, windowSettings);
     log("debug", "creating main window");
 
-    const webContents = await this.mMainWindow.create();
+    // Start window creation but don't wait for ready-to-show.
+    // The BrowserWindow is created synchronously inside create(),
+    // so getHandle() works immediately. The returned promise resolves
+    // once the window is ready to be shown.
+    this.mMainWindowReady = this.mMainWindow.create();
+  }
+
+  private async awaitMainWindowReady(): Promise<void> {
+    const webContents = await this.mMainWindowReady;
     if (!webContents) {
       throw new Error("no web contents from main window");
     }
+    log("debug", "window ready");
+  }
 
-    log("debug", "window created");
+  private showDialog(
+    options: Electron.MessageBoxOptions,
+  ): Promise<Electron.MessageBoxReturnValue> {
+    const parent = this.mMainWindow?.getHandle();
+    if (parent) {
+      return dialog.showMessageBox(parent, options);
+    }
+    return dialog.showMessageBox(options);
   }
 
   private async startSplash(): Promise<SplashScreen> {
@@ -368,20 +385,17 @@ class Application {
       } else if (err instanceof ProcessCanceled) {
         app.quit();
       } else if (err instanceof DocumentsPathMissing) {
-        const response = await dialog.showMessageBox(
-          this.mMainWindow.getHandle(),
-          {
-            type: "error",
-            buttons: ["Close", "More info"],
-            defaultId: 1,
-            title: "Error",
-            message: "Startup failed",
-            detail:
-              'Your "My Documents" folder is missing or is ' +
-              "misconfigured. Please ensure that the folder is properly " +
-              "configured and accessible, then try again.",
-          },
-        );
+        const response = await this.showDialog({
+          type: "error",
+          buttons: ["Close", "More info"],
+          defaultId: 1,
+          title: "Error",
+          message: "Startup failed",
+          detail:
+            'Your "My Documents" folder is missing or is ' +
+            "misconfigured. Please ensure that the folder is properly " +
+            "configured and accessible, then try again.",
+        });
 
         if (response.response === 1) {
           await shell.openExternal(
@@ -447,7 +461,7 @@ class Application {
       if (err instanceof DataInvalid) {
         log("error", "persistence data invalid", getErrorMessageOrDefault(err));
 
-        await dialog.showMessageBox(this.mMainWindow.getHandle(), {
+        await this.showDialog({
           type: "error",
           buttons: ["Continue"],
           title: "Error",
@@ -470,14 +484,20 @@ class Application {
       }
     }
 
-    log("debug", "checking admin rights");
-    await this.warnAdmin();
-
+    // Collect metadata before creating the main window — the renderer
+    // fetches it via getInitMetadata() early in its boot.
     log("debug", "checking how Vortex was installed");
     await this.identifyInstallType();
+    this.mAppMetadata.version = app.getVersion();
 
     log("debug", "checking if migration is required");
-    await this.checkUpgrade();
+    await this.migrateIfNecessary(this.mAppMetadata.version);
+
+    log("debug", "starting user interface");
+    await this.initMainWindow();
+
+    log("debug", "checking admin rights");
+    await this.warnAdmin();
 
     log("debug", "setting up error handlers");
     // Install error handler (no longer has access to store state)
@@ -491,8 +511,8 @@ class Application {
 
     this.setupContextMenu();
 
-    log("debug", "starting user interface");
-    await this.startUi();
+    log("debug", "waiting for user interface");
+    await this.awaitMainWindowReady();
 
     log("debug", "setting up tray icon");
     this.createTray();
@@ -592,7 +612,7 @@ class Application {
     }
 
     const uacEnabled = this.isUACEnabled();
-    const result = await dialog.showMessageBox(this.mMainWindow.getHandle(), {
+    const result = await this.showDialog({
       title: "Admin rights detected",
       message:
         `Vortex has detected that it is being run with administrator rights. It is strongly
@@ -615,13 +635,6 @@ class Application {
     }
   }
 
-  private async checkUpgrade(): Promise<void> {
-    const currentVersion = app.getVersion();
-    await this.migrateIfNecessary(currentVersion);
-    // Collect metadata - renderer will dispatch the action
-    this.mAppMetadata.version = currentVersion;
-  }
-
   private async migrateIfNecessary(currentVersion: string): Promise<void> {
     // Read appVersion from persistence since we don't have the store
     const lastVersionPersisted = await readPersistedValue<string>("app", [
@@ -635,7 +648,7 @@ class Application {
     }
 
     if (isMajorDowngrade(lastVersion, currentVersion)) {
-      const res = dialog.showMessageBoxSync(this.mMainWindow.getHandle(), {
+      const res = await this.showDialog({
         type: "warning",
         title: "Downgrade detected",
         message: `You're using a version of Vortex that is older than the version you ran previously.
@@ -645,7 +658,7 @@ class Application {
         noLink: true,
       });
 
-      if (res === 0) {
+      if (res.response === 0) {
         app.quit();
         throw new UserCanceled();
       }


### PR DESCRIPTION
Several startup methods (`warnAdmin`, `migrateIfNecessary`, `setupPersistence` error handler, `DocumentsPathMissing` handler) called `this.mMainWindow.getHandle()` to parent their dialogs, but `mMainWindow` wasn't created until `startUi()` ran later in the sequence — causing a crash if any of those paths were hit.

### Solution

Split `startUi()` into `initMainWindow()` (creates window, starts loading renderer) and `awaitMainWindowReady()` (waits for renderer to finish). This lets us slot window creation at the right point in the startup order.

Added `showDialog()` helper that uses the window as parent when available, or shows a parentless dialog when it isn't.

Moved metadata collection (`version`, `installType`) and the migration check before `initMainWindow()` to avoid a race with the renderer reading metadata on boot, and to prevent the renderer from hydrating state before we've decided whether to abort.

**New startup order:**
1. `setupPersistence` - parentless dialog on error
2. `identifyInstallType` + version metadata
3. `migrateIfNecessary` - parentless dialog, renderer not running yet
4. `initMainWindow` - window created, renderer starts loading
5. `warnAdmin` - window available as dialog parent
6. Error handlers, initDevel, setupContextMenu
7. `awaitMainWindowReady` - wait for renderer to finish
8. Tray, splash, connect
