### PR TITLE
fixed several issues with staging/game folders recovery after tampering

### DIFF
--- a/src/renderer/src/extensions/mod_management/LinkingDeployment.ts
+++ b/src/renderer/src/extensions/mod_management/LinkingDeployment.ts
@@ -476,7 +476,13 @@ abstract class LinkingActivator implements IDeploymentMethod {
       .statAsync(dataPath)
       .then(() => this.purgeLinks(installPath, dataPath, onProgress))
       .then(() => this.postLinkPurge(dataPath, false, true, directoryCleaning))
-      .then(() => undefined));
+      .then(() => undefined)
+      .catch((err: unknown) => {
+        if (getErrorCode(err) === "ENOENT") {
+          return Promise.resolve(undefined);
+        }
+        return Promise.reject(err);
+      }));
   }
 
   public postPurge(): PromiseLike<void> {

--- a/src/renderer/src/extensions/mod_management/stagingDirectory.ts
+++ b/src/renderer/src/extensions/mod_management/stagingDirectory.ts
@@ -7,7 +7,7 @@ import { getApplication } from "../../util/application";
 import { ProcessCanceled, UserCanceled } from "../../util/CustomErrors";
 import * as fs from "../../util/fs";
 import lazyRequire from "../../util/lazyRequire";
-import { log } from "../../util/log";
+import { log } from "../../logging";
 import { activeGameId, installPathForGame } from "../../util/selectors";
 import { getSafe } from "../../util/storeHelper";
 import { truthy } from "../../util/util";
@@ -203,29 +203,37 @@ async function ensureStagingDirectoryImpl(
         });
         try {
           await fallbackPurge(api, gameId);
-          await fs.ensureDirWritableAsync(instPath, () => Promise.resolve());
         } catch (purgeErr) {
           if (!partitionExists) {
             // Can't purge a non-existing partition!
             throw new ProcessCanceled("Invalid/Missing partition");
           }
+          const purgeError = unknownToError(purgeErr);
+
+          // purge failed but we still want to recreate the staging directory
+          // so the user can continue using Vortex
           if (purgeErr instanceof ProcessCanceled) {
-            log("warn", "Mods not purged", purgeErr.message);
+            log("warn", "Mods not purged", purgeError.message);
           } else {
-            api.showDialog(
-              "error",
-              "Mod Staging Folder missing!",
-              {
-                bbcode:
-                  "The staging folder could not be created. " +
-                  "You [b][color=red]have[/color][/b] to go to settings->mods and change it " +
-                  "to a valid directory [b][color=red]before doing anything else[/color][/b] " +
-                  "or you will get further error messages.",
-              },
-              [{ label: "Close" }],
-            );
+            log("warn", "Mods not purged during reinitialize", purgeError);
           }
-          throw new ProcessCanceled("Not purged");
+        }
+        try {
+          await fs.ensureDirWritableAsync(instPath);
+        } catch (dirErr) {
+          api.showDialog(
+            "error",
+            "Mod Staging Folder missing!",
+            {
+              bbcode:
+                "The staging folder could not be created. " +
+                "You [b][color=red]have[/color][/b] to go to settings->mods and change it " +
+                "to a valid directory [b][color=red]before doing anything else[/color][/b] " +
+                "or you will get further error messages.",
+            },
+            [{ label: "Close" }],
+          );
+          throw new ProcessCanceled("Staging folder could not be created");
         }
         api.dismissNotification(id);
       } else if (dialogResult.action === "Ignore") {

--- a/src/renderer/src/extensions/mod_management/util/deploy.ts
+++ b/src/renderer/src/extensions/mod_management/util/deploy.ts
@@ -164,23 +164,9 @@ export function purgeMods(
           // If the user is unmanaging the game and the purge was unable to find any
           //  of the game's mods path during the purge, that suggests that the user
           //  has uninstalled the game and is trying to "unmanage" the game.
+          //  In this case, there's nothing left to purge so we can safely resolve.
           if (["ENOENT"].includes(getErrorCode(err)) && isUnmanaging) {
-            const game = getGame(gameId);
-            const discovery = getSafe(
-              state,
-              ["settings", "gameMode", "discovered", gameId],
-              undefined,
-            );
-            if (game === undefined || discovery?.path === undefined) {
-              return Promise.reject(err);
-            }
-            const modTypePaths = game.getModPaths(discovery.path);
-            const modPaths = Object.keys(modTypePaths).map(
-              (modType) => modTypePaths[modType],
-            );
-            if (modPaths.includes((err as NodeJS.ErrnoException).path)) {
-              return Promise.resolve();
-            }
+            return Promise.resolve();
           } else {
             return Promise.reject(err);
           }


### PR DESCRIPTION
- user was unable to unmanage the game if the game folder was missing
- vortex would not attempt to re-initialize staging folder if it was removed externally

fixes https://linear.app/nexus-mods/issue/APP-239
fixes https://linear.app/nexus-mods/issue/APP-240