### PR TITLE
guard against undefined collection rules during install window

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -436,7 +436,7 @@ function findCollectionByDownload(
 
     // Download lookups will not hold any patch/filelist/installerChoices info.
     //  Which is why in this case we want to ensure that we only match using regular reference fields.
-    const matchingRule = collectionMod.rules.find((rule) => {
+    const matchingRule = collectionMod.rules?.find((rule) => {
       const { patches, fileList, installerChoices, ...refWithoutExtras } =
         rule.reference;
       return testModReference(lookup, refWithoutExtras);
@@ -643,7 +643,7 @@ class InstallManager {
 
         const filtered = rules.filter(
           (iter) =>
-            collection.rules.find((rule) => _.isEqual(iter, rule)) !==
+            collection.rules?.find((rule) => _.isEqual(iter, rule)) !==
             undefined,
         );
 


### PR DESCRIPTION
fixes a crash when downloading collection mods if the collection is being reinstalled or updated at the same time.

fixes https://github.com/Nexus-Mods/Vortex/issues/22505