### PR TITLE
Create IPC download adapter

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -53,7 +53,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | fs-extra | 9.1.0 |
 | fuzzball | 1.4.0 |
 | glob | 11.1.0 |
-| got | 15.0.0 |
+| got | 15.0.2 |
 | graphlib | 2.1.8 |
 | i18next | 19.9.2 |
 | i18next-fs-backend | 2.6.1 |
@@ -73,7 +73,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | mixpanel-browser | 2.77.0 |
 | modmeta-db | 0.9.3 |
 | native-errors | 2.0.3 |
-| node-7z | 0.8.0 |
+| node-7z | 0.8.1 |
 | normalize-url | 6.1.0 |
 | numeral | 2.0.6 |
 | p-queue | 9.1.0 |
@@ -114,6 +114,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | string-template | 1.0.0 |
 | tailwindcss | 4.2.2 |
 | tmp | 0.1.0 |
+| tough-cookie | 6.0.1 |
 | turbowalk | 3.1.1 |
 | universal-analytics | 0.4.23 |
 | uuid | 3.4.0 |

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -2235,6 +2235,11 @@ interface IExtensionContext {
     registerDashlet: RegisterDashlet;
     registerDeploymentMethod: (method: IDeploymentMethod) => void;
     registerDialog: RegisterDialog;
+    registerDownloadProtocol: (scheme: string, handler: (inputUrl: string, name: string, friendlyName: string) => PromiseLike<{
+        urls: string[];
+        updatedUrl?: string;
+        meta: unknown;
+    }>) => void;
     registerFooter: RegisterFooter;
     registerGame: (game: IGame) => void;
     registerGameInfoProvider: (id: string, priority: number, expireMS: number, keys: string[], query: GameInfoQuery) => void;

--- a/src/main/src/downloading/ipc.ts
+++ b/src/main/src/downloading/ipc.ts
@@ -14,6 +14,7 @@ import { staticChunker } from "@vortex/shared/download";
 import type { DownloadManager } from "./manager";
 
 import { betterIpcMain } from "../ipc";
+import { log } from "../logging";
 
 function wireToResolvedEndpoint(wire: WireEndpoint): ResolvedEndpoint {
   return { url: new URL(wire.url), headers: wire.headers };
@@ -50,6 +51,9 @@ export function init(manager: DownloadManager): void {
     const resolver = () => Promise.resolve(resource);
     const handle = manager.download(resource, dest, resolver);
     webContentsByDownloadId.set(handle.downloadId, webContents);
+    handle.promise.catch((err) =>
+      log("error", "download failed", { downloadId: handle.downloadId, err }),
+    );
     return { downloadId: handle.downloadId };
   });
 
@@ -93,8 +97,11 @@ export function init(manager: DownloadManager): void {
         etag: wireCheckpoint.etag,
       };
       const resolver = () => Promise.resolve(resource);
-      manager.resume(checkpoint, resolver, staticChunker());
+      const handle = manager.resume(checkpoint, resolver, staticChunker());
       webContentsByDownloadId.set(wireCheckpoint.downloadId, webContents);
+      handle.promise.catch((err) =>
+        log("error", "download failed", { downloadId: wireCheckpoint.downloadId, err }),
+      );
     },
   );
 

