### PR TITLE
Add store path provider types

### DIFF
--- a/packages/adaptor-api/src/stores/gog.ts
+++ b/packages/adaptor-api/src/stores/gog.ts
@@ -1,0 +1,7 @@
+import type { StoreBase, StorePathProviderBase } from "./providers";
+
+export type GOGBase = StoreBase;
+
+export interface GOGPathProvider extends StorePathProviderBase<GOGBase, "gog"> {
+  readonly scheme: "gog";
+}

--- a/packages/adaptor-api/src/stores/providers.ts
+++ b/packages/adaptor-api/src/stores/providers.ts
@@ -1,0 +1,25 @@
+import type { PathProvider, WindowsPathBase } from "@vortex/fs";
+
+import type { GOGPathProvider } from "./gog";
+import type { SteamPathProvider } from "./steam";
+
+export const StorePath = {
+  game: "game",
+} as const;
+
+export type StoreBase = (typeof StorePath)[keyof typeof StorePath];
+
+export type StorePathProvider = SteamPathProvider | GOGPathProvider;
+
+export type Store = "steam" | "gog";
+
+export interface StorePathProviderBase<
+  TBase extends string,
+  TStore extends Store,
+  IsWindows extends boolean = true,
+> extends PathProvider<
+  IsWindows extends true ? TBase | WindowsPathBase : TBase
+> {
+  readonly isWindows: IsWindows;
+  readonly store: TStore;
+}

--- a/packages/adaptor-api/src/stores/steam.ts
+++ b/packages/adaptor-api/src/stores/steam.ts
@@ -1,0 +1,37 @@
+import type { StoreBase, StorePathProviderBase } from "./providers";
+
+export const Steam = {
+  workshop: "workshop",
+} as const;
+
+export type SteamBase = StoreBase | (typeof Steam)[keyof typeof Steam];
+
+export type SteamPathProvider =
+  | SteamProtonPathProvider
+  | SteamWindowsPathProvider
+  | SteamLinuxPathProvider;
+
+export interface SteamProtonPathProvider extends StorePathProviderBase<
+  SteamBase,
+  "steam"
+> {
+  readonly scheme: "steam";
+  readonly isProton: true;
+}
+
+export interface SteamWindowsPathProvider extends StorePathProviderBase<
+  SteamBase,
+  "steam"
+> {
+  readonly scheme: "steam";
+  readonly isProton: false;
+}
+
+export interface SteamLinuxPathProvider extends StorePathProviderBase<
+  SteamBase,
+  "steam",
+  false
+> {
+  readonly scheme: "steam";
+  readonly isProton: false;
+}

--- a/packages/fs/src/browser/lib.ts
+++ b/packages/fs/src/browser/lib.ts
@@ -40,4 +40,5 @@ export {
 export { XDG } from "./paths.linux";
 export type { LinuxPathBase, LinuxPathProvider, XDGBase } from "./paths.linux";
 
+export { WindowsPath } from "./paths.windows";
 export type { WindowsPathBase, WindowsPathProvider } from "./paths.windows";

--- a/packages/fs/src/browser/paths.windows.ts
+++ b/packages/fs/src/browser/paths.windows.ts
@@ -1,7 +1,21 @@
 import type { OSPathBase, PathProvider, QualifiedPath } from "./paths";
 
+/**
+ * Bases supported by all OS path providers.
+ * @public */
+export const WindowsPath = {
+  /** `%USERPROFILE%/AppData` */
+  appData: "appData",
+  /** `%USERPROFILE%/Documents` also known as "My Documents" */
+  documents: "documents",
+  /** `%USERPROFILE%/Documents/My Games` */
+  myGames: "my games",
+} as const;
+
 /** @public */
-export type WindowsPathBase = OSPathBase;
+export type WindowsPathBase =
+  | OSPathBase
+  | (typeof WindowsPath)[keyof typeof WindowsPath];
 
 /** @public */
 export interface WindowsPathProvider extends PathProvider<WindowsPathBase> {

--- a/packages/fs/src/node/lib.ts
+++ b/packages/fs/src/node/lib.ts
@@ -44,6 +44,7 @@ export type {
   XDGBase,
 } from "../browser/paths.linux";
 
+export { WindowsPath } from "../browser/paths.windows";
 export type {
   WindowsPathBase,
   WindowsPathProvider,


### PR DESCRIPTION
Demo for @halgari. Closes APP-330.

Providing `StorePathProvider` to adaptors can look like this:

```typescript
async function getPath(provider: StorePathProvider): Promise<QualifiedPath> {
  // every store path provider has the game base:
  const gamePath = await provider.fromBase(StorePath.game);

  // if you need something store-specific:
  if (provider.store === "steam") {
    const workshop = await provider.fromBase(Steam.workshop);
  }

  // if you don't care about non-Windows installations:
  if (!provider.isWindows) throw new Error("Only supported on Windows");
  const myGames = await provider.fromBase(WindowsPath.myGames);
}
```