### PR TITLE
cherry-pick mechanism will now auto merge when no conflicts present

### DIFF
--- a/.github/scripts/cherry-pick.sh
+++ b/.github/scripts/cherry-pick.sh
@@ -59,7 +59,12 @@ for TARGET in "${TARGETS[@]}"; do
   else
     git push --force origin "$BRANCH"
 
-    if ! gh pr list --head "$BRANCH" --base "$TARGET" --json number --jq '.[0].number' | grep -q .; then
+    EXISTING_PR=$(gh pr list --head "$BRANCH" --base "$TARGET" --json number --jq '.[0].number')
+
+    if [ -n "$EXISTING_PR" ]; then
+      echo "PR #${EXISTING_PR} already exists for $BRANCH -> $TARGET, skipping creation."
+      PR_URL="https://github.com/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/pull/${EXISTING_PR}"
+    else
       DRAFT_FLAG=""
       BODY="Cherry-pick of #${PR_NUMBER} into \`${TARGET}\`."
 
@@ -71,14 +76,18 @@ for TARGET in "${TARGETS[@]}"; do
 > This cherry-pick had merge conflicts that need manual resolution."
       fi
 
-      gh pr create \
+      PR_URL=$(gh pr create \
         --base "$TARGET" \
         --head "$BRANCH" \
         --title "$PR_TITLE" \
         $DRAFT_FLAG \
-        --body "$BODY"
-    else
-      echo "PR already exists for $BRANCH -> $TARGET, skipping creation."
+        --body "$BODY")
+      echo "$PR_URL"
+    fi
+
+    if [ "$HAS_CONFLICTS" = "false" ]; then
+      echo "No conflicts detected, auto-merging..."
+      gh pr merge "$PR_URL" --merge --delete-branch
     fi
   fi
 

--- a/.github/scripts/cherry-pick.sh
+++ b/.github/scripts/cherry-pick.sh
@@ -86,8 +86,8 @@ for TARGET in "${TARGETS[@]}"; do
     fi
 
     if [ "$HAS_CONFLICTS" = "false" ]; then
-      echo "No conflicts detected, auto-merging..."
-      gh pr merge "$PR_URL" --merge --delete-branch
+      echo "No conflicts detected, enabling auto-merge (will land once branch protections are satisfied)..."
+      gh pr merge "$PR_URL" --auto --merge --delete-branch
     fi
   fi
 

--- a/docs/cherry-pick-workflow.md
+++ b/docs/cherry-pick-workflow.md
@@ -22,11 +22,13 @@ Multiple labels can be used on a single PR to cherry-pick into several branches.
 
 | Scenario | Result |
 |---|---|
-| Clean cherry-pick | Branch pushed, PR created and **auto-merged** |
+| Clean cherry-pick | Branch pushed, PR created with **auto-merge enabled** — lands once required reviews and CI pass |
 | Cherry-pick with conflicts | Branch pushed, **draft** PR created with warning (requires manual resolution) |
 | Target branch doesn't exist | Skipped with a warning |
 | Branch already exists remotely | Force-pushed, existing PR reused |
 | No `pick:` labels | Workflow exits early |
+
+> Auto-merge uses GitHub's native [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) feature, so cherry-pick PRs still respect the target branch's protection rules (required approvals, status checks, etc.). The repo must have **Allow auto-merge** enabled in *Settings → General → Pull Requests*.
 
 ## Cherry-pick branches
 

--- a/docs/cherry-pick-workflow.md
+++ b/docs/cherry-pick-workflow.md
@@ -22,8 +22,8 @@ Multiple labels can be used on a single PR to cherry-pick into several branches.
 
 | Scenario | Result |
 |---|---|
-| Clean cherry-pick | Branch pushed, PR created |
-| Cherry-pick with conflicts | Branch pushed, **draft** PR created with warning |
+| Clean cherry-pick | Branch pushed, PR created and **auto-merged** |
+| Cherry-pick with conflicts | Branch pushed, **draft** PR created with warning (requires manual resolution) |
 | Target branch doesn't exist | Skipped with a warning |
 | Branch already exists remotely | Force-pushed, existing PR reused |
 | No `pick:` labels | Workflow exits early |


### PR DESCRIPTION
We intentionally left out the auto-merge functionality initially as we wanted to observe whether we're happy with how the PR cherry-picks are submitted/used.

The mechanism appears to be functioning quite well, so lets auto merge if no conflicts are present.

Note that the repo settings must allow auto-merge for this to work. Will only auto-merge if no conflicts are present - the CI workflows have completed successfully + someone manually approves the change. (yes it's still partially manual)