### PR TITLE
fixed collection mods not considered when checking if req is installed

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -162,7 +162,10 @@ export async function checkModRequirements(
 
     const useCachedOnly = params?.cachedOnly === true;
 
-    const enabledMods = getEnabledMods(api, gameId).filter(
+    const allEnabledMods = getEnabledMods(api, gameId);
+
+    // Mods whose requirements we check: user-installed Nexus mods only
+    const checkableMods = allEnabledMods.filter(
       (mod: IMod) =>
         mod.type !== "collection" &&
         !mod.attributes?.installedAsDependency &&
@@ -170,7 +173,7 @@ export async function checkModRequirements(
         mod.attributes?.source === "nexus",
     );
 
-    if (enabledMods.length === 0) {
+    if (checkableMods.length === 0) {
       return createResult(
         startTime,
         "passed",
@@ -179,11 +182,13 @@ export async function checkModRequirements(
       );
     }
 
-    // Build lookup structures for O(1) access
+    // Build lookup structures from ALL enabled mods so that mods installed
+    // as dependencies (e.g. via collections) are recognized as satisfying
+    // requirements.
     const installedModIds = new Set<number>();
     const modsByNexusId = new Map<number, IMod>();
 
-    for (const mod of enabledMods) {
+    for (const mod of allEnabledMods) {
       const nexusModId = mod.attributes?.modId;
       if (nexusModId) {
         installedModIds.add(nexusModId);
@@ -200,8 +205,8 @@ export async function checkModRequirements(
       errors: [],
     };
 
-    const modLimit = params?.limit ?? enabledMods.length;
-    const modsToCheck = enabledMods.slice(0, modLimit);
+    const modLimit = params?.limit ?? checkableMods.length;
+    const modsToCheck = checkableMods.slice(0, modLimit);
 
     // Build a map of requirements: first from cache, then fetch missing ones
     const requirementsMap: {


### PR DESCRIPTION
We were filtering out collection mods from the "satisfies requirement" criteria. Separated now into two lists the "mods to check" and the "mods that satisfy requirements"

https://linear.app/nexus-mods/issue/APP-235/health-check-marks-updated-collection-mods-as-missing