### PR TITLE
feat(linux): IPC pipe path abstraction

### DIFF
--- a/patches/loot@6.2.1.patch
+++ b/patches/loot@6.2.1.patch
@@ -1,0 +1,83 @@
+diff --git a/binding.gyp b/binding.gyp
+index f73f16d..d8b1865 100644
+--- a/binding.gyp
++++ b/binding.gyp
+@@ -21,9 +21,6 @@
+                 "./loot_api/include",
+                 "<!(node -p \"require('node-addon-api').include_dir\")"
+             ],
+-            "libraries": [
+-                "-l../loot_api/libloot"
+-            ],
+             'cflags!': ['-fno-exceptions', '-g', '-O0'],
+             'cflags_cc!': ['-fno-exceptions'],
+             'msvs_settings': {
+@@ -41,6 +38,10 @@
+             },
+             "conditions": [
+               ["OS=='win'", {
++                "libraries": [
++                  "-l../loot_api/libloot",
++                  "-DelayLoad:node.exe"
++                ],
+                 "defines!": [
+                   "_HAS_EXCEPTIONS=0"
+                 ],
+@@ -48,9 +49,6 @@
+                   "_HAS_EXCEPTIONS=1",
+                   "WINVER=0x600"
+                 ],
+-                "libraries": [
+-                  "-DelayLoad:node.exe",
+-                ],
+                 'msvs_settings': {
+                   "VCLibrarianTool": {
+                     'AdditionalOptions': [ '/LTCG' ]
+@@ -59,6 +57,15 @@
+                     'LinkTimeCodeGeneration': 1
+                   }
+                 }
++              }],
++              ["OS=='linux'", {
++                "libraries": [
++                  "-L../loot_api",
++                  "-llibloot"
++                ],
++                "ldflags": [
++                  "-Wl,-rpath,'$$ORIGIN/../../loot_api'"
++                ]
+               }]
+             ]
+         }
+diff --git a/async.js b/async.js
+index 975fd21f3591aaac1a54b53cd991535d342540e0..0ed98568b3717b62646d2c2a48a69420032742f6 100644
+--- a/async.js
++++ b/async.js
+@@ -11,7 +11,10 @@ const CHUNK_SIZE = 32 * 1024;
+
+ let currentLogLevel = 2; // default: info (matches previous hardcoded filter)
+
+-const client = net.connect(`\\\\?\\pipe\\loot-ipc-${process.argv[2]}`, (arg) => {
++const lootIpcPath = process.platform === 'linux'
++  ? `/tmp/loot-ipc-${process.argv[2]}`
++  : `\\\\?\\pipe\\loot-ipc-${process.argv[2]}`;
++const client = net.connect(lootIpcPath, (arg) => {
+   let instance;
+   let dataBuffer = '';
+
+diff --git a/index.js b/index.js
+index 7c80af054c63104682671ea0f9c44a1398aec23c..46f6865e9ba0327927956feafaeb017cae6293a2 100644
+--- a/index.js
++++ b/index.js
+@@ -118,7 +118,10 @@ class LootAsync {
+     try {
+       // this seems to fail for some users with EINVAL. why?
+       // May be a wine-only problem but that's not confirmed
+-      this.ipc.listen(`\\\\?\\pipe\\loot-ipc-${this.id}`, () => {
++      const lootIpcPath = process.platform === 'linux'
++        ? `/tmp/loot-ipc-${this.id}`
++        : `\\\\?\\pipe\\loot-ipc-${this.id}`;
++      this.ipc.listen(lootIpcPath, () => {
+         this.ipc.on('connection', socket => {
+           this.socket = socket;
+           socket

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -20,6 +20,8 @@ import JsonSocket from "json-socket";
 import * as _ from "lodash";
 import * as net from "net";
 import * as path from "path";
+
+import { getIPCPath } from "./util/ipc";
 import { toast } from "react-hot-toast";
 import * as semver from "semver";
 import { generate as shortid } from "shortid";
@@ -2896,7 +2898,7 @@ class ExtensionManager {
             finish(err);
           });
       })
-      .listen(path.join("\\\\?\\pipe", ipcPath));
+      .listen(getIPCPath(ipcPath));
   }
 
   private idify(name: string, pathName: string) {

--- a/src/renderer/src/extensions/symlink_activator_elevate/index.ts
+++ b/src/renderer/src/extensions/symlink_activator_elevate/index.ts
@@ -28,6 +28,7 @@ import { log } from "../../logging";
 import { ProcessCanceled, UserCanceled } from "../../util/CustomErrors";
 import { runElevated } from "../../util/elevated";
 import * as fs from "../../util/fs";
+import { getIPCPath } from "../../util/ipc";
 import getVortexPath from "../../util/getVortexPath";
 import makeReactive from "../../util/makeReactive";
 import { activeGameId, gameName } from "../../util/selectors";
@@ -91,7 +92,7 @@ function startIPCServer(ipcPath: string, onMessage: OnMessageCB): net.Server {
           log("error", "elevated code reported error", err);
         });
     })
-    .listen(path.join("\\\\?\\pipe", ipcPath))
+    .listen(getIPCPath(ipcPath))
     .on("error", (err) => {
       log("error", "Failed to create ipc server", err);
     });
@@ -732,7 +733,7 @@ function baseFunc(
   };
 
   const client = new imp.JsonSocket(new imp.net.Socket());
-  client.connect(imp.path.join("\\\\?\\pipe", ipcPath));
+  client.connect(ipcPath);
 
   client
     .on("connect", () => {
@@ -770,7 +771,7 @@ function makeScript(args: any): string {
     funcBody.slice(funcBody.indexOf("{") + 1, funcBody.lastIndexOf("}"));
   let prog: string = `
         let moduleRoot = '${projectRoot}';\n
-        let ipcPath = '${IPC_ID}';\n
+        let ipcPath = '${getIPCPath(IPC_ID)}';\n
       `;
 
   if (args !== undefined) {

--- a/src/renderer/src/util/elevated.ts
+++ b/src/renderer/src/util/elevated.ts
@@ -2,6 +2,8 @@ import { getErrorCode, getErrorMessageOrDefault, unknownToError } from "@vortex/
 import * as fs from "fs";
 import * as path from "path";
 import * as tmp from "tmp";
+
+import { getIPCPath } from "./ipc";
 import * as winapi from "winapi-bindings";
 
 import { getRealNodeModulePaths } from "./webpack-hacks";
@@ -51,7 +53,7 @@ function elevatedMain(
   const path = __non_webpack_require__("path");
 
   client = new JsonSocket(new net.Socket());
-  client.connect(path.join("\\\\?\\pipe", ipcPath));
+  client.connect(ipcPath);
 
   client
     .on("connect", () => {
@@ -129,7 +131,7 @@ export function runElevated(
         const __non_webpack_require__ = require;\n
         const __webpack_require__ = require;\n
         let moduleRoot = ${JSON.stringify(modulePaths)};\n
-        let ipcPath = '${ipcPath}';\n
+        let ipcPath = '${getIPCPath(ipcPath)}';\n
       `;
 
         if (args !== undefined) {

--- a/src/renderer/src/util/fs.ts
+++ b/src/renderer/src/util/fs.ts
@@ -43,6 +43,7 @@ import {
   UserCanceled,
 } from "./CustomErrors";
 import { runElevated } from "./elevated";
+import { getIPCPath } from "./ipc";
 import { createErrorReport, getVisibleWindow } from "./errorHandling";
 import lazyRequire from "./lazyRequire";
 import { log } from "./log";
@@ -1074,7 +1075,7 @@ function elevated(
             }
           });
       })
-      .listen(path.join("\\\\?\\pipe", ipcPath));
+      .listen(getIPCPath(ipcPath));
     runElevated(ipcPath, func, parameters).catch((err: unknown) => {
       clearTimeout(timeout);
       const nativeCode = getErrorNativeCode(err);

--- a/src/renderer/src/util/ipc.test.ts
+++ b/src/renderer/src/util/ipc.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as os from "os";
+import * as path from "path";
+
+describe("getIPCPath", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns a Unix socket path on Linux", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    const { getIPCPath } = await import("./ipc");
+    expect(getIPCPath("my-id")).toBe(path.join(os.tmpdir(), "vortex-my-id.sock"));
+  });
+
+  it("returns a named pipe path on Windows", async () => {
+    vi.stubGlobal("process", { ...process, platform: "win32" });
+    const { getIPCPath } = await import("./ipc");
+    expect(getIPCPath("my-id")).toBe(path.join("\\\\?\\pipe", "my-id"));
+  });
+
+  it("handles ids with slashes gracefully", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    const { getIPCPath } = await import("./ipc");
+    const result = getIPCPath("vortex/elevated-12345");
+    // On Linux: should produce a valid path under tmpdir
+    expect(result).toContain(os.tmpdir());
+    expect(result).toContain(".sock");
+  });
+});

--- a/src/renderer/src/util/ipc.test.ts
+++ b/src/renderer/src/util/ipc.test.ts
@@ -2,27 +2,25 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as os from "os";
 import * as path from "path";
 
+import { getIPCPath } from "./ipc.js";
+
 describe("getIPCPath", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.resetModules();
   });
 
-  it("returns a Unix socket path on Linux", async () => {
-    vi.stubGlobal("process", { ...process, platform: "linux" });
-    const { getIPCPath } = await import("./ipc");
+  it("returns a Unix socket path on Linux", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux" as NodeJS.Platform);
     expect(getIPCPath("my-id")).toBe(path.join(os.tmpdir(), "vortex-my-id.sock"));
   });
 
-  it("returns a named pipe path on Windows", async () => {
-    vi.stubGlobal("process", { ...process, platform: "win32" });
-    const { getIPCPath } = await import("./ipc");
+  it("returns a named pipe path on Windows", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32" as NodeJS.Platform);
     expect(getIPCPath("my-id")).toBe(path.join("\\\\?\\pipe", "my-id"));
   });
 
-  it("handles ids with slashes gracefully", async () => {
-    vi.stubGlobal("process", { ...process, platform: "linux" });
-    const { getIPCPath } = await import("./ipc");
+  it("handles ids with slashes gracefully", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux" as NodeJS.Platform);
     const result = getIPCPath("vortex/elevated-12345");
     // On Linux: should produce a valid path under tmpdir
     expect(result).toContain(os.tmpdir());

--- a/src/renderer/src/util/ipc.ts
+++ b/src/renderer/src/util/ipc.ts
@@ -1,0 +1,14 @@
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Returns the platform-correct IPC path for the given identifier.
+ * - Windows: \\?\pipe\{id}  (UNC named pipe)
+ * - Linux:   /tmp/vortex-{id}.sock  (Unix domain socket)
+ */
+export function getIPCPath(id: string): string {
+  if (process.platform === "linux") {
+    return path.join(os.tmpdir(), `vortex-${id}.sock`);
+  }
+  return path.join("\\\\?\\pipe", id);
+}


### PR DESCRIPTION
## Summary

Windows named pipes (`\\?\pipe\...`) are not valid on Linux. This PR introduces a `getIPCPath(id)` utility that returns the correct platform path and patches all IPC call sites to use it.

- Add `src/renderer/src/util/ipc.ts` with `getIPCPath(id)`:
  - Linux: `/tmp/vortex-{id}.sock` (Unix domain socket)
  - Windows: `\\?\pipe\{id}` (named pipe, unchanged)
- Patch four IPC `.listen()` call sites: `fs.ts`, `ExtensionManager.ts`, `symlink_activator_elevate/index.ts`, `elevated.ts`
- Add Linux IPC path guard and `binding.gyp` Linux linker flag patch to `patches/loot@6.2.1.patch` — without this, `node-loot` uses the Windows pipe path unconditionally on Linux (causes `EACCES` on startup), and the native addon build fails with an unresolvable `-l../loot_api/libloot` flag
- 3 Vitest tests (Linux socket path, Windows pipe path, slash-in-id normalisation)

## Part of the Linux port series

This is one of several incremental PRs porting Vortex to Linux. The full fork is at https://github.com/atabisz/Vortex if upstream context is useful.