### PR TITLE
suppress error report when user declines Nexus login

### DIFF
--- a/src/renderer/src/views/components/Header/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/ProfileSection.tsx
@@ -14,18 +14,19 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
+import { setDialogVisible } from "../../../actions/session";
+import { useExtensionContext } from "../../../ExtensionProvider";
 import {
   clearOAuthCredentials,
   setUserAPIKey,
 } from "../../../extensions/nexus_integration/actions/account";
 import { NEXUS_BASE_URL } from "../../../extensions/nexus_integration/constants";
-import { setDialogVisible } from "../../../actions/session";
-import { useExtensionContext } from "../../../ExtensionProvider";
 import { Dropdown } from "../../../ui/components/dropdown/Dropdown";
 import { DropdownDivider } from "../../../ui/components/dropdown/DropdownDivider";
 import { DropdownItem } from "../../../ui/components/dropdown/DropdownItem";
 import { DropdownItems } from "../../../ui/components/dropdown/DropdownItems";
 import { Icon } from "../../../ui/components/icon/Icon";
+import { UserCanceled } from "../../../util/CustomErrors";
 import opn from "../../../util/opn";
 import {
   isLoggedIn as isLoggedInSelector,
@@ -82,8 +83,11 @@ export const ProfileSection: FC = () => {
     } else {
       dispatch(setDialogVisible("login-dialog"));
       api.events.emit("request-nexus-login", (err: Error) => {
-        if (err !== null) {
-          api.showErrorNotification?.("Login Failed", err);
+        if (err != null && !(err instanceof UserCanceled)) {
+          api.showErrorNotification?.("Login Failed", err, {
+            id: "failed-get-nexus-key",
+            allowReport: false,
+          });
         }
       });
     }


### PR DESCRIPTION
ProfileSection's login callback surfaced OAuth access_denied errors (the user clicking "Deny" on the Nexus consent page) via showErrorNotification without allowReport:false, so every user-declined login reached the crash reporter. Matches the pattern already used by LoginDialog / LoginIcon.

fixes https://linear.app/nexus-mods/issue/APP-382