### PR TITLE
only show "already running" dialog on real DB lock contention

### DIFF
--- a/docs/error-reporting/critical-errors.md
+++ b/docs/error-reporting/critical-errors.md
@@ -66,7 +66,7 @@ Separate from the renderer-side `errorIgnored` flag in `src/renderer/util/errorH
 |------|---------|
 | `src/main/main.ts` | `uncaughtException` / `unhandledRejection` during startup (after app ready); filtered through `Application.shouldIgnoreError()` |
 | `src/main/Application.ts` | `uncaughtException` / `unhandledRejection` during normal operation (replaces the startup handler once persistence is set up) |
-| `src/main/Application.ts` | Startup failure that is not `UserCanceled`, `ProcessCanceled`, `DocumentsPathMissing`, or `DatabaseLocked` |
+| `src/main/Application.ts` | Startup failure that is not `UserCanceled`, `ProcessCanceled`, `DocumentsPathMissing`, `DatabaseLocked`, or `DatabaseOpenError` |
 | `src/main/store/ReduxPersistorIPC.ts` | Disk-full error during state write (`IO error: ...Append: cannot write`) — user-friendly message; `allowReport = undefined` (default) |
 | `src/main/store/ReduxPersistorIPC.ts` | Any other persistence write failure — `allowReport = true` |
 | `src/main/MainWindow.ts` | Renderer emits a console error but the window has not shown within 15 seconds — `allowReport = true` |

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -39,7 +39,7 @@ import { log, setupLogging, changeLogPath } from "./logging";
 import MainWindow from "./MainWindow";
 import SplashScreen from "./SplashScreen";
 import DuckDBSingleton from "./store/DuckDBSingleton";
-import LevelPersist, { DatabaseLocked } from "./store/LevelPersist";
+import LevelPersist, { DatabaseLocked, DatabaseOpenError } from "./store/LevelPersist";
 import {
   initMainPersistence,
   readPersistedValue,
@@ -410,6 +410,17 @@ class Application {
           "Startup failed",
           "Vortex seems to be running already. " +
             "If you can't see it, please check the task manager.",
+        );
+
+        app.quit();
+      } else if (err instanceof DatabaseOpenError) {
+        dialog.showErrorBox(
+          "Startup failed",
+          `Vortex couldn't open its application database at:\n\n` +
+            `${err.path}\n\n` +
+            `Underlying error: ${err.cause}\n\n` +
+            `This is not a "database locked" condition — a different problem is preventing the database from opening. ` +
+            `Check that the path is accessible, the drive isn't full or read-only, and that no antivirus is quarantining files in that folder.`,
         );
 
         app.quit();

--- a/src/main/src/store/LevelPersist.ts
+++ b/src/main/src/store/LevelPersist.ts
@@ -20,6 +20,26 @@ export class DatabaseLocked extends Error {
   }
 }
 
+export class DatabaseOpenError extends Error {
+  public readonly path: string;
+  public readonly cause: string;
+  constructor(persistPath: string, cause: string) {
+    super(`Failed to open database at ${persistPath}: ${cause}`);
+    this.name = this.constructor.name;
+    this.path = persistPath;
+    this.cause = cause;
+  }
+}
+
+// Lock-contention text produced by leveldb's env layer when another process
+// holds the LOCK file — matched across platforms.  Only these messages should
+// trigger the "another instance is running" code path.
+function isLockContention(message: string): boolean {
+  return /being used by another process|already held|resource (temporarily )?unavailable|resource busy/i.test(
+    message,
+  );
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -46,19 +66,28 @@ class LevelPersist implements IPersistor {
       return new LevelPersist(connection, alias);
     } catch (unknownErr) {
       const err = unknownToError(unknownErr);
-      log("warn", "duckdb: openDB failed", {
-        message: err.message,
-        triesRemaining: tries,
-        path: persistPath,
-      });
       if (err instanceof DataInvalid) {
         throw err;
       }
       if (/corrupt/i.test(err.message)) {
         throw new DataInvalid(err.message);
       }
+      if (!isLockContention(err.message)) {
+        // Not a lock conflict — retrying won't help. Surface the real cause so
+        // the startup handler can show the user an accurate diagnostic instead
+        // of the misleading "another instance is running" dialog.
+        log("warn", "duckdb: openDB failed", {
+          message: err.message,
+          path: persistPath,
+        });
+        throw new DatabaseOpenError(persistPath, err.message);
+      }
+      log("warn", "duckdb: openDB locked, retrying", {
+        message: err.message,
+        triesRemaining: tries,
+        path: persistPath,
+      });
       if (tries === 0) {
-        log("info", "failed to open db", err);
         throw new DatabaseLocked();
       }
       await delay(500);


### PR DESCRIPTION
LevelPersist threw DatabaseLocked for any open failure, surfacing the "Vortex seems to be running already" dialog even when the real cause was path encoding, permissions, or disk full. Now only actual lock-contention messages retry and raise DatabaseLocked; everything else throws DatabaseOpenError and shows the real cause + path.

The underlying leveldb UTF-8 path bug is fixed upstream in https://github.com/halgari/duckdb-level-pivot/pull/1

part of https://linear.app/nexus-mods/issue/APP-377/vortex-doesnt-start-for-users-with-non-ascii-characters-in-their part of https://github.com/Nexus-Mods/Vortex/issues/22689