### PR TITLE
Docs: Add Platform-Specific Setup And Packaging Guides

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -14,7 +14,7 @@ Before you start, make sure you have:
 ## Setup
 
 1. Install distro-specific prerequisites:
-    - Microsoft Windows
+    - [Windows setup]
     - Linux:
         - [Arch-based setup] (Arch, CachyOS, Manjaro)
         - [Debian-based setup] (Debian, Ubuntu, Pop!_OS, Linux Mint)
@@ -77,4 +77,5 @@ information.
 [VS Code]: https://code.visualstudio.com/
 [VS Code download]: https://code.visualstudio.com/download
 [WebStorm]: https://www.jetbrains.com/webstorm/
+[Windows setup]: ./docs/install-instructions/windows.md
 [Windows packaging]: ./docs/packaging/windows.md

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,34 +1,32 @@
 # Contributing
 
+Recommended editor: [VS Code] with workspace extensions.
+You will be prompted to install them when you first open the repo.
+
 ## Requirements
 
-This document will explain how to get started with Vortex development. First, make sure you have these general coding requirements:
+Before you start, make sure you have:
 
-- a [GitHub account](https://github.com/login) for creating pull requests,
-- the `git` [CLI](https://git-scm.com/) or one [GUI client](https://git-scm.com/tools/guis) like [GitHub Desktop](https://github.com/apps/desktop),
-- an editor with TypeScript support like [VSCode](https://code.visualstudio.com/download), [WebStorm](https://www.jetbrains.com/webstorm/) or [Neovim](https://neovim.io/).
-
-Next, you need to install some build tools for Vortex:
-
-- [Volta](https://docs.volta.sh/guide/getting-started) for Node version management,
-- and the [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) for building .NET projects.
-
-Vortex depends on native Node modules which require [node-gyp](https://github.com/nodejs/node-gyp). You need to install a [supported Python version](https://devguide.python.org/versions/) and a C/C++ toolchain:
-
-- Windows: VS 2022 Build Tools, follow [node-gyp documentation](https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows) for installation instructions
-- Linux: make and GCC (package `build-essentails` on Debian/Ubuntu and `base-devel` on Arch Linux)
-
-Starting with Python 3.12 you also need to install the `setuptools` packages. Verify your version by running `python3 --version` and install the package through `pip` or your system's package manager.
+- A [GitHub account] for creating pull requests,
+- The `git` [CLI] or a [GUI client] such as [GitHub Desktop],
+- An editor with TypeScript support such as [VS Code download], [WebStorm] or [Neovim].
 
 ## Setup
 
-1. Clone the repository
-2. `volta install node@22`
-3. `npm install --global corepack@latest`
-4. `corepack install`
-5. `pnpm install`
+1. Install distro-specific prerequisites:
+    - Microsoft Windows
+    - Linux:
+        - [Arch-based setup] (Arch, CachyOS, Manjaro)
+        - [Debian-based setup] (Debian, Ubuntu, Pop!_OS, Linux Mint)
+        - [Fedora setup]
+        - [NixOS setup]
+    - If your distribution is not listed, try [Generic Installation Instructions].
+
+2. Continue with [Shared Setup].
 
 ## Developing
+
+After you have finished the setup steps:
 
 1. `pnpm run build:all`
 2. `pnpm run start`
@@ -37,37 +35,46 @@ Starting with Python 3.12 you also need to install the `setuptools` packages. Ve
 
 ### VS Code
 
-- **F5** - Debug both main and renderer processes
-- **Build first** - Always run `pnpm run build:all` before debugging
+- **F5** debugs both main and renderer processes
+- **Build first** by running `pnpm run build:all` before debugging
 
-See [docs/DEBUGGING-GUIDE.md](./docs/DEBUGGING-GUIDE.md) for detailed debugging instructions.
+See [docs/DEBUGGING-GUIDE.md] for detailed debugging
+instructions.
 
 ## Packaging
 
-### Local unsigned packages (Windows)
-
-To create a packaged installer for local testing without code signing:
-
-```
-pnpm run package:local
-```
-
-This downloads the required redistributables (VC++ and .NET Runtime) and creates an unsigned installer in the `dist/` directory.
-
-### Signed release builds
-
-Signed builds are created automatically via CI. Do not run `pnpm run package` locally.
+- [Windows packaging]
+- [Flatpak packaging]
 
 ## FAQ
 
 ### When will my changes be added to the stable release?
 
-Please see [docs/branching-and-release-strategy.md](https://github.com/Nexus-Mods/Vortex/blob/master/docs/branching-and-release-strategy.md) for more information
+See [docs/branching-and-release-strategy.md] for more
+information.
 
 ## Further Reading
 
-- [Debugging](./docs/DEBUGGING-GUIDE.md)
-- [Flatpak](./docs/flatpak-maintenance.md)
-- [Docker Dev Containers](./docker)
-- [Nix](./flake.nix)
+- [Debugging]
+- [Docker Dev Containers]
 
+[Arch-based setup]: ./docs/install-instructions/archlinux.md
+[CLI]: https://git-scm.com/
+[Debian-based setup]: ./docs/install-instructions/debian-based.md
+[Debugging]: ./docs/DEBUGGING-GUIDE.md
+[Docker Dev Containers]: ./docker
+[docs/DEBUGGING-GUIDE.md]: ./docs/DEBUGGING-GUIDE.md
+[docs/branching-and-release-strategy.md]: ./docs/branching-and-release-strategy.md
+[Fedora setup]: ./docs/install-instructions/fedora.md
+[Flatpak packaging]: ./docs/packaging/flatpak.md
+[GUI client]: https://git-scm.com/tools/guis
+[Generic Installation Instructions]: ./docs/install-instructions/generic.md
+[GitHub account]: https://github.com/login
+[GitHub Desktop]: https://github.com/apps/desktop
+[Neovim]: https://neovim.io/
+[NixOS setup]: ./docs/install-instructions/nixos.md
+[Shared Setup]: ./docs/install-instructions/shared.md
+[VS Code]: https://code.visualstudio.com/
+[VS Code download]: https://code.visualstudio.com/download
+[WebStorm]: https://www.jetbrains.com/webstorm/
+[Windows packaging]: ./docs/packaging/windows.md

--- a/docs/flatpak/maintenance.md
+++ b/docs/flatpak/maintenance.md
@@ -4,33 +4,34 @@ How to build and update the Flatpak package.
 
 > [!WARNING]
 > ## IMPORTANT: PNPM LOCKFILES ARE NOT SUPPORTED IN FLATPAK-BUILDER-TOOLS YET
-> Flatpak dependency source generation still relies on compatibility lockfiles (npm/yarn), not `pnpm-lock.yaml`.
-> - https://github.com/flatpak/flatpak-builder-tools/pull/511
-> - https://github.com/flatpak/flatpak-builder-tools/issues/383
+> Flatpak dependency source generation still relies on compatibility lockfiles
+> such as npm and Yarn, not `pnpm-lock.yaml`.
+> - [Flatpak Builder Tools PR 511]
+> - [Flatpak Builder Tools issue 383]
 
 > [!note] Prerequisites
-> See [Flatpak basics in CONTRIBUTE.md](../CONTRIBUTE.md#flatpak-basics-linux-packaging).
+> See [Flatpak packaging] for the basics and
+> first-time setup.
 
 ## Helper Scripts
 
-Scripts in `flatpak/scripts/` automate common tasks. They manage their own virtual environment and can run from any directory.
+Scripts in `flatpak/scripts/` automate common tasks. They manage their own
+virtual environment and can run from any directory.
 
 > [!tip]
 > Use `python` instead if `python3` does not work on your system.
 
-### Development workflow
+### Development Workflow
 
-| Script             | Purpose                                                         |
-| ------------------ | --------------------------------------------------------------- |
-| `flatpak_build.py` | Build the Flatpak with standard defaults                        |
-| `flatpak_run.py`   | Run the installed Flatpak (builds and installs first if needed) |
+- `flatpak_build.py`: build the Flatpak with standard defaults
+- `flatpak_run.py`: run the installed Flatpak, building and installing first
+  if needed
 
-### Distribution/UX Testing workflow
+### Distribution And UX Testing Workflow
 
-| Script               | Purpose                                                                 |
-| -------------------- | ----------------------------------------------------------------------- |
-| `flatpak_install.py` | Export to a local repo, install the app (appears in KDE Discover, etc.) |
-| `flatpak_bundle.py`  | Export to a local repo and create a `.flatpak` bundle                   |
+- `flatpak_install.py`: export to a local repo and install the app so it
+  appears in KDE Discover and similar software centers
+- `flatpak_bundle.py`: export to a local repo and create a `.flatpak` bundle
 
 ## Typical Workflows
 
@@ -82,15 +83,21 @@ python3 flatpak/scripts/flatpak_bundle.py --skip-build
 
 ### Workflow Notes
 
-- `flatpak_run.py` ensures the app is installed (builds and installs if needed), then runs it
-- `flatpak_install.py --skip-build` re-exports from existing build without rebuilding
+- `flatpak_run.py` ensures the app is installed, then runs it
+- `flatpak_install.py --skip-build` re-exports from an existing build without
+  rebuilding
 - `flatpak_bundle.py` creates a `.flatpak` file for distribution
-- `nxm://` protocol switching should work out of the box: whichever Vortex build you launched last should become the active handler
+- `nxm://` protocol switching should work out of the box. Whichever Vortex
+  build you launched last should become the active handler
 
 ## Script Differences
 
-- **`flatpak_run.py`**: Development testing with proper single-instance support. Installs the app if needed (so protocol handlers work correctly), then runs the installed version.
-- **`flatpak_install.py`**: UX testing. Installs the app properly so it appears in software centers. Creates a local OSTree repo at `flatpak/flatpak-repo/` (gitignored).
+- **`flatpak_run.py`**: development testing with proper single-instance
+  support. It installs the app if needed so protocol handlers work correctly,
+  then runs the installed version
+- **`flatpak_install.py`**: UX testing. It installs the app properly so it
+  appears in software centers and creates a local OSTree repo at
+  `flatpak/flatpak-repo/` which is gitignored
 
 ## Runtime Updates
 
@@ -116,8 +123,10 @@ This is required for _Flathub submission_ and ensures reproducible builds.
 
 To keep source files in sync automatically, build scripts now:
 
-- hash recursive repository `yarn.lock` files and compare against `flatpak/generated-sources.hash`
-- hash FOMOD `.csproj`/NuGet input files and compare against `flatpak/generated-nuget-sources.hash`
+- hash recursive repository `yarn.lock` files and compare against
+  `flatpak/generated-sources.hash`
+- hash FOMOD `.csproj` and NuGet input files and compare against
+  `flatpak/generated-nuget-sources.hash`
 - regenerate each generated source file only when needed
 
 To sync both generated source files manually, run:
@@ -138,11 +147,15 @@ If you are debugging `generated-nuget-sources.json` generation, run:
 python3 flatpak/scripts/flatpak_sources.py --only nuget --force
 ```
 
-NuGet source syncing scans `extensions/` by default. Use `--search-root` if you need to narrow the scope during debugging.
+NuGet source syncing scans `extensions/` by default. Use `--search-root` if
+you need to narrow the scope during debugging.
 
 ## Troubleshooting
 
-- Missing submodule files during Flatpak build: `yarn install` normally runs `preinstall.js`, which initializes submodules. If you have not run `yarn install` locally, run `git submodule update --init --recursive` first.
+- Missing submodule files during Flatpak build: `yarn install` normally runs
+  `preinstall.js`, which initializes submodules. If you have not run
+  `yarn install` locally, run `git submodule update --init --recursive`
+  first
 - `nxm://` handler did not switch automatically:
 
 ```bash
@@ -158,6 +171,13 @@ xdg-settings set default-url-scheme-handler nxm com.nexusmods.vortex.dev.desktop
 
 ## References
 
-- [Flatpak Electron guide](https://docs.flatpak.org/en/latest/electron.html)
-- [Flatpak .NET guide](https://docs.flatpak.org/en/latest/dotnet.html)
-- [flatpak-builder documentation](https://docs.flatpak.org/en/latest/flatpak-builder.html)
+- [Flatpak Electron guide]
+- [Flatpak .NET guide]
+- [flatpak-builder documentation]
+
+[Flatpak packaging]: ../packaging/flatpak.md
+[Flatpak builder tools issue 383]: https://github.com/flatpak/flatpak-builder-tools/issues/383
+[Flatpak Builder Tools PR 511]: https://github.com/flatpak/flatpak-builder-tools/pull/511
+[Flatpak .NET guide]: https://docs.flatpak.org/en/latest/dotnet.html
+[Flatpak Electron guide]: https://docs.flatpak.org/en/latest/electron.html
+[flatpak-builder documentation]: https://docs.flatpak.org/en/latest/flatpak-builder.html

--- a/docs/flatpak/technical.md
+++ b/docs/flatpak/technical.md
@@ -4,7 +4,9 @@ Technical notes for developers working on the Flatpak build.
 
 ## Build Pipeline
 
-Offline-first: `flatpak-node-generator` converts Yarn lockfiles into `generated-sources.json` so builds need no network. Yarn pulls from an offline mirror inside the sandbox.
+Offline-first: `flatpak-node-generator` converts Yarn lockfiles into
+`generated-sources.json` so builds need no network. Yarn pulls from an offline
+mirror inside the sandbox.
 
 Build stages (in the SDK sandbox):
 
@@ -54,18 +56,27 @@ Use this to test the actual user installation experience.
 
 `flatpak/run.sh` launches with `zypak-wrapper /app/main/vortex`.
 
-- Zypak runs Electron inside the sandbox (see [Zypak docs](https://github.com/refi64/zypak))
+- Zypak runs Electron inside the sandbox (see [Zypak docs])
 - Desktop file points to `run.sh`
 - Entrypoint must use Zypak per Flatpak Electron guidance
 
 ## Why These Choices
 
-**Full host filesystem access**: Game installs can be anywhere. Deployment uses hardlinks/symlinks/moves. Portals are not viable because scanning and deployment are background operations that cannot wait for user-mediated prompts.
+- **Full host filesystem access**: Game installs can be anywhere. Deployment
+  uses hardlinks, symlinks, and moves. Portals are not viable because scanning
+  and deployment are background operations that cannot wait for user prompts.
 
-**Offline builds**: Required for Flathub and reproducible builds. All Yarn/NPM dependencies must be in `generated-sources.json`.
+- **Offline builds**: Required for Flathub and reproducible builds. All
+  Yarn and NPM dependencies must be in `generated-sources.json`.
 
-**Zypak wrapper**: Required by the Electron BaseApp to run Chromium's sandbox inside Flatpak's sandbox.
+- **Zypak wrapper**: Required by the Electron BaseApp to run Chromium's
+  sandbox inside Flatpak's sandbox.
 
-**.NET runtime staging**: Framework-dependent tools (like `dotnetprobe`) need `DOTNET_ROOT` pointing to the staged runtime at `/app/lib/dotnet`.
+- **.NET runtime staging**: Framework-dependent tools such as `dotnetprobe`
+  need `DOTNET_ROOT` pointing to the staged runtime at `/app/lib/dotnet`.
 
-**Electron builder**: We use `electron-builder` with the `dir` target to package the app with the Electron runtime. This creates a complete distribution in `dist/linux-unpacked/` that gets copied to `/app/main`.
+- **Electron builder**: We use `electron-builder` with the `dir` target to
+  package the app with the Electron runtime. This creates a complete
+  distribution in `dist/linux-unpacked/` that gets copied to `/app/main`.
+
+[Zypak docs]: https://github.com/refi64/zypak

--- a/docs/install-instructions/archlinux.md
+++ b/docs/install-instructions/archlinux.md
@@ -1,0 +1,46 @@
+# Arch Linux Setup
+
+Install the distro packages here first, then continue with [Shared Setup].
+
+Validated on 13 April 2026 (`CachyOS 26.03`). If any deps are missing please open
+a [PR] or [issue].
+
+## Refresh Package Databases
+
+Refresh package lists so install uses latest repo data.
+
+```bash
+sudo pacman -Sy
+```
+
+## Install Dependencies
+
+```bash
+sudo pacman -S --needed base-devel git python python-setuptools dotnet-sdk-9.0
+```
+
+## Verify Install
+
+```bash
+python --version
+gcc --version
+dotnet --list-sdks
+```
+
+## Continue Setup
+
+After the packages above are installed, continue with [Shared Setup].
+
+## Extra Resources
+
+- [Arch package search]
+- [Arch package: dotnet-sdk-9.0]
+- [Generic .NET on Linux docs]
+
+[Arch package search]: https://archlinux.org/packages/
+[Arch package: dotnet-sdk-9.0]: https://archlinux.org/packages/extra/x86_64/dotnet-sdk-9.0/
+[Generic .NET on Linux docs]: https://learn.microsoft.com/en-gb/dotnet/core/install/linux?tabs=dotnet9
+[Shared Setup]: ./shared.md
+[PR]: https://github.com/Nexus-Mods/Vortex/compare
+[issue]: https://github.com/Nexus-Mods/Vortex/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=
+[.NET on Linux documentation]: https://learn.microsoft.com/en-gb/dotnet/core/install/linux?tabs=dotnet9

--- a/docs/install-instructions/debian-based.md
+++ b/docs/install-instructions/debian-based.md
@@ -1,0 +1,96 @@
+# Debian-based Setup
+
+Install distro packages here first, then continue with [Shared Setup].
+
+Validated on 13 April 2026. Verified on Ubuntu 24.04 and Pop!_OS 24.04.
+If any step is out of date, please open a [PR] or [issue].
+
+## System Packages
+
+### Refresh Package Metadata
+
+Refresh package lists so install uses latest repo data.
+
+```bash
+sudo apt update
+```
+
+### Install Dependencies
+
+```bash
+sudo apt install build-essential git python3 python3-setuptools curl wget libfontconfig-dev
+```
+
+## .NET 9 SDK
+
+### Debian
+
+Based on official [.NET 9 install docs for Debian].
+
+```bash
+# Add Microsoft package feed
+source /etc/os-release
+wget \
+  "https://packages.microsoft.com/config/debian/${VERSION_ID}/packages-microsoft-prod.deb" \
+  -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+# Refresh package lists
+sudo apt update
+
+# Install .NET 9 SDK
+sudo apt install dotnet-sdk-9.0
+```
+
+### Ubuntu-based Distros
+
+Based on official [.NET 9 install docs for Ubuntu].
+
+Try this first:
+
+```bash
+sudo apt install dotnet-sdk-9.0
+```
+
+If `apt` cannot find the package, add Ubuntu .NET backports and retry.
+
+```bash
+# Install helper for add-apt-repository
+sudo apt install software-properties-common
+
+# Add Ubuntu .NET backports
+sudo add-apt-repository ppa:dotnet/backports
+
+# Refresh package lists
+sudo apt update
+
+# Install .NET 9 SDK
+sudo apt install dotnet-sdk-9.0
+```
+
+## Verify Install
+
+```bash
+python3 --version
+gcc --version
+dotnet --list-sdks
+```
+
+## Continue Setup
+
+After the packages above are installed, continue with [Shared Setup].
+
+## Extra Resources
+
+- [Debian package tracker]
+- [.NET 9 install docs for Debian]
+- [Ubuntu .NET backports package repository]
+
+[Shared Setup]: ./shared.md
+[Debian package tracker]: https://tracker.debian.org/
+[.NET 9 install docs for Debian]: https://learn.microsoft.com/en-gb/dotnet/core/install/linux-debian?tabs=dotnet9
+[.NET 9 install docs for Ubuntu]: https://learn.microsoft.com/en-gb/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9
+[PR]: https://github.com/Nexus-Mods/Vortex/compare
+[issue]: https://github.com/Nexus-Mods/Vortex/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=
+[Ubuntu .NET backports package repository]: https://launchpad.net/~dotnet/+archive/ubuntu/backports

--- a/docs/install-instructions/fedora.md
+++ b/docs/install-instructions/fedora.md
@@ -1,0 +1,45 @@
+# Fedora Setup
+
+Install the distro packages here first, then continue with [Shared Setup].
+
+Validated on 13 April 2026 (Fedora 43). If any step is out of date, please open
+a [PR] or [issue].
+
+## Refresh Package Metadata
+
+Refresh package lists so install uses latest repo data.
+
+```bash
+sudo dnf makecache --refresh
+```
+
+## Install Dependencies
+
+```bash
+# Install dependencies.
+sudo dnf group install development-tools
+sudo dnf install git python3 python3-setuptools dotnet-sdk-9.0 gcc g++ fontconfig-devel
+```
+
+## Verify Install
+
+```bash
+python3 --version
+gcc --version
+dotnet --list-sdks
+```
+
+## Continue Setup
+
+After the packages above are installed, continue with [Shared Setup].
+
+## Extra Related Resources
+
+- [Fedora package search]
+- [.NET 9 install docs for Fedora]
+
+[Fedora package search]: https://packages.fedoraproject.org/
+[Shared Setup]: ./shared.md
+[.NET 9 install docs for Fedora]: https://learn.microsoft.com/en-gb/dotnet/core/install/linux-fedora?tabs=dotnet9
+[PR]: https://github.com/Nexus-Mods/Vortex/compare
+[issue]: https://github.com/Nexus-Mods/Vortex/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=

--- a/docs/install-instructions/generic.md
+++ b/docs/install-instructions/generic.md
@@ -13,7 +13,7 @@ Vortex depends on native Node modules which require [node-gyp]. You need a
 
 ### Windows
 
-Install VS 2022 Build Tools. Follow the [node-gyp Windows instructions].
+Use [Windows setup] for full Windows prerequisites.
 
 ### Linux
 
@@ -36,7 +36,7 @@ After these prerequisites are installed, continue with [Shared Setup].
 
 [.NET 9 SDK]: https://dotnet.microsoft.com/en-us/download/dotnet/9.0
 [node-gyp]: https://github.com/nodejs/node-gyp
-[node-gyp Windows instructions]: https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows
 [NixOS Setup]: ./nixos.md
 [Shared Setup]: ./shared.md
+[Windows setup]: ./windows.md
 [supported Python version]: https://devguide.python.org/versions/

--- a/docs/install-instructions/generic.md
+++ b/docs/install-instructions/generic.md
@@ -1,0 +1,42 @@
+# Generic Installation Instructions
+
+This page covers distro-specific prerequisites before [Shared Setup].
+
+## .NET 9 SDK
+
+Install [.NET 9 SDK] for building .NET projects.
+
+## Python And C/C++ Toolchain
+
+Vortex depends on native Node modules which require [node-gyp]. You need a
+[supported Python version] and a C/C++ toolchain.
+
+### Windows
+
+Install VS 2022 Build Tools. Follow the [node-gyp Windows instructions].
+
+### Linux
+
+Install `make` and `gcc`. Common package names are `build-essential` on Debian
+and Ubuntu, and `base-devel` on Arch Linux.
+
+### Python 3.12+
+
+Starting with Python 3.12 you also need `setuptools`. Verify your version with
+`python3 --version`, then install the package through `pip` or your system
+package manager.
+
+## Next Step
+
+After these prerequisites are installed, continue with [Shared Setup].
+
+## Notes
+
+- For NixOS, use [NixOS Setup] instead of [Shared Setup]
+
+[.NET 9 SDK]: https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+[node-gyp]: https://github.com/nodejs/node-gyp
+[node-gyp Windows instructions]: https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows
+[NixOS Setup]: ./nixos.md
+[Shared Setup]: ./shared.md
+[supported Python version]: https://devguide.python.org/versions/

--- a/docs/install-instructions/nixos.md
+++ b/docs/install-instructions/nixos.md
@@ -1,0 +1,74 @@
+# NixOS Setup
+
+NixOS `flake.nix` provides all the dependencies you need out of the box,
+skipping the Volta and Corepack flow.
+
+Validated on 13 April 2026. If any step is out of date, please open a [PR] or [issue].
+
+## Requirements
+
+- Nix with flakes enabled
+- [direnv]
+- [VS Code direnv extension]
+
+Example `direnv` configuration:
+
+```nix
+{...}: {
+  programs.direnv = {
+    enable = true;
+    enableBashIntegration = true;
+    enableZshIntegration = true;
+    nix-direnv.enable = true;
+  };
+}
+```
+
+## Setup
+
+1. Clone the repository
+2. Enable the dev shell:
+
+```bash
+direnv allow
+```
+
+From then on, the shell activates automatically when you enter the repo.
+
+3. Use the shell-provided `pnpm`
+4. Install dependencies:
+
+```bash
+pnpm install
+```
+
+5. Build the project:
+
+```bash
+pnpm run build:all
+```
+
+6. Start Vortex:
+
+```bash
+pnpm run start
+```
+
+## Debugging
+
+- Start VS Code from a shell activated by `direnv`
+- Use `Debug Electron (System Electron)`
+
+## Extra Resources
+
+- [Nix flake]
+- [Nix packages search]
+- [nix-direnv]
+
+[direnv]: https://github.com/nix-community/nix-direnv
+[Nix flake]: ../../flake.nix
+[Nix packages search]: https://search.nixos.org/packages
+[nix-direnv]: https://github.com/nix-community/nix-direnv
+[VS Code direnv extension]: https://marketplace.visualstudio.com/items?itemName=mkhl.direnv
+[PR]: https://github.com/Nexus-Mods/Vortex/compare
+[issue]: https://github.com/Nexus-Mods/Vortex/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=

--- a/docs/install-instructions/shared.md
+++ b/docs/install-instructions/shared.md
@@ -1,0 +1,70 @@
+# Shared Setup
+
+Use this page after you have installed the prerequisites from a distro-specific
+guide or from [Generic Installation Instructions].
+
+These steps cover the shared repository bootstrap flow for Windows and Linux.
+
+## Setup
+
+1. Install [Volta] via cmd/terminal.
+
+Linux:
+
+```bash
+curl https://get.volta.sh | bash
+```
+
+Windows:
+
+```powershell
+winget install Volta.Volta
+```
+
+After installing Volta, restart terminal to update `$PATH`.
+You can verify Volta is working by running `volta --version`.
+
+2. Clone the repository through your git client or CLI with submodules, then open command prompt/terminal in that folder:
+
+```bash
+git clone --recurse-submodules https://github.com/Nexus-Mods/Vortex.git
+cd Vortex
+```
+3. Install the pinned `node.js` and `yarn` versions:
+
+```bash
+volta install node@22 yarn@v1
+```
+
+4. Install `pnpm` through Corepack:
+
+```bash
+npm install --global corepack@latest
+corepack install
+```
+
+5. Install Vortex dependencies:
+
+```bash
+pnpm install
+```
+
+## Verify Setup
+
+```bash
+git --version
+volta --version
+node --version
+yarn --version
+pnpm --version
+python3 --version
+dotnet --list-sdks
+```
+
+## Notes
+
+- If `volta` is not available after terminal restart, add `~/.volta/bin` to your shell `PATH`
+- You may want to pin Node locally with `volta pin node@22.22.0` to match the repo's `package.json`
+
+[Generic Installation Instructions]: ./generic.md
+[Volta]: https://docs.volta.sh/guide/getting-started

--- a/docs/install-instructions/shared.md
+++ b/docs/install-instructions/shared.md
@@ -7,7 +7,7 @@ These steps cover the shared repository bootstrap flow for Windows and Linux.
 
 ## Setup
 
-1. Install [Volta] via cmd/terminal.
+1. Open a terminal and install [Volta].
 
 Linux:
 
@@ -21,15 +21,27 @@ Windows:
 winget install Volta.Volta
 ```
 
-After installing Volta, restart terminal to update `$PATH`.
+After installing Volta, close and reopen terminal to update `$PATH`.
 You can verify Volta is working by running `volta --version`.
 
-2. Clone the repository through your git client or CLI with submodules, then open command prompt/terminal in that folder:
+2. Clone the repository through your git client or CLI with submodules, then open a terminal in that folder:
+
+Linux:
 
 ```bash
 git clone --recurse-submodules https://github.com/Nexus-Mods/Vortex.git
 cd Vortex
 ```
+
+Windows:
+
+```powershell
+git clone --recurse-submodules https://github.com/Nexus-Mods/Vortex.git C:\v
+cd C:\v
+```
+
+Use `C:\v` on Windows to avoid path length issues.
+
 3. Install the pinned `node.js` and `yarn` versions:
 
 ```bash
@@ -63,7 +75,7 @@ dotnet --list-sdks
 
 ## Notes
 
-- If `volta` is not available after terminal restart, add `~/.volta/bin` to your shell `PATH`
+- If `volta` is not available after reopening terminal, add `~/.volta/bin` to your shell `PATH`
 - You may want to pin Node locally with `volta pin node@22.22.0` to match the repo's `package.json`
 
 [Generic Installation Instructions]: ./generic.md

--- a/docs/install-instructions/windows.md
+++ b/docs/install-instructions/windows.md
@@ -1,0 +1,107 @@
+# Windows Setup
+
+Open PowerShell or Command Prompt first. Install Windows prerequisites here,
+then continue with [Shared Setup].
+
+Validated on 13 April 2026 (Windows 11 25H2). If any step is out of date, please
+open a [PR] or [issue].
+
+## Install Dependencies
+
+### Visual Studio 2022 Build Tools
+
+```powershell
+winget install --id Microsoft.VisualStudio.2022.BuildTools -e
+```
+
+Open Visual Studio Installer and select:
+
+### Workload
+
+- Desktop development with C++
+
+### Individual Components
+
+- MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
+- C++ ATL for latest v143 build tools (x86 & x64)
+- C++ MFC for latest v143 build tools (x86 & x64)
+- Windows 11 SDK (10.0.22621.0)
+
+The default workload is not enough by itself. Vortex uses native Node modules,
+so `node-gyp` needs ATL, MFC, and Windows 11 SDK.
+
+### Git
+
+```powershell
+winget install --id Git.Git -e
+```
+
+Git for Windows should be on `PATH` after install.
+
+### Python 3.14
+
+```powershell
+winget install --id Python.Python.3.14 -e
+```
+
+Python 3.12+ needs `setuptools`:
+
+```powershell
+python -m pip install --upgrade setuptools
+```
+
+Close and reopen PowerShell or Command Prompt after install so `python` resolves
+from `PATH`.
+
+### CMake
+
+```powershell
+winget install --id Kitware.CMake -e
+```
+
+Some native build pieces need CMake during local builds.
+
+### .NET 9 SDK
+
+```powershell
+winget install --id Microsoft.DotNet.SDK.9 -e
+```
+
+## Verify Install
+
+```powershell
+git --version
+python --version
+cmake --version
+dotnet --list-sdks
+```
+
+## Continue Setup
+
+After the prerequisites above are installed, continue with [Shared Setup].
+
+## Notes
+
+- Use VS 2022 Build Tools for this repo, not newer MSVC toolsets.
+- Use `C:\v` due to path length limits in Windows and Git.
+
+## Troubleshooting
+
+- If Yarn 1 throws cache parse errors, run `yarn cache clean` and retry.
+
+## Extra Resources
+
+- [Git for Windows]
+- [Visual Studio 2022 Build Tools]
+- [.NET 9 install docs for Windows]
+- [winget]
+- [Windows CI build image]
+
+[Shared Setup]: ./shared.md
+[PR]: https://github.com/Nexus-Mods/Vortex/compare
+[issue]: https://github.com/Nexus-Mods/Vortex/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=
+[Git for Windows]: https://git-scm.com/downloads/win
+[Visual Studio 2022 Build Tools]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022
+[.NET 9 install docs for Windows]: https://learn.microsoft.com/en-gb/dotnet/core/install/windows?tabs=net9
+[winget]: https://learn.microsoft.com/windows/package-manager/winget/
+[Windows CI build image]: ../../docker/windows/Dockerfile

--- a/docs/packaging/flatpak.md
+++ b/docs/packaging/flatpak.md
@@ -1,0 +1,91 @@
+
+
+# Flatpak Packaging
+
+Use this page when you need to build, install, or bundle the Flatpak package.
+
+> [!WARNING]
+> Flatpak is broken right now.
+> `pnpm` support in Flatpak still needs fixing.
+
+## Flatpak Basics (Linux Packaging)
+
+These dependencies are only required if you are building the Flatpak package.
+
+### Requirements
+
+- `flatpak`
+- `flatpak-builder`
+- `appstream` for AppStream metadata validation via `appstreamcli`
+
+### Example Installs (Linux)
+
+- Ubuntu or Debian: `sudo apt install flatpak flatpak-builder appstream`
+- Fedora: `sudo dnf install flatpak flatpak-builder appstream`
+- Arch Linux: `sudo pacman -S flatpak flatpak-builder appstream`
+- NixOS: Included in `nix develop` through [Nix flake]
+
+> [!note]
+> There is an additional Python-based dependency,
+> `flatpak-node-generator`, but the scripts in `flatpak/scripts/`
+> automatically install it for you. The Flathub remote is also added
+> automatically if missing.
+
+## First-Time Setup
+
+Make sure submodules are available before the first Flatpak build:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Common Workflows
+
+### Quick Development Test
+
+Build the Flatpak with the standard defaults, then run the installed app:
+
+```bash
+python3 flatpak/scripts/flatpak_build.py
+python3 flatpak/scripts/flatpak_run.py
+```
+
+### Install Into A Local Repo
+
+This builds and installs the app so it appears in software centers such as
+KDE Discover or GNOME Software:
+
+```bash
+python3 flatpak/scripts/flatpak_install.py
+```
+
+If you already built with `flatpak_build.py`, you can skip the rebuild:
+
+```bash
+python3 flatpak/scripts/flatpak_install.py --skip-build
+```
+
+### Create A Bundle
+
+This builds the package and creates a `.flatpak` bundle for distribution:
+
+```bash
+python3 flatpak/scripts/flatpak_bundle.py
+```
+
+If you already built with `flatpak_build.py`, you can skip the rebuild:
+
+```bash
+python3 flatpak/scripts/flatpak_bundle.py --skip-build
+```
+
+## Further Reading
+
+- [Flatpak maintenance] for the full workflow and troubleshooting
+- [Flatpak technical notes] for manifest and runtime details
+- [Flatpak documentation]
+
+[Flatpak documentation]: https://docs.flatpak.org/en/latest/
+[Flatpak maintenance]: ../flatpak/maintenance.md
+[Flatpak technical notes]: ../flatpak/technical.md
+[Nix flake]: ../../flake.nix

--- a/docs/packaging/windows.md
+++ b/docs/packaging/windows.md
@@ -1,0 +1,46 @@
+# Windows Packaging
+
+Use this page when you need a Windows installer for local testing or you need
+to understand how signed release builds are produced.
+
+## Local Unsigned Packages
+
+To create a packaged installer for local testing without code signing:
+
+```bash
+pnpm run package:local
+```
+
+This prepares the Windows runtime assets, downloads the required
+redistributables, and creates an unsigned installer in `dist/`.
+
+The packaging workflow downloads:
+
+- The Microsoft Visual C++ Redistributable,
+- The .NET Desktop Runtime used by the packaged app.
+
+## Signed Release Builds
+
+Signed builds are created automatically through CI. Do not run `pnpm run package` locally unless you are working in the release automation context with the required signing secrets.
+
+The release workflow is defined in [package.yml] and runs on `windows-latest`.
+
+## Output
+
+Successful packaging produces files in `dist/`, including:
+
+- `vortex-setup-<version>.exe`
+- `latest.yml`
+
+CI can also upload unpacked and installer artifacts for release workflows.
+
+## References
+
+- [electron-builder documentation]
+- [electron-builder NSIS configuration]
+- [Package workflow]
+
+[Package workflow]: ../../.github/workflows/package.yml
+[electron-builder documentation]: https://www.electron.build/
+[electron-builder NSIS configuration]: https://www.electron.build/configuration/nsis
+[package.yml]: ../../.github/workflows/package.yml


### PR DESCRIPTION
## Summary
- Split contributor setup into distro-specific install pages for Windows, Arch, Debian/Ubuntu, Fedora, NixOS, and generic Linux.
- Add shared bootstrap steps for Volta, Node/Yarn/pnpm setup, and setup verification.
- Expand packaging docs for Windows and Flatpak, including maintenance and technical notes.

## Improvements
- Link to VS2022 Build Tools directly, since Microsoft no longer keeps open download links on main page.
- Call out VS2022 components that were not mentioned before in direct or linked docs:
  - `Desktop development with C++`
  - MSVC v143 build tools
  - C++ ATL
  - C++ MFC
  - Windows 11 SDK
- Note that Yarn v1 cache may need a reset.
- Clarify VS2022 vs newer toolsets and avoid broken Microsoft doc path.

## Validation
- Every OS page was validated step by step in a virtual machine.
- Post-install backups were kept for each VM state, so re-tests are trivial to do (~6-8 mins including restore).
- Coverage should fit every OS at the office except Mari's Mac, based on last year's survey.

## Testing
- Successfully built.