### PR TITLE
fixed UIV2 profile pages respect Enable Profile Management toggle

### DIFF
--- a/src/renderer/src/contexts/PagesContext.tsx
+++ b/src/renderer/src/contexts/PagesContext.tsx
@@ -77,6 +77,9 @@ export const PagesProvider: FC<IPagesProviderProps> = ({ children }) => {
   const useModernLayout = useSelector(
     (state: IState) => state.settings.window.useModernLayout,
   );
+  const profilesVisible = useSelector(
+    (state: IState) => state.settings.interface.profilesVisible,
+  );
 
   const sortedPages = useMemo(
     () =>
@@ -116,7 +119,7 @@ export const PagesProvider: FC<IPagesProviderProps> = ({ children }) => {
         dispatch(setOpenMainPage(firstVisible.id, false));
       }
     }
-  }, [mainPage, sortedPages, activeProfileId, activeGameId, dispatch]);
+  }, [mainPage, sortedPages, activeProfileId, activeGameId, profilesVisible, dispatch]);
 
   const contextValue = useMemo(
     () => ({

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -958,7 +958,8 @@ function init(context: IExtensionContext): boolean {
     group: "per-game",
     isModernOnly: true,
     visible: () =>
-      activeGameId(context.api.store.getState()) !== undefined,
+      activeGameId(context.api.store.getState()) !== undefined &&
+      context.api.store.getState().settings.interface.profilesVisible,
     props: () => ({ features: profileFeatures }),
   });
 

--- a/src/renderer/src/extensions/settings_interface/reducers/interface.ts
+++ b/src/renderer/src/extensions/settings_interface/reducers/interface.ts
@@ -29,7 +29,7 @@ const settingsReducer: IReducerSpec = {
   defaults: {
     language: "en",
     advanced: false,
-    profilesVisible: false,
+    profilesVisible: true,
     desktopNotifications: false,
     hideTopLevelCategory: false,
     relativeTimes: true,

--- a/src/renderer/src/util/migrate.ts
+++ b/src/renderer/src/util/migrate.ts
@@ -10,6 +10,7 @@ import {
   setForcedLogout,
   setDownloadPath,
   setInstallPath,
+  setProfilesVisible,
   setUseModernLayout,
   setUserAPIKey,
   setUserInfo,
@@ -28,6 +29,7 @@ import type * as Redux from "redux";
 import * as semver from "semver";
 import format from "string-template";
 import { getErrorCode } from "@vortex/shared";
+import { batchDispatch } from './util';
 
 interface IMigration {
   id: string;
@@ -248,7 +250,10 @@ function enableModernLayout_2_0(
   _window: BrowserWindow,
   store: Redux.Store<IState>,
 ): PromiseBB<void> {
-  store.dispatch(setUseModernLayout(true));
+  batchDispatch(store, [
+    setUseModernLayout(true),
+    setProfilesVisible(true),
+  ]);
   return PromiseBB.resolve();
 }
 

--- a/src/renderer/src/views/components/Spine/SpineContext.tsx
+++ b/src/renderer/src/views/components/Spine/SpineContext.tsx
@@ -52,6 +52,9 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
   const { mainPages } = usePagesContext();
   const dispatch = useDispatch();
 
+  const profilesVisible = useSelector(
+    (state: IState) => state.settings.interface.profilesVisible,
+  );
   const lastActiveProfile = useSelector(lastActiveProfilesSelector);
   const activeProfileId = useSelector(activeProfileIdSelector);
   const activeGameId = useSelector(activeGameIdSelector);
@@ -103,7 +106,7 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
           page.id !== "Downloads" &&
           isPageVisible(page),
       ),
-    [mainPages, isPageVisible, activeGameId],
+    [mainPages, isPageVisible, activeGameId, profilesVisible],
   );
 
   const gamePages: IMainPage[] = useMemo(
@@ -114,7 +117,7 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
           page.id !== "game-downloads" &&
           isPageVisible(page),
       ),
-    [mainPages, isPageVisible, activeGameId],
+    [mainPages, isPageVisible, activeGameId, profilesVisible],
   );
 
   const mainPage = useSelector(mainPageSelector);


### PR DESCRIPTION
Also made sure that we're defaulting to profilesVisible too for new users, or migrate existing users to always visible.

fixes https://linear.app/nexus-mods/issue/APP-236/profile-management-toggle-is-still-visible-in-alpha3