### PR TITLE
include extension identity in failed-init error payload

### DIFF
--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -1817,8 +1817,9 @@ class ExtensionManager {
         const extProxy = new Proxy(contextProxy, apiProxy);
         const init = ext.initFunc();
         if (typeof init !== "function") {
+        const relevantInfo = _.pick(ext, ["name", "namespace", "path"]);
           throw new Error(
-            `init isn't a function but ${typeof init}: ${init} for ${Object.keys(ext)}`,
+            `corrupt extension, failed to initialize: ${JSON.stringify(relevantInfo)}`,
           );
         }
         init(extProxy as IExtensionContext);


### PR DESCRIPTION
closes https://linear.app/nexus-mods/issue/APP-361/some-users-hit-a-startup-crash-with-an-error-report-that-doesnt