### PR TITLE
feat(linux): winapi-bindings Linux shim

### DIFF
--- a/extensions/games/game-fallout4/src/index.js
+++ b/extensions/games/game-fallout4/src/index.js
@@ -1,9 +1,8 @@
 const Promise = require('bluebird');
 const path = require('path');
 const { util } = require('vortex-api');
-const winapi = require('winapi-bindings');
 
-/* 
+/*
 Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetData.txt file as a conflict. 
 It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
 This issue is compounded by users extracting all their BA2s. 

--- a/rolldown.base.mjs
+++ b/rolldown.base.mjs
@@ -17,6 +17,7 @@ export const mainOutputDirectory = path.resolve(
  * @param {"cjs" | "esm"} format
  * @param {import("rolldown").Plugin[]} [customPlugins=[]]
  * @param {import("rolldown").ExternalOption} [external=undefined]
+ * @param {Record<string, string>} [alias=undefined]
  * @returns {import("rolldown").RolldownOptions}
  * */
 export function createConfig(
@@ -25,12 +26,14 @@ export function createConfig(
   format,
   customPlugins = [],
   external = undefined,
+  alias = undefined,
 ) {
   return defineConfig({
     input: input,
     platform: "node",
     plugins: customPlugins,
     external: external,
+    ...(alias !== undefined && { resolve: { alias } }),
     onLog: (level, log, defaultHandler) => {
       if (log.code === "UNRESOLVED_IMPORT") {
         defaultHandler("error", log);

--- a/src/main/build.mjs
+++ b/src/main/build.mjs
@@ -6,6 +6,16 @@ import { createConfig, mainOutputDirectory } from "../../rolldown.base.mjs";
 const INPUT = path.resolve(import.meta.dirname, "src", "main.ts");
 const OUTPUT = path.join(mainOutputDirectory, "main.cjs");
 
+const SHIM_PATH = path.resolve(
+  import.meta.dirname,
+  "../../src/renderer/src/util/winapi-shim.ts",
+);
+
+const linuxAlias =
+  process.platform === "linux"
+    ? { "winapi-bindings": SHIM_PATH }
+    : undefined;
+
 const config = createConfig(INPUT, OUTPUT, "cjs", [], (id) => {
   if (id.startsWith("@vortex/shared")) return false;
 
@@ -13,7 +23,7 @@ const config = createConfig(INPUT, OUTPUT, "cjs", [], (id) => {
   if (path.isAbsolute(id)) return false;
 
   return true;
-});
+}, linuxAlias);
 
 const bundle = await rolldown(config);
 await bundle.write(config.output);

--- a/src/main/prepare-dist-package.mjs
+++ b/src/main/prepare-dist-package.mjs
@@ -178,8 +178,18 @@ async function createMinimalPackageJson(workspacePackageMap, catalog) {
   };
 
   if (mainPkg.dependencies && Object.keys(mainPkg.dependencies).length > 0) {
+    const deps = { ...mainPkg.dependencies };
+
+    // On Linux, winapi-bindings is replaced at bundle time by a JS shim
+    // (see build.mjs linuxAlias). The native .node binary is not needed at
+    // runtime and causes an EEXIST conflict in electron-builder packaging
+    // when combined with the asarUnpack "**/*.node" pattern.
+    if (process.platform === "linux") {
+      delete deps["winapi-bindings"];
+    }
+
     minimal.dependencies = rewriteFileDependencies(
-      mainPkg.dependencies,
+      deps,
       workspacePackageMap,
       catalog,
     );

--- a/src/main/prepare-dist-package.mjs
+++ b/src/main/prepare-dist-package.mjs
@@ -237,8 +237,21 @@ async function preparePNPM(rawWorkspaceYaml) {
   const catalog = extractCatalogBlock(rawWorkspaceYaml);
   const overrides = extractOverridesBlock(rawWorkspaceYaml);
 
+  // On Linux, prevent winapi-bindings from compiling its native binary.
+  // The JS shim is bundled into main.cjs at build time; the .node file is not
+  // needed at runtime and causes an EEXIST conflict in electron-builder.
+  const neverBuild =
+    process.platform === "linux"
+      ? "\nneverBuiltDependencies:\n  - winapi-bindings\n"
+      : "";
+
   const minimalYaml =
-    (overrides ? overrides + "\n" : "") + catalog + "\n" + allowBuilds + "\n";
+    (overrides ? overrides + "\n" : "") +
+    catalog +
+    "\n" +
+    allowBuilds +
+    neverBuild +
+    "\n";
 
   await writeFile(resolve(DIST_DIR, "pnpm-workspace.yaml"), minimalYaml);
   console.log("✔  Created dist/pnpm-workspace.yaml");

--- a/src/renderer/src/util/winapi-shim.test.ts
+++ b/src/renderer/src/util/winapi-shim.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import * as shimNs from "./winapi-shim";
+import shimDefault from "./winapi-shim";
+import {
+  GetDiskFreeSpaceEx,
+  GetVolumePathName,
+  ShellExecuteEx,
+  RegGetValue,
+  GetNativeArch,
+  GetProcessList,
+  IsThisWine,
+  SupportsAppContainer,
+  GetProcessToken,
+  CheckYourPrivilege,
+  WalkDir,
+  Access,
+} from "./winapi-shim";
+
+describe("GetDiskFreeSpaceEx", () => {
+  it("returns total, free, freeToCaller as positive numbers for /tmp", () => {
+    const result = GetDiskFreeSpaceEx("/tmp");
+    expect(result).toHaveProperty("total");
+    expect(result).toHaveProperty("free");
+    expect(result).toHaveProperty("freeToCaller");
+    expect(typeof result.total).toBe("number");
+    expect(typeof result.free).toBe("number");
+    expect(typeof result.freeToCaller).toBe("number");
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.free).toBeGreaterThan(0);
+    expect(result.freeToCaller).toBeGreaterThan(0);
+  });
+
+  it("throws or returns for a nonexistent path (caller catches)", () => {
+    // Callers already catch errors; just verify it doesn't crash the test with something unexpected
+    try {
+      GetDiskFreeSpaceEx("/nonexistent/path/abc123xyz987");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+});
+
+describe("GetVolumePathName", () => {
+  it("returns a non-empty string for /tmp", () => {
+    const result = GetVolumePathName("/tmp");
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns '/' as fallback for nonexistent path (ENOENT)", () => {
+    const result = GetVolumePathName("/nonexistent/path/abc123xyz987");
+    expect(result).toBe("/");
+  });
+});
+
+describe("ShellExecuteEx", () => {
+  it("throws an Error whose message contains 'Linux'", () => {
+    expect(() => ShellExecuteEx({} as any)).toThrow(Error);
+    expect(() => ShellExecuteEx({} as any)).toThrow(/Linux/);
+  });
+});
+
+describe("no-op stubs", () => {
+  it("RegGetValue returns undefined", () => {
+    expect(RegGetValue("HKEY_LOCAL_MACHINE" as any, "path", "key")).toBeUndefined();
+  });
+
+  it("GetProcessList returns []", () => {
+    expect(GetProcessList()).toEqual([]);
+  });
+
+  it("IsThisWine returns false", () => {
+    expect(IsThisWine()).toBe(false);
+  });
+
+  it("SupportsAppContainer returns false", () => {
+    expect(SupportsAppContainer()).toBe(false);
+  });
+
+  it("GetProcessToken('elevation') returns { isElevated: false }", () => {
+    expect(GetProcessToken("elevation")).toEqual({ isElevated: false });
+  });
+
+  it("CheckYourPrivilege returns []", () => {
+    expect(CheckYourPrivilege()).toEqual([]);
+  });
+});
+
+describe("GetNativeArch", () => {
+  it("returns object with nativeArch equal to process.arch", () => {
+    const result = GetNativeArch();
+    expect(result).toHaveProperty("nativeArch", process.arch);
+    expect(result).toHaveProperty("nativeMachineCode", 0);
+    expect(result).toHaveProperty("usedFallback", false);
+  });
+});
+
+describe("WalkDir", () => {
+  it("calls callback with null or undefined without throwing (3-arg form)", () => {
+    let cbArg: unknown = "NOT_CALLED";
+    WalkDir("/tmp", () => true, (err: Error | null) => {
+      cbArg = err;
+    });
+    expect(cbArg === null || cbArg === undefined).toBe(true);
+  });
+
+  it("calls callback with null when options object provided (4-arg form)", () => {
+    let cbArg: unknown = "NOT_CALLED";
+    WalkDir("/tmp", () => true, {}, (err: Error | null) => {
+      cbArg = err;
+    });
+    expect(cbArg === null || cbArg === undefined).toBe(true);
+  });
+});
+
+describe("Access constant", () => {
+  it("Access.Grant is a function", () => {
+    expect(typeof Access.Grant).toBe("function");
+  });
+
+  it("Access.Deny is a function", () => {
+    expect(typeof Access.Deny).toBe("function");
+  });
+
+  it("Access.Revoke is a function", () => {
+    expect(typeof Access.Revoke).toBe("function");
+  });
+});
+
+describe("export completeness", () => {
+  it("all named exports are typeof function or object", () => {
+    for (const [key, val] of Object.entries(shimNs)) {
+      if (key === "default") continue;
+      const t = typeof val;
+      expect(["function", "object"], `${key} should be function or object`).toContain(t);
+    }
+  });
+
+  it("default export contains every named export key", () => {
+    for (const key of Object.keys(shimNs)) {
+      if (key === "default") continue;
+      expect(shimDefault, `default export should have key ${key}`).toHaveProperty(key);
+    }
+  });
+});

--- a/src/renderer/src/util/winapi-shim.ts
+++ b/src/renderer/src/util/winapi-shim.ts
@@ -1,0 +1,419 @@
+/**
+ * Linux shim for the Windows-only `winapi-bindings` native module.
+ *
+ * Provides:
+ *   - Functional Linux equivalents for GetDiskFreeSpaceEx, GetVolumePathName,
+ *     GetNativeArch, SetProcessPreferredUILanguages (WAPI-02, WAPI-03)
+ *   - Throwing stubs for Windows-only elevated / UI operations (WAPI-04)
+ *   - Safe no-op / empty-return stubs for registry, ACL, task scheduler, etc. (WAPI-05)
+ *   - Both named exports and a default export object covering every function so
+ *     `import winapi from "winapi-bindings"` and `import * as winapi from "..."` both work
+ *
+ * NOTE: The Jest mock at src/renderer/src/__mocks__/winapi-bindings.js is NOT modified
+ * by this shim — it exists for existing renderer unit tests and deliberately diverges
+ * (e.g. RegGetValue returns an object there).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function unsupported(name: string): never {
+  throw new Error(`${name} is not supported on Linux`);
+}
+
+// ---------------------------------------------------------------------------
+// FUNCTIONAL STUBS (real Linux equivalents)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns available disk space for the volume containing filePath.
+ * Uses fs.statfsSync which exposes POSIX statvfs data.
+ * Callers already catch errors, so ENOENT is allowed to propagate.
+ */
+export function GetDiskFreeSpaceEx(
+  filePath: string,
+): { total: number; free: number; freeToCaller: number } {
+  const stats = fs.statfsSync(filePath);
+  return {
+    total: stats.blocks * stats.bsize,
+    free: stats.bfree * stats.bsize,
+    freeToCaller: stats.bavail * stats.bsize,
+  };
+}
+
+/**
+ * Returns the mount-point path for the volume containing filePath.
+ * Walks up the directory tree comparing st_dev values. When a device
+ * boundary is crossed the previous path is the mount point.
+ * Falls back to path.parse(p).root on ENOENT (always "/" on Linux).
+ */
+export function GetVolumePathName(filePath: string): string {
+  try {
+    const targetDev = fs.statSync(filePath).dev;
+    let current = path.resolve(filePath);
+    while (true) {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return current;
+      }
+      try {
+        if (fs.statSync(parent).dev !== targetDev) {
+          return current;
+        }
+      } catch {
+        return current;
+      }
+      current = parent;
+    }
+  } catch {
+    return path.parse(path.resolve(filePath)).root;
+  }
+}
+
+/** Returns the current architecture. usedFallback is always false on Linux. */
+export function GetNativeArch(): {
+  nativeMachineCode: number;
+  nativeArch: string;
+  usedFallback: boolean;
+} {
+  return { nativeMachineCode: 0, nativeArch: process.arch, usedFallback: false };
+}
+
+/** No-op — language preference is handled via environment variables on Linux. */
+export function SetProcessPreferredUILanguages(_languages: string[]): void {
+  // no-op
+}
+
+// ---------------------------------------------------------------------------
+// THROWING STUBS — Windows-only features that callers already catch
+// ---------------------------------------------------------------------------
+
+export function ShellExecuteEx(_options: unknown): void {
+  throw new Error(
+    "ShellExecuteEx is not supported on Linux — elevation requires pkexec (deferred)",
+  );
+}
+
+export function CreateTask(_name: string, _options: unknown): void {
+  unsupported("CreateTask");
+}
+
+export function RunTask(_name: string): void {
+  unsupported("RunTask");
+}
+
+export function StopTask(_name: string): void {
+  unsupported("StopTask");
+}
+
+export function DeleteTask(_name: string): void {
+  unsupported("DeleteTask");
+}
+
+export function InitiateSystemShutdown(
+  _message: string,
+  _delay: number,
+  _askToClose: boolean,
+  _reboot: boolean,
+): boolean {
+  return unsupported("InitiateSystemShutdown");
+}
+
+export function AbortSystemShutdown(): boolean {
+  return unsupported("AbortSystemShutdown");
+}
+
+export function CreateAppContainer(
+  _containerName: string,
+  _displayName: string,
+  _description: string,
+): void {
+  unsupported("CreateAppContainer");
+}
+
+export function DeleteAppContainer(_containerName: string): void {
+  unsupported("DeleteAppContainer");
+}
+
+export function GrantAppContainer(
+  _containerName: string,
+  _objectName: string,
+  _typeName: string,
+  _permissions: unknown[],
+): void {
+  unsupported("GrantAppContainer");
+}
+
+export function RunInContainer(
+  _containerName: string,
+  _commandLine: string,
+  _cwdPath: string,
+  _onExit: (code: number) => void,
+  _onStdOut: (message: string) => void,
+): void {
+  unsupported("RunInContainer");
+}
+
+export function CreateProcessWithIntegrity(
+  _commandLine: string,
+  _cwdPath: string,
+  _integrity: string,
+  _onExit: (code: number) => void,
+  _onStdOut: (message: string) => void,
+): void {
+  unsupported("CreateProcessWithIntegrity");
+}
+
+export function AddUserPrivilege(_sid: string, _privilege: string): void {
+  unsupported("AddUserPrivilege");
+}
+
+export function RemoveUserPrivilege(_sid: string, _privilege: string): void {
+  unsupported("RemoveUserPrivilege");
+}
+
+export function GetUserPrivilege(_sid: string): string[] {
+  return unsupported("GetUserPrivilege");
+}
+
+export function GetFileVersionInfo(_filePath: string): never {
+  return unsupported("GetFileVersionInfo");
+}
+
+export function SHGetKnownFolderPath(_folder: string, _flag?: string[]): string {
+  return unsupported("SHGetKnownFolderPath");
+}
+
+// ---------------------------------------------------------------------------
+// NO-OP / SAFE RETURN STUBS — registry, ACL, process, task scheduler, etc.
+// ---------------------------------------------------------------------------
+
+export function RegGetValue(
+  _hkey: unknown,
+  _path: string,
+  _key: string,
+): undefined {
+  return undefined;
+}
+
+export function RegSetKeyValue(
+  _key: unknown,
+  _path: string,
+  _keyName: string,
+  _value: unknown,
+): void {
+  // no-op
+}
+
+export function RegEnumKeys(
+  _hkey: unknown,
+): Array<{ class: string; key: string; lastWritten: number }> {
+  return [];
+}
+
+export function RegEnumValues(
+  _hkey: unknown,
+): Array<{ type: string; key: string }> {
+  return [];
+}
+
+export function WithRegOpen(
+  _hive: unknown,
+  _path: string,
+  _cb: (hkey: unknown) => void,
+): void {
+  // no-op — deliberately does NOT call _cb to avoid registry-dependent code paths
+}
+
+export function GetProcessList(): unknown[] {
+  return [];
+}
+
+export function GetModuleList(_pid: number): unknown[] {
+  return [];
+}
+
+export function GetProcessWindowList(_pid: number): number[] {
+  return [];
+}
+
+export function SetForegroundWindow(_hwnd: number): boolean {
+  return false;
+}
+
+export function GetUserSID(): string {
+  return "";
+}
+
+export function LookupAccountName(_name: string): undefined {
+  return undefined;
+}
+
+export function CheckYourPrivilege(): unknown[] {
+  return [];
+}
+
+export function GetTasks(_path?: string): unknown[] {
+  return [];
+}
+
+export function SupportsAppContainer(): boolean {
+  return false;
+}
+
+export function IsThisWine(): boolean {
+  return false;
+}
+
+export function WhoLocks(_filePath: string): unknown[] {
+  return [];
+}
+
+/**
+ * Immediately calls the callback with null (no entries, no error).
+ * Supports both the 3-arg and 4-arg overloads from index.d.ts.
+ */
+export function WalkDir(
+  _basePath: string,
+  _progress: (entries: unknown[]) => boolean,
+  ...args: unknown[]
+): void {
+  // last argument is always the callback
+  const cb = args[args.length - 1];
+  if (typeof cb === "function") {
+    cb(null);
+  }
+}
+
+export function SetFileAttributes(
+  _filePath: string,
+  _attributes: unknown[],
+): void {
+  // no-op
+}
+
+export function AddFileACE(_acc: unknown, _filePath: string): void {
+  // no-op
+}
+
+export function GetProcessToken(
+  _type: string,
+  _pid?: number,
+): { isElevated: boolean } {
+  return { isElevated: false };
+}
+
+export function GetPrivateProfileSection(
+  _section: string,
+  _fileName: string,
+): string {
+  return "";
+}
+
+export function GetPrivateProfileSectionNames(_fileName: string): string[] {
+  return [];
+}
+
+export function GetPrivateProfileString(
+  _section: string,
+  _key: string,
+  _defaultValue: string,
+  _fileName: string,
+): string {
+  return "";
+}
+
+export function WritePrivateProfileString(
+  _section: string,
+  _key: string,
+  _value: string,
+  _fileName: string,
+): void {
+  // no-op
+}
+
+export function GetSystemPreferredUILanguages(): string[] {
+  return [];
+}
+
+export function GetUserPreferredUILanguages(): string[] {
+  return [];
+}
+
+export function GetProcessPreferredUILanguages(): string[] {
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Access constant
+// ---------------------------------------------------------------------------
+
+export const Access = {
+  Grant: (_sid: unknown, _permissions: unknown) => ({} as unknown),
+  Deny: (_sid: unknown, _permissions: unknown) => ({} as unknown),
+  Revoke: (_sid: unknown, _permissions: unknown) => ({} as unknown),
+};
+
+// ---------------------------------------------------------------------------
+// Default export — aggregates all named exports so both import styles work:
+//   import winapi from "winapi-bindings"        (default import)
+//   import * as winapi from "winapi-bindings"   (namespace import)
+// ---------------------------------------------------------------------------
+
+const winapiShim = {
+  GetDiskFreeSpaceEx,
+  GetVolumePathName,
+  GetNativeArch,
+  SetProcessPreferredUILanguages,
+  ShellExecuteEx,
+  CreateTask,
+  RunTask,
+  StopTask,
+  DeleteTask,
+  InitiateSystemShutdown,
+  AbortSystemShutdown,
+  CreateAppContainer,
+  DeleteAppContainer,
+  GrantAppContainer,
+  RunInContainer,
+  CreateProcessWithIntegrity,
+  AddUserPrivilege,
+  RemoveUserPrivilege,
+  GetUserPrivilege,
+  GetFileVersionInfo,
+  SHGetKnownFolderPath,
+  RegGetValue,
+  RegSetKeyValue,
+  RegEnumKeys,
+  RegEnumValues,
+  WithRegOpen,
+  GetProcessList,
+  GetModuleList,
+  GetProcessWindowList,
+  SetForegroundWindow,
+  GetUserSID,
+  LookupAccountName,
+  CheckYourPrivilege,
+  GetTasks,
+  SupportsAppContainer,
+  IsThisWine,
+  WhoLocks,
+  WalkDir,
+  SetFileAttributes,
+  AddFileACE,
+  GetProcessToken,
+  GetPrivateProfileSection,
+  GetPrivateProfileSectionNames,
+  GetPrivateProfileString,
+  WritePrivateProfileString,
+  GetSystemPreferredUILanguages,
+  GetUserPreferredUILanguages,
+  GetProcessPreferredUILanguages,
+  Access,
+};
+
+export default winapiShim;

--- a/src/renderer/webpack.config.cjs
+++ b/src/renderer/webpack.config.cjs
@@ -47,6 +47,16 @@ const config = {
     resolve: {
         plugins: [new TsconfigPathsPlugin()],
         extensions: [".js", ".jsx", ".ts", ".tsx", ".json"],
+        ...(process.platform === "linux" && {
+            alias: {
+                "winapi-bindings": path.resolve(
+                    __dirname,
+                    "src",
+                    "util",
+                    "winapi-shim.ts",
+                ),
+            },
+        }),
     },
     // NOTE(erri120): disable polyfills for browser because nodeIntegration is enabled
     node: { __filename: false, __dirname: false },


### PR DESCRIPTION
## Summary

On Linux, `winapi-bindings` is a Windows-only native module that fails to load. This PR provides a pure-JS shim with full export coverage so the rest of the codebase can import it unconditionally.

- Add `winapi-shim.ts` with safe Linux implementations:
  - `GetDiskFreeSpaceEx` — uses `fs.statfsSync` for real disk stats
  - `GetVolumePathName` — walks `stat.dev` with `ENOENT` fallback
  - `GetNativeArch` — returns `process.arch`
  - `ShellExecuteEx` — throws with a descriptive Linux message
  - All Windows-only elevated/UI/registry/ACL/task-scheduler APIs — throwing stubs or no-ops
- Wire the shim into the webpack (renderer) and rolldown (main) build configs via a platform-conditional `resolve.alias` — shim is inlined at build time, no runtime require
- Remove dead `require('winapi-bindings')` from the Fallout 4 extension (variable was never read; causes `MODULE_NOT_FOUND` on Linux since bundled extensions use `copyfiles`, not webpack)
- Add `winapi-bindings` to `neverBuiltDependencies` on Linux and exclude it from the dist `package.json` to prevent `EEXIST` conflicts during `electron-builder` packaging
- 19 Vitest tests covering all shim behaviours

## Part of the Linux port series

This is one of several incremental PRs porting Vortex to Linux. The full fork is at https://github.com/atabisz/Vortex if upstream context is useful.