### PR TITLE
Change resolveGameFolders to use store/game QualifiedPath bases

### DIFF
--- a/packages/adaptor-api/src/contracts/game-paths.test.ts
+++ b/packages/adaptor-api/src/contracts/game-paths.test.ts
@@ -11,7 +11,7 @@ import type {
 describe("GameFolder", () => {
   it("is a union of well-known folder names", () => {
     expectTypeOf<GameFolder>().toEqualTypeOf<
-      "install" | "saves" | "preferences" | "config" | "cache"
+      "install" | "saves" | "preferences"
     >();
   });
 });
@@ -35,5 +35,11 @@ describe("IGamePathService", () => {
     expectTypeOf<
       IGamePathService["resolveGameFolders"]
     >().returns.resolves.toMatchTypeOf<GameFolderMap>();
+  });
+
+  it("accepts storeBase and gameBase QualifiedPath parameters", () => {
+    expectTypeOf<
+      IGamePathService["resolveGameFolders"]
+    >().parameters.toEqualTypeOf<[QualifiedPath, QualifiedPath]>();
   });
 });

--- a/packages/adaptor-api/src/contracts/game-paths.ts
+++ b/packages/adaptor-api/src/contracts/game-paths.ts
@@ -8,8 +8,6 @@ export const GameFolder = {
   install: "install",
   saves: "saves",
   preferences: "preferences",
-  config: "config",
-  cache: "cache",
 } as const;
 
 export type GameFolder = (typeof GameFolder)[keyof typeof GameFolder];
@@ -24,33 +22,49 @@ export type GameFolderMap = Partial<Record<GameFolder, QualifiedPath>> & {
 };
 
 /**
- * Adaptor-provided service that resolves a game's auxiliary folder paths
- * given a discovered installation location and the store that found it.
+ * Adaptor-provided service that resolves a game's folder paths given
+ * store-scoped and game-scoped base paths.
  *
  * Each game adaptor `@provides` this at its own URI
  * (e.g. `"vortex:adaptor/skyrim-se/paths"`).
  */
 export interface IGamePathService {
   /**
-   * Resolves the game's auxiliary folders relative to its installation.
+   * Resolves the game's folders by composing paths onto the store base.
    *
-   * @param store - Which store discovered the game (`"steam"`, `"epic"`, `"gog"`, `"xbox"`).
-   * @param installPath - The discovered game installation path
-   *   (e.g. `steam://SteamApps/common/Skyrim Special Edition/`).
-   * @returns A map of folder short names to qualified paths.
+   * The adaptor constructs store-scheme paths for each folder using
+   * well-known sub-paths on `storeBase`:
+   * - `storeBase/install` -- the game's install directory
+   * - `storeBase/home` -- OS home directory (`%USERPROFILE%`)
+   * - `storeBase/documents` -- OS Documents directory
+   * - `storeBase/my games` -- OS My Games directory
+   * - `storeBase/appData` -- OS AppData directory
+   *
+   * The framework builds a game resolver from the returned map by
+   * mapping each folder name onto `gameBase`:
+   * ```
+   * gameBase.join(folderName) → returned storePath
+   * ```
+   *
+   * @param storeBase - Store-scoped root path (e.g. `steam://1234`).
+   *   The adaptor joins OS bases and game-specific sub-paths onto this.
+   * @param gameBase - Game-scoped root path (e.g. `game://steam/1234`).
+   *   Passed for context; the framework uses it to build resolver mappings.
+   * @returns A map of folder short names to store-scheme qualified paths.
    *
    * @example
    * ```ts
+   * // storeBase = steam://1234
    * // A Skyrim SE adaptor might return:
    * {
-   *   [GameFolder.preferences]: QualifiedPath.parse("steam://documents/My Games/Skyrim Special Edition/"),
-   *   [GameFolder.saves]:       QualifiedPath.parse("steam://documents/My Games/Skyrim Special Edition/Saves/"),
-   *   [GameFolder.config]:      QualifiedPath.parse("steam://localAppData/Skyrim Special Edition/"),
+   *   [GameFolder.install]:     qpath`${storeBase}/install`,
+   *   [GameFolder.saves]:       qpath`${storeBase}/my games/Skyrim Special Edition/Saves`,
+   *   [GameFolder.preferences]: qpath`${storeBase}/appData/Local/Skyrim Special Edition`,
    * }
    * ```
    */
   resolveGameFolders(
-    store: string,
-    installPath: QualifiedPath,
+    storeBase: QualifiedPath,
+    gameBase: QualifiedPath,
   ): Promise<GameFolderMap>;
 }

