### PR TITLE
stop recording eslify environment errors as false successes

### DIFF
--- a/extensions/gamebryo-plugin-management/src/index.ts
+++ b/extensions/gamebryo-plugin-management/src/index.ts
@@ -1982,18 +1982,9 @@ function init(context: IExtensionContextExt) {
       return;
     }
 
-    try {
-      const esp = new ESPFile(plugin.filePath, profile.gameId);
-      esp.setLightFlag(enable);
-    } catch (err) {
-      if (err.nativeCode !== 0) {
-        context.api.showErrorNotification("Failed to set light flag", err, {
-          message: plugin.filePath,
-          allowReport: true,
-        });
-        return;
-      }
-    }
+    const esp = new ESPFile(plugin.filePath, profile.gameId);
+    esp.setLightFlag(enable);
+
     context.api.ext.addToHistory("plugins", {
       type: "plugin-eslified",
       gameId: profile.gameId,

--- a/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
+++ b/extensions/gamebryo-plugin-management/src/views/PluginList.tsx
@@ -1218,7 +1218,7 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
       })
       .catch((err) => {
         const isUserError =
-          ["EPERM", "EACCESS"].includes(err.code) ||
+          ["EPERM", "EACCESS", "UNKNOWN"].includes(err.code) ||
           err.message.includes("file not found") ||
           // TODO: error messages from the library are localized, this is what we
           //   actually want to filter by, rather than rename:
@@ -1250,7 +1250,7 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
       })
       .catch((err) => {
         const isUserError =
-          ["EPERM", "EACCESS"].includes(err.code) ||
+          ["EPERM", "EACCESS", "UNKNOWN"].includes(err.code) ||
           err.message.includes("file not found") ||
           // TODO: error messages from the library are localized, this is what we
           //   actually want to filter by, rather than rename:


### PR DESCRIPTION
Previously, failures to change the light flag on gamebryo plugins were being treated as "success" adding the action to history. Trying to interact with the history entry will obviously fail as we never actually managed to change the flag.

fixes https://linear.app/nexus-mods/issue/APP-385