--- a/src/main/src/downloading/ipc.ts
+++ b/src/main/src/downloading/ipc.ts
@@ -36,11 +36,9 @@ function wireToResolvedResource(wire: WireResolvedResource): ResolvedResource {
 export function init(manager: DownloadManager): void {
   const timeout = 30_000;
 
-  let nextCollationId = 0;
   const webContentsByDownloadId = new Map<string, WebContents>();
 
-  betterIpcMain.handle("download:start", async (event, dest) => {
-    const collationId = nextCollationId++;
+  betterIpcMain.handle("download:start", async (event, dest, collationId) => {
     const webContents = event.sender;
     const wireResource = await betterIpcMain.callback(
       "download:resolve",
@@ -52,7 +50,7 @@ export function init(manager: DownloadManager): void {
     const resolver = () => Promise.resolve(resource);
     const handle = manager.download(resource, dest, resolver);
     webContentsByDownloadId.set(handle.downloadId, webContents);
-    return { downloadId: handle.downloadId, collationId };
+    return { downloadId: handle.downloadId };
   });
 
   betterIpcMain.handle("download:cancel", (_event, downloadId) => {
@@ -76,27 +74,29 @@ export function init(manager: DownloadManager): void {
     return wire;
   });
 
-  betterIpcMain.handle("download:resume", async (event, wireCheckpoint) => {
-    const collationId = nextCollationId++;
-    const webContents = event.sender;
-    const wireResource = await betterIpcMain.callback(
-      "download:resolve",
-      webContents,
-      timeout,
-      collationId,
-    );
-    const resource = wireToResolvedResource(wireResource);
-    const checkpoint = {
-      downloadId: wireCheckpoint.downloadId,
-      resource,
-      dest: wireCheckpoint.dest,
-      completedRanges: wireCheckpoint.completedRanges,
-      etag: wireCheckpoint.etag,
-    };
-    const resolver = () => Promise.resolve(resource);
-    manager.resume(checkpoint, resolver, staticChunker());
-    webContentsByDownloadId.set(wireCheckpoint.downloadId, webContents);
-  });
+  betterIpcMain.handle(
+    "download:resume",
+    async (event, wireCheckpoint, collationId) => {
+      const webContents = event.sender;
+      const wireResource = await betterIpcMain.callback(
+        "download:resolve",
+        webContents,
+        timeout,
+        collationId,
+      );
+      const resource = wireToResolvedResource(wireResource);
+      const checkpoint = {
+        downloadId: wireCheckpoint.downloadId,
+        resource,
+        dest: wireCheckpoint.dest,
+        completedRanges: wireCheckpoint.completedRanges,
+        etag: wireCheckpoint.etag,
+      };
+      const resolver = () => Promise.resolve(resource);
+      manager.resume(checkpoint, resolver, staticChunker());
+      webContentsByDownloadId.set(wireCheckpoint.downloadId, webContents);
+    },
+  );
 
   betterIpcMain.handle("download:getProgress", (_event, downloadId) => {
     const handle = manager.get(downloadId);

--- a/src/main/src/downloading/manager.ts
+++ b/src/main/src/downloading/manager.ts
@@ -314,7 +314,7 @@ export class DownloadManager {
     this.#downloads.set(downloadId, handle);
 
     // Handle terminal status transitions not covered by cancel() or pause().
-    // Only updates status if it is still "running" — explicit control operations
+    // Only updates status if it is still "running" - explicit control operations
     // (cancel/pause) set status synchronously before aborting, so they take
     // precedence.
     void rawPromise.then(

--- a/src/main/src/downloading/manager.ts
+++ b/src/main/src/downloading/manager.ts
@@ -19,6 +19,7 @@ import type { DownloadStatus } from "./progress";
 import { download } from "./downloader";
 import { ProgressReporter } from "./progress";
 import { defaultRetryStrategy } from "./retry";
+import { log } from "../logging";
 
 export type DownloadState = DownloadProgress & { status: DownloadStatus };
 
@@ -205,7 +206,10 @@ export class DownloadManager {
     const progressReporter = new ProgressReporter();
     const abortController = new AbortController();
 
+    log("debug", "queuing download", { downloadId, dest });
+
     const rawPromise = this.#downloadQueue.add(() => {
+      log("debug", "download starting", { downloadId });
       progressReporter.status = "running";
       return download(
         resource,
@@ -241,6 +245,7 @@ export class DownloadManager {
 
     const cancel = (): DownloadState => {
       if (progressReporter.status === "running") {
+        log("debug", "cancelling download", { downloadId });
         progressReporter.status = "canceled";
         abortController.abort();
       }
@@ -290,10 +295,12 @@ export class DownloadManager {
         };
       }
 
+      log("debug", "pausing download", { downloadId });
       progressReporter.status = "paused";
       abortController.abort();
       // Wait for the download to fully settle (settled never rejects).
       await settled;
+      log("debug", "download paused", { downloadId });
 
       return {
         ...progressReporter.getProgress(),
@@ -319,14 +326,17 @@ export class DownloadManager {
     // precedence.
     void rawPromise.then(
       () => {
+        log("debug", "download completed", { downloadId });
         progressReporter.status = "completed";
       },
       (err) => {
         if (progressReporter.status !== "running") return;
-        progressReporter.status =
-          err instanceof DownloadError && err.code === "cancellation"
-            ? "canceled"
-            : "failed";
+        const isCancellation =
+          err instanceof DownloadError && err.code === "cancellation";
+        progressReporter.status = isCancellation ? "canceled" : "failed";
+        if (!isCancellation) {
+          log("warn", "download failed", { downloadId, err });
+        }
       },
     );
 

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -284,11 +284,12 @@ try {
     },
 
     downloader: {
-      start: (dest) => betterIpcRenderer.invoke("download:start", dest),
+      start: (dest, collationId) =>
+        betterIpcRenderer.invoke("download:start", dest, collationId),
       pause: (downloadId) =>
         betterIpcRenderer.invoke("download:pause", downloadId),
-      resume: (checkpoint) =>
-        betterIpcRenderer.invoke("download:resume", checkpoint),
+      resume: (checkpoint, collationId) =>
+        betterIpcRenderer.invoke("download:resume", checkpoint, collationId),
       cancel: (downloadId) =>
         betterIpcRenderer.invoke("download:cancel", downloadId),
       onResolve: (handler) => {

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -134,6 +134,7 @@ import {
   wrapExtCBSync,
 } from "./util/util";
 import { webpackRequireHack } from "./util/webpack-hacks";
+import { IPCDownloadAdapter } from "./IPCDownloadAdapter";
 
 const modmeta = lazyRequire<typeof modmetaT>(() => require("modmeta-db"));
 
@@ -711,6 +712,7 @@ class ContextProxyHandler implements ProxyHandler<any> {
       registerLoadOrder: undefined,
       registerGameSpecificCollectionsData: undefined,
       registerHistoryStack: undefined,
+      registerDownloadProtocol: undefined,
       registerAPI: undefined,
       requireVersion: undefined,
       requireExtension: undefined,
@@ -788,6 +790,7 @@ class ExtensionManager {
   private mModDBAPIKey: string;
   private mModDBCache: { [id: string]: ILookupResult[] } = {};
   private mContextProxyHandler: ContextProxyHandler;
+  private mDownloadAdapter: IPCDownloadAdapter;
   private mExtensionState: { [extId: string]: IExtensionState };
   private mLoadFailures: { [extId: string]: IExtensionLoadFailure[] } = {};
   private mOptionalExtensions: { [extId: string]: IExtensionOptional[] } = {};
@@ -900,6 +903,8 @@ class ExtensionManager {
       ext: {},
       NAMESPACE: "common",
     };
+
+    this.mDownloadAdapter = new IPCDownloadAdapter(this.mApi);
 
     // Use provided extension state directly (renderer-only architecture)
     // Extensions that need to be removed will be handled when setStore() is called
@@ -1228,6 +1233,12 @@ class ExtensionManager {
    */
   public applyExtensionsOfExtensions() {
     this.mContextProxyHandler.invokeAdditions(this.mExtensions);
+    this.mContextProxyHandler
+      .getCalls("registerDownloadProtocol")
+      .forEach((call) => {
+        const [scheme, handler] = call.arguments as [string, Parameters<IPCDownloadAdapter["registerProtocol"]>[1]];
+        this.mDownloadAdapter.registerProtocol(scheme, handler);
+      });
   }
 
   /**

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -1,0 +1,176 @@
+import type { WireResolvedResource } from "@vortex/shared/ipc";
+
+import { unknownToError } from "@vortex/shared";
+import * as path from "node:path";
+import { z } from "zod";
+
+import type { IProtocolHandlers } from "./extensions/download_management/types/ProtocolHandlers";
+import type { IExtensionApi } from "./types/IExtensionContext";
+
+import { downloadPathForGame } from "./extensions/download_management/selectors";
+import { activeGameId } from "./extensions/profile_management/selectors";
+import { log } from "./logging";
+
+const modInfoSchema = z
+  .looseObject({
+    game: z.string().optional(),
+    name: z.string().optional(),
+  })
+  .catch({ game: undefined, name: undefined });
+
+type ModInfo = z.infer<typeof modInfoSchema>;
+
+const startDownloadArgsSchema = z
+  .tuple([
+    z.array(z.string()),
+    modInfoSchema,
+    z.string().optional(),
+    z
+      .function({ input: [z.unknown().nullable(), z.string().optional()] })
+      .optional(),
+  ])
+  .rest(z.unknown());
+
+const removeDownloadArgsSchema = z
+  .tuple([
+    z.string(),
+    z
+      .function({
+        input: [z.unknown().nullable()],
+      })
+      .optional(),
+  ])
+  .rest(z.unknown());
+
+type StoredDownloadInfo = {
+  url: string;
+  name: string;
+  friendlyName: string;
+};
+
+export class IPCDownloadAdapter {
+  readonly #api: IExtensionApi;
+  readonly #handlers: IProtocolHandlers;
+
+  readonly #pending = new Map<number, StoredDownloadInfo>();
+
+  constructor(api: IExtensionApi, handlers: IProtocolHandlers) {
+    this.#api = api;
+    this.#handlers = handlers;
+
+    window.api.downloader.onResolve((collationId) =>
+      this.#resolve(collationId),
+    );
+
+    api.events.on("start-download", (...args: unknown[]) => {
+      const parsed = startDownloadArgsSchema.safeParse(args);
+      if (!parsed.success) {
+        log("warn", "failed to parse 'start-download' args", {
+          error: parsed.error,
+        });
+        return;
+      }
+
+      const [urls, modInfo, fileName, callback] = parsed.data;
+
+      this.#handleStartDownload(urls, modInfo, fileName, callback).catch(
+        (err) => {
+          log("error", "failed to start download", err);
+        },
+      );
+    });
+
+    api.events.on("remove-download", (...args: unknown[]) => {
+      const parsed = removeDownloadArgsSchema.safeParse(args);
+      if (!parsed.success) {
+        log("warn", "failed to parse 'remove-download' args", {
+          error: parsed.error,
+        });
+        return;
+      }
+
+      const [downloadId, callback] = parsed.data;
+      this.#handleRemoveDownload(downloadId, callback).catch((err) => {
+        log("error", "failed to remove download", err);
+      });
+    });
+  }
+
+  async start(
+    url: string,
+    dest: string,
+    name: string = "",
+    friendlyName: string = "",
+  ): Promise<string> {
+    const { downloadId, collationId } = await window.api.downloader.start(dest);
+    this.#pending.set(collationId, { url, name, friendlyName });
+    return downloadId;
+  }
+
+  cancel(downloadId: string): Promise<void> {
+    return window.api.downloader.cancel(downloadId);
+  }
+
+  async #handleStartDownload(
+    urls: string[],
+    modInfo: ModInfo,
+    fileName?: string,
+    callback?: (err: Error | null, id?: string) => void,
+  ): Promise<void> {
+    const url = urls[0].toString().split("<")[0];
+    const state = this.#api.getState();
+    const dest = downloadPathForGame(
+      state,
+      modInfo.game ?? activeGameId(state),
+    );
+
+    let name: string;
+    try {
+      name = fileName || path.basename(new URL(url).pathname);
+    } catch {
+      name = fileName ?? "";
+    }
+
+    try {
+      const downloadId = await this.start(url, dest, name, modInfo.name ?? "");
+      callback?.(null, downloadId);
+    } catch (err) {
+      callback?.(unknownToError(err));
+    }
+  }
+
+  async #handleRemoveDownload(
+    downloadId: string,
+    callback?: (err: Error | null) => void,
+  ): Promise<void> {
+    try {
+      await this.cancel(downloadId);
+      callback?.(null);
+    } catch (err) {
+      callback?.(unknownToError(err));
+    }
+  }
+
+  async #resolve(collationId: number): Promise<WireResolvedResource> {
+    const info = this.#pending.get(collationId);
+    if (info === undefined) {
+      throw new Error(`No pending download for collationId ${collationId}`);
+    }
+    this.#pending.delete(collationId);
+
+    const { url, name, friendlyName } = info;
+    const scheme = new URL(url).protocol.replace(/:$/, "");
+    const handler = this.#handlers[scheme];
+
+    if (handler !== undefined) {
+      const resolved = await handler(url, name, friendlyName);
+      return { probeEndpoint: { url: resolved.urls[0] } };
+    }
+
+    if (scheme === "http" || scheme === "https") {
+      return { probeEndpoint: { url } };
+    }
+
+    throw new Error(`No protocol handler registered for scheme: ${scheme}`);
+  }
+}

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -148,7 +148,7 @@ export class IPCDownloadAdapter {
     }
 
     try {
-      const downloadId = await this.start(url, dest, name, modInfo.name ?? "");
+      const downloadId = await this.start(url, path.join(dest, name), name, modInfo.name ?? "");
       callback?.(null, downloadId);
     } catch (err) {
       callback?.(unknownToError(err));

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -163,7 +163,7 @@ export class IPCDownloadAdapter {
     const handler = this.#handlers[scheme];
 
     if (handler !== undefined) {
-      const resolved = await handler(url, name, friendlyName);
+      const resolved = await Promise.resolve(handler(url, name, friendlyName));
       return { probeEndpoint: { url: resolved.urls[0] } };
     }
 

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -4,7 +4,6 @@ import { unknownToError } from "@vortex/shared";
 import * as path from "node:path";
 import { z } from "zod";
 
-import type { IProtocolHandlers } from "./extensions/download_management/types/ProtocolHandlers";
 import type { IExtensionApi } from "./types/IExtensionContext";
 
 import { downloadPathForGame } from "./extensions/download_management/selectors";
@@ -42,6 +41,12 @@ const removeDownloadArgsSchema = z
   ])
   .rest(z.unknown());
 
+type ProtocolHandler = (
+  inputUrl: string,
+  name: string,
+  friendlyName: string,
+) => PromiseLike<{ urls: string[]; updatedUrl?: string; meta: unknown }>;
+
 type StoredDownloadInfo = {
   url: string;
   name: string;
@@ -50,17 +55,18 @@ type StoredDownloadInfo = {
 
 export class IPCDownloadAdapter {
   readonly #api: IExtensionApi;
-  readonly #handlers: IProtocolHandlers;
+  readonly #handlers: Record<string, ProtocolHandler> = {};
 
   readonly #pending = new Map<number, StoredDownloadInfo>();
 
-  constructor(api: IExtensionApi, handlers: IProtocolHandlers) {
+  constructor(api: IExtensionApi) {
     this.#api = api;
-    this.#handlers = handlers;
 
     window.api.downloader.onResolve((collationId) =>
       this.#resolve(collationId),
     );
+
+    if (process.env.VORTEX_USE_IPC_DOWNLOADER !== "1") return;
 
     api.events.on("start-download", (...args: unknown[]) => {
       const parsed = startDownloadArgsSchema.safeParse(args);
@@ -94,6 +100,10 @@ export class IPCDownloadAdapter {
         log("error", "failed to remove download", err);
       });
     });
+  }
+
+  registerProtocol(scheme: string, handler: ProtocolHandler): void {
+    this.#handlers[scheme] = handler;
   }
 
   async start(

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -58,6 +58,7 @@ export class IPCDownloadAdapter {
   readonly #handlers: Record<string, ProtocolHandler> = {};
 
   readonly #pending = new Map<number, StoredDownloadInfo>();
+  #nextCollationId = 0;
 
   constructor(api: IExtensionApi) {
     this.#api = api;
@@ -113,9 +114,10 @@ export class IPCDownloadAdapter {
     name: string = "",
     friendlyName: string = "",
   ): Promise<string> {
-    log("debug", "starting download", { url, dest, name });
-    const { downloadId, collationId } = await window.api.downloader.start(dest);
+    const collationId = this.#nextCollationId++;
     this.#pending.set(collationId, { url, name, friendlyName });
+    log("debug", "starting download", { url, dest, name, collationId });
+    const { downloadId } = await window.api.downloader.start(dest, collationId);
     log("debug", "download queued", { downloadId, collationId });
     return downloadId;
   }

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -104,6 +104,7 @@ export class IPCDownloadAdapter {
 
   registerProtocol(scheme: string, handler: ProtocolHandler): void {
     this.#handlers[scheme] = handler;
+    log("debug", `registered protocol handler for scheme '${scheme}'`);
   }
 
   async start(
@@ -112,12 +113,15 @@ export class IPCDownloadAdapter {
     name: string = "",
     friendlyName: string = "",
   ): Promise<string> {
+    log("debug", "starting download", { url, dest, name });
     const { downloadId, collationId } = await window.api.downloader.start(dest);
     this.#pending.set(collationId, { url, name, friendlyName });
+    log("debug", "download queued", { downloadId, collationId });
     return downloadId;
   }
 
   cancel(downloadId: string): Promise<void> {
+    log("debug", "cancelling download", { downloadId });
     return window.api.downloader.cancel(downloadId);
   }
 
@@ -173,11 +177,14 @@ export class IPCDownloadAdapter {
     const handler = this.#handlers[scheme];
 
     if (handler !== undefined) {
+      log("debug", "resolving download via protocol handler", { scheme, url });
       const resolved = await Promise.resolve(handler(url, name, friendlyName));
+      log("debug", "download resolved", { resolvedUrl: resolved.urls[0] });
       return { probeEndpoint: { url: resolved.urls[0] } };
     }
 
     if (scheme === "http" || scheme === "https") {
+      log("debug", "resolving download directly", { url });
       return { probeEndpoint: { url } };
     }
 

--- a/src/renderer/src/extensions/download_management/DownloadObserver.ts
+++ b/src/renderer/src/extensions/download_management/DownloadObserver.ts
@@ -119,6 +119,8 @@ export class DownloadObserver {
     const events = api.events;
     this.mManager = manager;
 
+    if (process.env.VORTEX_USE_IPC_DOWNLOADER === "1") return;
+
     events.on(
       "remove-download",
       (downloadId, callback?, options?: IDownloadRemoveOptions) =>
@@ -705,13 +707,16 @@ export class DownloadObserver {
           try {
             callback?.(null, id);
           } finally {
-            this.mApi.events.removeListener("start-install-download", onInstallFromCallback);
+            this.mApi.events.removeListener(
+              "start-install-download",
+              onInstallFromCallback,
+            );
           }
           if (
             !installTriggeredByCallback &&
             ((state.settings.automation?.install && allowInstall === true) ||
-            allowInstall === "force" ||
-            download.modInfo?.["startedAsUpdate"] === true)
+              allowInstall === "force" ||
+              download.modInfo?.["startedAsUpdate"] === true)
           ) {
             this.mApi.events.emit("start-install-download", id);
           }

--- a/src/renderer/src/extensions/download_management/index.ts
+++ b/src/renderer/src/extensions/download_management/index.ts
@@ -131,15 +131,8 @@ function refreshDownloads(
 export type ProtocolHandler = (
   inputUrl: string,
   name: string,
+  friendlyName: string,
 ) => PromiseBB<IResolvedURL>;
-
-export interface IExtensionContextExt extends IExtensionContext {
-  // register a download protocol handler
-  // TODO: these kinds of handlers are rather limited as they can only return
-  // ftp/http/https urls that can be downloaded directly, you can't add
-  // meta information about the file.
-  registerDownloadProtocol: (schema: string, handler: ProtocolHandler) => void;
-}
 
 function attributeExtractor(input: any) {
   let downloadGame: string | string[] = getSafe(
@@ -1076,7 +1069,7 @@ function processCommandline(api: IExtensionApi) {
   }
 }
 
-function init(context: IExtensionContextExt): boolean {
+function init(context: IExtensionContext): boolean {
   const downloadCount = new ReduxProp(
     context.api,
     [["persistent", "downloads", "files"]],

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -404,16 +404,6 @@ const requestLog = {
   },
 };
 
-export interface IExtensionContextExt extends IExtensionContext {
-  registerDownloadProtocol: (
-    schema: string,
-    handler: (
-      inputUrl: string,
-      name: string,
-    ) => PromiseBB<{ urls: string[]; meta: any }>,
-  ) => void;
-}
-
 function retrieveCategories(api: IExtensionApi, isUpdate: boolean) {
   let askUser: PromiseBB<boolean>;
   if (isUpdate) {
@@ -2064,7 +2054,7 @@ function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
   }
 }
 
-function init(context: IExtensionContextExt): boolean {
+function init(context: IExtensionContext): boolean {
   context.registerReducer(["confidential", "account", "nexus"], accountReducer);
   context.registerReducer(["settings", "nexus"], settingsReducer);
   context.registerReducer(["persistent", "nexus"], persistentReducer);

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -1166,6 +1166,20 @@ export interface IExtensionContext {
   registerSettingsHive: (type: PersistingType, hive: string) => void;
 
   /**
+   * registers a handler for a download URL scheme (e.g. "nxm"). The handler
+   * resolves the scheme-specific URL to a plain http/https URL that can be
+   * downloaded directly.
+   */
+  registerDownloadProtocol: (
+    scheme: string,
+    handler: (
+      inputUrl: string,
+      name: string,
+      friendlyName: string,
+    ) => PromiseLike<{ urls: string[]; updatedUrl?: string; meta: unknown }>,
+  ) => void;
+
+  /**
    * register a new persistor that will hook a data file into the application store,
    * meaning any part of the application can access that data like any other data in the application
    * state and the UI will automatically refresh if it's tied to that data.

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -359,9 +359,13 @@ export interface InvokeChannels {
   // Download channels
   "download:start": (
     dest: string,
-  ) => Promise<{ downloadId: string; collationId: number }>;
+    collationId: number,
+  ) => Promise<{ downloadId: string }>;
   "download:pause": (downloadId: string) => Promise<WireDownloadCheckpoint>;
-  "download:resume": (checkpoint: WireDownloadCheckpoint) => Promise<void>;
+  "download:resume": (
+    checkpoint: WireDownloadCheckpoint,
+    collationId: number,
+  ) => Promise<void>;
   "download:cancel": (downloadId: string) => Promise<void>;
   "download:getProgress": (downloadId: string) => Promise<DownloadProgress>;
 

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -437,14 +437,24 @@ export interface UpdaterApi {
 
 /** API for interacting with the DownloadManager in main */
 export interface DownloaderApi {
-  /** Enqueues a download. Returns a globally unique `downloadId` and the `collationId` for resolve callbacks. */
-  start(dest: string): Promise<{ downloadId: string; collationId: number }>;
+  /**
+   * Enqueues a download. The caller must generate `collationId` and register
+   * any resolve handler before calling this, so that the main-side resolve
+   * callback cannot arrive before the handler is ready.
+   */
+  start(dest: string, collationId: number): Promise<{ downloadId: string }>;
 
   /** Pauses an active download and returns a checkpoint for later resumption. */
   pause(downloadId: string): Promise<WireDownloadCheckpoint>;
 
-  /** Resumes a download from a checkpoint. */
-  resume(checkpoint: WireDownloadCheckpoint): Promise<void>;
+  /**
+   * Resumes a download from a checkpoint. The caller must generate `collationId`
+   * and register any resolve handler before calling this.
+   */
+  resume(
+    checkpoint: WireDownloadCheckpoint,
+    collationId: number,
+  ): Promise<void>;
 
   /** Cancels an active download. */
   cancel(downloadId: string): Promise<void>;


### PR DESCRIPTION
This removes the hacky `registerDownloadProtocol` from the extensions and adds it directly to the context. There are no other extensions using it, only our nexus integration extension and the previous download manager. Implementation can be toggled with an environment variable for now.