### PR TITLE
multiple Starfield enhancements and fixes

### DIFF
--- a/extensions/gamebryo-plugin-management/src/index.ts
+++ b/extensions/gamebryo-plugin-management/src/index.ts
@@ -36,6 +36,7 @@ import {
   revisionText,
   syncGameSupport,
   supportedGames,
+  supportsBlueprintPlugins,
   supportsESL,
   supportsMediumMasters,
 } from "./util/gameSupport";
@@ -262,7 +263,24 @@ function updatePluginListImpl(
               {},
             );
             if (pluginPersistor !== undefined) {
-              pluginPersistor.setKnownPlugins(knownPlugins);
+              let blueprintIds: Set<string> | undefined;
+              if (supportsBlueprintPlugins(gameId)) {
+                blueprintIds = new Set<string>();
+                for (const pluginId of Object.keys(pluginStates)) {
+                  try {
+                    const esp = new ESPFile(
+                      pluginStates[pluginId].filePath,
+                      gameId,
+                    );
+                    if (esp.isBlueprint) {
+                      blueprintIds.add(pluginId);
+                    }
+                  } catch (err) {
+                    // parse failures are already reported elsewhere; skip
+                  }
+                }
+              }
+              pluginPersistor.setKnownPlugins(knownPlugins, blueprintIds);
             }
           }
           return Promise.resolve();
