### PR TITLE
re-use InitFunc resolver for extension dependency scan

### DIFF
--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -2992,7 +2992,7 @@ class ExtensionManager {
   }
 
   /** Finds the default exported extension init function of a module */
-  private static getExtensionInitFunc(mod: unknown): ExtensionInit | undefined {
+  public static getExtensionInitFunc(mod: unknown): ExtensionInit | undefined {
     if (!mod) return undefined;
 
     if (typeof mod === "function") return mod as ExtensionInit;

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -1,29 +1,29 @@
-import { removeExtension } from "../../actions";
+import type ZipT from "node-7z";
+
 import { unknownToError } from "@vortex/shared";
+import PromiseBB from "bluebird";
+import * as _ from "lodash";
+import * as path from "path";
+import rimraf from "rimraf";
+
+import type { ExtensionType, IExtension } from "../../types/extensions";
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
+
+import { removeExtension } from "../../actions";
+import ExtensionManager from "../../ExtensionManager";
+import { log } from "../../logging";
 import { DataInvalid } from "../../util/CustomErrors";
+import { withTrackedActivity } from "../../util/errorHandling";
 import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
-import lazyRequire from "../../util/lazyRequire";
-import { log } from "../../util/log";
-import { withTrackedActivity } from "../../util/errorHandling";
 import { INVALID_FILENAME_RE } from "../../util/util";
 import { webpackRequireHack } from "../../util/webpack-hacks";
-
 import {
   countryExists,
   languageExists,
 } from "../settings_interface/languagemap";
-
-import type { ExtensionType, IExtension } from "../../types/extensions";
 import { readExtensionInfo } from "./util";
-
-import PromiseBB from "bluebird";
-import * as _ from "lodash";
-import type ZipT from "node-7z";
-import * as path from "path";
-import rimraf from "rimraf";
 
 const rimrafAsync: (removePath: string, options: any) => PromiseBB<void> =
   PromiseBB.promisify(rimraf);
@@ -68,7 +68,14 @@ function installExtensionDependencies(
 
   try {
     const extension = webpackRequireHack(path.join(extPath, "index.js"));
-    extension.default(context);
+    const initFunc = ExtensionManager.getExtensionInitFunc(extension);
+    if (initFunc === undefined) {
+      log("warn", "extension has no init function, skipping dependency scan", {
+        extPath,
+      });
+      return PromiseBB.resolve();
+    }
+    initFunc(context);
 
     const state: IState = api.store.getState();
 


### PR DESCRIPTION
installExtensionDependencies called extension.default(context) unconditionally, which throws when an extension's index.js exports its init function as a raw CommonJS value. The crash aborted the post-install dependency scan and surfaced an error to the user.

Make ExtensionManager.getExtensionInitFunc public and reuse it — it already handles raw functions, __esModule/default, and plain default. Log and skip the scan when no init function is found.

closes https://linear.app/nexus-mods/issue/APP-362/installing-certain-extensions-fails-to-pull-in-their-dependencies