### PR TITLE
Refresh IsValid check (exe is present) on deploy

### DIFF
--- a/src/renderer/src/views/components/Menu/useTools.ts
+++ b/src/renderer/src/views/components/Menu/useTools.ts
@@ -47,6 +47,7 @@ export const useTools = (
     discoveryPath,
     primaryToolId,
     pinnedToolsMap,
+    deploymentCounter,
   } = useToolsData();
 
   // Get all starters for validation
@@ -55,7 +56,7 @@ export const useTools = (
     [gameStarter, tools],
   );
 
-  const { isToolValid } = useToolsValidation(allStarters, discoveryPath);
+  const { isToolValid } = useToolsValidation(allStarters, discoveryPath, deploymentCounter);
 
   const { exclusiveRunning, isToolRunning } = useToolsRunning();
 

--- a/src/renderer/src/views/components/Menu/useToolsData.ts
+++ b/src/renderer/src/views/components/Menu/useToolsData.ts
@@ -22,6 +22,7 @@ export interface UseToolsDataResult {
   discoveryPath: string | undefined;
   primaryToolId: string | undefined;
   pinnedToolsMap: { [key: string]: boolean };
+  deploymentCounter: number;
 }
 
 /**
@@ -52,6 +53,10 @@ export const useToolsData = (): UseToolsDataResult => {
     (state: IState) =>
       state.settings?.interface?.tools?.pinned?.[gameId ?? ""] ?? {},
     shallowEqual,
+  );
+  const deploymentCounter = useSelector(
+    (state: IState) =>
+      state.persistent?.deployment?.deploymentCounter?.[gameId ?? ""] ?? 0,
   );
 
   const gameStarter = useMemo((): StarterInfo | undefined => {
@@ -145,5 +150,6 @@ export const useToolsData = (): UseToolsDataResult => {
     discoveryPath: gameDiscovery?.path,
     primaryToolId,
     pinnedToolsMap,
+    deploymentCounter,
   };
 };

--- a/src/renderer/src/views/components/Menu/useToolsValidation.ts
+++ b/src/renderer/src/views/components/Menu/useToolsValidation.ts
@@ -49,6 +49,7 @@ export interface UseToolsValidationResult {
 export const useToolsValidation = (
   starters: IStarterInfo[],
   discoveryPath: string | undefined,
+  deploymentCounter: number = 0,
 ): UseToolsValidationResult => {
   const [validToolIds, setValidToolIds] = useState<Set<string>>(
     () => new Set(),
@@ -66,7 +67,7 @@ export const useToolsValidation = (
     return () => {
       cancelled = true;
     };
-  }, [starters, discoveryPath]);
+  }, [starters, discoveryPath, deploymentCounter]);
 
   const isToolValid = useMemo(() => {
     return (info: IStarterInfo): boolean => {


### PR DESCRIPTION
It was a bit hard to repro, but I think I've fixed it. Basically there was a race condition with SMAPI/SKSE - we created the tool entity in Vortex and checked that the .exe exists before it actually got deployed. I've fixed it by re-checking that the .exe exists on deployment

Original bug was that the "make tool default launcher" was disabled sometimes