### PR TITLE
adding cherry-pick workflow to mirror PRs on v2* to other branches

### DIFF
--- a/.github/scripts/cherry-pick.sh
+++ b/.github/scripts/cherry-pick.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables:
+#   PR_NUMBER   - The PR number to cherry-pick
+#   PR_TITLE    - The title for the new PR
+#   MERGE_SHA   - The merge commit SHA to cherry-pick
+#   LABELS      - Space-separated list of PR labels
+#
+# Optional:
+#   DRY_RUN     - Set to "true" to skip push and PR creation
+
+DRY_RUN="${DRY_RUN:-false}"
+
+TARGETS=()
+for label in $LABELS; do
+  if [[ "$label" == pick:* ]]; then
+    TARGETS+=("${label#pick:}")
+  fi
+done
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  echo "No pick: labels found, skipping."
+  exit 0
+fi
+
+for TARGET in "${TARGETS[@]}"; do
+  echo "--- Cherry-picking to $TARGET ---"
+  BRANCH="cherry-pick/pr-${PR_NUMBER}-to-${TARGET}"
+
+  if ! git rev-parse --verify "origin/$TARGET" > /dev/null 2>&1; then
+    echo "WARNING: Target branch '$TARGET' does not exist, skipping."
+    continue
+  fi
+
+  git checkout -b "$BRANCH" "origin/$TARGET"
+
+  # Use -m 1 for merge commits to cherry-pick just the PR's changes
+  PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')
+  CHERRY_PICK_ARGS=("$MERGE_SHA" --no-edit)
+  if [ "$PARENT_COUNT" -gt 1 ]; then
+    CHERRY_PICK_ARGS+=(-m 1)
+  fi
+
+  HAS_CONFLICTS=false
+  if git cherry-pick "${CHERRY_PICK_ARGS[@]}"; then
+    echo "Cherry-pick succeeded cleanly."
+  else
+    echo "Cherry-pick had conflicts, committing with conflict markers."
+    HAS_CONFLICTS=true
+    git add -A
+    git commit --no-edit -m "cherry-pick of #${PR_NUMBER} (conflicts)" || true
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[DRY RUN] Would push branch '$BRANCH' and create PR to '$TARGET'"
+    echo "[DRY RUN] Has conflicts: $HAS_CONFLICTS"
+    git log --oneline -1
+  else
+    git push --force origin "$BRANCH"
+
+    if ! gh pr list --head "$BRANCH" --base "$TARGET" --json number --jq '.[0].number' | grep -q .; then
+      DRAFT_FLAG=""
+      BODY="Cherry-pick of #${PR_NUMBER} into \`${TARGET}\`."
+
+      if [ "$HAS_CONFLICTS" = "true" ]; then
+        DRAFT_FLAG="--draft"
+        BODY="${BODY}
+
+> [!WARNING]
+> This cherry-pick had merge conflicts that need manual resolution."
+      fi
+
+      gh pr create \
+        --base "$TARGET" \
+        --head "$BRANCH" \
+        --title "$PR_TITLE" \
+        $DRAFT_FLAG \
+        --body "$BODY"
+    else
+      echo "PR already exists for $BRANCH -> $TARGET, skipping creation."
+    fi
+  fi
+
+  git checkout --detach
+  git branch -D "$BRANCH"
+  echo ""
+done

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,34 @@
+name: Cherry Pick
+
+on:
+  pull_request_target:
+    branches: [v2*]
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherry-pick:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Cherry-pick to target branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: bash .github/scripts/cherry-pick.sh

--- a/docs/cherry-pick-workflow.md
+++ b/docs/cherry-pick-workflow.md
@@ -1,0 +1,63 @@
+# Cherry-Pick Workflow
+
+Automatically cherry-picks merged PRs from release branches (e.g. `v2.0`) to other branches (e.g. `master`) via GitHub Actions.
+
+## How it works
+
+1. A PR is merged into a release branch (any branch matching `v2*`)
+2. The workflow checks for labels matching the pattern `pick:<target-branch>`
+3. For each matching label, it cherry-picks the merge commit onto a new branch and opens a PR targeting that branch
+4. If the cherry-pick has conflicts, a **draft** PR is created with a warning so the conflicts can be resolved manually
+
+## Usage
+
+Add a `pick:<branch>` label to your PR **before merging**. Examples:
+
+- `pick:master` — cherry-pick into `master`
+- `pick:v3.0` — cherry-pick into `v3.0`
+
+Multiple labels can be used on a single PR to cherry-pick into several branches.
+
+## Behavior
+
+| Scenario | Result |
+|---|---|
+| Clean cherry-pick | Branch pushed, PR created |
+| Cherry-pick with conflicts | Branch pushed, **draft** PR created with warning |
+| Target branch doesn't exist | Skipped with a warning |
+| Branch already exists remotely | Force-pushed, existing PR reused |
+| No `pick:` labels | Workflow exits early |
+
+## Cherry-pick branches
+
+Created branches follow the naming convention:
+
+```
+cherry-pick/pr-{number}-to-{target}
+```
+
+For example, PR #22246 with label `pick:master` creates branch `cherry-pick/pr-22246-to-master`.
+
+## Merge commits
+
+The workflow detects whether the merge commit has multiple parents (i.e. a merge commit rather than a squash/rebase). For merge commits it uses `git cherry-pick -m 1` to pick only the PR's changes relative to the base branch.
+
+## Files
+
+- Workflow: `.github/workflows/cherry-pick.yml`
+- Script: `.github/scripts/cherry-pick.sh`
+
+## Local testing
+
+The script can be run locally with `DRY_RUN=true` to verify the cherry-pick without pushing or creating PRs:
+
+```bash
+DRY_RUN=true \
+PR_NUMBER=12345 \
+PR_TITLE="your PR title" \
+MERGE_SHA=abc123 \
+LABELS="pick:master" \
+bash .github/scripts/cherry-pick.sh
+```
+
+Note: this will temporarily check out branches in your working tree. Stash or commit local changes first.


### PR DESCRIPTION
please see [docs/cherry-pick-workflow.md](https://github.com/Nexus-Mods/Vortex/blob/ec9bd770dbee49825fad7f81908aaa529062c90a/docs/cherry-pick-workflow.md) for details on how this works

Could change the workflow target branches from `v2*` to `**` if we want @insomnious (that way we won't have to worry about which branch the workflow is running on, could do `pick:v2.0` from master PRs for example)

closes https://linear.app/nexus-mods/issue/APP-213/automate-cherry-picking-from-release-branches-to-master