### PR TITLE
bumped fomod installer package to 0.13.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,11 +53,11 @@ catalogs:
       specifier: ^2.7.0
       version: 2.8.0
     '@nexusmods/fomod-installer-ipc':
-      specifier: ^0.13.0
-      version: 0.13.0
+      specifier: ^0.13.1
+      version: 0.13.1
     '@nexusmods/fomod-installer-native':
-      specifier: ^0.13.0
-      version: 0.13.0
+      specifier: ^0.13.1
+      version: 0.13.1
     '@nexusmods/nexus-api':
       specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
       version: 1.5.2
@@ -3983,10 +3983,10 @@ importers:
         version: 2.8.0
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.13.1
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
@@ -4480,10 +4480,10 @@ importers:
         version: 2.8.0
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.13.1
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
@@ -6043,12 +6043,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@nexusmods/fomod-installer-ipc@0.13.0':
-    resolution: {integrity: sha512-oWc2eCsu8FewYFq3w5gRFtiDZFbRPIWi1VgvqHJQhKN93WTmzVf0po7r3F/604SDTpNAuquHgFqWU8np7S83yA==}
+  '@nexusmods/fomod-installer-ipc@0.13.1':
+    resolution: {integrity: sha512-Q3tZIMWjMV0J8wJAe2qPCMQQJP+MlI7fn60UFtRYcO8igdaevQvI0OPprH8bJyFOe3WMDyrpyyQiD9vTjwPqww==}
     engines: {node: '>=22'}
 
-  '@nexusmods/fomod-installer-native@0.13.0':
-    resolution: {integrity: sha512-jkoXlWllwWXiQKrN1tKvTl7e86yw8kis3dA8FdPvzlxuYY/MkMThMzlIe81zlh0fROBEvcxHTy9SUZVbST4UDQ==}
+  '@nexusmods/fomod-installer-native@0.13.1':
+    resolution: {integrity: sha512-6fcow0nDO8I4KFYG1ffa5z9FcKkZsW/D1Axjkb5ebmV47JKg10nJALv8sVkd0hCrKCW8oJZEEvgHKOkF2Pn9ww==}
     engines: {node: '>=22'}
 
   '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161':
@@ -14952,9 +14952,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nexusmods/fomod-installer-ipc@0.13.0': {}
+  '@nexusmods/fomod-installer-ipc@0.13.1': {}
 
-  '@nexusmods/fomod-installer-native@0.13.0':
+  '@nexusmods/fomod-installer-native@0.13.1':
     dependencies:
       node-gyp-build: 4.8.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,8 +49,8 @@ catalog:
   "@mdi/js": 7.4.47
   "@microsoft/api-extractor": ^7.57.6
   "@msgpack/msgpack": ^2.7.0
-  "@nexusmods/fomod-installer-ipc": ^0.13.0
-  "@nexusmods/fomod-installer-native": ^0.13.0
+  "@nexusmods/fomod-installer-ipc": ^0.13.1
+  "@nexusmods/fomod-installer-native": ^0.13.1
   "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
   "@opentelemetry/api": ^1.9.0
   "@opentelemetry/context-async-hooks": ^2.5.1


### PR DESCRIPTION
Picks up the APP-379 preset-conversion fix (KeyNotFoundException when saved choices reference steps that no longer exist).