### PR TITLE
Create callback IPC channels

### DIFF
--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -73,10 +73,12 @@ function mainCallback<C extends keyof CallbackChannels>(
 ): Promise<AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>> {
   const collationId = args[0];
 
-  let resolve: (
-    value: AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>,
-  ) => void | undefined = undefined;
-  let reject: (reason?: Error) => void | undefined = undefined;
+  let resolve:
+    | ((
+        value: AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>,
+      ) => void)
+    | undefined = undefined;
+  let reject: ((reason?: Error) => void) | undefined = undefined;
 
   const promise = new Promise<
     AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>
@@ -85,23 +87,19 @@ function mainCallback<C extends keyof CallbackChannels>(
     reject = rej;
   });
 
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      if (reject) {
-        resolve = undefined;
+  const timer = setTimeout(() => {
+    if (reject) {
+      resolve = undefined;
 
-        reject(
-          new Error(
-            `Callback for channel '${channel}' timed out after ${timeout}ms`,
-          ),
-        );
+      reject(
+        new Error(
+          `Callback for channel '${channel}' timed out after ${timeout}ms`,
+        ),
+      );
 
-        reject = undefined;
-      }
-
-      resolve();
-    }, timeout);
-  }).catch(() => {});
+      reject = undefined;
+    }
+  }, timeout);
 
   const off = mainOn(`callback:${channel}`, (event, ...args) => {
     const { sender } = event;
@@ -112,15 +110,18 @@ function mainCallback<C extends keyof CallbackChannels>(
 
     const result = args[1];
     if (resolve) {
+      reject = undefined;
       resolve(
         result as AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>,
       );
+      resolve = undefined;
     }
   });
 
   mainSend(webContents, channel, ...args);
   return promise.finally(() => {
     off();
+    clearTimeout(timer);
   });
 }
 

--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -2,7 +2,6 @@ import type {
   RendererChannels,
   MainChannels,
   InvokeChannels,
-  SyncChannels,
   SerializableArgs,
   AssertSerializable,
 } from "@vortex/shared/ipc";
@@ -14,7 +13,6 @@ import { log } from "./logging";
 export const betterIpcMain = {
   on: mainOn,
   handle: mainHandle,
-  handleSync: mainHandleSync,
   send: mainSend,
 };
 
@@ -77,22 +75,6 @@ function mainHandle<C extends keyof InvokeChannels>(
       ipcLogger(logOptions, channel, event, args);
       assertTrustedSender(event);
       return listener(event, ...args);
-    },
-  );
-}
-
-function mainHandleSync<C extends keyof SyncChannels>(
-  channel: C,
-  listener: (
-    event: Electron.IpcMainEvent,
-    ...args: SerializableArgs<Parameters<SyncChannels[C]>>
-  ) => AssertSerializable<ReturnType<SyncChannels[C]>>,
-): void {
-  ipcMain.on(
-    channel,
-    (event, ...args: SerializableArgs<Parameters<SyncChannels[C]>>) => {
-      assertTrustedSender(event);
-      event.returnValue = listener(event, ...args);
     },
   );
 }

--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -4,6 +4,8 @@ import type {
   InvokeChannels,
   SerializableArgs,
   AssertSerializable,
+  CallbackChannels,
+  MainCallbackChannels,
 } from "@vortex/shared/ipc";
 
 import { ipcMain, type WebContents } from "electron";
@@ -14,6 +16,7 @@ export const betterIpcMain = {
   on: mainOn,
   handle: mainHandle,
   send: mainSend,
+  callback: mainCallback,
 };
 
 export type LogOptions = boolean | { includeArgs: boolean };
@@ -48,15 +51,77 @@ function mainOn<C extends keyof RendererChannels>(
     ...args: SerializableArgs<Parameters<RendererChannels[C]>>
   ) => void,
   logOptions: LogOptions = false,
