### PR TITLE
fixed UIBlocker/dimmer not cleared on successful OAuth login

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -2049,7 +2049,10 @@ export function updateToken(
     ),
   )
     .then(() => getUserInfo(api, nexus)) // update userinfo as we've set some new nexus credentials, either by launch, login or token refresh
-    .then(() => true)
+    .then(() => {
+      api.events.emit("did-login", null);
+      return BluebirdPromise.resolve(true);
+    })
     .catch((err) => {
       api.showErrorNotification(
         "Authentication failed, please log in again",


### PR DESCRIPTION
Apparently we weren't calling 'did-login' on OAuth success paths 🤷 

fixes https://linear.app/nexus-mods/issue/APP-161/majority-of-ui-darkens-and-becomes-unusable-when-asked-to-log-in-to