### PR TITLE
Update wiki links

### DIFF
--- a/extensions/games/game-stardewvalley/README.md
+++ b/extensions/games/game-stardewvalley/README.md
@@ -231,4 +231,4 @@ A test only answers "can I handle this archive?" (`supported: true/false`).
 - SMAPI: <https://smapi.io/>
 - Stardew modding wiki index: <https://stardewvalleywiki.com/Modding:Index>
 - Vortex game extension guide:
-  <https://github.com/Nexus-Mods/Vortex/wiki/How-to-develop-a-game-extension>
+  <https://github.com/Nexus-Mods/Vortex/wiki/MODDINGWIKI-Developers-General-Creating-a-game-extension>

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -458,7 +458,7 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
 
   private openGameExtWiki = () => {
     opn(
-      "https://github.com/Nexus-Mods/Vortex/wiki/LEGACY-General-Creating-a-game-extension",
+      "https://github.com/Nexus-Mods/Vortex/wiki/MODDINGWIKI-Developers-General-Creating-a-game-extension",
     ).catch(() => null);
   };
 


### PR DESCRIPTION
Updated the wiki links for developing a new game extension.
The link in gamemode_management was a 404, and the one in game-stardewvalley was a mostly empty page.