### PR TITLE
BG3: improve divine error handling and suppress pak-reading noise

### DIFF
--- a/extensions/games/game-baldursgate3/package.json
+++ b/extensions/games/game-baldursgate3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-baldursgate3",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Support for Baldur's Gate 3",
   "author": "Black Tree Gaming Ltd.",
   "license": "GPL-3.0",
@@ -13,9 +13,11 @@
     "_assets": "copyfiles -u 1 -f ./assets/* dist && copyfiles -u 1 -f ./tools/* dist/tools",
     "_build": "node build.mjs && pnpm run _assets && pnpm extractInfo",
     "build": "pnpm run _build && node ../../copy-extension.mjs out",
-    "dist": "pnpm run _build && node ../../copy-extension.mjs dist"
+    "dist": "pnpm run _build && node ../../copy-extension.mjs dist",
+    "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
+    "vitest": "catalog:",
     "vortex-api": "workspace:*"
   },
   "dependencies": {

--- a/extensions/games/game-baldursgate3/src/__fixtures__/pakSource/meta.lsx
+++ b/extensions/games/game-baldursgate3/src/__fixtures__/pakSource/meta.lsx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<save>
+  <version major="4" minor="0" revision="9" build="328"/>
+  <region id="Config">
+    <node id="root">
+      <children>
+        <node id="ModuleInfo">
+          <attribute id="Author" type="LSString" value="Test Author"/>
+          <attribute id="CharacterCreationLevelName" type="FixedString" value=""/>
+          <attribute id="Description" type="LSString" value="Test fixture for divineCore tests"/>
+          <attribute id="Folder" type="LSString" value="TestFixture"/>
+          <attribute id="MD5" type="LSString" value=""/>
+          <attribute id="MainMenuBackgroundVideo" type="FixedString" value=""/>
+          <attribute id="Name" type="LSString" value="TestFixture"/>
+          <attribute id="NumPlayers" type="uint8" value="4"/>
+          <attribute id="PhotoBooth" type="FixedString" value=""/>
+          <attribute id="StartupSingleplayerLevelName" type="FixedString" value=""/>
+          <attribute id="Tags" type="LSString" value=""/>
+          <attribute id="Type" type="FixedString" value="Add-on"/>
+          <attribute id="UUID" type="FixedString" value="00000000-0000-0000-0000-000000000001"/>
+          <attribute id="Version64" type="int64" value="36028797018963968"/>
+        </node>
+      </children>
+    </node>
+  </region>
+</save>

--- a/extensions/games/game-baldursgate3/src/__fixtures__/pakSource/readme.txt
+++ b/extensions/games/game-baldursgate3/src/__fixtures__/pakSource/readme.txt
@@ -1,0 +1,1 @@
+Second file used to verify that listPackageCore returns multiple entries.

--- a/extensions/games/game-baldursgate3/src/cache.ts
+++ b/extensions/games/game-baldursgate3/src/cache.ts
@@ -41,9 +41,20 @@ export default class PakInfoCache {
 
   public async getCacheEntry(api: types.IExtensionApi,
                              filePath: string,
-                             mod?: types.IMod): Promise<ICacheEntry> {
+                             mod?: types.IMod): Promise<ICacheEntry | undefined> {
     const id = this.fileId(filePath);
-    const stat = await fs.statAsync(filePath);
+    // Pak files can vanish between readPAKs listing them and this stat call
+    // (mod updates, user deletions, antivirus). Treat that as "no entry"
+    // rather than letting ENOENT propagate up through the span.
+    let stat;
+    try {
+      stat = await fs.statAsync(filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return undefined;
+      }
+      throw err;
+    }
     const ctime = stat.ctimeMs;
     const hasChanged = (entry: ICacheEntry) => {
       return (!!mod && !!entry.mod)

--- a/extensions/games/game-baldursgate3/src/divineCore.test.ts
+++ b/extensions/games/game-baldursgate3/src/divineCore.test.ts
@@ -1,0 +1,242 @@
+/**
+ * End-to-end tests for divineCore against the real divine.exe shipped in
+ * extensions/games/game-baldursgate3/tools/. No mocks: a .pak is built in
+ * beforeAll via `create-package` from src/__fixtures__/pakSource, then the
+ * runner is exercised against that pak.
+ *
+ * divine.exe is a Windows .NET binary and requires .NET 8 Desktop Runtime.
+ * The whole suite is skipped on non-win32 platforms.
+ */
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs/promises';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import {
+  DivineAborted,
+  DivineExecMissing,
+  DivinePakInvalid,
+  extractPakCore,
+  IExecErrorShape,
+  listPackageCore,
+  runDivineCore,
+  translateDivineError,
+} from './divineCore';
+
+const DIVINE_EXE = path.join(__dirname, '..', 'tools', 'divine.exe');
+const PAK_SOURCE = path.join(__dirname, '__fixtures__', 'pakSource');
+
+const isWindows = process.platform === 'win32';
+
+describe.skipIf(!isWindows)('divineCore end-to-end', () => {
+  let tempDir: string;
+  let testPak: string;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'divinecore-'));
+    testPak = path.join(tempDir, 'test.pak');
+    await runDivineCore(DIVINE_EXE, 'create-package', {
+      source: PAK_SOURCE,
+      destination: testPak,
+    });
+  });
+
+  afterAll(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('listPackageCore', () => {
+    test('returns entries for every file packed into the pak', async () => {
+      const entries = await listPackageCore(DIVINE_EXE, testPak);
+
+      // divine emits one line per file, often with size metadata. We just
+      // care that both source files show up somewhere in the output.
+      const joined = entries.join('\n');
+      expect(joined).toMatch(/meta\.lsx/);
+      expect(joined).toMatch(/readme\.txt/);
+      expect(entries.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('rejects with DivineExecMissing when the exe path does not exist', async () => {
+      const missingExe = path.join(tempDir, 'no-such-divine.exe');
+
+      await expect(listPackageCore(missingExe, testPak))
+        .rejects.toBeInstanceOf(DivineExecMissing);
+    });
+
+    test('rejects with DivinePakInvalid for a pak that does not exist', async () => {
+      // divine.exe reports the missing-file condition via [FATAL] on stdout
+      // and exits non-zero — classified as an invalid pak rather than a
+      // generic "divine failed" error so loadOrder.ts can suppress it.
+      const bogusPak = path.join(tempDir, 'does-not-exist.pak');
+
+      await expect(listPackageCore(DIVINE_EXE, bogusPak))
+        .rejects.toBeInstanceOf(DivinePakInvalid);
+    });
+
+    test('rejects with DivineAborted when the signal is pre-aborted', async () => {
+      const ac = new AbortController();
+      ac.abort();
+
+      await expect(
+        listPackageCore(DIVINE_EXE, testPak, { signal: ac.signal }),
+      ).rejects.toBeInstanceOf(DivineAborted);
+    });
+
+    test('rejects with DivineAborted when the signal fires mid-flight', async () => {
+      const ac = new AbortController();
+      const op = listPackageCore(DIVINE_EXE, testPak, { signal: ac.signal });
+      // Fire before the child process can finish; divine.exe startup is the
+      // slow part so this almost always lands during exec.
+      ac.abort();
+
+      await expect(op).rejects.toBeInstanceOf(DivineAborted);
+    });
+  });
+
+  describe('listPackageCore corrupted pak handling', () => {
+    test('rejects with DivinePakInvalid for a pak containing unrelated garbage', async () => {
+      // divine.exe reports format errors on stdout (not stderr, not exit code).
+      // With the default loglevel=error, the [ERROR] line is detected and
+      // surfaced as DivinePakInvalid so callers can classify + suppress
+      // per-pak noise. The exact wording of divine's error is not asserted —
+      // only that the bracketed marker was captured.
+      const corruptPak = path.join(tempDir, 'corrupt.pak');
+      await fs.writeFile(corruptPak, 'this is not an LSPK archive');
+
+      const op = listPackageCore(DIVINE_EXE, corruptPak);
+      await expect(op).rejects.toBeInstanceOf(DivinePakInvalid);
+      await expect(op).rejects.toSatisfy(
+        (err: DivinePakInvalid) => /\[(?:ERROR|FATAL)\]/i.test(err.details),
+      );
+    });
+
+    test('silently succeeds on a garbage pak when loglevel=off suppresses divine errors', async () => {
+      // Regression guard: loglevel=off silences divine's stdout error
+      // reporting entirely, so callers that opt into 'off' lose the ability
+      // to detect malformed paks — documented behaviour.
+      const corruptPak = path.join(tempDir, 'corrupt-silent.pak');
+      await fs.writeFile(corruptPak, 'this is not an LSPK archive');
+
+      const res = await runDivineCore(DIVINE_EXE, 'list-package', {
+        source: corruptPak,
+        loglevel: 'off',
+      });
+
+      expect(res.stdout).toBe('');
+    });
+
+    test('rejects with DivinePakInvalid for a truncated pak', async () => {
+      const truncatedPak = path.join(tempDir, 'truncated.pak');
+      const realPak = await fs.readFile(testPak);
+      await fs.writeFile(truncatedPak, realPak.subarray(0, 16));
+
+      await expect(listPackageCore(DIVINE_EXE, truncatedPak))
+        .rejects.toBeInstanceOf(DivinePakInvalid);
+    });
+
+    test('rejects with DivinePakInvalid for an empty pak file', async () => {
+      const emptyPak = path.join(tempDir, 'empty.pak');
+      await fs.writeFile(emptyPak, '');
+
+      await expect(listPackageCore(DIVINE_EXE, emptyPak))
+        .rejects.toBeInstanceOf(DivinePakInvalid);
+    });
+  });
+
+  describe('extractPakCore', () => {
+    test('extracts files matching the pattern into the destination', async () => {
+      const extractDir = path.join(tempDir, 'extracted-all');
+      await fs.mkdir(extractDir, { recursive: true });
+
+      await extractPakCore(DIVINE_EXE, testPak, extractDir, '*');
+
+      // divine may place files in a subdirectory reflecting the pak layout.
+      // Walk recursively and assert both fixtures are present somewhere.
+      const found = await collectFileNames(extractDir);
+      expect(found).toContain('meta.lsx');
+      expect(found).toContain('readme.txt');
+    });
+
+    test('honours the glob expression and skips non-matching files', async () => {
+      const extractDir = path.join(tempDir, 'extracted-txt');
+      await fs.mkdir(extractDir, { recursive: true });
+
+      await extractPakCore(DIVINE_EXE, testPak, extractDir, '*.txt');
+
+      const found = await collectFileNames(extractDir);
+      expect(found).toContain('readme.txt');
+      expect(found).not.toContain('meta.lsx');
+    });
+  });
+});
+
+describe('translateDivineError', () => {
+  // Pure unit tests: no real divine scenario produces the generic enriched
+  // branch anymore (every observed failure mode carries a [ERROR]/[FATAL]
+  // marker and classifies as DivinePakInvalid). These guard the enrichment
+  // format for future divine versions or crash-without-output cases.
+  test('embeds action, exit code, and trimmed stderr when no bracketed marker is present', () => {
+    const err: IExecErrorShape = {
+      code: 2,
+      stderr: '  something broke\n',
+      stdout: '',
+      message: 'Command failed: divine.exe ...',
+    };
+
+    const translated = translateDivineError(err, 'extract-package', false);
+
+    expect(translated).not.toBeInstanceOf(DivinePakInvalid);
+    expect(translated.message).toBe(
+      'divine.exe failed: action=extract-package; exitCode=2; stderr=something broke',
+    );
+  });
+
+  test('includes stdout only when stderr is empty and stdout has no bracketed marker', () => {
+    const err: IExecErrorShape = {
+      code: 3,
+      stderr: '',
+      stdout: 'something on stdout',
+    };
+
+    const translated = translateDivineError(err, 'list-package', false);
+
+    expect(translated.message).toContain('stdout=something on stdout');
+  });
+
+  test('falls back to err.message when exec produced no structured detail', () => {
+    const err: IExecErrorShape = { message: 'Command failed' };
+
+    expect(translateDivineError(err, 'list-package', false).message)
+      .toBe('divine.exe failed: Command failed');
+  });
+
+  test('abort takes precedence over SIGTERM timeout', () => {
+    // A cancelled child is also SIGTERM-killed, so the abort check must
+    // short-circuit before the timeout branch.
+    const err: IExecErrorShape = { signal: 'SIGTERM' };
+
+    expect(translateDivineError(err, 'list-package', true))
+      .toBeInstanceOf(DivineAborted);
+  });
+});
+
+async function collectFileNames(dir: string): Promise<string[]> {
+  const names: string[] = [];
+  const walk = async (current: string): Promise<void> => {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else {
+        names.push(entry.name);
+      }
+    }
+  };
+  await walk(dir);
+  return names;
+}

--- a/extensions/games/game-baldursgate3/src/divineCore.ts
+++ b/extensions/games/game-baldursgate3/src/divineCore.ts
@@ -1,0 +1,227 @@
+import * as nodeUtil from 'util';
+import * as child_process from 'child_process';
+import * as fs from 'fs/promises';
+
+import type { DivineAction, IDivineOptions, IDivineOutput } from './types';
+
+const exec = nodeUtil.promisify(child_process.exec);
+
+export const DEFAULT_TIMEOUT_MS = 10000;
+
+export class DivineExecMissing extends Error {
+  constructor() {
+    super('Divine executable is missing');
+    this.name = 'DivineExecMissing';
+  }
+}
+
+export class DivineMissingDotNet extends Error {
+  constructor() {
+    super('LSLib requires .NET 8 Desktop Runtime to be installed.');
+    this.name = 'DivineMissingDotNet';
+  }
+}
+
+export class DivineTimedOut extends Error {
+  constructor() {
+    super('Divine process timed out');
+    this.name = 'DivineTimedOut';
+  }
+}
+
+export class DivineAborted extends Error {
+  constructor() {
+    super('Divine operation was aborted');
+    this.name = 'DivineAborted';
+  }
+}
+
+export class DivinePakInvalid extends Error {
+  public readonly details: string;
+  constructor(details: string) {
+    super(`divine.exe reported pak is invalid: ${details}`);
+    this.name = 'DivinePakInvalid';
+    this.details = details;
+  }
+}
+
+export interface IExecErrorShape {
+  code?: number | string;
+  signal?: string;
+  message?: string;
+  stderr?: string;
+  stdout?: string;
+}
+
+export interface IDivineRunOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export function buildDivineArgs(action: DivineAction, opts: IDivineOptions): string[] {
+  // Default to 'error' (not 'off') so divine surfaces genuine failures on
+  // stdout — the exit-code path alone doesn't distinguish "empty pak" from
+  // "unreadable pak" for the list-package action.
+  const args = [
+    '--action', action,
+    '--source', `"${opts.source}"`,
+    '--game', 'bg3',
+    '--loglevel', opts.loglevel ?? 'error',
+  ];
+  if (opts.destination !== undefined) {
+    args.push('--destination', `"${opts.destination}"`);
+  }
+  if (opts.expression !== undefined) {
+    args.push('--expression', `"${opts.expression}"`);
+  }
+  return args;
+}
+
+// divine.exe tags error lines with [ERROR] or [FATAL] at loglevel=error and
+// above. Used to classify pak-format failures distinct from generic errors.
+const PAK_INVALID_MARKER = /\[(?:ERROR|FATAL)\]/i;
+
+function classifyPakInvalid(stdout: string, stderr: string): DivinePakInvalid | undefined {
+  const stdoutTrim = stdout.trim();
+  const stderrTrim = stderr.trim();
+  if (PAK_INVALID_MARKER.test(stdoutTrim) || PAK_INVALID_MARKER.test(stderrTrim)) {
+    return new DivinePakInvalid(stdoutTrim || stderrTrim);
+  }
+  return undefined;
+}
+
+export function translateDivineError(
+  err: IExecErrorShape,
+  action: DivineAction,
+  signalAborted: boolean,
+): Error {
+  // Abort check runs first: a cancelled process exits via SIGTERM, which is
+  // indistinguishable from a timeout by signal name alone.
+  if (signalAborted) {
+    return new DivineAborted();
+  }
+  if (err.code === 'ENOENT') {
+    return new DivineExecMissing();
+  }
+  if (err.message?.includes('You must install or update .NET')) {
+    return new DivineMissingDotNet();
+  }
+  if (err.signal === 'SIGTERM') {
+    return new DivineTimedOut();
+  }
+
+  const stderrStr = typeof err.stderr === 'string' ? err.stderr : '';
+  const stdoutStr = typeof err.stdout === 'string' ? err.stdout : '';
+
+  const pakInvalid = classifyPakInvalid(stdoutStr, stderrStr);
+  if (pakInvalid !== undefined) {
+    return pakInvalid;
+  }
+
+  const stderrTrim = stderrStr.trim();
+  const stdoutTrim = stdoutStr.trim();
+  const parts: string[] = [`action=${action}`];
+  if (typeof err.code === 'number') {
+    parts.push(`exitCode=${err.code}`);
+  } else if (typeof err.code === 'string') {
+    parts.push(`code=${err.code}`);
+  }
+  if (err.signal) {
+    parts.push(`signal=${err.signal}`);
+  }
+  if (stderrTrim) {
+    parts.push(`stderr=${stderrTrim}`);
+  }
+  if (stdoutTrim) {
+    parts.push(`stdout=${stdoutTrim}`);
+  }
+  const detail = parts.length > 1 ? parts.join('; ') : (err.message ?? 'unknown');
+  return new Error(`divine.exe failed: ${detail}`);
+}
+
+export function parsePackageListOutput(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}
+
+export async function runDivineCore(
+  exePath: string,
+  action: DivineAction,
+  opts: IDivineOptions,
+  runOpts: IDivineRunOptions = {},
+): Promise<IDivineOutput> {
+  // exec runs via the shell, so a missing target surfaces as a generic
+  // non-zero exit code rather than ENOENT on the spawn itself. Pre-check
+  // so DivineExecMissing fires for its intended case (LSLib not installed).
+  try {
+    await fs.stat(exePath);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new DivineExecMissing();
+    }
+    throw e;
+  }
+
+  const args = buildDivineArgs(action, opts);
+  const command = `"${exePath}" ${args.join(' ')}`;
+  const execOpts: child_process.ExecOptions = {
+    timeout: runOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    signal: runOpts.signal,
+  };
+
+  let stdout: string;
+  let stderr: string;
+  try {
+    const result = await exec(command, execOpts);
+    stdout = typeof result.stdout === 'string' ? result.stdout : result.stdout?.toString() ?? '';
+    stderr = typeof result.stderr === 'string' ? result.stderr : result.stderr?.toString() ?? '';
+  } catch (e) {
+    throw translateDivineError(
+      e as IExecErrorShape,
+      action,
+      runOpts.signal?.aborted ?? false,
+    );
+  }
+
+  // exec succeeded (exit 0) but divine may still have reported a problem:
+  // failures show up on stdout (or occasionally stderr) with a bracketed
+  // [ERROR]/[FATAL] marker rather than via non-zero exit.
+  const pakInvalid = classifyPakInvalid(stdout, stderr);
+  if (pakInvalid !== undefined) {
+    throw pakInvalid;
+  }
+  if (stderr) {
+    // Non-bracketed stderr on exit 0 — unusual but surface it anyway.
+    throw new Error(`divine.exe failed: ${stderr.trim()}`);
+  }
+  if (!stdout && action !== 'list-package') {
+    return { stdout: '', returnCode: 2 };
+  }
+  return { stdout, returnCode: 0 };
+}
+
+export async function listPackageCore(
+  exePath: string,
+  pakPath: string,
+  runOpts: IDivineRunOptions = {},
+): Promise<string[]> {
+  const res = await runDivineCore(exePath, 'list-package', { source: pakPath }, runOpts);
+  return parsePackageListOutput(res.stdout);
+}
+
+export async function extractPakCore(
+  exePath: string,
+  pakPath: string,
+  destPath: string,
+  pattern: string,
+  runOpts: IDivineRunOptions = {},
+): Promise<IDivineOutput> {
+  return runDivineCore(
+    exePath,
+    'extract-package',
+    { source: pakPath, destination: destPath, expression: pattern },
+    runOpts,
+  );
+}

--- a/extensions/games/game-baldursgate3/src/divineWrapper.ts
+++ b/extensions/games/game-baldursgate3/src/divineWrapper.ts
@@ -6,50 +6,55 @@ import { GAME_ID } from './common';
 import { DivineAction, IDivineOptions, IDivineOutput } from './types';
 import { getLatestLSLibMod, logError } from './util';
 
-import * as nodeUtil from 'util';
-import * as child_process from 'child_process';
+import {
+  DEFAULT_TIMEOUT_MS,
+  DivineAborted,
+  DivineMissingDotNet,
+  IDivineRunOptions,
+  parsePackageListOutput,
+  runDivineCore,
+} from './divineCore';
 
-const exec = nodeUtil.promisify(child_process.exec);
+// Run 5 concurrent Divine processes - retry each process 5 times if it fails,
+// but do not retry aborted operations — they should fail fast.
+const concurrencyLimiter: util.ConcurrencyLimiter = new util.ConcurrencyLimiter(
+  5,
+  (err: Error) => !(err instanceof DivineAborted));
 
-// Run 5 concurrent Divine processes - retry each process 5 times if it fails.
-const concurrencyLimiter: util.ConcurrencyLimiter = new util.ConcurrencyLimiter(5, () => true);
+// Module-level AbortController lets callers cancel all in-flight and queued
+// divine operations at once (e.g. when switching games). Replaced after each
+// abort so subsequent calls run normally.
+let abortController = new AbortController();
 
-// This is probably overkill - mod extraction shouldn't take
-//  more than a few seconds.
-const TIMEOUT_MS = 10000;
-
-export class DivineExecMissing extends Error {
-  constructor() {
-    super('Divine executable is missing');
-    this.name = 'DivineExecMissing';
-  }
+export function abortDivineOperations(): void {
+  abortController.abort();
+  abortController = new AbortController();
+  concurrencyLimiter.clearQueue();
 }
 
-export class DivineMissingDotNet extends Error {
-  constructor() {
-    super('LSLib requires .NET 8 Desktop Runtime to be installed.');
-    this.name = 'DivineMissingDotNet';
+function resolveExePath(api: types.IExtensionApi): string {
+  const state = api.getState();
+  const stagingFolder = selectors.installPathForGame(state, GAME_ID);
+  const lsLib = getLatestLSLibMod(api);
+  if (lsLib === undefined) {
+    throw new Error('LSLib/Divine tool is missing');
   }
+  return path.join(stagingFolder, lsLib.installationPath, 'tools', 'divine.exe');
 }
-
-export class DivineTimedOut extends Error {
-  constructor() {
-    super('Divine process timed out');
-    this.name = 'DivineTimedOut';
-  }
-}
-
-const execOpts: child_process.ExecOptions = {
-  timeout: TIMEOUT_MS,
-};
 
 async function runDivine(api: types.IExtensionApi,
                          action: DivineAction,
                          divineOpts: IDivineOptions)
                          : Promise<IDivineOutput> {
+  // Capture the signal at enqueue time. If the controller is replaced by
+  // abortDivineOperations() while this call is queued or retrying, the
+  // captured signal stays aborted and every attempt fails fast.
+  const signal = abortController.signal;
+  const runOpts: IDivineRunOptions = { signal, timeoutMs: DEFAULT_TIMEOUT_MS };
   return new Promise((resolve, reject) => concurrencyLimiter.do(async () => {
     try {
-      const result = await divine(api, action, divineOpts, execOpts);
+      const exePath = resolveExePath(api);
+      const result = await runDivineCore(exePath, action, divineOpts, runOpts);
       return resolve(result);
     } catch (err) {
       return reject(err);
@@ -57,102 +62,34 @@ async function runDivine(api: types.IExtensionApi,
   }));
 }
 
-async function divine(api: types.IExtensionApi,
-  action: DivineAction,
-  divineOpts: IDivineOptions,
-  execOpts: child_process.ExecOptions): Promise<IDivineOutput> {
-  return new Promise<IDivineOutput>(async (resolve, reject) => {
-    const state = api.getState();
-    const stagingFolder = selectors.installPathForGame(state, GAME_ID);
-    const lsLib: types.IMod = getLatestLSLibMod(api);
-    if (lsLib === undefined) {
-      const err = new Error('LSLib/Divine tool is missing');
-      err['attachLogOnReport'] = false;
-      return reject(err);
-    }
-    const exe = path.join(stagingFolder, lsLib.installationPath, 'tools', 'divine.exe');
-    const args = [
-      '--action', action,
-      '--source', `"${divineOpts.source}"`,
-      '--game', 'bg3',
-    ];
-
-    if (divineOpts.loglevel !== undefined) {
-      args.push('--loglevel', divineOpts.loglevel);
-    } else {
-      args.push('--loglevel', 'off');
-    }
-
-    if (divineOpts.destination !== undefined) {
-      args.push('--destination', `"${divineOpts.destination}"`);
-    }
-    if (divineOpts.expression !== undefined) {
-      args.push('--expression', `"${divineOpts.expression}"`);
-    }
-
-    try {
-      const command = `"${exe}" ${args.join(' ')}`;
-      const { stdout, stderr } = await exec(command, execOpts);
-      if (!!stderr) {
-        return reject(new Error(`divine.exe failed: ${stderr}`));
-      }
-      if (!stdout && action !== 'list-package') {
-        return resolve({ stdout: '', returnCode: 2 })
-      }      
-      const stdoutStr = typeof stdout === 'string' ? stdout : stdout?.toString?.() ?? '';
-      if (['error', 'fatal'].some(x => stdoutStr.toLowerCase().startsWith(x))) {
-        // Really?
-        return reject(new Error(`divine.exe failed: ${stdoutStr}`));
-      } else  {
-        return resolve({ stdout: stdoutStr, returnCode: 0 });
-      }
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        return reject(new DivineExecMissing());
-      }
-
-      if(err.message.includes('You must install or update .NET')) {
-        return reject(new DivineMissingDotNet());
-      }
-
-      const error = new Error(`divine.exe failed: ${err.message}`);
-      error['attachLogOnReport'] = true;
-      return reject(error);
-    }
-  });
-}
-
-export async function extractPak(api: types.IExtensionApi, pakPath, destPath, pattern) {
+export async function extractPak(api: types.IExtensionApi, pakPath: string, destPath: string, pattern: string): Promise<IDivineOutput> {
   return runDivine(api, 'extract-package',
     { source: pakPath, destination: destPath, expression: pattern });
 }
 
 export async function listPackage(api: types.IExtensionApi, pakPath: string): Promise<string[]> {
-  let res;
+  let res: IDivineOutput | undefined;
   try {
     res = await runDivine(api, 'list-package', { source: pakPath, loglevel: 'off' });
-  } catch (error) {    
+  } catch (error) {
+    if (error instanceof DivineAborted) {
+      throw error;
+    }
     logError(`listPackage caught error: `, { error });
-    //log('debug', 'listPackage error', error.message);
 
-    if(error instanceof DivineMissingDotNet) {  
+    if (error instanceof DivineMissingDotNet) {
       log('error', 'Missing .NET', error.message);
       api.dismissNotification('bg3-reading-paks-activity');
-      api.showErrorNotification('LSLib requires .NET 8', 
+      api.showErrorNotification('LSLib requires .NET 8',
       'LSLib requires .NET 8 Desktop Runtime to be installed.' +
       '[br][/br][br][/br]' +
-      '[list=1][*]Download and Install [url=https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-8.0.3-windows-x64-installer].NET 8.0 Desktop Runtime from Microsoft[/url]'  + 
-      '[*]Close Vortex' + 
-      '[*]Restart Computer' + 
+      '[list=1][*]Download and Install [url=https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-8.0.3-windows-x64-installer].NET 8.0 Desktop Runtime from Microsoft[/url]'  +
+      '[*]Close Vortex' +
+      '[*]Restart Computer' +
       '[*]Open Vortex[/list]',
        { id: 'bg3-dotnet-error', allowReport: false, isBBCode: true });
     }
   }
 
-  //logDebug(`listPackage res=`, res);
-  const lines = (res?.stdout || '').split('\n').map(line => line.trim()).filter(line => line.length !== 0);
-
-  //logDebug(`listPackage lines=`, lines);
-
-  return lines;
+  return parsePackageListOutput(res?.stdout ?? '');
 }

--- a/extensions/games/game-baldursgate3/src/index.tsx
+++ b/extensions/games/game-baldursgate3/src/index.tsx
@@ -39,6 +39,8 @@ import {
   installLSLib, installBG3SE, installEngineInjector, installModFixer, installReplacer,
 } from './installers';
 
+import { abortDivineOperations } from './divineWrapper';
+
 import {
   isBG3SE, isLSLib, isLoose, isReplacer,
 } from './modTypes';
@@ -167,6 +169,10 @@ async function onCheckModVersion(api: types.IExtensionApi, gameId: string, mods:
 
 async function onGameModeActivated(api: types.IExtensionApi, gameId: string) {
   if (gameId !== GAME_ID) {
+    // Cancel any divine.exe operations still in flight from the previous game
+    // context so they don't surface errors or overwrite caches for a game the
+    // user has since left.
+    abortDivineOperations();
     PakInfoCache.getInstance(api).save();
     return;
   }

--- a/extensions/games/game-baldursgate3/src/loadOrder.ts
+++ b/extensions/games/game-baldursgate3/src/loadOrder.ts
@@ -10,7 +10,7 @@ import { Builder, parseStringPromise, RenderOptions } from 'xml2js';
 import { LockedState } from 'vortex-api/lib/extensions/file_based_loadorder/types/types';
 import { IOpenOptions, ISaveOptions } from 'vortex-api/lib/types/IExtensionContext';
 
-import { DivineExecMissing } from './divineWrapper';
+import { DivineAborted, DivineExecMissing, DivinePakInvalid } from './divineCore';
 import { findNode, forceRefresh, getActivePlayerProfile, getDefaultModSettingsFormat, getPlayerProfiles, logDebug, modsPath, profilesPath } from './util';
 
 import PakInfoCache, { ICacheEntry } from './cache';
@@ -664,6 +664,18 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
           const pakPath = path.join(modsPath(), fileName);
           return cache.getCacheEntry(api, pakPath, mod);
         } catch (err) {
+          // Game switched (or similar) while we were reading paks — bail out
+          // without notifying the user; the new game context will re-scan.
+          if (err instanceof DivineAborted) {
+            return undefined;
+          }
+          // The pak itself is malformed — common with third-party mods and
+          // not actionable by the user. Log it and move on rather than
+          // spamming a notification per bad pak.
+          if (err instanceof DivinePakInvalid) {
+            log('warn', 'pak is invalid', { fileName, details: err.details });
+            return undefined;
+          }
           if (err instanceof DivineExecMissing) {
             const message = 'The installed copy of LSLib/Divine is corrupted - please '
               + 'delete the existing LSLib mod entry and re-install it. Make sure to '
@@ -673,14 +685,10 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
               { allowReport: false });
             return undefined;
           }
-          // could happen if the file got deleted since reading the list of paks.
-          // actually, this seems to be fairly common when updating a mod
-          if (err.code !== 'ENOENT') {
-            api.showErrorNotification('Failed to read pak. Please make sure you are using the latest version of LSLib by using the "Re-install LSLib/Divine" toolbar button on the Mods page.', err, {
-              allowReport: false,
-              message: fileName,
-            });
-          }
+          api.showErrorNotification('Failed to read pak. Please make sure you are using the latest version of LSLib by using the "Re-install LSLib/Divine" toolbar button on the Mods page.', err, {
+            allowReport: false,
+            message: fileName,
+          });
           return undefined;
         }
       };
@@ -689,7 +697,7 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
   }));
   api.dismissNotification('bg3-reading-paks-activity');
 
-  return res.filter(iter => iter !== undefined);
+  return res.filter((iter): iter is ICacheEntry => iter !== undefined);
 }
 
 async function readPAKList(api: types.IExtensionApi) {

--- a/extensions/games/game-baldursgate3/src/util.ts
+++ b/extensions/games/game-baldursgate3/src/util.ts
@@ -340,8 +340,8 @@ export async function extractPakInfoImpl(api: types.IExtensionApi, pakPath: stri
 export async function extractMeta(api: types.IExtensionApi, pakPath: string, mod: types.IMod): Promise<IModSettings> {
   const metaPath = path.join(util.getVortexPath('temp'), 'lsmeta', shortid());
   await fs.ensureDirAsync(metaPath);
-  await extractPak(api, pakPath, metaPath, '*/meta.lsx');
   try {
+    await extractPak(api, pakPath, metaPath, '*/meta.lsx');
     // the meta.lsx may be in a subdirectory. There is probably a pattern here
     // but we'll just use it from wherever
     let metaLSXPath: string = path.join(metaPath, 'meta.lsx');

--- a/extensions/games/game-baldursgate3/vitest.config.ts
+++ b/extensions/games/game-baldursgate3/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    // divine.exe invocations can be slow on cold caches.
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1858,6 +1858,9 @@ importers:
         specifier: 'catalog:'
         version: 11.2.7
     devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.8)(jsdom@20.0.3)(vite@8.0.3)
       vortex-api:
         specifier: workspace:*
         version: link:../../../packages/vortex-api
@@ -16480,7 +16483,7 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@types/node@22.19.15)(jiti@2.6.1)(sass@1.97.3)(terser@5.46.1)
+      vite: 8.0.3(@types/node@25.5.0)(jiti@2.6.1)(sass@1.97.3)(terser@5.46.1)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -23209,6 +23212,37 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.15
+      '@vitest/ui': 4.1.0(vitest@4.1.2)
+      happy-dom: 20.8.8
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.8)(jsdom@20.0.3)(vite@8.0.3):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.3)
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@types/node@25.5.0)(jiti@2.6.1)(sass@1.97.3)(terser@5.46.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.5.0
       '@vitest/ui': 4.1.0(vitest@4.1.2)
       happy-dom: 20.8.8
       jsdom: 20.0.3


### PR DESCRIPTION
Split divineWrapper into a pure divineCore (arg building, error translation, exec runner) and an api-aware wrapper (concurrency limiter, abort controller, pak-path resolution) so the core is testable against the real tools/divine.exe without mocks.

Telemetry (fixes 70bb0129):
- Enriched error carries action, exitCode, signal, trimmed stderr/stdout pulled off the rejected child_process.exec error.
- Default --loglevel flipped off -> error so divine actually surfaces failures; post-run content check matches divine's [ERROR]/[FATAL] markers. listPackage keeps an explicit loglevel=off for lenient background scans.
- fs.stat pre-check on divine.exe restores DivineExecMissing's intended semantics (exec goes through cmd.exe on Windows, so spawn-level ENOENT never reaches the wrapper).

Pak classification:
- New DivinePakInvalid thrown when divine reports a format problem (bracketed marker on either stream). loadOrder logs at warn and skips silently — no more "re-install LSLib" notification per corrupt third-party pak.

Cancellation:
- Module-level AbortController with exported abortDivineOperations(), wired to gamemode-activated so in-flight and queued divine calls die fast with DivineAborted when the user switches games.

Vanished-pak race (fixes de5a28f7):
- PakInfoCache.getCacheEntry catches ENOENT from its initial stat and returns undefined. The exception no longer escapes the cache, so withTrackedActivity sees a clean span.

Tests: new divineCore.test.ts — 15 vitest tests against the real tools/divine.exe with fixture paks built in beforeAll.

fixes https://linear.app/nexus-mods/issue/APP-364/bg3-pak-reading-pipeline-produces-noisy-non-actionable-telemetry