### PR TITLE
redact user-identifying paths from telemetry error payloads

### DIFF
--- a/src/main/src/errorReporting.ts
+++ b/src/main/src/errorReporting.ts
@@ -5,6 +5,7 @@ import {
   BasicTracerProvider,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { sanitizeFramePath } from "@vortex/shared";
 import { recordErrorOnSpan } from "@vortex/shared/telemetry";
 import { app } from "electron";
 import { readFile } from "node:fs/promises";
@@ -78,7 +79,7 @@ export async function reportCrash(
       attributes: {
         "crash.type": type,
         "crash.sourceProcess": sourceProcess ?? "unknown",
-        "error.message": error.message,
+        "error.message": sanitizeFramePath(error.message),
         "error.code": error.code ?? "",
       },
     });

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -125,6 +125,120 @@ describe("sanitizeFramePath", () => {
       expect(sanitizeFramePath(frame)).toBe(frame);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // User-home redaction for paths with no Vortex-install anchor.
+  //
+  // Paths like C:\Users\user\AppData\Local\Larian Studios\... surface in
+  // ENOENT-style error messages where the existing anchor-strip doesn't
+  // apply. We redact just the username segment (GDPR Art. 5(1)(c) data
+  // minimisation) and preserve the rest so errors stay diagnosable.
+  //
+  // Cases are taken directly from observed ClickHouse rows.
+  // -------------------------------------------------------------------------
+
+  describe("user-home redaction (no Vortex anchor)", () => {
+    it("redacts Windows C:\\Users\\<name> in a bare path", () => {
+      expect(
+        sanitizeFramePath(
+          `C:\\Users\\user\\AppData\\Local\\Larian Studios\\Baldur's Gate 3\\Mods\\foo.pak`,
+        ),
+      ).toBe(
+        `C:/Users/<USER>/AppData/Local/Larian Studios/Baldur's Gate 3/Mods/foo.pak`,
+      );
+    });
+
+    it("redacts the username inside an ENOENT message body", () => {
+      const input = `ENOENT: no such file or directory, stat 'C:\\Users\\user\\AppData\\Local\\Larian Studios\\Baldur's Gate 3\\Mods\\AuriesVanillaTreasures.pak'`;
+      const expected = `ENOENT: no such file or directory, stat 'C:/Users/<USER>/AppData/Local/Larian Studios/Baldur's Gate 3/Mods/AuriesVanillaTreasures.pak'`;
+      expect(sanitizeFramePath(input)).toBe(expected);
+    });
+
+    it("redacts every username line of a multi-line Require stack", () => {
+      const input = [
+        `Error: Cannot find module 'harmony-patcher'`,
+        `Require stack:`,
+        `- C:\\Users\\user\\AppData\\Roaming\\Vortex\\plugins\\Vortex Extension Update - UnderMine Support v1.0.1\\index.js`,
+        `- C:\\Program Files\\Black Tree Gaming Ltd\\Vortex\\resources\\app.asar\\renderer.js`,
+      ].join("\n");
+      // The `plugins` and `app.asar` anchors strip the full install prefix, so
+      // neither username nor Program Files survives.
+      const expected = [
+        `Error: Cannot find module 'harmony-patcher'`,
+        `Require stack:`,
+        `- plugins/Vortex Extension Update - UnderMine Support v1.0.1/index.js`,
+        `- app.asar/renderer.js`,
+      ].join("\n");
+      expect(sanitizeFramePath(input)).toBe(expected);
+    });
+
+    it("redacts usernames across every 'at' frame of a stack trace", () => {
+      const input = [
+        `TypeError: Cannot read properties of undefined (reading 'app')`,
+        `    at Object.<anonymous> (C:\\Users\\user\\AppData\\Roaming\\Vortex\\plugins\\Fallout 76 Support v2.2.1\\index.js:15:34)`,
+        `    at Object.<anonymous> (C:\\Users\\user\\AppData\\Roaming\\Vortex\\plugins\\Fallout 76 Support v2.2.1\\index.js:304:3)`,
+      ].join("\n");
+      const expected = [
+        `TypeError: Cannot read properties of undefined (reading 'app')`,
+        `    at Object.<anonymous> (plugins/Fallout 76 Support v2.2.1/index.js:15:34)`,
+        `    at Object.<anonymous> (plugins/Fallout 76 Support v2.2.1/index.js:304:3)`,
+      ].join("\n");
+      expect(sanitizeFramePath(input)).toBe(expected);
+    });
+
+    it("redacts Windows path written with forward slashes", () => {
+      expect(sanitizeFramePath(`C:/Users/user/AppData/Local/foo.pak`)).toBe(
+        `C:/Users/<USER>/AppData/Local/foo.pak`,
+      );
+    });
+
+    it("redacts macOS /Users/<name>", () => {
+      expect(sanitizeFramePath(`/Users/user/Library/foo.plist`)).toBe(
+        `/Users/<USER>/Library/foo.plist`,
+      );
+    });
+
+    it("redacts Linux /home/<name>", () => {
+      expect(sanitizeFramePath(`/home/user/.config/vortex/x`)).toBe(
+        `/home/<USER>/.config/vortex/x`,
+      );
+    });
+
+    it("redacts every occurrence in a single string", () => {
+      const input = `C:\\Users\\user\\a.txt and C:\\Users\\user\\b.txt`;
+      expect(sanitizeFramePath(input)).toBe(
+        `C:/Users/<USER>/a.txt and C:/Users/<USER>/b.txt`,
+      );
+    });
+
+    it("is idempotent — running twice gives the same result", () => {
+      const input = `C:\\Users\\user\\file.txt and /home/user/other.txt`;
+      const once = sanitizeFramePath(input);
+      expect(sanitizeFramePath(once)).toBe(once);
+    });
+
+    it("leaves C:\\Program Files paths unchanged (no user segment)", () => {
+      const input = `C:\\Program Files\\Black Tree Gaming Ltd\\Vortex\\readme.txt`;
+      expect(sanitizeFramePath(input)).toBe(
+        `C:/Program Files/Black Tree Gaming Ltd/Vortex/readme.txt`,
+      );
+    });
+
+    it("leaves portable-install drive paths unchanged (no user segment)", () => {
+      const input = `E:\\Vortex\\resources\\readme.txt`;
+      expect(sanitizeFramePath(input)).toBe(`E:/Vortex/resources/readme.txt`);
+    });
+
+    it("prefers anchor-strip over user-redact when both apply", () => {
+      // An anchored path gets the full install prefix stripped, not just the
+      // username redacted — the anchor form loses more info and is preferred.
+      expect(
+        sanitizeFramePath(
+          `at f (C:\\Users\\user\\AppData\\Roaming\\Vortex\\plugins\\x\\index.js:1:2)`,
+        ),
+      ).toBe(`at f (plugins/x/index.js:1:2)`);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -100,10 +100,19 @@ export function isErrorWithSystemCode(
 }
 
 /**
- * Strip the installation-specific path prefix from a stack frame, keeping
- * only from `src/` or `node_modules/` onward so fingerprints are stable
- * across different machines and install locations. Path separators are
- * normalized to forward slashes.
+ * Sanitize paths embedded in a string — stack frames, error messages, or any
+ * free-form text that may contain absolute paths. Two passes:
+ *
+ *   1. Install-prefix strip: when a path reaches a known Vortex anchor (src/,
+ *      node_modules/, app.asar, plugins/) everything before the anchor is
+ *      dropped, making fingerprints stable across machines.
+ *   2. User-home redact: any remaining `C:/Users/<name>/`, `/Users/<name>/`,
+ *      or `/home/<name>/` has the username replaced with `<USER>`. This
+ *      covers paths with no Vortex anchor (e.g. game install dirs in ENOENT
+ *      messages) where we want to keep diagnostic context but not the OS
+ *      username — GDPR Art. 5(1)(c) data minimisation.
+ *
+ * Path separators are normalized to forward slashes.
  *
  * Examples:
  *   "at f (D:\Dev\Vortex\src\foo.ts:1:2)" → "at f (src/foo.ts:1:2)"
@@ -111,10 +120,14 @@ export function isErrorWithSystemCode(
  *   "at f (C:\Program Files\Vortex\resources\app.asar\renderer.js:1:2)" → "at f (app.asar/renderer.js:1:2)"
  *   "at f (D:\Program Files\Vortex\resources\app.asar.unpacked\bundledPlugins\x\index.js:1:2)" → "at f (app.asar.unpacked/bundledPlugins/x/index.js:1:2)"
  *   "at f (C:\Users\user\AppData\Roaming\Vortex\plugins\x\index.js:1:2)" → "at f (plugins/x/index.js:1:2)"
+ *   "ENOENT ... 'C:\Users\bob\AppData\Local\Larian\Mods\foo.pak'" → "ENOENT ... 'C:/Users/<USER>/AppData/Local/Larian/Mods/foo.pak'"
  *   "at f (chrome-extension://id/page.js:1:2)" → unchanged
  */
 export const sanitizeFramePath = (frame: string): string =>
-  frame.replace(INSTALL_PATH_RE, "").replace(/\\/g, "/");
+  frame
+    .replace(INSTALL_PATH_RE, "")
+    .replace(/\\/g, "/")
+    .replace(USER_HOME_RE, "$1<USER>");
 
 const _SEP = String.raw`[/\\]`;
 const _WIN = String.raw`[A-Za-z]:${_SEP}`; // C:\ or C:/
@@ -127,6 +140,12 @@ const INSTALL_PATH_RE = new RegExp(
   String.raw`(?:${_WIN}|${_UNIX})${_SEGS}(?=${_ANCHORS}${_SEP})`,
   "g",
 );
+
+/** Matches the username segment of a user-home path (`/Users/<name>` or
+ * `/home/<name>`). Run after backslash normalization so only forward slashes
+ * need to be considered. The username character class excludes `<` so that
+ * already-redacted `<USER>` is not matched again (idempotence). */
+const USER_HOME_RE = /(\/(?:Users|home)\/)([^/\s'"<>:|?*]+)/gi;
 
 /**
  * Compute a fingerprint from the stack trace call frames and app version.

--- a/src/shared/src/telemetry/spans.ts
+++ b/src/shared/src/telemetry/spans.ts
@@ -2,12 +2,17 @@ import type { Span } from "@opentelemetry/api";
 
 import { SpanStatusCode } from "@opentelemetry/api";
 
-import { computeErrorFingerprint } from "../errors";
+import { computeErrorFingerprint, sanitizeFramePath } from "../errors";
 
 /**
  * Record an error on a span: compute fingerprint, record the exception,
  * and set ERROR status. Optionally attach extra attributes and
  * ambient context entries (prefixed with `context.`).
+ *
+ * The error's message and stack are passed through `sanitizeFramePath`
+ * before being attached, so OS usernames and absolute install paths do
+ * not reach the telemetry backend (GDPR Art. 5(1)(c) data minimisation).
+ * The caller's Error object is not mutated.
  */
 export const recordErrorOnSpan = (
   span: Span,
@@ -16,6 +21,13 @@ export const recordErrorOnSpan = (
   context?: Record<string, string>,
   attributes?: Record<string, string | number | boolean>,
 ): void => {
+  const sanitizedMessage = sanitizeFramePath(error.message);
+  const sanitizedStack =
+    error.stack !== undefined ? sanitizeFramePath(error.stack) : undefined;
+  const sanitized = new Error(sanitizedMessage);
+  sanitized.name = error.name;
+  sanitized.stack = sanitizedStack;
+
   if (attributes !== undefined) {
     for (const [key, value] of Object.entries(attributes)) {
       span.setAttribute(key, value);
@@ -28,11 +40,11 @@ export const recordErrorOnSpan = (
     }
   }
 
-  const fingerprint = computeErrorFingerprint(error.stack, appVersion);
+  const fingerprint = computeErrorFingerprint(sanitizedStack, appVersion);
   if (fingerprint !== undefined) {
     span.setAttribute("error.fingerprint", fingerprint);
   }
 
-  span.recordException(error);
-  span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  span.recordException(sanitized);
+  span.setStatus({ code: SpanStatusCode.ERROR, message: sanitizedMessage });
 };


### PR DESCRIPTION
closes https://linear.app/nexus-mods/issue/APP-358/gdpr-review-telemetry-stacks-and-payloads-forwarded-to-clickhouse