### PR TITLE
Fix formatting of game name for Fallout: New Vegas

### DIFF
--- a/extensions/games/game-falloutnv/src/index.ts
+++ b/extensions/games/game-falloutnv/src/index.ts
@@ -230,7 +230,7 @@ function main(context: types.IExtensionContext): boolean {
 
   context.registerGame({
     id: GAME_ID,
-    name: 'Fallout:\tNew Vegas',
+    name: 'Fallout: New Vegas',
     setup: (discovery) => prepareForModding(context.api, discovery) as any,
     shortName: 'New Vegas',
     mergeMods: true,


### PR DESCRIPTION
Removed the `/t` character. I believe this was added as a workaround for the old games UI?