### PR TITLE
use main logging instead of console

### DIFF
--- a/src/main/src/telemetry/setup.ts
+++ b/src/main/src/telemetry/setup.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-ho
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 
+import { log } from "../logging";
 import { createVortexResource } from "./resources";
 import {
   RingBufferSpanProcessor,
@@ -34,7 +35,10 @@ export const createMainTelemetryProvider = (
       if (!isTelemetryEnabled()) return;
       exporter.export(spans, (result) => {
         if (result.error) {
-          console.error("[telemetry] OTLP export failed", result.error);
+          const { message, code } = result.error as Error & {
+            code?: string | number;
+          };
+          log("warn", "OTLP export failed", { message, code });
         }
       });
     },


### PR DESCRIPTION
also don't log the entire error - data might be an entire CF HTML page which will spam the log needlessly.