### PR TITLE
chore: update tool page styling

### DIFF
--- a/assets/pictograms/tools.svg
+++ b/assets/pictograms/tools.svg
@@ -1,0 +1,35 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_d_4948_3614)">
+        <path d="M20.7741 117.827C19.4616 116.963 19.4616 115.037 20.7741 114.173L98.797 62.7922C99.527 62.3115 100.473 62.3115 101.203 62.7922L179.226 114.173C180.538 115.037 180.538 116.963 179.226 117.827L101.203 169.208C100.473 169.688 99.527 169.688 98.797 169.208L20.7741 117.827Z" style="fill: currentColor"/>
+    </g>
+    <g filter="url(#filter1_d_4948_3614)">
+        <path d="M126.399 126.291L102.661 102.242C100.278 103.071 97.8955 103.744 95.5127 104.262C93.1298 104.78 90.6952 105.039 88.2088 105.039C78.1594 105.039 69.6123 101.543 62.5674 94.5495C55.5225 87.5564 52 79.0351 52 68.9858C52 65.7741 52.4144 62.6402 53.2432 59.5839C54.072 56.5277 55.2635 53.6527 56.8175 50.9591L79.3508 73.4925L93.6479 60.1278L70.4929 36.9729C73.1865 35.4189 76.0356 34.2015 79.04 33.3209C82.0445 32.4403 85.1007 32 88.2088 32C98.4653 32 107.194 35.6002 114.394 42.8005C121.594 50.0008 125.195 58.7292 125.195 68.9858C125.195 71.4722 124.936 73.9069 124.418 76.2897C123.9 78.6725 123.226 81.0554 122.397 83.4382L146.291 107.176C147.43 108.316 148 109.688 148 111.294C148 112.9 147.43 114.273 146.291 115.412L134.48 126.291C133.34 127.43 131.994 128 130.44 128C128.885 128 127.539 127.43 126.399 126.291Z" fill="url(#paint0_radial_4948_3614)"/>
+    </g>
+    <defs>
+        <filter id="filter0_d_4948_3614" x="19.7897" y="62.4317" width="169.185" height="115.617" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+            <feOffset dx="5.53991" dy="5.25581"/>
+            <feGaussianBlur stdDeviation="1.61226"/>
+            <feComposite in2="hardAlpha" operator="out"/>
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4948_3614"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4948_3614" result="shape"/>
+        </filter>
+        <filter id="filter1_d_4948_3614" x="50" y="32" width="112" height="116" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+            <feOffset dx="6" dy="12"/>
+            <feGaussianBlur stdDeviation="4"/>
+            <feComposite in2="hardAlpha" operator="out"/>
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.55 0"/>
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4948_3614"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4948_3614" result="shape"/>
+        </filter>
+        <radialGradient id="paint0_radial_4948_3614" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(73.2907 59.3621) rotate(45) scale(121.335 99.6373)">
+            <stop offset="0.221154" stop-color="white"/>
+            <stop offset="0.764423" stop-color="#7D88ED"/>
+            <stop offset="1" stop-color="white"/>
+        </radialGradient>
+    </defs>
+</svg>

--- a/src/renderer/src/ui/components/pictogram/Pictogram.tsx
+++ b/src/renderer/src/ui/components/pictogram/Pictogram.tsx
@@ -26,7 +26,7 @@ const themeMap = {
   primary: "text-primary-moderate",
 } as const satisfies Record<Theme, string>;
 
