### PR TITLE
fixed install crash from fileList.push spread on large archives

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1143,7 +1143,7 @@ class InstallManager {
         ));
     }
 
-    const fileList: string[] = [];
+    let fileList: string[] = [];
 
     return extractProm
       .then(({ code, errors }: { code: number; errors: string[] }) => {
@@ -1171,9 +1171,8 @@ class InstallManager {
           return Promise.resolve();
         }
       })
-      .then(() => buildFileList(tempPath))
-      .then((result) => { fileList.push(...result); })
-      .then(() => {
+      .then(async () => {
+        fileList = await buildFileList(tempPath);
         if (truthy(extractList) && extractList.length > 0) {
           return makeListInstaller(extractList, tempPath);
         } else {
@@ -4021,7 +4020,7 @@ class InstallManager {
     unattended?: boolean,
     details?: IInstallationDetails,
   ): Promise<IInstallResult> {
-    const fileList: string[] = [];
+    let fileList: string[] = [];
     let phase = "Extracting";
 
     const progress = (files: string[], percent: number) => {
@@ -4075,9 +4074,8 @@ class InstallManager {
           await this.queryContinue(api, errors, archivePath);
         }
       })
-      .then(() => buildFileList(tempPath))
-      .then((result) => { fileList.push(...result); })
       .then(async () => {
+        fileList = await buildFileList(tempPath);
         const hasFomodSegment = (file: string) => {
           const segments = file.toLowerCase().split(path.sep);
           return segments.includes("fomod");


### PR DESCRIPTION
Replaces `fileList.push(...result)` with direct assignment from `buildFileList`, folded into the following .then block. The spread overflows the call stack when archives contain ~100k+ files.

fixes https://linear.app/nexus-mods/issue/APP-378