### PR TITLE
use new fomod preselect parameter instead of UI syncing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,11 +53,11 @@ catalogs:
       specifier: ^2.7.0
       version: 2.8.0
     '@nexusmods/fomod-installer-ipc':
-      specifier: ^0.12.0
-      version: 0.12.0
+      specifier: ^0.13.0
+      version: 0.13.0
     '@nexusmods/fomod-installer-native':
-      specifier: ^0.12.0
-      version: 0.12.0
+      specifier: ^0.13.0
+      version: 0.13.0
     '@nexusmods/nexus-api':
       specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
       version: 1.5.2
@@ -3983,10 +3983,10 @@ importers:
         version: 2.8.0
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.12.0
+        version: 0.13.0
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.12.0
+        version: 0.13.0
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
@@ -4480,10 +4480,10 @@ importers:
         version: 2.8.0
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.12.0
+        version: 0.13.0
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.12.0
+        version: 0.13.0
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
@@ -6038,12 +6038,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@nexusmods/fomod-installer-ipc@0.12.0':
-    resolution: {integrity: sha512-zMfV1ctfrklyQmUNjF/nLe9HHv+cTT8s4LBc3crh4u+w3/EWTYOBZcmmu19oWFeDkZwpwgS+Qf6WyCwiAe36Kw==}
+  '@nexusmods/fomod-installer-ipc@0.13.0':
+    resolution: {integrity: sha512-oWc2eCsu8FewYFq3w5gRFtiDZFbRPIWi1VgvqHJQhKN93WTmzVf0po7r3F/604SDTpNAuquHgFqWU8np7S83yA==}
     engines: {node: '>=22'}
 
-  '@nexusmods/fomod-installer-native@0.12.0':
-    resolution: {integrity: sha512-BrmUafwSm1U40h3oNjcFTVcJ/aJpv5grZP6oguW0+sqdXFjW/YzHyqHwbOI+5pGRna0D+syzCv73U8YOnhW62A==}
+  '@nexusmods/fomod-installer-native@0.13.0':
+    resolution: {integrity: sha512-jkoXlWllwWXiQKrN1tKvTl7e86yw8kis3dA8FdPvzlxuYY/MkMThMzlIe81zlh0fROBEvcxHTy9SUZVbST4UDQ==}
     engines: {node: '>=22'}
 
   '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161':
@@ -14945,9 +14945,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nexusmods/fomod-installer-ipc@0.12.0': {}
+  '@nexusmods/fomod-installer-ipc@0.13.0': {}
 
-  '@nexusmods/fomod-installer-native@0.12.0':
+  '@nexusmods/fomod-installer-native@0.13.0':
     dependencies:
       node-gyp-build: 4.8.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,8 +49,8 @@ catalog:
   "@mdi/js": 7.4.47
   "@microsoft/api-extractor": ^7.57.6
   "@msgpack/msgpack": ^2.7.0
-  "@nexusmods/fomod-installer-ipc": ^0.12.0
-  "@nexusmods/fomod-installer-native": ^0.12.0
+  "@nexusmods/fomod-installer-ipc": ^0.13.0
+  "@nexusmods/fomod-installer-native": ^0.13.0
   "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
   "@opentelemetry/api": ^1.9.0
   "@opentelemetry/context-async-hooks": ^2.5.1