@@ -457,6 +475,7 @@ function register(
       isLight: fileInfo.isLight,
       isMedium: fileInfo.isMedium,
       isDummy: fileInfo.isDummy,
+      isBlueprint: supportsBlueprintPlugins(gameMode) && fileInfo.isBlueprint,
       author: fileInfo.author,
       description: fileInfo.description,
       masterList: fileInfo.masterList,
@@ -686,6 +705,38 @@ function register(
 
   const pluginInfoCache = new PluginInfoCache(context.api);
 
+  // Cross-extension API: lets other extensions (e.g. game-starfield) query
+  // Blueprint-plugin status without having to take a native-addon dependency
+  // on esptk themselves.
+  //
+  // Takes an absolute plugin file path so the lookup is self-contained — the
+  // API never depends on Vortex's pluginList Redux state being populated, and
+  // can be called at any point after gamemode activation.
+  //
+  // Returns false for non-Starfield game modes (supportsBlueprintPlugins gate),
+  // for files the parser can't read, and for files whose TES4 header doesn't
+  // set the Blueprint flag. Consumers should treat a thrown/non-boolean result
+  // as a no-op and not assume anything about blueprint-ness.
+  context.registerAPI(
+    "isBlueprintPlugin",
+    (pluginFilePath: string): boolean => {
+      const gameMode = selectors.activeGameId(context.api.getState());
+      if (!supportsBlueprintPlugins(gameMode)) {
+        return false;
+      }
+      try {
+        return pluginInfoCache.getInfo(pluginFilePath).isBlueprint;
+      } catch (err) {
+        log("warn", "isBlueprintPlugin parse failed", {
+          pluginFilePath,
+          err: (err as Error).message,
+        });
+        return false;
+      }
+    },
+    { minArguments: 1 },
+  );
+
   context.registerTest("plugins-locked", "gamemode-activated", () =>
     testPluginsLocked(selectors.activeGameId(context.api.store.getState())),
   );
@@ -694,6 +745,12 @@ function register(
   );
   context.registerTest("master-missing", "plugins-changed" as any, () =>
     testMissingMasters(context.api, pluginInfoCache),
+  );
+  context.registerTest("blueprint-master", "gamemode-activated", () =>
+    testBlueprintMasters(context.api, pluginInfoCache),
+  );
+  context.registerTest("blueprint-master", "plugins-changed" as any, () =>
+    testBlueprintMasters(context.api, pluginInfoCache),
   );
   context.registerTest("rules-unfulfilled", "loot-info-updated" as any, () =>
     testRulesUnfulfilled(context.api),
@@ -1202,6 +1259,7 @@ function testExceededPluginLimit(
 
 interface IESPInfo {
   isLight: boolean;
+  isBlueprint: boolean;
   masterList: string[];
 }
 
@@ -1242,6 +1300,8 @@ class PluginInfoCache {
         lastINO: ino,
         info: {
           isLight: info.isLight,
+          isBlueprint:
+            supportsBlueprintPlugins(activeGameMode) && info.isBlueprint,
           masterList: info.masterList,
         },
       };
@@ -1386,6 +1446,135 @@ function testMissingMasters(
       severity: "warning" as types.ProblemSeverity,
     });
   }
+}
+
+/**
+ * For Starfield only. Verifies that no non-Blueprint plugin declares a Blueprint
+ * plugin as a master. The game strips Blueprint masters from non-Blueprint
+ * plugins in memory, which destroys references and produces unresolved FormIDs.
+ */
+function testBlueprintMasters(
+  api: types.IExtensionApi,
+  infoCache: PluginInfoCache,
+): Promise<types.ITestResult> {
+  const { translate, store } = api;
+  const state = store.getState();
+  const gameMode = selectors.activeGameId(state);
+  if (!gameSupported(gameMode) || !supportsBlueprintPlugins(gameMode)) {
+    return Promise.resolve(undefined);
+  }
+
+  const pluginList = state.session.plugins.pluginList ?? {};
+  const natives = new Set<string>(nativePlugins(gameMode));
+  const loadOrder: { [plugin: string]: ILoadOrder } = state.loadOrder;
+  const enabledPlugins = Object.keys(loadOrder).filter(
+    (plugin: string) => loadOrder[plugin].enabled || natives.has(plugin),
+  );
+
+  interface IParsedPlugin {
+    name: string;
+    isBlueprint: boolean;
+    masterList: string[];
+  }
+
+  const pluginDetails: IParsedPlugin[] = enabledPlugins
+    .filter((name: string) => pluginList[name] !== undefined)
+    .map((plugin) => {
+      try {
+        const info = infoCache.getInfo(pluginList[plugin].filePath);
+        return {
+          name: plugin,
+          isBlueprint: info.isBlueprint,
+          masterList: info.masterList,
+        };
+      } catch (err) {
+        log("warn", "failed to parse esp file", {
+          name: pluginList[plugin].filePath,
+          err: err.message,
+        });
+        return { name: plugin, isBlueprint: false, masterList: [] };
+      }
+    });
+
+  const blueprintPlugins = new Set<string>(
+    pluginDetails
+      .filter((plugin) => plugin.isBlueprint)
+      .map((plugin) => plugin.name),
+  );
+
+  if (blueprintPlugins.size === 0) {
+    return Promise.resolve(undefined);
+  }
+
+  const broken = pluginDetails.reduce((prev, plugin) => {
+    if (plugin.isBlueprint) {
+      return prev;
+    }
+    const offendingMasters = plugin.masterList.filter((master) =>
+      blueprintPlugins.has(master.toLowerCase()),
+    );
+    if (offendingMasters.length > 0) {
+      prev[plugin.name] = offendingMasters;
+    }
+    return prev;
+  }, {} as { [pluginName: string]: string[] });
+
+  if (Object.keys(broken).length === 0) {
+    return Promise.resolve(undefined);
+  }
+
+  const link = (pluginName: string) =>
+    `[link="cb://showplugin/${pluginName}"]${pluginName}[/link]`;
+
+  return Promise.resolve({
+    description: {
+      short: translate("Blueprint plugin used as master"),
+      long:
+        translate(
+          "The following enabled plugins declare a Blueprint plugin as a master. " +
+            "Starfield strips Blueprint masters from non-Blueprint plugins at load, " +
+            "which will break references and corrupt your save. These plugins must " +
+            "be disabled or rebuilt against a non-Blueprint master:",
+        ) +
+        "[table][tbody]" +
+        Object.keys(broken)
+          .map((plugin) => {
+            const offending = broken[plugin].map(link).join("[br][/br]");
+            const detail = pluginList[plugin];
+            const name =
+              detail !== undefined ? path.basename(detail.filePath) : plugin;
+            return (
+              "[tr]" +
+              [link(name), translate("has Blueprint master"), offending]
+                .map((iter) => `[td]${iter}[/td]`)
+                .join() +
+              "[/tr]" +
+              "[tr][/tr]"
+            );
+          })
+          .join("\n") +
+        "[/tbody][/table]",
+      context: {
+        callbacks: {
+          showplugin: (pluginName: string) => {
+            const stateNow: types.IState = store.getState();
+            const gameModeNow = selectors.activeGameId(stateNow);
+            if (gameSupported(gameModeNow)) {
+              api.events.emit("show-main-page", "gamebryo-plugins");
+              store.dispatch(
+                actions.setAttributeFilter(
+                  "gamebryo-plugins",
+                  "name",
+                  pluginName,
+                ),
+              );
+            }
+          },
+        },
+      },
+    },
+    severity: "error" as types.ProblemSeverity,
+  });
 }
 
 function testRulesUnfulfilled(

--- a/extensions/gamebryo-plugin-management/src/types/IESPFile.ts
+++ b/extensions/gamebryo-plugin-management/src/types/IESPFile.ts
@@ -4,6 +4,7 @@ export interface IESPFile {
   isLight: boolean;
   isMedium: boolean;
   isDummy: boolean;
+  isBlueprint: boolean;
   author: string;
   description: string;
   masterList: string[];

--- a/extensions/gamebryo-plugin-management/src/types/IPlugins.ts
+++ b/extensions/gamebryo-plugin-management/src/types/IPlugins.ts
@@ -65,6 +65,7 @@ export interface IPluginParsed {
   isMaster: boolean;
   isLight: boolean;
   isMedium: boolean;
+  isBlueprint: boolean;
   parseFailed: boolean;
   masterList: string[];
   author: string;

--- a/extensions/gamebryo-plugin-management/src/util/PluginPersistor.ts
+++ b/extensions/gamebryo-plugin-management/src/util/PluginPersistor.ts
@@ -45,6 +45,9 @@ class PluginPersistor implements types.IPersistor {
   private mPlugins: IPluginMap;
   // deployed plugins, mapping their plugin id to their file name on disk
   private mKnownPlugins: { [pluginId: string]: string } = {};
+  // plugin ids of Blueprint plugins (Starfield-only) — these are managed by
+  // the game itself and must not be written to plugins.txt / loadorder.txt.
+  private mBlueprintPluginIds: Set<string> = new Set();
   private mInstalledNative: string[] = [];
   private mRetryCounter: number = retryCount;
   private mLoaded: boolean = false;
@@ -122,8 +125,20 @@ class PluginPersistor implements types.IPersistor {
     });
   }
 
-  public setKnownPlugins(knownPlugins: { [pluginId: string]: string }) {
+  /**
+   * Update the set of known plugins and — atomically — the set of Blueprint
+   * plugin ids (Starfield-only). Blueprint plugins are managed by the game
+   * itself and must not appear in plugins.txt or loadorder.txt; writing them
+   * causes the game to strip them on launch. Passing both in a single call
+   * guarantees the serializer never observes a state where known plugins have
+   * been updated but the Blueprint filter has not.
+   */
+  public setKnownPlugins(
+    knownPlugins: { [pluginId: string]: string },
+    blueprintPluginIds: Set<string> = new Set(),
+  ) {
     this.mKnownPlugins = knownPlugins;
+    this.mBlueprintPluginIds = blueprintPluginIds;
     this.updateNative();
     this.serialize();
   }
@@ -310,7 +325,10 @@ class PluginPersistor implements types.IPersistor {
     // we need a list that includes all deployed plugins and only those,
     // sorted by their load order
     // this includes native plugins, which may be filtered out later, depending on the game
+    // Blueprint plugins (Starfield) are excluded entirely: the game manages them
+    // itself and strips any that appear in plugins.txt / loadorder.txt on launch.
     const sorted: string[] = Object.keys(this.mKnownPlugins)
+      .filter((pluginId) => !this.mBlueprintPluginIds.has(pluginId))
       .sort(
         (lhs: string, rhs: string) => this.loadOrder(lhs) - this.loadOrder(rhs),
       )

--- a/extensions/gamebryo-plugin-management/src/util/gameSupport.ts
+++ b/extensions/gamebryo-plugin-management/src/util/gameSupport.ts
@@ -27,6 +27,7 @@ export interface IGameSupport {
   nativePluginsPatterns?: string[];
   supportsESL?: boolean | (() => boolean);
   supportsMediumMasters?: boolean | (() => boolean);
+  supportsBlueprintPlugins?: boolean | (() => boolean);
   minRevision?: number;
 }
 
@@ -155,15 +156,23 @@ const gameSupport = util.makeOverlayableDictionary<string, IGameSupport>(
         "oldmars.esm",
         "shatteredspace.esm",
         "blueprintships-starfield.esm",
+        "blueprintships-sfbgs050.esm", // Terran Armada (APP-260)
         "sfbgs003.esm",
         "sfbgs004.esm",
         "sfbgs006.esm",
         "sfbgs007.esm",
         "sfbgs008.esm",
+        "sfbgs00d.esm", // Free Lanes (APP-260)
+        "sfbgs047.esm", // Moon Jumper (APP-260)
+        "sfbgs050.esm", // Terran Armada (APP-260)
       ],
-      nativePluginsPatterns: ["^sfbgs00[0-8]\.esm$"],
+      // SFBGS is Bethesda's reserved namespace for Starfield DLC/Creation Club
+      // plugins; three hex digits covers the known scheme and future DLC
+      // following the same pattern without needing code changes.
+      nativePluginsPatterns: ["^sfbgs[0-9a-f]{3}\\.esm$"],
       supportsESL: true,
       supportsMediumMasters: true,
+      supportsBlueprintPlugins: true,
     },
     oblivion: {
       appDataPath: "oblivion",
@@ -445,6 +454,20 @@ export const supportsMediumMasters = memoizeOne((gameMode: string): boolean => {
   }
   return supportsMediumMasters;
 });
+
+export const supportsBlueprintPlugins = memoizeOne(
+  (gameMode: string): boolean => {
+    if (!gameSupport.has(gameMode)) {
+      return false;
+    }
+    const supported =
+      gameSupport.get(gameMode, "supportsBlueprintPlugins") ?? false;
+    if (typeof supported === "function") {
+      return supported();
+    }
+    return supported;
+  },
+);
 
 export function pluginExtensions(gameMode: string): string[] {
   return supportsESL(gameMode) ? [".esm", ".esp", ".esl"] : [".esm", ".esp"];

--- a/extensions/gamebryo-plugin-management/src/views/PluginFlags.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/PluginFlags.tsx
@@ -24,6 +24,10 @@ export function getPluginFlags(
     result.push("Master");
   }
 
+  if (plugin.isBlueprint) {
+    result.push("Blueprint");
+  }
+
   if (supportsESL) {
     if (plugin.isLight) {
       result.push("Light");
@@ -136,6 +140,22 @@ const PluginFlags = (props: IProps): JSX.Element => {
         key={key}
         name="plugin-master"
         tooltip={t("Master")}
+      />,
+    );
+  }
+
+  if (plugin.isBlueprint) {
+    const key = `ico-blueprint-${plugin.id}`;
+    flags.push(
+      <tooltip.Icon
+        id={key}
+        key={key}
+        name="locked"
+        tooltip={t(
+          "Blueprint plugin - force-loaded by the game and pinned to the end " +
+            "of the load order. Managed by the game, not Vortex.",
+          { ns: NAMESPACE },
+        )}
       />,
     );
   }

--- a/extensions/gamebryo-plugin-management/src/views/PluginFlagsFilter.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/PluginFlagsFilter.tsx
@@ -13,6 +13,7 @@ export class PluginFlagFilterComponent extends React.Component<
 
     const selectionFilters = [
       "Master",
+      "Blueprint",
       "Light",
       "Dummy",
       "Loads Archive",

--- a/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
@@ -437,7 +437,9 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
       description: "Is plugin enabled in current profile",
       icon: "check-o",
       calc: (plugin: IPluginCombined) => {
-        return plugin.isNative
+        // Blueprint plugins are managed by the game engine itself, so treat
+        // them like natives: no user-visible status / no inline toggle.
+        return plugin.isNative || plugin.isBlueprint
           ? undefined
           : plugin.filePath.toLowerCase().endsWith(GHOST_EXT)
             ? "Ghost"
@@ -455,8 +457,11 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
           { key: "ghost", text: "Ghost", icon: "ghost" },
         ],
         onChangeValue: (plugin: IPluginCombined, value: any) => {
-          if (plugin.isNative) {
-            // safeguard so we don't accidentally disable a native plugin
+          if (plugin.isNative || plugin.isBlueprint) {
+            // safeguard so we don't accidentally disable a native or Blueprint
+            // plugin — Blueprint plugins are force-loaded by the game and
+            // stripping them from plugins.txt would just cause the engine to
+            // re-add them on next launch.
             return;
           }
 
@@ -588,6 +593,7 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
         isMaster: false,
         isLight: false,
         isMedium: false,
+        isBlueprint: false,
         parseFailed: false,
         masterList: [],
         author: "",
@@ -898,6 +904,7 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
               esp.isMedium,
               this.props.gameMode,
             ),
+            isBlueprint: esp.isBlueprint,
             parseFailed: false,
             description: esp.description,
             author: esp.author,
@@ -917,6 +924,7 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
             isMaster: false,
             isLight: false,
             isMedium: false,
+            isBlueprint: false,
             parseFailed: true,
             description: "",
             author: "",
@@ -994,7 +1002,12 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
 
     pluginIds.forEach((key: string) => {
       const plugin = plugins[key];
-      if (plugin === undefined || plugin.isNative) {
+      const combined = this.state.pluginsCombined[key];
+      if (
+        plugin === undefined ||
+        plugin.isNative ||
+        combined?.isBlueprint
+      ) {
         return;
       }
       if (plugin.filePath.toLowerCase().endsWith(GHOST_EXT)) {
@@ -1010,7 +1023,12 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
 
     pluginIds.forEach((key: string) => {
       const plugin = plugins[key];
-      if (plugin === undefined || plugin.isNative) {
+      const combined = this.state.pluginsCombined[key];
+      if (
+        plugin === undefined ||
+        plugin.isNative ||
+        combined?.isBlueprint
+      ) {
         return;
       }
 
@@ -1026,6 +1044,10 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
     const { gameMode, onSetPluginGhost, plugins } = this.props;
 
     pluginIds.forEach((key: string) => {
+      const combined = this.state.pluginsCombined[key];
+      if (plugins[key]?.isNative || combined?.isBlueprint) {
+        return;
+      }
       if (
         plugins[key]?.filePath !== undefined &&
         !plugins[key]?.filePath.toLowerCase().endsWith(GHOST_EXT)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ catalogs:
       specifier: ^5.4.0
       version: 5.7.0
     esptk:
-      specifier: git+https://github.com/Nexus-Mods/node-esptk#6b8900658d66438fe92ac55bc182a45404e8bf3f
-      version: 2.2.1
+      specifier: git+https://github.com/Nexus-Mods/node-esptk#7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd
+      version: 2.2.2
     exe-version:
       specifier: git+https://github.com/Nexus-Mods/node-exe-version#eded60fc0a0f3c234e1d586d2eb9952401945406
       version: 2.3.0
@@ -527,8 +527,8 @@ catalogs:
       specifier: ^4.17.21
       version: 4.17.23
     loot:
-      specifier: git+https://github.com/Nexus-Mods/node-loot#04a77fcae028b0838b5e0c53cfcdc65898c49727
-      version: 6.2.1
+      specifier: git+https://github.com/Nexus-Mods/node-loot#7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d
+      version: 6.2.2
     lru-cache:
       specifier: ^11.2.6
       version: 11.2.7
@@ -1684,10 +1684,10 @@ importers:
     optionalDependencies:
       esptk:
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/6b8900658d66438fe92ac55bc182a45404e8bf3f
+        version: https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd
       loot:
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727
+        version: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d
 
   extensions/gamebryo-savegame-management:
     devDependencies:
@@ -9420,9 +9420,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esptk@https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/6b8900658d66438fe92ac55bc182a45404e8bf3f:
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/6b8900658d66438fe92ac55bc182a45404e8bf3f}
-    version: 2.2.1
+  esptk@https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd:
+    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd}
+    version: 2.2.2
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -10883,9 +10883,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727:
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727}
-    version: 6.2.1
+  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d:
+    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d}
+    version: 6.2.2
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -18707,7 +18707,7 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  esptk@https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/6b8900658d66438fe92ac55bc182a45404e8bf3f:
+  esptk@https://codeload.github.com/Nexus-Mods/node-esptk/tar.gz/7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd:
     dependencies:
       autogypi: 0.2.2
       node-addon-api: 8.5.0
@@ -20526,7 +20526,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/04a77fcae028b0838b5e0c53cfcdc65898c49727:
+  loot@https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d:
     dependencies:
       autogypi: 0.2.2
       lodash: 4.17.23

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -178,7 +178,7 @@ catalog:
   eslint-plugin-better-tailwindcss: ^4.0.2
   eslint-plugin-import: ^2.32.0
   eslint-plugin-perfectionist: ^5.4.0
-  esptk: git+https://github.com/Nexus-Mods/node-esptk#6b8900658d66438fe92ac55bc182a45404e8bf3f
+  esptk: git+https://github.com/Nexus-Mods/node-esptk#7b7db98d2c69b6b6cad2cb3dcd7972143adaa7bd
   exe-version: git+https://github.com/Nexus-Mods/node-exe-version#eded60fc0a0f3c234e1d586d2eb9952401945406
   feedparser: ^2.2.9
   font-scanner: ^0.2.1
@@ -209,7 +209,7 @@ catalog:
   levelup: ^4.4.0
   limiter: ^3.0.0
   lodash: ^4.17.21
-  loot: git+https://github.com/Nexus-Mods/node-loot#04a77fcae028b0838b5e0c53cfcdc65898c49727
+  loot: git+https://github.com/Nexus-Mods/node-loot#7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d
   lru-cache: ^11.2.6
   markdown-ast: ^0.2.1
   memoize-one: ^5.1.1

--- a/src/renderer/src/views/components/Spine/SpineContext.tsx
+++ b/src/renderer/src/views/components/Spine/SpineContext.tsx
@@ -59,6 +59,19 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
   const activeProfileId = useSelector(activeProfileIdSelector);
   const activeGameId = useSelector(activeGameIdSelector);
 
+  // APP-261: page.visible() predicates owned by extensions read state slices
+  // the Spine does not natively track. Subscribe to this one so the per-game
+  // page memos recompute when the user flips plugin management on/off via
+  // the game-starfield "Load Order Management Method" setting (which always
+  // dispatches GAMEBRYO_SET_PLUGIN_MANAGEMENT_ENABLED alongside its own
+  // management-type action), otherwise the left menu stays stale until a
+  // restart. Typed as `any` because this path lives in the gamebryo-plugin-
+  // management extension and isn't in core IState.
+  const pluginManagementEnabled = useSelector(
+    (state: IState) =>
+      (state as any).settings?.plugins?.pluginManagementEnabled,
+  );
+
   // Tracks the gameId that was active when the user navigated to home.
   // When non-null and matches activeGameId, we show home pages.
   // When activeGameId changes externally (e.g., via extension or deep-link),
@@ -96,7 +109,9 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
   }, []);
 
   // activeGameId is included as dependency to re-filter when game changes
-  // since page.visible() checks often depend on the active game
+  // since page.visible() checks often depend on the active game.
+  // pluginManagementEnabled is included so APP-261's stale-menu bug clears
+  // when the user flips the starfield load-order management method.
   const homePages: IMainPage[] = useMemo(
     () =>
       mainPages.filter(
@@ -106,7 +121,7 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
           page.id !== "Downloads" &&
           isPageVisible(page),
       ),
-    [mainPages, isPageVisible, activeGameId, profilesVisible],
+    [mainPages, isPageVisible, activeGameId, profilesVisible, pluginManagementEnabled],
   );
 
   const gamePages: IMainPage[] = useMemo(
@@ -117,7 +132,7 @@ export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
           page.id !== "game-downloads" &&
           isPageVisible(page),
       ),
-    [mainPages, isPageVisible, activeGameId, profilesVisible],
+    [mainPages, isPageVisible, activeGameId, profilesVisible, pluginManagementEnabled],
   );
 
   const mainPage = useSelector(mainPageSelector);


### PR DESCRIPTION
- Added support for blueprint plugins
- Updated native plugin list
- Updated to libloot 0.29.3
- Fixed plugin management switch mechanism requiring app restart when checking page condition() (switching between rules-based/drag-and-drop)

Note that the Starfield game extension changes are on a different PR:
https://github.com/Nexus-Mods/game-starfield/pull/57

fixes https://linear.app/nexus-mods/issue/APP-260/update-starfield-native-plugins-list-for-new-dlcs fixes https://linear.app/nexus-mods/issue/APP-261/load-order-menu-doesnt-update-until-restart fixes https://linear.app/nexus-mods/issue/APP-263/add-support-for-blueprint-plugins-in-starfields-load-order