-export type PictogramName = "health-check";
+export type PictogramName = "health-check" | "tools";
 
 export const Pictogram = ({
   className,

--- a/src/renderer/src/views/pages/Tools/ToolRow.tsx
+++ b/src/renderer/src/views/pages/Tools/ToolRow.tsx
@@ -10,22 +10,20 @@ import {
   mdiPlay,
   mdiFlash,
   mdiFlashOff,
-  mdiWrench,
 } from "@mdi/js";
 import React, { type FC } from "react";
 import { Image } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { pathToFileURL } from "url";
 
-import type { IStarterInfo } from "../../../util/StarterInfo";
+import { Button } from '@/ui/components/button/Button';
+import { Dropdown } from "@/ui/components/dropdown/Dropdown";
+import { DropdownItem } from "@/ui/components/dropdown/DropdownItem";
+import { DropdownItems } from "@/ui/components/dropdown/DropdownItems";
+import { Typography } from "@/ui/components/typography/Typography";
+import StarterInfo, { type IStarterInfo } from "@/util/StarterInfo";
 
-import { Button } from "../../../ui/components/button/Button";
-import { Dropdown } from "../../../ui/components/dropdown/Dropdown";
-import { DropdownItem } from "../../../ui/components/dropdown/DropdownItem";
-import { DropdownItems } from "../../../ui/components/dropdown/DropdownItems";
-import { Icon } from "../../../ui/components/icon/Icon";
-import { Typography } from "../../../ui/components/typography/Typography";
-import StarterInfo from "../../../util/StarterInfo";
+const Divider = () => <div className="h-7 w-px bg-stroke-weak" />;
 
 export interface ToolRowProps {
   starter: IStarterInfo;
@@ -82,106 +80,114 @@ export const ToolRow: FC<ToolRowProps> = ({
   }
 
   return (
-    <div className="hover-overlay-weak flex w-full items-center gap-x-3 rounded-sm bg-surface-mid px-4 py-3 shadow-xs">
-      <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-xs">
+    <div className="hover-overlay-weak flex w-full min-w-0 items-center gap-x-4 rounded-sm bg-surface-mid pr-3 shadow-xs">
+      <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-l-sm bg-surface-high">
         {iconSrc ? (
-          <Image className="size-full object-contain" src={iconSrc} />
+          <Image src={iconSrc} />
         ) : (
-          <Icon className="text-translucent-moderate" path={mdiWrench} />
-        )}
-      </div>
-
-      <div className="grow space-y-0.5">
-        <Typography>{starterInfo.name}</Typography>
-
-        {isRunning && (
-          <Typography appearance="subdued" typographyType="body-sm">
-            {t("Running...")}
+          <Typography appearance="moderate" className="uppercase" typographyType="body-lg">
+            {starterInfo.name?.charAt(0) || 'T'}
           </Typography>
         )}
       </div>
 
-      <div className="flex shrink-0 items-center gap-x-1">
+      <Typography as="div" className="flex min-w-0 grow items-center gap-x-2">
+        <span className="truncate">
+          {starterInfo.name}
+        </span>
+
+        {isRunning && (
+          <span className="shrink-0 text-neutral-subdued">
+            {t("Running...")}
+          </span>
+        )}
+      </Typography>
+
+      <div className="flex shrink-0 items-center gap-x-4">
         {showReorder && isPinned && (
           <>
-            <Button
-              buttonType="tertiary"
-              disabled={isFirst}
-              leftIconPath={mdiArrowUp}
-              size="xs"
-              title={isFirst ? t("Already at the top") : t("Move up")}
-              onClick={() => onMoveUp?.(starter)}
-            />
+            <div className="flex gap-x-2">
+              <Button
+                buttonType="tertiary"
+                disabled={isFirst}
+                leftIconPath={mdiArrowUp}
+                size="sm"
+                title={isFirst ? t("Already at the top") : t("Move up")}
+                onClick={() => onMoveUp?.(starter)}
+              />
 
-            <Button
-              buttonType="tertiary"
-              disabled={isLast}
-              leftIconPath={mdiArrowDown}
-              size="xs"
-              title={isLast ? t("Already at the bottom") : t("Move down")}
-              onClick={() => onMoveDown?.(starter)}
-            />
+              <Button
+                buttonType="tertiary"
+                disabled={isLast}
+                leftIconPath={mdiArrowDown}
+                size="sm"
+                title={isLast ? t("Already at the bottom") : t("Move down")}
+                onClick={() => onMoveDown?.(starter)}
+              />
+            </div>
 
-            <div className="mx-0.5 h-4 w-px bg-stroke-weak" />
+            <Divider />
           </>
         )}
 
-        {!starter.isGame && !isPrimary && (
-          <Button
-            buttonType="tertiary"
-            disabled={!isPinned && pinDisabled}
-            leftIconPath={isPinned ? mdiPinOff : mdiPin}
-            size="xs"
-            title={
-              !isPinned && pinDisabled
-                ? pinDisabledReason
-                : isPinned
-                  ? t("Unpin tool")
-                  : t("Pin tool")
-            }
-            onClick={() => onTogglePin(starter)}
-          />
-        )}
+        <div className="flex gap-x-2">
+          {!starter.isGame && !isPrimary && (
+            <Button
+              buttonType="tertiary"
+              disabled={!isPinned && pinDisabled}
+              leftIconPath={isPinned ? mdiPinOff : mdiPin}
+              size="sm"
+              title={
+                !isPinned && pinDisabled
+                  ? pinDisabledReason
+                  : isPinned
+                    ? t("Unpin tool")
+                    : t("Pin tool")
+              }
+              onClick={() => onTogglePin(starter)}
+            />
+          )}
 
-        <Dropdown>
-          <Menu.Button
-            as={Button}
-            buttonType="tertiary"
-            leftIconPath={mdiDotsVertical}
-            size="xs"
-          />
+          <Dropdown>
+            <Menu.Button
+              as={Button}
+              buttonType="tertiary"
+              leftIconPath={mdiDotsVertical}
+              size="sm"
+            />
 
-          <DropdownItems>
-            <DropdownItem
-              leftIconPath={mdiPencil}
-              onClick={() => onEdit(starterInfo)}
-            >
-              {t("Edit")}
-            </DropdownItem>
-
-            <DropdownItem
-              disabled={!isPrimary && !isValid}
-              leftIconPath={isPrimary ? mdiFlashOff : mdiFlash}
-              onClick={() => onSetPrimary(starterInfo)}
-            >
-              {isPrimary
-                ? t("Remove default launcher")
-                : t("Set as default launcher")}
-            </DropdownItem>
-
-            {!starter.isGame && (
+            <DropdownItems>
               <DropdownItem
-                className="nxm-dropdown-item-danger"
-                leftIconPath={mdiDelete}
-                onClick={() => onRemove(starterInfo)}
+                leftIconPath={mdiPencil}
+                onClick={() => onEdit(starterInfo)}
               >
-                {t("Delete")}
+                {t("Edit")}
               </DropdownItem>
-            )}
-          </DropdownItems>
-        </Dropdown>
 
-        <div className="mx-0.5 h-4 w-px bg-stroke-weak" />
+              <DropdownItem
+                disabled={!isPrimary && !isValid}
+                leftIconPath={isPrimary ? mdiFlashOff : mdiFlash}
+                onClick={() => onSetPrimary(starterInfo)}
+              >
+                {isPrimary
+                  ? t("Remove default launcher")
+                  : t("Set as default launcher")}
+              </DropdownItem>
+
+              {!starter.isGame && (
+                <DropdownItem
+                  className="nxm-dropdown-item-danger"
+                  leftIconPath={mdiDelete}
+                  onClick={() => onRemove(starterInfo)}
+                >
+                  {t("Delete")}
+                </DropdownItem>
+              )}
+            </DropdownItems>
+          </Dropdown>
+        </div>
+
+        <Divider />
 
         <Button
           buttonType="secondary"

--- a/src/renderer/src/views/pages/Tools/index.tsx
+++ b/src/renderer/src/views/pages/Tools/index.tsx
@@ -1,15 +1,42 @@
 import { mdiPin, mdiPlus, mdiFlash, mdiWrench } from "@mdi/js";
-import React, { type FC } from "react";
+import React, { type FC, type PropsWithChildren, type ReactNode } from 'react';
 import { useTranslation } from "react-i18next";
+
+import { Button } from '@/ui/components/button/Button';
+import { Icon } from '@/ui/components/icon/Icon';
+import { Pictogram } from '@/ui/components/pictogram/Pictogram';
+import { Typography } from '@/ui/components/typography/Typography';
 
 import EmptyPlaceholder from "../../../controls/EmptyPlaceholder";
 import ToolEditDialog from "../../../extensions/starter_dashlet/ToolEditDialog";
-import { Button } from "../../../ui/components/button/Button";
-import { Icon } from "../../../ui/components/icon/Icon";
-import { Typography } from "../../../ui/components/typography/Typography";
 import MainPage from "../../MainPage";
 import { ToolRow } from "./ToolRow";
 import { useToolsPage } from "./useToolsPage";
+
+const Panel = ({ actions, children, heading, iconPath, tooltip }: PropsWithChildren<{ actions?: () => ReactNode; heading:string; iconPath: string; tooltip: string; }>) => (
+  <div className="space-y-2">
+    <div
+      className="flex items-center gap-x-4"
+      title={tooltip}
+    >
+      <Typography appearance="subdued" className="flex grow items-center gap-x-2 font-semibold" typographyType="body-sm">
+        <Icon
+          className="shrink-0"
+          path={iconPath}
+          size="sm"
+        />
+
+        {heading}
+      </Typography>
+
+      {actions?.()}
+    </div>
+
+    <div className="space-y-2">
+      {children}
+    </div>
+  </div>
+);
 
 export const ToolsPage: FC = () => {
   const { t } = useTranslation();
@@ -44,9 +71,7 @@ export const ToolsPage: FC = () => {
             <EmptyPlaceholder
               fill={true}
               icon="game"
-              text={t(
-                "When you are managing a game, supported tools will appear here",
-              )}
+              text={t("When you are managing a game, supported tools will appear here")}
             />
           </div>
         </MainPage.Body>
@@ -58,30 +83,22 @@ export const ToolsPage: FC = () => {
     <MainPage id="tools-page">
       <MainPage.Body>
         <div className="h-full overflow-y-auto p-6">
-          <div className="space-y-6">
-            {/* Header */}
-            <div className="flex items-start gap-x-4">
-              <Icon
-                className="mt-0.5 shrink-0 text-primary-moderate"
-                path={mdiWrench}
-                size="lg"
-              />
+          {/* Header */}
+          <div className="mb-4 flex items-start gap-x-2 border-b border-stroke-weak pb-4">
+            <Pictogram name="tools" size="sm" />
 
-              <div className="grow">
-                <Typography as="h2" className="m-0" typographyType="heading-xs">
-                  {t("Tools")}
-                </Typography>
+            <div className="grow">
+              <Typography as="h2" typographyType="heading-xs">
+                {t("Tools")}
+              </Typography>
 
-                <Typography appearance="moderate">
-                  {t(
-                    "Tools are external programs or launch options used alongside the game.",
-                  )}
-                </Typography>
-              </div>
+              <Typography appearance="moderate">
+                {t("Tools are external programs or launch options used alongside the game.")}
+              </Typography>
             </div>
+          </div>
 
-            <hr className="border-stroke-weak" />
-
+          <div className="space-y-6">
             {/* Edit dialog */}
             {toolBeingEdited !== undefined && (
               <ToolEditDialog
@@ -96,22 +113,11 @@ export const ToolsPage: FC = () => {
               unpinnedTools.length > 0) && (
               <>
                 {/* Default launcher section */}
-                <div className="space-y-2">
-                  <div
-                    className="flex items-center gap-x-2"
-                    title={t("Runs instead of the game when you hit Play")}
-                  >
-                    <Icon
-                      className="shrink-0 text-translucent-moderate"
-                      path={mdiFlash}
-                      size="sm"
-                    />
-
-                    <Typography appearance="moderate" typographyType="body-sm">
-                      {t("Default launcher")}
-                    </Typography>
-                  </div>
-
+                <Panel
+                  heading={t("Default launcher")}
+                  iconPath={mdiFlash}
+                  tooltip={t("Runs instead of the game when you hit Play")}
+                >
                   {launcherTool ? (
                     <ToolRow
                       counter={counter}
@@ -128,129 +134,92 @@ export const ToolsPage: FC = () => {
                     />
                   ) : (
                     <Typography appearance="subdued" typographyType="body-sm">
-                      {t(
-                        "Runs instead of the game when you hit Play. Set default launcher with the ⚡ button on the tool.",
-                      )}
+                      {t("Runs instead of the game when you hit Play.")}
                     </Typography>
                   )}
-                </div>
+                </Panel>
 
                 {/* Pinned tools section */}
-                <div className="space-y-2">
-                  <div
-                    className="flex items-center gap-x-2"
-                    title={t("Pin shortcuts to your most used tools")}
-                  >
-                    <Icon
-                      className="shrink-0 text-translucent-moderate"
-                      path={mdiPin}
-                      size="sm"
-                    />
-
-                    <Typography appearance="moderate" typographyType="body-sm">
-                      {t("Pinned tools {{count}}/{{max}}", {
-                        count: pinnedCount,
-                        max: MAX_PINNED_TOOLS,
-                      })}
-                    </Typography>
-                  </div>
-
+                <Panel
+                  heading={t("Pinned tools {{count}}/{{max}}", {count: pinnedCount, max: MAX_PINNED_TOOLS })}
+                  iconPath={mdiPin}
+                  tooltip={t("Pin shortcuts to your most used tools in the left menu")}
+                >
                   {otherPinnedTools.length > 0 ? (
-                    <div className="space-y-1">
-                      {otherPinnedTools.map((starter, idx) => (
-                        <ToolRow
-                          counter={counter}
-                          isFirst={idx === 0}
-                          isLast={idx === otherPinnedTools.length - 1}
-                          isPinned={true}
-                          isPrimary={false}
-                          isRunning={isToolRunning(starter)}
-                          isValid={isToolValid(starter)}
-                          key={starter.id}
-                          showReorder={true}
-                          starter={starter}
-                          onEdit={editTool}
-                          onMoveDown={moveToolDown}
-                          onMoveUp={moveToolUp}
-                          onRemove={removeTool}
-                          onRun={startTool}
-                          onSetPrimary={setToolPrimary}
-                          onTogglePin={togglePin}
-                        />
-                      ))}
-                    </div>
+                    otherPinnedTools.map((starter, idx) => (
+                      <ToolRow
+                        counter={counter}
+                        isFirst={idx === 0}
+                        isLast={idx === otherPinnedTools.length - 1}
+                        isPinned={true}
+                        isPrimary={false}
+                        isRunning={isToolRunning(starter)}
+                        isValid={isToolValid(starter)}
+                        key={starter.id}
+                        showReorder={true}
+                        starter={starter}
+                        onEdit={editTool}
+                        onMoveDown={moveToolDown}
+                        onMoveUp={moveToolUp}
+                        onRemove={removeTool}
+                        onRun={startTool}
+                        onSetPrimary={setToolPrimary}
+                        onTogglePin={togglePin}
+                      />
+                    ))
                   ) : (
                     <Typography appearance="subdued" typographyType="body-sm">
-                      {t(
-                        "Pin shortcuts to your most used tools using the 📌 button on the tool.",
-                      )}
+                      {t("Pin shortcuts to your most used tools in the left menu.")}
                     </Typography>
                   )}
-                </div>
+                </Panel>
               </>
             )}
 
             {/* Tools section */}
-            <div className="space-y-2">
-              <div
-                className="flex items-center gap-x-2"
-                title={t(
-                  "External programs or launch options used alongside the game",
-                )}
-              >
-                <Icon
-                  className="shrink-0 text-translucent-moderate"
-                  path={mdiWrench}
-                  size="sm"
-                />
-
-                <Typography
-                  appearance="moderate"
-                  className="grow"
-                  typographyType="body-sm"
-                >
-                  {t("Tools")}
-                </Typography>
-
+            <Panel
+              actions={() => (
                 <Button
                   buttonType="tertiary"
+                  filled="weak"
                   leftIconPath={mdiPlus}
-                  size="xs"
+                  size="sm"
                   title={t("Add tool")}
                   onClick={addNewTool}
                 />
-              </div>
-
+              )}
+              heading={t("Tools")}
+              iconPath={mdiWrench}
+              tooltip={t("Use the + button to add a new tool")}
+            >
               {unpinnedTools.length > 0 ? (
-                <div className="space-y-1">
-                  {unpinnedTools.map((starter) => (
-                    <ToolRow
-                      counter={counter}
-                      isPinned={false}
-                      isPrimary={false}
-                      isRunning={isToolRunning(starter)}
-                      isValid={isToolValid(starter)}
-                      key={starter.id}
-                      pinDisabled={maxPinnedReached}
-                      pinDisabledReason={t(
-                        "Max pinned tools reached ({{count}}/{{max}})",
-                        { count: pinnedCount, max: MAX_PINNED_TOOLS },
-                      )}
-                      starter={starter}
-                      onEdit={editTool}
-                      onRemove={removeTool}
-                      onRun={startTool}
-                      onSetPrimary={setToolPrimary}
-                      onTogglePin={togglePin}
-                    />
-                  ))}
-                </div>
+                unpinnedTools.map((starter) => (
+                  <ToolRow
+                    counter={counter}
+                    isPinned={false}
+                    isPrimary={false}
+                    isRunning={isToolRunning(starter)}
+                    isValid={isToolValid(starter)}
+                    key={starter.id}
+                    pinDisabled={maxPinnedReached}
+                    pinDisabledReason={t(
+                      "Max pinned tools reached ({{count}}/{{max}})",
+                      { count: pinnedCount, max: MAX_PINNED_TOOLS },
+                    )}
+                    starter={starter}
+                    onEdit={editTool}
+                    onRemove={removeTool}
+                    onRun={startTool}
+                    onSetPrimary={setToolPrimary}
+                    onTogglePin={togglePin}
+                  />
+                ))
               ) : (
                 <Typography appearance="subdued" typographyType="body-sm">
                   {t("Use the + button to add a new tool.")}
                 </Typography>
               )}
-            </div>
+            </Panel>
           </div>
         </div>
       </MainPage.Body>

--- a/src/stylesheets/ui/elements/button.css
+++ b/src/stylesheets/ui/elements/button.css
@@ -72,6 +72,7 @@
 
         &.nxm-button-icon-only {
             min-width: 0;
+            width: calc(var(--spacing) * 9);
         }
 
         &:not(.nxm-button-icon-only) .nxm-button-icon {
@@ -242,8 +243,16 @@
 
 .nxm-button-sm {
     min-height: calc(var(--spacing) * 7);
+
+    &.nxm-button-icon-only {
+        width: calc(var(--spacing) * 7);
+    }
 }
 
 .nxm-button-xs {
     min-height: calc(var(--spacing) * 6);
+
+    &.nxm-button-icon-only {
+        width: calc(var(--spacing) * 6);
+    }
 }

--- a/src/stylesheets/ui/elements/dropdown.css
+++ b/src/stylesheets/ui/elements/dropdown.css
@@ -128,7 +128,7 @@
         }
 
         &.nxm-dropdown-item-danger {
-            color: var(--color-danger-moderate);
+            color: var(--color-danger-strong);
 
             &:enabled:hover,
             &.nxm-dropdown-item-active {


### PR DESCRIPTION
### Summary

 - Restyle the Tools page with a new Panel component, page header with a "tools" pictogram, and cleaner section layout
  - Redesign ToolRow with a larger icon area showing the tool's first letter as fallback, improved layout with dividers, and bumped button/control sizes from xs to sm
  - Fix icon-only buttons rendering 2px wider with secondary (bordered) styles by setting an explicit square width matching min-height for each button size
  - Add new tools pictogram SVG asset and register it in the PictogramName type
  - Change dropdown danger item color from danger-moderate to danger-strong

Closes APP-332