### PR TITLE
fixed incorrect fallback value for FOMOD installer choices

### DIFF
--- a/src/renderer/src/extensions/installer_fomod_native/installer.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/installer.ts
@@ -24,18 +24,23 @@ export const install = async (
   files: string[],
   scriptPath: string,
   gameId: string,
-  choicesIn?: {  type: string; options: IChoices },
+  choicesIn?: unknown,
   unattended?: boolean,
   details?: IInstallationDetails,
 ) => {
   const instanceId = shortid();
 
-  const fomodChoices: IChoices =
-    choicesIn !== undefined
-    && choicesIn.type === "fomod"
-    && Array.isArray(choicesIn.options)
-      ? choicesIn.options
-      : undefined;
+  const isFomodChoicesIn = (
+    value: unknown,
+  ): value is { type: string; options: IChoices } =>
+    typeof value === "object"
+    && value != null
+    && (value as { type?: unknown }).type === "fomod"
+    && Array.isArray((value as { options?: unknown }).options);
+
+  const fomodChoices: IChoices = isFomodChoicesIn(choicesIn)
+    ? choicesIn.options
+    : undefined;
 
   const invokeInstall = async (validate: boolean) => {
     // When override instructions file is present, use only the universal stop patterns and null pluginPath

--- a/src/renderer/src/extensions/installer_fomod_native/installer.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/installer.ts
@@ -1,40 +1,40 @@
 import { generate as shortid } from "shortid";
 
-import { VortexModInstaller } from "./utils/VortexModInstaller";
-
-import type { IChoices } from "../installer_fomod_shared/types/interface";
-import {
-  getPluginPath,
-  getStopPatterns,
-  uniPatterns,
-} from "../installer_fomod_shared/utils/gameSupport";
-import { getChoicesFromState } from "../installer_fomod_shared/utils/helpers";
-
-import type { IInstallationDetails } from "../mod_management/types/InstallFunc";
-
 import type {
   IExtensionApi,
   IInstallResult,
   IInstruction,
   InstructionType,
 } from "../../types/api";
-import { getGame } from "../gamemode_management/util/getGame";
+import type { IChoices } from "../installer_fomod_shared/types/interface";
+import type { IInstallationDetails } from "../mod_management/types/InstallFunc";
+
 import { UserCanceled } from "../../util/CustomErrors";
+import { getGame } from "../gamemode_management/util/getGame";
+import {
+  getPluginPath,
+  getStopPatterns,
+  uniPatterns,
+} from "../installer_fomod_shared/utils/gameSupport";
+import { getChoicesFromState } from "../installer_fomod_shared/utils/helpers";
+import { VortexModInstaller } from "./utils/VortexModInstaller";
 
 export const install = async (
   api: IExtensionApi,
   files: string[],
   scriptPath: string,
   gameId: string,
-  choicesIn?: any,
+  choicesIn?: {  type: string; options: IChoices },
   unattended?: boolean,
   details?: IInstallationDetails,
 ) => {
   const instanceId = shortid();
 
   const fomodChoices: IChoices =
-    choicesIn !== undefined && choicesIn.type === "fomod"
-      ? (choicesIn.options ?? {})
+    choicesIn !== undefined
+    && choicesIn.type === "fomod"
+    && Array.isArray(choicesIn.options)
+      ? choicesIn.options
       : undefined;
 
   const invokeInstall = async (validate: boolean) => {


### PR DESCRIPTION
IChoices is typed as Step[] | undefined, but the preset builder fell back to {} when choicesIn.options was missing. That empty object reached the native fomod-installer, whose ParseJsonArray rejects any non-array root with "JSON root must be an array". Guard with Array.isArray so "no options" actually means no preset.

fixes https://linear.app/nexus-mods/issue/APP-383