### PR TITLE
guard undefined currentProfile in install fallback path

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1322,7 +1322,8 @@ class InstallManager {
     );
     const profileId =
       batchContext?.get<string>("profileId") ?? activeProfile(state)?.id;
-    const currentProfile = profileById(state, profileId);
+    const currentProfile =
+      profileById(state, profileId) ?? activeProfile(state);
 
     // Use parallel installation concurrency limiter instead of sequential mQueue
     this.mMainInstallsLimit
@@ -1430,6 +1431,13 @@ class InstallManager {
                       installGameId,
                       modId,
                     });
+                    if (currentProfile === undefined) {
+                      return Promise.reject(
+                        new ProcessCanceled(
+                          "You need to manage a game before installing this mod",
+                        ),
+                      );
+                    }
                     installGameId = currentProfile.gameId;
                   }
                   const discovery = discoveryByGame(state, installGameId);


### PR DESCRIPTION
currentProfile could be undefined when the batch-context profileId was stale or no active profile existed. Fall back to activeProfile(state), and ProcessCanceled-reject when neither is available.

fingerprint: `ab325d1c`

fixes https://linear.app/nexus-mods/issue/APP-366/mod-install-pipeline-crashes-with-undefined-gameid-when-current