### PR TITLE
fixed w3 script merger dummy installer + error handling for undefined instructions in InstallManager

### DIFF
--- a/extensions/games/game-witcher3/package.json
+++ b/extensions/games/game-witcher3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-witcher3",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Support for The Witcher 3",
   "scripts": {
     "_assets": "copyfiles -u 1 -f ./assets/* dist",

--- a/extensions/games/game-witcher3/src/index.ts
+++ b/extensions/games/game-witcher3/src/index.ts
@@ -157,7 +157,7 @@ function main(context: types.IExtensionContext) {
     },
   });
 
-  context.registerInstaller('scriptmergerdummy', 15, scriptMergerTest as any, scriptMergerDummyInstaller as any);
+  context.registerInstaller('scriptmergerdummy', 15, scriptMergerTest as any, (() => scriptMergerDummyInstaller(context.api)) as any);
   context.registerInstaller('witcher3menumodroot', 20, testMenuModRoot as any, installMenuMod as any);
   context.registerInstaller('witcher3mixed', 25, testSupportedMixed as any, installMixed as any);
   context.registerInstaller('witcher3tl', 30, testSupportedTL as any, installTL as any);

--- a/extensions/games/game-witcher3/src/installers.ts
+++ b/extensions/games/game-witcher3/src/installers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import path from 'path';
-import { types } from 'vortex-api';
+import { types, util } from 'vortex-api';
 import { CONFIG_MATRIX_REL_PATH, GAME_ID, SCRIPT_MERGER_FILES, PART_SUFFIX } from './common';
 import { PrefixType } from './types';
 
@@ -11,19 +11,15 @@ export function scriptMergerTest(files, gameId) {
   return Promise.resolve({ supported, requiredFiles: SCRIPT_MERGER_FILES });
 }
 
-export function scriptMergerDummyInstaller() {
-  return (api: types.IExtensionApi) => {
-    api.showErrorNotification('Invalid Mod', 'It looks like you tried to install '
-      + 'The Witcher 3 Script Merger, which is a tool and not a mod for The Witcher 3.\n\n'
-      + 'The script merger should\'ve been installed automatically by Vortex as soon as you activated this extension. '
-      + 'If the download or installation has failed for any reason - please let us know why, by reporting the error through '
-      + 'our feedback system and make sure to include vortex logs. Please note: if you\'ve installed '
-      + 'the script merger in previous versions of Vortex as a mod and STILL have it installed '
-      + '(it\'s present in your mod list) - you should consider un-installing it followed by a Vortex restart; '
-      + 'the automatic merger installer/updater should then kick off and set up the tool for you.',
-      { allowReport: false });
-    return Promise.reject(new util.ProcessCanceled('Invalid mod'));
-  }
+export function scriptMergerDummyInstaller(api: types.IExtensionApi): Promise<types.IInstallResult> {
+  api.showErrorNotification?.(
+    'The Witcher 3 Script Merger is a tool, not a mod — it can\'t be installed this way.',
+    'The script merger should\'ve been installed automatically by Vortex as soon as you activated this extension. '
+    + 'If the download or installation failed, please let us know via the feedback system and include your Vortex logs. '
+    + 'Note: if you installed the script merger as a mod in an older Vortex and it\'s still in your mod list, '
+    + 'uninstall it and restart Vortex — the automatic installer will then set it up for you.',
+    { allowReport: false });
+  return Promise.reject(new util.ProcessCanceled('Invalid mod'));
 }
 
 export function testMenuModRoot(instructions: any[], gameId: string): Promise<types.ISupportedResult | boolean> {

--- a/extensions/mod-dependency-manager/src/index.tsx
+++ b/extensions/mod-dependency-manager/src/index.tsx
@@ -1139,9 +1139,10 @@ function makeLoadOrderAttribute(
     calc: (mod: types.IMod) => loadOrder[mod.id],
     condition: () => {
       const gameMode = selectors.activeGameId(api.store.getState());
+      const game = gameMode !== undefined ? util.getGame(gameMode) : undefined;
       // if mergeMods is a function we could still actually get file conflicts, because
       // it's then not guaranteed that the mod path is unique
-      return util.getGame(gameMode).mergeMods !== false;
+      return game !== undefined && game.mergeMods !== false;
     },
     edit: {},
     externalData: (onChange: () => void) => {
@@ -1169,7 +1170,8 @@ function makeDependenciesAttribute(
     ),
     condition: () => {
       const gameMode = selectors.activeGameId(api.store.getState());
-      return util.getGame(gameMode).mergeMods !== false;
+      const game = gameMode !== undefined ? util.getGame(gameMode) : undefined;
+      return game !== undefined && game.mergeMods !== false;
     },
     calc: (mod: types.IMod) => mod,
     isToggleable: true,

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1852,6 +1852,11 @@ class InstallManager {
                 .then((result: IInstallResult & { installerId?: string }) => {
                   setAttribute("mod.modId", modId);
                   setAttribute("mod.installerId", result.installerId ?? "unknown");
+                  if (!Array.isArray(result.instructions)) {
+                    return Promise.reject(
+                      new DataInvalid("Installer produced no instructions"),
+                    );
+                  }
                   setAttribute("mod.fileCount",
                     result.instructions.filter(i => i.type === "copy").length);
                   // update choices now that the installer may have produced new ones


### PR DESCRIPTION
The script merger dummy installer is meant to block users from installing it as a mod. Not sure if it ever functioned correctly. Was causing crashes + misleading error notifications were shown to the user.

- this PR also adds protective code to mod dependency table attributes (it caused crashes on my end as the game extension failed to initialize)

closes https://linear.app/nexus-mods/issue/APP-363/installing-the-witcher-3-script-merger-archive-as-a-mod-crashes-the