### PR TITLE
plugin rules per-profile and add controls to prevent rule contamination

### DIFF
--- a/extensions/collections/src/types/ICollectionConfig.ts
+++ b/extensions/collections/src/types/ICollectionConfig.ts
@@ -3,6 +3,7 @@ import { types } from "vortex-api";
 
 export interface ICollectionConfig {
   recommendNewProfile: boolean;
+  excludePluginRules: boolean;
 }
 
 export interface IConfigGeneratorProps {

--- a/extensions/collections/src/util/collectionConfig/index.ts
+++ b/extensions/collections/src/util/collectionConfig/index.ts
@@ -7,6 +7,7 @@ import { util } from "vortex-api";
 
 const configDefaults: ICollectionConfig = {
   recommendNewProfile: false,
+  excludePluginRules: false,
 };
 
 export async function generateConfig(

--- a/extensions/collections/src/util/gameSupport/gamebryo.tsx
+++ b/extensions/collections/src/util/gameSupport/gamebryo.tsx
@@ -33,7 +33,7 @@ function getEnabledPlugins(
 interface IUserlistEntry {
   name: string;
   group?: string;
-  after?: string[];
+  after?: Array<string | ILootReference>;
 }
 
 interface IGamebryoRules {
@@ -42,13 +42,13 @@ interface IGamebryoRules {
 }
 
 function extractPluginRules(
-  state: types.IState,
+  state: IStateWithLootLists,
   plugins: string[],
 ): IGamebryoRules {
   const installedPlugins: Set<string> = new Set(
     plugins.map((name) => name.toLowerCase()),
   );
-  const customisedPlugins = state["userlist"].plugins.filter(
+  const customisedPlugins = (state.userlist?.plugins ?? []).filter(
     (plug: IUserlistEntry) =>
       installedPlugins.has(plug.name.toLowerCase()) &&
       (plug.after !== undefined || plug.group !== undefined),
@@ -59,7 +59,7 @@ function extractPluginRules(
   // aren't included in the pack
   return {
     plugins: customisedPlugins,
-    groups: state["userlist"].groups,
+    groups: state.userlist?.groups ?? [],
   };
 }
 
@@ -150,20 +150,29 @@ export async function parser(
   collection: ICollection,
   collectionMod: types.IMod,
 ) {
-  const state: types.IState = api.getState();
+  const state: IStateWithLootLists = api.getState();
 
-  if ((state as any).userlist === undefined) {
+  if (state.userlist === undefined) {
     // may be that the plugin extension is disabled.
     // if so, that may be intentional so can't report an error.
     return;
   }
 
+  // re-read the mod from state to pick up attributes set during install dialog
+  const currentMod = state.persistent.mods[gameId]?.[collectionMod.id];
+  const skipPluginRules = currentMod?.attributes?.skipPluginRules === true;
+
   const mods = state.persistent.mods[gameId];
 
-  // set up groups and their rules
-  if (Array.isArray(collection.pluginRules?.groups)) {
+  const userlist = state.userlist;
+
+  // set up groups and their rules (skipped if user opted out)
+  if (!skipPluginRules && Array.isArray(collection.pluginRules?.groups)) {
     util.batchDispatch(api.store, collection.pluginRules.groups.reduce((prev, group) => {
-      if ((state as any).userlist.groups[group.name] === undefined) {
+      const isNew = userlist.groups.find(
+        (g) => g.name.toUpperCase() === group.name.toUpperCase(),
+      ) === undefined;
+      if (isNew) {
         prev.push({
           type: 'ADD_PLUGIN_GROUP', payload: {
             group: group.name,
@@ -223,10 +232,14 @@ export async function parser(
     .filter((noti) => noti.id.startsWith("multiple-plugins-"))
     .forEach((noti) => api.dismissNotification(noti.id));
 
+  if (skipPluginRules) {
+    return;
+  }
+
   util.batchDispatch(
     api.store,
     (collection.pluginRules?.plugins ?? []).reduce((prev, plugin) => {
-      const existing = (state as any).userlist.plugins.find(
+      const existing = userlist.plugins.find(
         (plug) => plug.name.toUpperCase() === plugin.name.toUpperCase(),
       );
 
@@ -325,6 +338,12 @@ interface ILOOTList {
   plugins: ILOOTPlugin[];
   groups: ILOOTGroup[];
 }
+
+type IStateWithLootLists = types.IState & {
+  userlist?: ILOOTList;
+  masterlist?: ILOOTList;
+};
+
 
 function ruleName(rule: string | ILootReference): string {
   if (typeof rule === "string") {

--- a/extensions/collections/src/util/transformCollection.ts
+++ b/extensions/collections/src/util/transformCollection.ts
@@ -830,6 +830,11 @@ export async function modToCollection(
     bundleTags,
   );
 
+  const { pluginRules, ...gameSpecificWithoutRules } = gameSpecific;
+  const filteredGameSpecific = collectionConfig.excludePluginRules
+    ? gameSpecificWithoutRules
+    : gameSpecific;
+
   const res: ICollection = {
     info: collectionInfo,
     mods: await rulesToCollectionMods(
@@ -846,7 +851,7 @@ export async function modToCollection(
     ),
     modRules,
     ...extData,
-    ...gameSpecific,
+    ...filteredGameSpecific,
     collectionConfig: { ...collectionConfig },
   };
 

--- a/extensions/collections/src/views/CollectionPageEdit/Instructions.tsx
+++ b/extensions/collections/src/views/CollectionPageEdit/Instructions.tsx
@@ -24,6 +24,9 @@ const settings = (props: IInstructionProps) => {
   const [recommendNewProfile, setRecommendNewProfile] = React.useState(
     collection.attributes?.collection?.collectionConfig?.recommendNewProfile,
   );
+  const [excludePluginRules, setExcludePluginRules] = React.useState(
+    collection.attributes?.collection?.collectionConfig?.excludePluginRules,
+  );
 
   const toggleRecommendNewProfile = React.useCallback(() => {
     const newValue = !recommendNewProfile;
@@ -33,6 +36,15 @@ const settings = (props: IInstructionProps) => {
       newValue,
     );
   }, [onSetCollectionAttribute, recommendNewProfile, setRecommendNewProfile]);
+
+  const toggleExcludePluginRules = React.useCallback(() => {
+    const newValue = !excludePluginRules;
+    setExcludePluginRules(newValue);
+    onSetCollectionAttribute(
+      ["collectionConfig", "excludePluginRules"],
+      newValue,
+    );
+  }, [onSetCollectionAttribute, excludePluginRules, setExcludePluginRules]);
 
   return (
     <FlexLayout
@@ -59,6 +71,23 @@ const settings = (props: IInstructionProps) => {
         >
           {t(
             "If enabled, Vortex will recommend creating a new profile when installing this collection. If disabled, the collection will be installed into the currently active profile.",
+          )}
+        </More>
+      </Toggle>
+
+      <Toggle
+        id={"settings-exclude-plugin-rules"}
+        onToggle={toggleExcludePluginRules}
+        checked={excludePluginRules}
+      >
+        {t("Exclude plugin rules")}
+        <More
+          id="collection-settings-excludepluginrules"
+          name={t("Exclude plugin rules")}
+        >
+          {t(
+            "If enabled, custom LOOT plugin rules and groups will not be included when exporting this collection. "
+            + "This prevents inherited rules from spreading between collections.",
           )}
         </More>
       </Toggle>

--- a/extensions/collections/src/views/InstallDialog/InstallStartDialog.tsx
+++ b/extensions/collections/src/views/InstallDialog/InstallStartDialog.tsx
@@ -67,6 +67,7 @@ interface IInstallDialogState {
   selectedProfile: string;
   confirmProfile: boolean;
   recommendedNewProfile: boolean;
+  skipPluginRules: boolean;
 }
 
 function nop() {
@@ -166,6 +167,7 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
       selectedProfile: undefined,
       confirmProfile: false,
       recommendedNewProfile: false,
+      skipPluginRules: false,
     });
 
     if (props.driver !== undefined) {
@@ -308,6 +310,22 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
           >
             {t("Install mods during collection downloads")}
           </Toggle>
+          <Toggle
+            checked={this.state.skipPluginRules}
+            onToggle={this.toggleSkipPluginRules}
+          >
+            {t("Skip plugin rules")}
+            <More
+              id="install-skip-plugin-rules"
+              name={t("Skip plugin rules")}
+            >
+              {t(
+                "If enabled, custom LOOT plugin rules and groups included in this collection "
+                + "will not be applied. This can help prevent inherited plugin rules from "
+                + "causing conflicts.",
+              )}
+            </More>
+          </Toggle>
         </Modal.Body>
         <Modal.Footer>
           {this.state.confirmProfile ? (
@@ -329,6 +347,19 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
   private changeProfile = (value: { value: string; label: string }) => {
     if (!!value) {
       this.nextState.selectedProfile = value.value;
+    }
+  };
+
+  private toggleSkipPluginRules = (checked: boolean) => {
+    this.nextState.skipPluginRules = checked;
+    const { driver, onSetModAttribute } = this.props;
+    if (driver?.collection !== undefined) {
+      onSetModAttribute(
+        driver.profile.gameId,
+        driver.collection.id,
+        "skipPluginRules",
+        checked,
+      );
     }
   };
 

--- a/extensions/gamebryo-plugin-management/src/actions/userlist.ts
+++ b/extensions/gamebryo-plugin-management/src/actions/userlist.ts
@@ -33,3 +33,5 @@ export const removeGroupRule = createAction(
   "REMOVE_GROUP_RULE",
   (groupId: string, reference: string) => ({ groupId, reference }),
 );
+
+export const clearUserlist = createAction("CLEAR_USERLIST");

--- a/extensions/gamebryo-plugin-management/src/index.ts
+++ b/extensions/gamebryo-plugin-management/src/index.ts
@@ -11,7 +11,7 @@ import {
   setPluginList,
   updatePluginWarnings,
 } from "./actions/plugins";
-import { removeGroupRule, setGroup } from "./actions/userlist";
+import { clearUserlist, removeGroupRule, setGroup } from "./actions/userlist";
 import { openGroupEditor, setCreateRule } from "./actions/userlistEdit";
 import { loadOrderReducer } from "./reducers/loadOrder";
 import { pluginsReducer } from "./reducers/plugins";
@@ -560,6 +560,15 @@ function register(
     );
   }
 
+  context.registerProfileFeature(
+    "local_loot_rules",
+    "boolean",
+    "connection",
+    "LOOT Rules",
+    "This profile has its own plugin rules and groups",
+    () => gameSupported(selectors.activeGameId(context.api.store.getState())),
+  );
+
   context.registerSettings("Workarounds", Settings, undefined, () => {
     const state = context.api.store.getState();
     const gameMode = selectors.activeGameId(state);
@@ -656,6 +665,42 @@ function register(
     "History",
     () => {
       context.api.ext.showHistory?.("plugins");
+    },
+  );
+
+  context.registerAction(
+    "gamebryo-plugin-icons",
+    300,
+    "undo",
+    {},
+    "Reset Plugin Rules",
+    () => {
+      context.api
+        .showDialog("question", "Reset Plugin Rules", {
+          text:
+            "This will remove ALL custom plugin rules, plugin group assignments, " +
+            "and custom groups. Only rules from the LOOT masterlist will remain.\n\n" +
+            "This cannot be undone.",
+        }, [{ label: "Cancel" }, { label: "Reset" }])
+        .then((result: types.IDialogResult) => {
+          if (result.action === "Reset") {
+            const state: IStateWithGamebryo = context.api.store.getState();
+            const userlist = state.userlist;
+            // explicitly unset group assignments so the UI updates
+            const unsetGroups = (userlist?.plugins ?? [])
+              .filter((plugin) => plugin.group !== undefined)
+              .map((plugin) => setGroup(plugin.name, undefined));
+            util.batchDispatch(
+              context.api.store,
+              [...unsetGroups, clearUserlist()],
+            );
+            context.api.sendNotification({
+              type: "success",
+              message: "Plugin rules have been reset to defaults",
+              displayMS: 3000,
+            });
+          }
+        });
     },
   );
 
@@ -831,6 +876,80 @@ function updateCurrentProfile(api: types.IExtensionApi): Promise<void> {
       resolve,
     );
   });
+}
+
+/**
+ * swap the userlist.yaml file between profiles when the local_loot_rules
+ * feature toggle is enabled. Called after persistors are disabled to prevent
+ * stale writes.
+ */
+async function swapUserlistForProfile(
+  oldProfile: types.IProfile | undefined,
+  newProfile: types.IProfile | undefined,
+): Promise<void> {
+  const oldHasLocal = oldProfile?.features?.local_loot_rules === true;
+  const newHasLocal = newProfile?.features?.local_loot_rules === true;
+
+  if (!oldHasLocal && !newHasLocal) {
+    return;
+  }
+
+  const gameId = oldProfile?.gameId ?? newProfile?.gameId;
+  if (gameId === undefined) {
+    return;
+  }
+
+  const userDataPath = util.getVortexPath("userData");
+  const activeFile = path.join(userDataPath, gameId, "userlist.yaml");
+  const globalBackup = path.join(userDataPath, gameId, "userlist.yaml.global");
+
+  const getProfileDir = (profile: types.IProfile) =>
+    path.join(userDataPath, gameId, "profiles", profile.id);
+  const getProfileFile = (profile: types.IProfile) =>
+    path.join(getProfileDir(profile), "userlist.yaml");
+
+  const copyIgnoringMissing = async (src: string, dest: string) => {
+    try {
+      await fs.copyAsync(src, dest, { noSelfCopy: true });
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        throw err;
+      }
+    }
+  };
+
+  // save old profile's rules to its profile directory
+  if (oldHasLocal && oldProfile?.pendingRemove !== true) {
+    await fs.ensureDirAsync(getProfileDir(oldProfile));
+    await copyIgnoringMissing(activeFile, getProfileFile(oldProfile));
+
+    if (!newHasLocal) {
+      // restore global backup
+      await copyIgnoringMissing(globalBackup, activeFile);
+    }
+  }
+
+  // load new profile's rules from its profile directory
+  if (newHasLocal) {
+    if (!oldHasLocal) {
+      // back up the current global userlist
+      await copyIgnoringMissing(activeFile, globalBackup);
+    }
+
+    try {
+      await fs.statAsync(getProfileFile(newProfile));
+      // profile has a saved copy — restore it
+      await fs.copyAsync(getProfileFile(newProfile), activeFile, { noSelfCopy: true });
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        // first time: seed the profile dir from the current file
+        await fs.ensureDirAsync(getProfileDir(newProfile));
+        await copyIgnoringMissing(activeFile, getProfileFile(newProfile));
+      } else {
+        throw err;
+      }
+    }
+  }
 }
 
 let watcher: fs.FSWatcher;
@@ -2094,6 +2213,69 @@ function init(context: IExtensionContextExt) {
           },
         );
 
+        // when the user toggles local_loot_rules on the active profile,
+        // immediately back up the global userlist and seed the profile copy
+        context.api.onStateChange(
+          ["persistent", "profiles"],
+          (previous, current) => {
+            const activeProfileId = util.getSafe(
+              context.api.store.getState(),
+              ["settings", "profiles", "activeProfileId"],
+              undefined,
+            );
+            if (activeProfileId === undefined) {
+              return;
+            }
+            const prevFeature = previous[activeProfileId]?.features?.local_loot_rules;
+            const currFeature = current[activeProfileId]?.features?.local_loot_rules;
+            if (prevFeature === currFeature) {
+              return;
+            }
+            const profile = current[activeProfileId];
+            if (profile === undefined || !gameSupported(profile.gameId)) {
+              return;
+            }
+            const userDataPath = util.getVortexPath("userData");
+            const activeFile = path.join(userDataPath, profile.gameId, "userlist.yaml");
+            const globalBackup = path.join(userDataPath, profile.gameId, "userlist.yaml.global");
+            const profDir = path.join(userDataPath, profile.gameId, "profiles", profile.id);
+            const profFile = path.join(profDir, "userlist.yaml");
+
+            const copyIgnoringMissing = async (src: string, dest: string) => {
+              try {
+                await fs.copyAsync(src, dest, { noSelfCopy: true });
+              } catch (err) {
+                if (err.code !== "ENOENT") {
+                  throw err;
+                }
+              }
+            };
+
+            if (currFeature && !prevFeature) {
+              // toggled ON: back up global and seed profile copy
+              (async () => {
+                await copyIgnoringMissing(activeFile, globalBackup);
+                await fs.ensureDirAsync(profDir);
+                await copyIgnoringMissing(activeFile, profFile);
+              })().catch((err) => {
+                log("warn", "failed to initialize per-profile userlist", err.message);
+              });
+            } else if (!currFeature && prevFeature) {
+              // toggled OFF: save profile state, restore global backup
+              (async () => {
+                await fs.ensureDirAsync(profDir);
+                await copyIgnoringMissing(activeFile, profFile);
+                await copyIgnoringMissing(globalBackup, activeFile);
+                if (userlistPersistor !== undefined) {
+                  await userlistPersistor.loadFiles(profile.gameId);
+                }
+              })().catch((err) => {
+                log("warn", "failed to restore global userlist", err.message);
+              });
+            }
+          },
+        );
+
         context.api.events.on(
           "set-plugin-list",
           (newPlugins: string[], setEnabled?: boolean) => {
@@ -2114,13 +2296,44 @@ function init(context: IExtensionContextExt) {
             nextProfileId: string,
             enqueue: (cb: () => Promise<void>) => void,
           ) => {
+            const state = context.api.store.getState();
+            const oldProfileId = util.getSafe(
+              state, ["settings", "profiles", "activeProfileId"], undefined,
+            );
+            const oldProfile = state.persistent.profiles[oldProfileId];
+            const nextProfile = nextProfileId !== undefined
+              ? selectors.profileById(state, nextProfileId)
+              : undefined;
+
             if (nextProfileId === undefined) {
               context.api.store.dispatch(setPluginList(undefined));
+              // still need to save per-profile userlist before deactivation
+              if (oldProfile?.features?.local_loot_rules) {
+                enqueue(() =>
+                  stopSync()
+                    .then(() =>
+                      userlistPersistor !== undefined
+                        ? userlistPersistor.disable()
+                        : Promise.resolve(),
+                    )
+                    .then(() =>
+                      masterlistPersistor !== undefined
+                        ? masterlistPersistor.disable()
+                        : Promise.resolve(),
+                    )
+                    .then(() => swapUserlistForProfile(oldProfile, undefined))
+                    .then(() => loot.wait())
+                    .catch((err) => {
+                      context.api.showErrorNotification(
+                        "Failed to change profile", err,
+                      );
+                      return Promise.resolve();
+                    }),
+                );
+              }
               return;
             }
-            const state = context.api.store.getState();
             const gameMode = selectors.activeGameId(state);
-            const nextProfile = selectors.profileById(state, nextProfileId);
             if (nextProfile !== undefined && nextProfile.gameId !== gameMode) {
               context.api.store.dispatch(setPluginList(undefined));
             }
@@ -2136,6 +2349,7 @@ function init(context: IExtensionContextExt) {
                     ? masterlistPersistor.disable()
                     : Promise.resolve(),
                 )
+                .then(() => swapUserlistForProfile(oldProfile, nextProfile))
                 .then(() => loot.wait())
                 .catch((err) => {
                   context.api.showErrorNotification(

--- a/extensions/gamebryo-plugin-management/src/reducers/userlist.ts
+++ b/extensions/gamebryo-plugin-management/src/reducers/userlist.ts
@@ -137,6 +137,7 @@ const userlistReducer: types.IReducerSpec = {
         );
       }
     },
+    [actions.clearUserlist as any]: () => ({ plugins: [], groups: [] }),
     [actions.removeGroupRule as any]: (state, payload) => {
       const idx = state.groups.findIndex(
         (group) => group.name.toUpperCase() === payload.groupId.toUpperCase(),


### PR DESCRIPTION
- added ability to isolate userlist configuration per profile (same as savegames and ini config)
- added "Reset Plugin Rules" button to the plugin list page
- added ability to skip/exclude plugin rules both as a curator (via the workshop page), and as a consumer (added toggle to the collection install dialog)

closes https://linear.app/nexus-mods/issue/APP-62/make-vortex-profiles-independent-plugin-rule-and-plugin-group-wise closes https://github.com/Nexus-Mods/Vortex/issues/20926