### PR TITLE
Morrowind: skip missing mod dirs in migrate103 plugin scan

### DIFF
--- a/extensions/games/game-morrowind/src/migrations.js
+++ b/extensions/games/game-morrowind/src/migrations.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const semver = require('semver');
-const { actions, selectors, util } = require('vortex-api');
+const { actions, log, selectors, util } = require('vortex-api');
 const { MORROWIND_ID } = require('./constants');
 
 const walk = require('turbowalk').default;
@@ -24,13 +24,19 @@ async function migrate103(api, oldVersion) {
     }
     const modPath = path.join(installPath, mod.installationPath);
     const plugins = [];
-    await walk(modPath, entries => {
-      for (let entry of entries) {
-        if (['.esp', '.esm'].includes(path.extname(entry.filePath.toLowerCase()))) {
-          plugins.push(path.basename(entry.filePath));
+    try {
+      await walk(modPath, entries => {
+        for (let entry of entries) {
+          if (['.esp', '.esm'].includes(path.extname(entry.filePath.toLowerCase()))) {
+            plugins.push(path.basename(entry.filePath));
+          }
         }
-      }
-    }, { recurse: true, skipLinks: true, skipInaccessible: true });
+      }, { recurse: true, skipLinks: true, skipInaccessible: true });
+    } catch {
+      // don't know, don't care, just skip it
+      log('warn', 'morrowind migrate103: mod directory missing or inaccessible, skipping', { modPath });
+      continue;
+    }
     if ( plugins.length > 0) {
       batched.push(actions.setModAttribute(MORROWIND_ID, mod.id, 'plugins', plugins));
     }


### PR DESCRIPTION
migrate103 walks each mod's install directory to scrape plugin filenames. If the directory no longer exists on disk, turbowalk throws WinApiException on the root and aborts the whole loop, leaving every remaining mod unscanned. Per-mod try/catch so a missing/inaccessible root just logs and continues.

fixes https://linear.app/nexus-mods/issue/APP-381