### PR TITLE
fixed several race conditions when switching collection revisions

### DIFF
--- a/extensions/collections/src/eventHandlers.ts
+++ b/extensions/collections/src/eventHandlers.ts
@@ -1,7 +1,10 @@
 import { ICollection, IDownloadURL, IRevision } from "@nexusmods/nexus-api";
 import Bluebird from "bluebird";
-import { actions, selectors, types, util } from "vortex-api";
+import * as path from "path";
+import { actions, fs, selectors, types, util } from "vortex-api";
 import InstallDriver from "./util/InstallDriver";
+import { readCollection } from "./util/importCollection";
+import { collectionModToRule } from "./util/transformCollection";
 import showChangelog from "./views/InstallDialog/InstallChangelogDialog";
 
 async function collectionUpdate(
@@ -90,21 +93,43 @@ async function collectionUpdate(
       "Update Collection",
     );
 
-    const oldRules = oldMod?.rules ?? [];
+    // Determine obsolete mods and clean up BEFORE installing the new revision.
+    // This prevents a race condition where did-install-mod starts the InstallDriver
+    // concurrently with the cleanup below.
 
-    const newModId = await util.toPromise<string | undefined>((cb) =>
-      api.events.emit("start-install-download", dlId, undefined, cb),
+    // Extract collection.json from the downloaded archive to get the new revision's
+    // full mod list (including tags, external and bundled mods).
+    const dlPath = selectors.downloadPathForGame(
+      api.getState(),
+      downloadGameId,
+    );
+    const localPath =
+      api.getState().persistent.downloads.files[dlId]?.localPath;
+    const archivePath = path.join(dlPath, localPath);
+    const tempDir = path.join(
+      util.getVortexPath("temp"),
+      "collection-update-" + oldModId,
     );
 
-    // remove old revision and mods installed for the old revision that are no longer required
-
-    const mods = api.getState().persistent.mods[gameMode];
-
-    if (newModId === undefined || mods[newModId] === undefined) {
-      throw new util.ProcessCanceled(
-        "Download failed, update archive not found",
+    let newRules: types.IModRule[];
+    const szip = new util.SevenZip();
+    await szip.extractFull(archivePath, tempDir);
+    try {
+      const newCollectionData = await readCollection(
+        api,
+        path.join(tempDir, "collection.json"),
       );
+      const knownGames = selectors.knownGames(api.getState());
+      newRules = newCollectionData.mods.map((mod) =>
+        collectionModToRule(knownGames, mod),
+      );
+    } catch (err) {
+      await fs.removeAsync(tempDir).catch(() => undefined);
+      throw err;
     }
+
+    const oldRules = oldMod?.rules ?? [];
+    const mods = api.getState().persistent.mods[gameMode];
 
     // candidates is any mod that is depended upon by the old revision that was installed
     // as a dependency
@@ -118,8 +143,7 @@ async function collectionUpdate(
       );
 
     const notCandidates = Object.values(mods).filter(
-      (mod) =>
-        !candidates.includes(mod) && ![oldModId, newModId].includes(mod.id),
+      (mod) => !candidates.includes(mod) && mod.id !== oldModId,
     );
 
     const references = (rules: types.IModRule[], mod: types.IMod) =>
@@ -133,13 +157,15 @@ async function collectionUpdate(
     const obsolete = candidates
       // see if there is a mod outside candidates that requires it but before anything we
       // check the new version of the collection because that's the most likely to require it
-      .filter((mod) => !references(mods[newModId].rules, mod))
+      .filter((mod) => !references(newRules, mod))
       .filter(
         (mod) =>
           notCandidates
             // that depends upon the candidate,
             .find((other) => references(other.rules, mod)) === undefined,
       );
+
+    await fs.removeAsync(tempDir).catch(() => undefined);
 
     let ops = { remove: [], keep: [] };
 
@@ -223,12 +249,52 @@ async function collectionUpdate(
       ),
     );
 
+    // Snapshot which optional mods are enabled before removing the old collection
+    const profile = selectors.activeProfile(api.getState());
+    const enabledOptionalMods: string[] = candidates
+      .filter((mod) => {
+        const isOptional = oldRules.some(
+          (r) =>
+            r.type === "recommends" &&
+            util.testModReference(mod, r.reference),
+        );
+        return (
+          isOptional &&
+          util.getSafe(profile?.modState, [mod.id, "enabled"], false)
+        );
+      })
+      .map((mod) => mod.id);
+
+    // Remove old collection and obsolete mods
     await util.toPromise((cb) =>
       api.events.emit("remove-mods", gameMode, [oldModId, ...ops.remove], cb, {
         incomplete: true,
         ignoreInstalling: true,
       }),
     );
+
+    // Install the new revision — did-install-mod will start the driver
+    // cleanly since cleanup is already done
+    const newModId = await util.toPromise<string | undefined>((cb) =>
+      api.events.emit("start-install-download", dlId, undefined, cb),
+    );
+
+    if (newModId === undefined) {
+      throw new util.ProcessCanceled(
+        "Download failed, update archive not found",
+      );
+    }
+
+    // Restore enabled state for optional mods that survived the update
+    if (profile !== undefined && enabledOptionalMods.length > 0) {
+      const currentMods = api.getState().persistent.mods[gameMode];
+      util.batchDispatch(
+        api.store,
+        enabledOptionalMods
+          .filter((id) => currentMods?.[id] !== undefined)
+          .map((id) => actions.setModEnabled(profile.id, id, true)),
+      );
+    }
   } catch (err) {
     if (!(err instanceof util.UserCanceled)) {
       api.showErrorNotification("Failed to download collection", err, {

--- a/extensions/collections/src/reducers/persistent.ts
+++ b/extensions/collections/src/reducers/persistent.ts
@@ -21,7 +21,7 @@ const persistentReducer: types.IReducerSpec = {
       const { revisionId, revisionInfo, timestamp } = payload;
 
       if (revisionInfo === undefined) {
-        return util.deleteOrNop(state, ["revisions", "revisionId"]);
+        return util.deleteOrNop(state, ["revisions", revisionId]);
       } else {
         return util.setSafe(state, ["revisions", revisionId], {
           timestamp,

--- a/extensions/collections/src/util/InstallDriver.ts
+++ b/extensions/collections/src/util/InstallDriver.ts
@@ -1109,9 +1109,15 @@ class InstallDriver {
       ["requires", "recommends"].includes(rule.type),
     );
     const dependencies: types.IModRule[] = required.reduce((accum, rule) => {
+      // Mods with binary patches are always reinstalled as variants so the
+      // correct diffs are applied to clean files.
+      if (rule.extra?.patches != null) {
+        accum.push(rule);
+        return accum;
+      }
       const modRef: any = {
         ...rule.reference,
-        patches: rule?.extra?.patches ? { ...rule.extra.patches } : undefined,
+        patches: undefined,
         fileList: rule?.fileList,
       };
       const mod = util.findModByRef(modRef, mods);

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1674,13 +1674,14 @@ class InstallManager {
                   installingFileId = fileId;
                   const isCollection = modInfo.revisionId !== undefined;
 
+                  // Collections handle their own update flow via collectionUpdate
+                  // in the collections extension — skip previous version detection.
                   existingMod =
-                    fileId !== undefined
+                    fileId !== undefined && !isCollection
                       ? this.findPreviousVersionMod(
                           fileId,
                           api.store,
                           installGameId,
-                          isCollection,
                           modInfo.modId,
                           modInfo.logicalFileName,
                         )
@@ -1697,6 +1698,11 @@ class InstallManager {
                       },
                       iter,
                     ) => {
+                      // Skip the source collection when checking dependents — it's
+                      // being updated itself so its rules will be replaced.
+                      if (iter === sourceModId) {
+                        return prev;
+                      }
                       const depRule = (mods[iter].rules ?? []).find(
                         (rule) =>
                           rule.type === "requires" &&
@@ -2670,15 +2676,22 @@ class InstallManager {
           }
 
           const sourceMod = api.getState().persistent.mods[gameId][sourceModId];
-          // Check if mod is already installed with matching installer choices and patches
           const mods = api.getState().persistent.mods[gameId];
+
+          // Mods with patches are always reinstalled as variants so the
+          // correct diffs are applied to clean files - skip the lookup.
+          const hasPatches =
+            currentDep.patches != null &&
+            Object.keys(currentDep.patches).length > 0;
           const fullReference: IModReference = {
             ...currentDep.reference,
             installerChoices: currentDep.installerChoices,
             patches: currentDep.patches,
             fileList: currentDep.fileList,
           };
-          const existingMod = findModByRef(fullReference, mods);
+          const existingMod = hasPatches
+            ? undefined
+            : findModByRef(fullReference, mods);
           const modId =
             existingMod != null
               ? existingMod.id
@@ -2780,6 +2793,21 @@ class InstallManager {
 
             // Clear retry counter on successful installation
             this.mDependencyRetryCount.delete(installKey);
+
+            // When the mod was already installed (existingMod found), we still
+            // need to signal completion so session tracking updates its status
+            // from "downloaded" to "installed". Without this, retained mods get
+            // stuck in "downloaded" state and are requeued indefinitely.
+            // Skip for newly-installed mods — installModAsync already emits.
+            if (existingMod != null) {
+              api.events.emit(
+                "did-install-mod",
+                gameId,
+                downloadId,
+                modId,
+                api.getState().persistent.mods[gameId]?.[modId]?.attributes,
+              );
+            }
           }
 
           this.mActiveInstalls.delete(installKey);
@@ -4921,60 +4949,45 @@ class InstallManager {
 
   private findPreviousVersionMod(
     fileId: number,
-    store: Redux.Store<any>,
+    store: Redux.Store<IState>,
     gameMode: string,
-    isCollection: boolean,
     nexusModId?: number,
     logicalFileName?: string,
-  ): IMod {
-    const mods = store.getState().persistent.mods[gameMode] || {};
-    // This is not great, but we need to differentiate between revisionIds and fileIds
-    //  as it's perfectly possible for a collection's revision id to match a regular
-    //  mod's fileId resulting in false positives and therefore mashed up metadata.
-    const filterFunc = (modId: string) =>
-      isCollection
-        ? mods[modId].type === "collection"
-        : mods[modId].type !== "collection";
-    let mod: IMod;
-    Object.keys(mods)
-      .filter(filterFunc)
-      .forEach((key) => {
-        // TODO: fileId/revisionId can potentially be more up to date than the last
-        //  known "newestFileId" property if the curator/mod author has released a new
-        //  version of his collection/mod since the last time the user checked for updates
-        const newestFileId: number = mods[key].attributes?.newestFileId;
-        const currentFileId: number =
-          mods[key].attributes?.fileId ?? mods[key].attributes?.revisionId;
-        if (newestFileId !== currentFileId && newestFileId === fileId) {
-          mod = mods[key];
-        }
-        // Also detect same-file different-version by Nexus modId + logicalFileName.
-        // logicalFileName identifies the specific file on a mod page, so matching both
-        // avoids false positives when a mod page hosts multiple unrelated files.
-        if (
-          mod === undefined &&
-          nexusModId != null &&
-          logicalFileName != null
-        ) {
-          const installedModId: number = mods[key].attributes?.modId;
-          const installedLogicalFileName: string =
-            mods[key].attributes?.logicalFileName;
-          const installedFileId: number = mods[key].attributes?.fileId;
-          if (
-            installedModId === nexusModId &&
-            installedLogicalFileName === logicalFileName &&
-            installedFileId !== fileId
-          ) {
-            mod = mods[key];
-          }
-        }
-      });
+  ): IMod | undefined {
+    const mods = (store.getState().persistent.mods[gameMode] || {}) as Record<string, IMod>;
 
-    return mod;
+    const candidates: IMod[] = Object.values(mods).filter(
+      (m: IMod) => m.type !== "collection",
+    );
+
+    // Primary: the update check already told us which fileId is newest
+    const byNewestId: IMod | undefined = candidates.find((m: IMod) => {
+      const newestFileId: number | undefined = m.attributes?.newestFileId;
+      const currentFileId: number | undefined = m.attributes?.fileId;
+      return newestFileId !== currentFileId && newestFileId === fileId;
+    });
+    if (byNewestId !== undefined) {
+      return byNewestId;
+    }
+
+    // Fallback: same Nexus mod page, different file. Use logicalFileName as a
+    // tiebreaker when available to avoid false positives on pages that host
+    // multiple unrelated files.
+    if (nexusModId != null) {
+      return candidates.find(
+        (m: IMod) =>
+          m.attributes?.modId === nexusModId &&
+          (logicalFileName == null ||
+            m.attributes?.logicalFileName === logicalFileName) &&
+          m.attributes?.fileId !== fileId,
+      );
+    }
+
+    return undefined;
   }
 
   private queryIgnoreDependent(
-    store: ThunkStore<any>,
+    store: ThunkStore<IState>,
     gameId: string,
     dependents: Array<{ owner: string; rule: IModRule }>,
   ): Promise<void> {
@@ -5041,7 +5054,7 @@ class InstallManager {
     });
   }
 
-  private queryProfileCount(store: ThunkStore<any>): number {
+  private queryProfileCount(store: ThunkStore<IState>): number {
     const state = store.getState();
     const profiles = gameProfiles(state);
     return profiles.length;
@@ -5049,7 +5062,7 @@ class InstallManager {
 
   private userVersionChoice(
     oldMod: IMod,
-    store: ThunkStore<any>,
+    store: ThunkStore<IState>,
   ): Promise<string> {
     const totalProfiles = this.queryProfileCount(store);
     const batchAction = "remember-user-version-choice-action";
@@ -5071,7 +5084,7 @@ class InstallManager {
     const rememberAction = context?.get?.(batchAction);
     return rememberAction
       ? Promise.resolve(rememberAction)
-      : totalProfiles === 1
+      : totalProfiles === 1 && oldMod.type !== "collection"
         ? Promise.resolve(REPLACE_ACTION)
         : new Promise<string>((resolve, reject) => {
             store
@@ -6780,6 +6793,14 @@ class InstallManager {
               dependency: dep.reference.logicalFileName,
               downloadId,
             });
+          }
+
+          // Mods with patches are always reinstalled as variants so the
+          // correct diffs are applied to clean files. Clear any existing mod
+          // match so they flow through to queueInstallation regardless of
+          // whether the tag matched above.
+          if (dep.patches != null && Object.keys(dep.patches).length > 0) {
+            dep.mod = undefined;
           }
 
           return dep.mod == null

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -805,6 +805,10 @@ function processAttributes(
         nexusCollectionInfo?.revisionNumber?.toString?.(),
       allowRating: input?.download?.modInfo?.nexus?.modInfo?.allow_rating,
       customFileName: fuzzRatio < 50 ? `${modName} - ${fileName}` : undefined,
+      newestFileId:
+        nexusCollectionInfo?.collection?.latestPublishedRevision?.id,
+      newestVersion:
+        nexusCollectionInfo?.collection?.latestPublishedRevision?.revisionNumber?.toString?.(),
       rating: nexusCollectionInfo?.rating,
       requirements: nexusModInfo?.requirements,
     };


### PR DESCRIPTION
Several bugs prevented collection updates from working correctly. Especially for collections that include binary patches.

Fixed:
- Patched mods (e.g. binary diff variants) were not always reinstalled during a collection update, leaving stale files
- A race condition could cause the install driver to start processing dependencies before old mods were cleaned up
- Optional mods lost their enabled state after updating a collection
- Collection update notification could appear even when already on the latest revision
- Collection installing activity would run indefinitely in some cases

fixes https://linear.app/nexus-mods/issue/APP-345/collection-update-paths-multiple-bugs-across-normal-and-add-to