--- a/packages/adaptors/cyberpunk2077/src/index.ts
+++ b/packages/adaptors/cyberpunk2077/src/index.ts
@@ -30,14 +30,13 @@ export class GameInfoService implements IGameInfoService {
 @provides("vortex:adaptor/cyberpunk2077/paths")
 export class GamePathService implements IGamePathService {
   resolveGameFolders(
-    _store: string,
-    installPath: QualifiedPath,
+    storeBase: QualifiedPath,
+    _gameBase: QualifiedPath,
   ): Promise<GameFolderMap> {
     return Promise.resolve({
-      [GameFolder.install]: installPath,
-      [GameFolder.config]: qpath`${installPath}/engine/config`,
-      [GameFolder.preferences]: qpath`${installPath}/engine/config/platform/pc`,
-      [GameFolder.saves]: qpath`${installPath}/saved_games`,
+      [GameFolder.install]: qpath`${storeBase}/install`,
+      [GameFolder.saves]: qpath`${storeBase}/home/Saved Games/CD Projekt Red/Cyberpunk 2077`,
+      [GameFolder.preferences]: qpath`${storeBase}/appData/Local/CD Projekt Red/Cyberpunk 2077`,
     });
   }
 }

--- a/src/renderer/src/extensions/adaptor_bridge/index.ts
+++ b/src/renderer/src/extensions/adaptor_bridge/index.ts
@@ -126,6 +126,60 @@ function gameIdFromUri(gameUri: string): string {
 }
 
 /**
+ * Looks up the store-specific game ID from the game info based on which
+ * store discovered the game. Returns `undefined` if the store is unknown
+ * or the game info lacks an entry for that store.
+ */
+function storeGameId(store: string, info: GameInfo): string | undefined {
+  if (store === "steam" && info.steam?.length) {
+    return String(info.steam[0].appId);
+  }
+  if (store === "gog" && info.gog?.length) {
+    return String(info.gog[0].gameId);
+  }
+  if (store === "epic" && info.epic?.length) {
+    return info.epic[0].catalogNamespace;
+  }
+  if (store === "xbox" && info.xbox?.length) {
+    return info.xbox[0].packageFamilyName;
+  }
+  return undefined;
+}
+
+/** Serialized QualifiedPath shape that survives IPC. */
+interface SerializedQualifiedPath {
+  value: string;
+  scheme: string;
+  path: string;
+}
+
+/**
+ * Constructs the store-scoped and game-scoped base QualifiedPaths used by
+ * adaptor services.
+ *
+ * - `storeBase`: e.g. `steam://1091500` -- the adaptor joins OS bases and
+ *   game-specific sub-paths onto this.
+ * - `gameBase`: e.g. `game://steam/1091500` -- the framework uses this to
+ *   build resolver mappings from the folder names returned by the adaptor.
+ */
+function buildBasePaths(
+  store: string,
+  id: string,
+): { storeBase: SerializedQualifiedPath; gameBase: SerializedQualifiedPath } {
+  const storeBase: SerializedQualifiedPath = {
+    value: `${store}://${id}`,
+    scheme: store,
+    path: "",
+  };
+  const gameBase: SerializedQualifiedPath = {
+    value: `game://${store}/${id}`,
+    scheme: "game",
+    path: "",
+  };
+  return { storeBase, gameBase };
+}
+
+/**
  * Converts adaptor store IDs into the queryArgs format that Vortex's
  * GameStoreHelper understands. This is how Vortex discovers installed
  * games on disk — it queries Steam, Epic, GOG, etc. with these IDs.
@@ -189,11 +243,7 @@ async function registerAdaptor(
 
   // Fetch game info eagerly — we need the game ID and store IDs
   // for registerGame which must happen synchronously during init
-  const info = (await callAdaptor(
-    name,
-    infoUri,
-    "getGameInfo",
-  )) as GameInfo;
+  const info = (await callAdaptor(name, infoUri, "getGameInfo")) as GameInfo;
 
   const gameId = gameIdFromUri(info.gameUri);
 
@@ -210,14 +260,21 @@ async function registerAdaptor(
   let cachedTools: GameToolsInfo | null = null;
 
   /** Resolves game folder paths. Called once after discovery. */
-  async function getFolders(
-    store: string,
-    gamePath: string,
-  ): Promise<GameFolderMap> {
+  async function getFolders(store: string): Promise<GameFolderMap> {
     if (!cachedFolders && pathsUri) {
+      const id = storeGameId(store, info);
+      if (!id) {
+        log(
+          "warn",
+          "[adaptor-bridge] No store-specific game ID for {{store}} on {{name}}, skipping folder resolution",
+          { store, name },
+        );
+        return {};
+      }
+      const { storeBase, gameBase } = buildBasePaths(store, id);
       cachedFolders = (await callAdaptor(name, pathsUri, "resolveGameFolders", [
-        store,
-        gamePath,
+        storeBase,
+        gameBase,
       ])) as GameFolderMap;
     }
     return cachedFolders ?? {};
@@ -264,9 +321,9 @@ async function registerAdaptor(
   context.registerGame({
     id: gameId,
     name: info.displayName,
-    logo: "",              // TODO: adaptor-provided logo
+    logo: "", // TODO: adaptor-provided logo
     executable: () => ".", // Placeholder — updated in setup after tools resolve
-    requiredFiles: [],     // Adaptors don't use file-based discovery
+    requiredFiles: [], // Adaptors don't use file-based discovery
     mergeMods: true,
     queryModPath: () => ".", // Actual paths come from mod type registrations
     queryArgs: buildQueryArgs(info), // Enables GameStoreHelper discovery
@@ -281,46 +338,52 @@ async function registerAdaptor(
      *
      * Resolution chain: paths → tools + mod types (both need folders)
      */
-    setup: (discovery) => Bluebird.resolve((async () => {
-      const store = discovery.store ?? "unknown";
-      const gamePath = discovery.path;
-      if (!gamePath) {
-        log("warn", `[adaptor-bridge] No discovery path for ${name}, skipping setup`);
-        return;
-      }
+    setup: (discovery) =>
+      Bluebird.resolve(
+        (async () => {
+          const store = discovery.store ?? "unknown";
+          const gamePath = discovery.path;
+          if (!gamePath) {
+            log(
+              "warn",
+              `[adaptor-bridge] No discovery path for ${name}, skipping setup`,
+            );
+            return;
+          }
 
-      // Step 1: Resolve folder paths (install, saves, config, etc.)
-      const folders = await getFolders(store, gamePath);
+          // Step 1: Resolve folder paths (install, saves, preferences, etc.)
+          const folders = await getFolders(store);
 
-      // Step 2: Resolve tools (depends on folders)
-      const tools = await getTools(folders);
+          // Step 2: Resolve tools (depends on folders)
+          const tools = await getTools(folders);
 
-      // Step 3: Wire the game executable from the tools service
-      if (tools) {
-        discovery.executable = tools.game.executable.path;
-      }
+          // Step 3: Wire the game executable from the tools service
+          if (tools) {
+            discovery.executable = tools.game.executable.path;
+          }
 
-      // Step 4: Populate supported tools
-      if (tools?.tools) {
-        for (const [toolId, tool] of Object.entries(tools.tools)) {
-          supportedTools.push({
-            id: `${gameId}-${toolId}`,
-            name: tool.name,
-            shortName: tool.shortName,
-            executable: () => tool.executable.path,
-            requiredFiles: (tool.requiredFiles ?? []).map((f) => f.path),
-            parameters: tool.parameters,
-            environment: tool.environment,
-            exclusive: tool.exclusive,
-            defaultPrimary: tool.defaultPrimary,
-            shell: tool.shell,
-            detach: tool.detach,
-            onStart: tool.onStart,
-            relative: true, // Always relative to game folder
-          });
-        }
-      }
-    })()),
+          // Step 4: Populate supported tools
+          if (tools?.tools) {
+            for (const [toolId, tool] of Object.entries(tools.tools)) {
+              supportedTools.push({
+                id: `${gameId}-${toolId}`,
+                name: tool.name,
+                shortName: tool.shortName,
+                executable: () => tool.executable.path,
+                requiredFiles: (tool.requiredFiles ?? []).map((f) => f.path),
+                parameters: tool.parameters,
+                environment: tool.environment,
+                exclusive: tool.exclusive,
+                defaultPrimary: tool.defaultPrimary,
+                shell: tool.shell,
+                detach: tool.detach,
+                onStart: tool.onStart,
+                relative: true, // Always relative to game folder
+              });
+            }
+          }
+        })(),
+      ),
   });
 }
 


### PR DESCRIPTION
## Summary

Refactors the `IGamePathService.resolveGameFolders` contract so adaptors receive **store-scoped and game-scoped base `QualifiedPath`s** instead of a raw store name string and install path. This lets adaptors express folder locations *outside* the game's install directory (saves in Documents, preferences in AppData, etc.) using the store's path scheme.

### Before

```ts
resolveGameFolders(store: string, installPath: QualifiedPath): Promise<GameFolderMap>
```

Adaptors received the store name and the discovered install path, and could only describe folders relative to the installation directory.

### After

```ts
resolveGameFolders(storeBase: QualifiedPath, gameBase: QualifiedPath): Promise<GameFolderMap>
```

- **`storeBase`** (e.g. `steam://1091500`) -- the adaptor joins well-known OS sub-paths onto this to describe where folders actually live on disk:

  | Sub-path | Resolves to |
  |---|---|
  | `storeBase/install` | Game install directory |
  | `storeBase/home` | `%USERPROFILE%` |
  | `storeBase/documents` | `%USERPROFILE%/Documents` |
  | `storeBase/my games` | `%USERPROFILE%/Documents/My Games` |
  | `storeBase/appData` | `%USERPROFILE%/AppData` |

- **`gameBase`** (e.g. `game://steam/1091500`) -- passed for context; the framework maps each returned folder name onto this to build the game resolver.

### Example (Cyberpunk 2077)

```ts
resolveGameFolders(storeBase, _gameBase) {
  return {
    [GameFolder.install]:     qpath`${storeBase}/install`,
    [GameFolder.saves]:       qpath`${storeBase}/home/Saved Games/CD Projekt Red/Cyberpunk 2077`,
    [GameFolder.preferences]: qpath`${storeBase}/appData/Local/CD Projekt Red/Cyberpunk 2077`,
  };
}
```

### Other changes

- Removes `GameFolder.config` and `GameFolder.cache` (zero consumers in the codebase).
- Adds `storeGameId()` helper to look up store-specific game IDs from `GameInfo` metadata.
- Adds `buildBasePaths()` to construct the serialized `QualifiedPath` pair for IPC.
- Updates type-level tests to match the new signature and reduced `GameFolder` union.
