### PR TITLE
wait for renderer process exit before relaunching the app

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -229,6 +229,7 @@ class Application {
     app.on("window-all-closed", () => {
       log("info", "Vortex closing");
       finalizeMainWrite()
+        .then(() => this.waitForRendererExit())
         .then(() => {
           log("info", "clean application end");
           DuckDBSingleton.getInstance().close();
@@ -1112,6 +1113,45 @@ class Application {
         // Fall back to non-maximized
         this.mMainWindow?.show(false, startMinimized);
       });
+  }
+
+  /**
+   * Wait for the renderer process to fully exit so that all its file handles
+   * are released by the OS. This prevents EPERM errors on the next startup
+   * when trying to remove extension directories that the old renderer had loaded.
+   */
+  private async waitForRendererExit(): Promise<void> {
+    const pid = this.mMainWindow?.getRendererPid();
+    if (pid === undefined) {
+      return;
+    }
+
+    const isRunning = (p: number): boolean => {
+      try {
+        process.kill(p, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    if (!isRunning(pid)) {
+      return;
+    }
+
+    log("debug", "waiting for renderer process to exit", { pid });
+    const MAX_WAIT_MS = 5000;
+    const POLL_INTERVAL_MS = 50;
+    const start = Date.now();
+    while (isRunning(pid) && Date.now() - start < MAX_WAIT_MS) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    if (isRunning(pid)) {
+      log("warn", "renderer process did not exit in time", { pid });
+    } else {
+      log("debug", "renderer process exited", { pid, elapsed: Date.now() - start });
+    }
   }
 
   private testUserEnvironment(): void {

--- a/src/main/src/MainWindow.ts
+++ b/src/main/src/MainWindow.ts
@@ -78,6 +78,7 @@ class MainWindow {
   private mShown: boolean;
   private mInspector: boolean;
   private mInitialWindowSettings: IWindow | null = null;
+  private mRendererPid: number | undefined;
 
   /**
    * Create a MainWindow instance.
@@ -364,6 +365,10 @@ class MainWindow {
     return this.mWindow;
   }
 
+  public getRendererPid(): number | undefined {
+    return this.mRendererPid;
+  }
+
   private getWindowSettings(
     windowMetrics: IWindow | null | undefined,
   ): Electron.BrowserWindowConstructorOptions {
@@ -416,6 +421,13 @@ class MainWindow {
       // electron.exe (STATUS_FATAL_USER_CALLBACK_EXCEPTION / 0xC000041D).
       // See: https://github.com/electron/electron/issues/50040
       event.preventDefault();
+      // Save the renderer process PID before destroying so Application can
+      // wait for the process to fully exit and release file handles.
+      try {
+        this.mRendererPid = this.mWindow.webContents.getOSProcessId();
+      } catch {
+        // webContents may already be gone
+      }
       this.mWindow.webContents.send("window:event:close");
       closeAllViews(this.mWindow);
       this.mWindow.destroy();

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -935,9 +935,19 @@ class ExtensionManager {
     Object.keys(this.mExtensionState)
       .filter((extId) => this.mExtensionState[extId].remove)
       .forEach((extId) => {
-        log("info", "removing", path.join(extensionsPath, extId));
-        fs.removeSync(path.join(extensionsPath, extId));
-        this.mPendingRemoves.push(extId);
+        const extPath = path.join(extensionsPath, extId);
+        log("info", "removing", extPath);
+        try {
+          fs.removeSync(extPath);
+          this.mPendingRemoves.push(extId);
+        } catch (err) {
+          // On Windows the previous renderer process may not have fully released
+          // file handles yet despite waitForRendererExit in the main process.
+          // Log and continue — the remove flag stays in state so it retries on
+          // next startup.
+          log("warn", "failed to remove extension, will retry on next startup",
+            { extId, error: getErrorMessageOrDefault(err) });
+        }
       });
 
     // Dynamic require to prevent TypeScript from analyzing StyleManager during api build


### PR DESCRIPTION
This fixes the use case where the user is updating a community game extension and the application relaunches before the previous session had a chance to release all of its file handles.

fixes https://github.com/Nexus-Mods/Vortex/issues/22252 fixes https://linear.app/nexus-mods/issue/APP-251/eperm-during-extension-update-prevents-vortex-startup