-): void {
-  ipcMain.on(
-    channel,
-    (event, ...args: SerializableArgs<Parameters<RendererChannels[C]>>) => {
-      ipcLogger(logOptions, channel, event, args);
-      assertTrustedSender(event);
-      listener(event, ...args);
-    },
-  );
+): () => void {
+  const outerListener = (
+    event: Electron.IpcMainEvent,
+    ...args: SerializableArgs<Parameters<RendererChannels[C]>>
+  ) => {
+    ipcLogger(logOptions, channel, event, args);
+    assertTrustedSender(event);
+    listener(event, ...args);
+  };
+
+  ipcMain.on(channel, outerListener);
+  return () => ipcMain.off(channel, outerListener);
+}
+
+function mainCallback<C extends keyof CallbackChannels>(
+  channel: C,
+  webContents: WebContents,
+  timeout: number,
+  ...args: SerializableArgs<Parameters<MainCallbackChannels[C]>>
+): Promise<AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>> {
+  const collationId = args[0];
+
+  let resolve: (
+    value: AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>,
+  ) => void | undefined = undefined;
+  let reject: (reason?: Error) => void | undefined = undefined;
+
+  const promise = new Promise<
+    AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>
+  >((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  new Promise<void>((resolve) => {
+    setTimeout(() => {
+      if (reject) {
+        resolve = undefined;
+
+        reject(
+          new Error(
+            `Callback for channel '${channel}' timed out after ${timeout}ms`,
+          ),
+        );
+
+        reject = undefined;
+      }
+
+      resolve();
+    }, timeout);
+  }).catch(() => {});
+
+  const off = mainOn(`callback:${channel}`, (event, ...args) => {
+    const { sender } = event;
+    if (sender.id !== webContents.id) return;
+
+    const receivedCollationId = args[0];
+    if (receivedCollationId !== collationId) return;
+
+    const result = args[1];
+    if (resolve) {
+      resolve(
+        result as AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>,
+      );
+    }
+  });
+
+  mainSend(webContents, channel, ...args);
+  return promise.finally(() => {
+    off();
+  });
 }
 
 function mainHandle<C extends keyof InvokeChannels>(

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -16,30 +16,37 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./cli": {
+      "development": "./src/api/cli.ts",
       "import": "./dist/cli.js",
       "require": "./dist/cli.cjs"
     },
     "./errors": {
+      "development": "./src/api/errors.ts",
       "import": "./dist/errors.js",
       "require": "./dist/errors.cjs"
     },
     "./ipc": {
+      "development": "./src/api/ipc.ts",
       "import": "./dist/ipc.js",
       "require": "./dist/ipc.cjs"
     },
     "./preload": {
+      "development": "./src/api/preload.ts",
       "import": "./dist/preload.js",
       "require": "./dist/preload.cjs"
     },
     "./state": {
+      "development": "./src/api/state.ts",
       "import": "./dist/state.js",
       "require": "./dist/state.cjs"
     },
     "./telemetry": {
+      "development": "./src/api/telemetry.ts",
       "import": "./dist/telemetry.js",
       "require": "./dist/telemetry.cjs"
     },
@@ -56,20 +63,32 @@
   "publishConfig": {
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
+        "import": "./dist/index.js",
         "require": "./dist/index.cjs"
       },
+      "./cli": {
+        "import": "./dist/cli.js",
+        "require": "./dist/cli.cjs"
+      },
+      "./errors": {
+        "import": "./dist/errors.js",
+        "require": "./dist/errors.cjs"
+      },
       "./ipc": {
-        "import": "./dist/ipc.mjs",
+        "import": "./dist/ipc.js",
         "require": "./dist/ipc.cjs"
       },
       "./preload": {
-        "import": "./dist/preload.mjs",
+        "import": "./dist/preload.js",
         "require": "./dist/preload.cjs"
       },
       "./state": {
-        "import": "./dist/state.mjs",
+        "import": "./dist/state.js",
         "require": "./dist/state.cjs"
+      },
+      "./telemetry": {
+        "import": "./dist/telemetry.js",
+        "require": "./dist/telemetry.cjs"
       },
       "./package.json": "./package.json"
     }

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -87,8 +87,28 @@ export type VortexPaths = {
   desktop: string;
 };
 
+export interface CallbackChannels {
+  "example:ping": (ping: string) => Promise<{ pong: string }>;
+}
+
+export type MainCallbackChannels = {
+  [C in keyof CallbackChannels]: CallbackChannels[C] extends (
+    ...args: infer Args
+  ) => Promise<infer _Return>
+    ? (collationId: number, ...args: Args) => void
+    : never;
+};
+
+export type RendererCallbackChannels = {
+  [C in keyof CallbackChannels as `callback:${C}`]: CallbackChannels[C] extends (
+    ...args: infer _Args
+  ) => Promise<infer Return>
+    ? (collationId: number, result: Return) => void
+    : never;
+};
+
 /** Type containing all known channels used by renderer processes to send messages to the main process */
-export interface RendererChannels {
+export interface RendererChannels extends RendererCallbackChannels {
   // NOTE(erri120): Parameters must be serializable and return values must be void.
 
   /** Logs a message */
@@ -130,7 +150,7 @@ export interface RendererChannels {
 }
 
 /** Type containing all known channels used by the main process to send messages to a renderer process */
-export interface MainChannels {
+export interface MainChannels extends MainCallbackChannels {
   // NOTE(erri120): Parameters must be serializable and return values must be void.
 
   // Examples:

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -189,7 +189,7 @@ export interface MainChannels extends MainCallbackChannels {
   "menu:click": (menuItemId: string) => void;
 }
 
-/* Type containing all known channels used by renderer processes to send to and receive messages from the main process */
+/** Type containing all known channels used by renderer processes to send to and receive messages from the main process */
 export interface InvokeChannels {
   // NOTE(erri120): Parameters must be serializable and return values must be Promises resolving serializable content.
 

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -169,14 +169,7 @@ export interface MainChannels {
   "menu:click": (menuItemId: string) => void;
 }
 
-/** Type containing all known channels for synchronous IPC operations (used primarily by preload scripts) */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface SyncChannels {
-  // NOTE: These are synchronous IPC channels used during preload initialization.
-  // Use sparingly as they block the renderer process.
-}
-
-/** Type containing all known channels used by renderer processes to send to and receive messages from the main process */
+/* Type containing all known channels used by renderer processes to send to and receive messages from the main process */
 export interface InvokeChannels {
   // NOTE(erri120): Parameters must be serializable and return values must be Promises resolving serializable content.
 

--- a/src/shared/tsdown.config.ts
+++ b/src/shared/tsdown.config.ts
@@ -10,7 +10,9 @@ const config: UserConfig = defineConfig({
   dts: {
     sourcemap: true,
   },
-  exports: true,
+  exports: {
+    devExports: "development",
+  },
   platform: "neutral",
 });
 


### PR DESCRIPTION
Closes APP-336.

Adds a mechanism for callbacks across IPC. Required for the downloader.