### PR TITLE
Add downloadid when throwing AlredyDownloaded error

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -471,7 +471,12 @@ export class IPCDownloadAdapter {
         () => false,
       );
       if (fileExists) {
-        callback?.(new AlreadyDownloaded(fileName));
+        const downloads = state.persistent.downloads.files;
+        const [existingId, _] = Object.entries(downloads).find(
+          ([_, download]) => download.localPath === fileName,
+        );
+
+        callback?.(new AlreadyDownloaded(fileName, existingId));
         return;
       }
     }


### PR DESCRIPTION
Closes APP-389.
