### PR TITLE
collection edit no longer warns collaborators with edit permissions

### DIFF
--- a/extensions/collections/src/views/CollectionList/index.tsx
+++ b/extensions/collections/src/views/CollectionList/index.tsx
@@ -34,7 +34,7 @@ import {
   types,
   util,
 } from "vortex-api";
-import { uploadCollection } from "../../util/util";
+import { hasEditPermissions, uploadCollection } from "../../util/util";
 
 export interface ICollectionsMainPageBaseProps extends WithTranslation {
   active: boolean;
@@ -292,8 +292,15 @@ class CollectionsMainPage extends ComponentEx<
     }
 
     const author = mods[modId].attributes?.["uploaderId"];
+    const canContribute = hasEditPermissions(
+      mods[modId].attributes?.permissions,
+    );
 
-    if (author !== undefined && author !== userInfo?.userId) {
+    if (
+      author !== undefined &&
+      author !== userInfo?.userId &&
+      !canContribute
+    ) {
       const result = await api.showDialog(
         "question",
         "Edit Collection",


### PR DESCRIPTION
There was no regression - just a scary warning dialog

fixes https://linear.app/nexus-mods/issue/APP-242/investigate-possible-regression-in-collection-collaboration-editing