### PR TITLE
fix gamebryo savegame metadata regression

### DIFF
--- a/extensions/gamebryo-savegame-management/src/actions/session.ts
+++ b/extensions/gamebryo-savegame-management/src/actions/session.ts
@@ -3,7 +3,8 @@ import { ISavegame } from "../types/ISavegame";
 
 export const setSavegames = createAction(
   "SET_SAVEGAMES",
-  (savegames: ISavegame[], truncated: boolean) => ({ savegames, truncated }),
+  (savegames: { [id: string]: ISavegame }, truncated: boolean) =>
+    ({ savegames, truncated }),
 );
 
 export const setSavegameAttribute = createAction(

--- a/extensions/gamebryo-savegame-management/src/index.ts
+++ b/extensions/gamebryo-savegame-management/src/index.ts
@@ -109,7 +109,7 @@ function updateSaves(
         const oldSaves: { [id: string]: ISavegame } = state.session.saves.saves;
 
         if (!saveDictEqual(oldSaves, savesDict)) {
-          store.dispatch(setSavegames(result.newSavegames, result.truncated));
+          store.dispatch(setSavegames(savesDict, result.truncated));
         }
         return Promise.resolve(result.failedReads);
       },


### PR DESCRIPTION
setSavegames was being dispatched with an ISavegame[] array, but the Redux state, reducers, and consumers all expect a
{ [id: string]: ISavegame } dictionary. With an array in state, the Table rendered basic metadata for each numeric index, and updateSavegame(id, fullSave) only attached string-keyed properties to the array, leaving the original rows stale. Only one enriched row survived React's row-key de-duplication — the single thumbnail the user saw.

Pass savesDict instead, and correct the action creator's type signature so the next call site can't make the same mistake.

closes https://linear.app/nexus-mods/issue/APP-335/savegame-list-thumbnail-and-plugins-only-render-for-one-entry