### PR TITLE
on manual fomod re-install, show fomod dialog with preselected values

### DIFF
--- a/src/renderer/src/extensions/installer_fomod_native/installer.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/installer.ts
@@ -53,11 +53,22 @@ export const install = async (
     // thread — converting/dispatching large installSteps arrays — for no
     // visible benefit since the dialog is never shown.
     const isUnattended = unattended === true && fomodChoices != null;
+
+    // When attended (manual reinstall) with saved choices, don't pass them to
+    // the C# engine — it would auto-advance through matching steps without
+    // showing the dialog. Instead, pass them as "attended presets" so the
+    // DialogManager can pre-select options in the UI while still showing the
+    // dialog for user modification.
+    const attendedPresets =
+      !isUnattended && fomodChoices != null ? fomodChoices : undefined;
+    const enginePreset = isUnattended ? fomodChoices : undefined;
+
     const modInstaller = await VortexModInstaller.create(
       api,
       instanceId,
       gameId,
       isUnattended,
+      attendedPresets,
     );
 
     const result = await modInstaller.installAsync(
@@ -65,7 +76,7 @@ export const install = async (
       stopPatterns,
       pluginPath,
       scriptPath,
-      fomodChoices,
+      enginePreset,
       validate,
     );
 

--- a/src/renderer/src/extensions/installer_fomod_native/utils/DialogManager.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/utils/DialogManager.ts
@@ -12,6 +12,7 @@ import {
   startDialog,
 } from "../../installer_fomod_shared/actions/installerUI";
 import type {
+  IChoices,
   IHeaderImage,
   IInstallerState,
   IInstallStep,
@@ -39,6 +40,12 @@ export class DialogManager implements IDialogManager {
   private mModuleName: string;
   private mImage: IHeaderImage;
   private mScriptPath: string;
+  // Saved choices from a previous installation used to pre-select options
+  // in the dialog while still allowing the user to modify them.
+  private mAttendedPresets: IChoices;
+  // Tracks which steps have already had presets applied to avoid re-applying
+  // on the subsequent uiUpdateState callback triggered by selectCallback.
+  private mPresetsAppliedSteps: Set<number> = new Set();
 
   public get instanceId(): string {
     return this.mInstanceId;
@@ -52,13 +59,16 @@ export class DialogManager implements IDialogManager {
     api: IExtensionApi,
     instanceId: string,
     scriptPath: string,
+    attendedPresets?: IChoices,
   ) {
     this.mApi = api;
     this.mInstanceId = instanceId;
     this.mScriptPath = scriptPath;
+    this.mAttendedPresets = attendedPresets;
 
     log("debug", "Created DialogManager instance", {
       instanceId: this.mInstanceId,
+      hasAttendedPresets: attendedPresets != null,
     });
   }
 
@@ -125,6 +135,12 @@ export class DialogManager implements IDialogManager {
       };
 
       this.mApi.store.dispatch(setDialogState(state, this.mInstanceId));
+
+      // Apply attended presets: when the user is reinstalling a mod, pre-select
+      // the options they chose last time via selectCallback so the C# engine
+      // reflects the correct state — then the next uiUpdateState callback from
+      // the engine will carry the updated selections into Redux/UI.
+      this.applyAttendedPresets(installSteps, currentStep);
 
       const dialogQueue = DialogQueue.getInstance(this.mApi);
       dialogQueue.processNext();
@@ -226,6 +242,59 @@ export class DialogManager implements IDialogManager {
     });
     this.onDialogEnd();
   };
+
+  /**
+   * Apply saved choices from a previous installation to the current step.
+   * Matches by step name and group name, then calls selectCallback to
+   * sync the C# engine state. The engine will fire another uiUpdateState
+   * with the updated selections, which we skip via mPresetsAppliedSteps.
+   */
+  private applyAttendedPresets(
+    installSteps: fomodT.types.IInstallStep[],
+    currentStep: number,
+  ): void {
+    if (this.mAttendedPresets == null || !this.mSelectCB) {
+      return;
+    }
+
+    if (this.mPresetsAppliedSteps.has(currentStep)) {
+      return;
+    }
+    this.mPresetsAppliedSteps.add(currentStep);
+
+    const step = installSteps[currentStep];
+    if (!step?.optionalFileGroups?.group) {
+      return;
+    }
+
+    const presetStep = this.mAttendedPresets.find((s) => s.name === step.name);
+    if (!presetStep) {
+      return;
+    }
+
+    for (const group of step.optionalFileGroups.group) {
+      const presetGroup = presetStep.groups.find(
+        (g) => g.name === group.name,
+      );
+      if (!presetGroup) {
+        continue;
+      }
+
+      const pluginIds = presetGroup.choices.map((c) => {
+        // Match by index first, fall back to name lookup
+        const byIdx = group.options.find((opt) => opt.id === c.idx);
+        if (byIdx) {
+          return byIdx.id;
+        }
+        const byName = group.options.find((opt) => opt.name === c.name);
+        return byName?.id;
+      }).filter((id): id is number => id != null);
+
+      if (pluginIds.length > 0) {
+        this.mSelectCB(step.id, group.id, pluginIds);
+      }
+    }
+  }
 
   /**
    * Event handler: User selected options in the dialog

--- a/src/renderer/src/extensions/installer_fomod_native/utils/VortexModInstaller.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/utils/VortexModInstaller.ts
@@ -3,6 +3,7 @@ import lazyRequire from "../../../util/lazyRequire";
 import { log } from "../../../util/log";
 import { DialogManager } from "./DialogManager";
 import { SharedDelegates } from "../../installer_fomod_shared/delegates/SharedDelegates";
+import type { IChoices } from "../../installer_fomod_shared/types/interface";
 
 import type * as fomodT from "@nexusmods/fomod-installer-native";
 
@@ -12,12 +13,14 @@ export class VortexModInstaller {
     instanceId: string,
     gameId: string,
     unattended: boolean = false,
+    attendedPresets?: IChoices,
   ): Promise<VortexModInstaller> {
     const delegates = new VortexModInstaller(
       api,
       instanceId,
       gameId,
       unattended,
+      attendedPresets,
     );
     await delegates.initialize();
     return delegates;
@@ -37,12 +40,17 @@ export class VortexModInstaller {
   // choices come from the input preset, not from Redux state. Skipping these
   // eliminates dozens of expensive main-thread TSFN callbacks per fomod mod.
   private mUnattended: boolean;
+  // Saved choices from a previous installation. When set (and not unattended),
+  // the dialog is shown but options matching these choices are pre-selected,
+  // allowing the user to review and modify them.
+  private mAttendedPresets: IChoices;
 
   private constructor(
     api: IExtensionApi,
     instanceId: string,
     gameId: string,
     unattended: boolean = false,
+    attendedPresets?: IChoices,
   ) {
     this.fomod = lazyRequire<typeof fomodT>(() =>
       require("@nexusmods/fomod-installer-native"),
@@ -61,6 +69,7 @@ export class VortexModInstaller {
     this.mInstanceId = instanceId;
     this.mGameId = gameId;
     this.mUnattended = unattended;
+    this.mAttendedPresets = attendedPresets;
   }
 
   private async initialize(): Promise<void> {
@@ -147,6 +156,7 @@ export class VortexModInstaller {
       this.mApi,
       this.mInstanceId,
       this.mScriptPath,
+      this.mAttendedPresets,
     );
     this.mDialogManager.enqueueDialog(
       moduleName,


### PR DESCRIPTION
Rather than keep flip flopping between fresh fomod dialog and re-install automatically with preset. We now show the dialog with pre-selected choices. (not applied when installing a collection)

Users that want to maintain the preset without changing anything can just keep clicking next -> next -> finish

Users that want to add/modify something can change the pre-selection as they choose.

This is the only middleground currently.

fixes nexus-mods/vortex#21864