--- a/src/renderer/src/extensions/installer_fomod_native/installer.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/installer.ts
@@ -54,21 +54,16 @@ export const install = async (
     // visible benefit since the dialog is never shown.
     const isUnattended = unattended === true && fomodChoices != null;
 
-    // When attended (manual reinstall) with saved choices, don't pass them to
-    // the C# engine — it would auto-advance through matching steps without
-    // showing the dialog. Instead, pass them as "attended presets" so the
-    // DialogManager can pre-select options in the UI while still showing the
-    // dialog for user modification.
-    const attendedPresets =
-      !isUnattended && fomodChoices != null ? fomodChoices : undefined;
-    const enginePreset = isUnattended ? fomodChoices : undefined;
+    // When attended (manual reinstall) with saved choices, pass them as a
+    // preset with preselect=true so the C# engine pre-selects options in
+    // the dialog while still showing it for user modification.
+    const preselect = !isUnattended && fomodChoices != null;
 
     const modInstaller = await VortexModInstaller.create(
       api,
       instanceId,
       gameId,
       isUnattended,
-      attendedPresets,
     );
 
     const result = await modInstaller.installAsync(
@@ -76,7 +71,8 @@ export const install = async (
       stopPatterns,
       pluginPath,
       scriptPath,
-      enginePreset,
+      fomodChoices,
+      preselect,
       validate,
     );
 

--- a/src/renderer/src/extensions/installer_fomod_native/utils/DialogManager.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/utils/DialogManager.ts
@@ -12,7 +12,6 @@ import {
   startDialog,
 } from "../../installer_fomod_shared/actions/installerUI";
 import type {
-  IChoices,
   IHeaderImage,
   IInstallerState,
   IInstallStep,
@@ -40,12 +39,6 @@ export class DialogManager implements IDialogManager {
   private mModuleName: string;
   private mImage: IHeaderImage;
   private mScriptPath: string;
-  // Saved choices from a previous installation used to pre-select options
-  // in the dialog while still allowing the user to modify them.
-  private mAttendedPresets: IChoices;
-  // Tracks which steps have already had presets applied to avoid re-applying
-  // on the subsequent uiUpdateState callback triggered by selectCallback.
-  private mPresetsAppliedSteps: Set<number> = new Set();
 
   public get instanceId(): string {
     return this.mInstanceId;
@@ -59,16 +52,13 @@ export class DialogManager implements IDialogManager {
     api: IExtensionApi,
     instanceId: string,
     scriptPath: string,
-    attendedPresets?: IChoices,
   ) {
     this.mApi = api;
     this.mInstanceId = instanceId;
     this.mScriptPath = scriptPath;
-    this.mAttendedPresets = attendedPresets;
 
     log("debug", "Created DialogManager instance", {
       instanceId: this.mInstanceId,
-      hasAttendedPresets: attendedPresets != null,
     });
   }
 
@@ -135,12 +125,6 @@ export class DialogManager implements IDialogManager {
       };
 
       this.mApi.store.dispatch(setDialogState(state, this.mInstanceId));
-
-      // Apply attended presets: when the user is reinstalling a mod, pre-select
-      // the options they chose last time via selectCallback so the C# engine
-      // reflects the correct state — then the next uiUpdateState callback from
-      // the engine will carry the updated selections into Redux/UI.
-      this.applyAttendedPresets(installSteps, currentStep);
 
       const dialogQueue = DialogQueue.getInstance(this.mApi);
       dialogQueue.processNext();
@@ -242,59 +226,6 @@ export class DialogManager implements IDialogManager {
     });
     this.onDialogEnd();
   };
-
-  /**
-   * Apply saved choices from a previous installation to the current step.
-   * Matches by step name and group name, then calls selectCallback to
-   * sync the C# engine state. The engine will fire another uiUpdateState
-   * with the updated selections, which we skip via mPresetsAppliedSteps.
-   */
-  private applyAttendedPresets(
-    installSteps: fomodT.types.IInstallStep[],
-    currentStep: number,
-  ): void {
-    if (this.mAttendedPresets == null || !this.mSelectCB) {
-      return;
-    }
-
-    if (this.mPresetsAppliedSteps.has(currentStep)) {
-      return;
-    }
-    this.mPresetsAppliedSteps.add(currentStep);
-
-    const step = installSteps[currentStep];
-    if (!step?.optionalFileGroups?.group) {
-      return;
-    }
-
-    const presetStep = this.mAttendedPresets.find((s) => s.name === step.name);
-    if (!presetStep) {
-      return;
-    }
-
-    for (const group of step.optionalFileGroups.group) {
-      const presetGroup = presetStep.groups.find(
-        (g) => g.name === group.name,
-      );
-      if (!presetGroup) {
-        continue;
-      }
-
-      const pluginIds = presetGroup.choices.map((c) => {
-        // Match by index first, fall back to name lookup
-        const byIdx = group.options.find((opt) => opt.id === c.idx);
-        if (byIdx) {
-          return byIdx.id;
-        }
-        const byName = group.options.find((opt) => opt.name === c.name);
-        return byName?.id;
-      }).filter((id): id is number => id != null);
-
-      if (pluginIds.length > 0) {
-        this.mSelectCB(step.id, group.id, pluginIds);
-      }
-    }
-  }
 
   /**
    * Event handler: User selected options in the dialog

--- a/src/renderer/src/extensions/installer_fomod_native/utils/VortexModInstaller.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/utils/VortexModInstaller.ts
@@ -3,7 +3,6 @@ import lazyRequire from "../../../util/lazyRequire";
 import { log } from "../../../util/log";
 import { DialogManager } from "./DialogManager";
 import { SharedDelegates } from "../../installer_fomod_shared/delegates/SharedDelegates";
-import type { IChoices } from "../../installer_fomod_shared/types/interface";
 
 import type * as fomodT from "@nexusmods/fomod-installer-native";
 
@@ -13,14 +12,12 @@ export class VortexModInstaller {
     instanceId: string,
     gameId: string,
     unattended: boolean = false,
-    attendedPresets?: IChoices,
   ): Promise<VortexModInstaller> {
     const delegates = new VortexModInstaller(
       api,
       instanceId,
       gameId,
       unattended,
-      attendedPresets,
     );
     await delegates.initialize();
     return delegates;
@@ -40,17 +37,12 @@ export class VortexModInstaller {
   // choices come from the input preset, not from Redux state. Skipping these
   // eliminates dozens of expensive main-thread TSFN callbacks per fomod mod.
   private mUnattended: boolean;
-  // Saved choices from a previous installation. When set (and not unattended),
-  // the dialog is shown but options matching these choices are pre-selected,
-  // allowing the user to review and modify them.
-  private mAttendedPresets: IChoices;
 
   private constructor(
     api: IExtensionApi,
     instanceId: string,
     gameId: string,
     unattended: boolean = false,
-    attendedPresets?: IChoices,
   ) {
     this.fomod = lazyRequire<typeof fomodT>(() =>
       require("@nexusmods/fomod-installer-native"),
@@ -69,7 +61,6 @@ export class VortexModInstaller {
     this.mInstanceId = instanceId;
     this.mGameId = gameId;
     this.mUnattended = unattended;
-    this.mAttendedPresets = attendedPresets;
   }
 
   private async initialize(): Promise<void> {
@@ -96,6 +87,7 @@ export class VortexModInstaller {
     pluginPath: string,
     scriptPath: string,
     preset: any,
+    preselect: boolean,
     validate: boolean,
   ): Promise<fomodT.types.InstallResult | null> => {
     this.mScriptPath = scriptPath;
@@ -105,6 +97,7 @@ export class VortexModInstaller {
       pluginPath,
       scriptPath,
       preset,
+      preselect,
       validate,
     );
   };
@@ -156,7 +149,6 @@ export class VortexModInstaller {
       this.mApi,
       this.mInstanceId,
       this.mScriptPath,
-      this.mAttendedPresets,
     );
     this.mDialogManager.enqueueDialog(
       moduleName,


### PR DESCRIPTION
previous implementation was fine, but created overhead trying to sync the UI and C# engine on every installer step. Using the new fomod preselect flag, we offload the entire install option pre-select mechanism to the C# engine which is much more efficient and reliable

closes https://linear.app/nexus-mods/issue/APP-252/use-fomod-preselect-parameter-instead-of-ts-syncing