### PR TITLE
prevent false external-changes dialog after remove/replace

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -605,10 +605,15 @@ class InstallManager {
   //  to inspect the state of ongoing installations
   private mActiveInstalls: Map<string, IActiveInstallation> = new Map();
 
-  // Mod IDs that completed installation since the last deployment.
-  // Consumed (and cleared) by the deployment flow to auto-resolve expected
-  // external changes caused by reinstalls/updates.
-  private mRecentlyInstalledMods: Set<string> = new Set();
+  // Installation paths (mod.installationPath) of mods that completed
+  // installation or removal since the last deployment. Consumed (and cleared)
+  // by the deployment flow to auto-resolve expected external changes caused by
+  // Vortex's own operations. We track installation paths rather than mod IDs
+  // because that's what the deployment manifest stores in IDeployedFile.source,
+  // and in the update-via-replace flow a new mod can end up with id !=
+  // installationPath (e.g. new mod id reusing the previous version's staging
+  // folder), which would otherwise miss the auto-resolve filter.
+  private mRecentChangedPaths: Set<string> = new Set();
 
   // Tracks retry counts for failed dependency installations
   private mDependencyRetryCount: Map<string, number> = new Map();
@@ -1018,20 +1023,38 @@ class InstallManager {
 
   /**
    * Record that a mod was recently installed/reinstalled. The deployment flow
-   * uses this to auto-resolve expected external changes for these mods.
+   * uses this to auto-resolve expected external changes for these mods. We
+   * resolve to mod.installationPath because that's what the deployment
+   * manifest's IDeployedFile.source field stores; for the replace-existing-mod
+   * flow this can differ from `modId`.
    */
-  public markRecentInstall(modId: string): void {
-    this.mRecentlyInstalledMods.add(modId);
+  public markRecentInstall(modId: string, gameId: string): void {
+    if (!modId) {
+      return;
+    }
+    const mod = this.mApi.getState().persistent.mods?.[gameId]?.[modId];
+    this.mRecentChangedPaths.add(mod?.installationPath ?? modId);
   }
 
   /**
-   * Returns the set of mod IDs that completed installation since the last
-   * deployment and clears the internal tracking. Intended to be called once
-   * per deployment cycle.
+   * Record that a mod was just removed by Vortex. The next deployment flow
+   * will treat any srcdeleted/refchange entries from this installation path as
+   * expected (and drop them from the manifest).
    */
-  public consumeRecentInstalls(): Set<string> {
-    const result = new Set(this.mRecentlyInstalledMods);
-    this.mRecentlyInstalledMods.clear();
+  public markRecentRemoval(installationPath: string): void {
+    if (installationPath) {
+      this.mRecentChangedPaths.add(installationPath);
+    }
+  }
+
+  /**
+   * Returns the set of installation paths whose mods finished installing or
+   * were removed since the last deployment, and clears the internal tracking.
+   * Intended to be called once per deployment cycle.
+   */
+  public consumeRecentChanges(): Set<string> {
+    const result = new Set(this.mRecentChangedPaths);
+    this.mRecentChangedPaths.clear();
     return result;
   }
 
@@ -1301,7 +1324,7 @@ class InstallManager {
             duration: Date.now() - activeInstall.startTime,
           });
           if (id) {
-            this.markRecentInstall(id);
+            this.markRecentInstall(id, activeInstall.gameId);
           }
         }
       }

--- a/src/renderer/src/extensions/mod_management/eventHandlers.ts
+++ b/src/renderer/src/extensions/mod_management/eventHandlers.ts
@@ -835,6 +835,7 @@ function undeployMods(
 export function onRemoveMods(
   api: IExtensionApi,
   activators: IDeploymentMethod[],
+  installManager: InstallManager,
   gameId: string,
   modIds: string[],
   callback?: (error: Error) => void,
@@ -948,6 +949,11 @@ export function onRemoveMods(
               forwardOptions,
             );
 
+            // Tell the deployment flow this removal is expected, so the
+            // next external-changes scan auto-resolves the now-srcdeleted
+            // manifest entries instead of surfacing a confusing dialog.
+            installManager.markRecentRemoval(mod.installationPath);
+
             batched.push(removeMod(gameId, mod.id));
             if (batched.length >= 10 || completedCount + 1 === totalCount) {
               batchDispatch(store, batched);
@@ -1000,6 +1006,7 @@ export function onRemoveMods(
 export function onRemoveMod(
   api: IExtensionApi,
   activators: IDeploymentMethod[],
+  installManager: InstallManager,
   gameId: string,
   modId: string,
   callback?: (error: Error) => void,
@@ -1009,7 +1016,15 @@ export function onRemoveMod(
     callback?.(null);
     return;
   }
-  return onRemoveMods(api, activators, gameId, [modId], callback, options);
+  return onRemoveMods(
+    api,
+    activators,
+    installManager,
+    gameId,
+    [modId],
+    callback,
+    options,
+  );
 }
 
 export function onAddMod(

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -829,10 +829,11 @@ function genUpdateModDeployment(installManager: InstallManager) {
               await installManager.waitForIdle();
             }
 
-            // Consume the set of mod IDs that finished installing since the
-            // last deployment. Their external changes (refchange / srcdeleted)
-            // are expected and will be auto-resolved per-mod.
-            const recentInstalls = installManager.consumeRecentInstalls();
+            // Consume the set of installation paths whose mods finished
+            // installing or were removed since the last deployment. Their
+            // external changes (refchange / srcdeleted) are expected and
+            // will be auto-resolved per-mod.
+            const recentChanges = installManager.consumeRecentChanges();
 
             let mergeResult: { [modType: string]: IMergeResultByType };
             const lastDeployment: { [typeId: string]: IDeployedFile[] } = {};
@@ -853,6 +854,40 @@ function genUpdateModDeployment(installManager: InstallManager) {
                 activator,
               );
               lastDeployment[typeId] = deployedFiles;
+            }
+
+            // Drop manifest entries whose source mod is no longer in Redux
+            // state. These are orphans from a prior remove (or any operation
+            // that failed to clean up the manifest synchronously) and would
+            // otherwise surface as srcdeleted/refchange against the user
+            // dialog on every subsequent deploy — including across restarts,
+            // when the in-memory recentChanges allow-list is empty. Merged
+            // entries are preserved: they belong to the merge step, not to
+            // any specific mod.
+            if (Object.keys(mods).length > 0) {
+              const knownInstallationPaths = new Set<string>(
+                Object.values(mods)
+                  .map((mod) => mod.installationPath)
+                  .filter(
+                    (p): p is string => typeof p === "string" && p.length > 0,
+                  ),
+              );
+              for (const typeId of Object.keys(lastDeployment)) {
+                const before = lastDeployment[typeId].length;
+                lastDeployment[typeId] = lastDeployment[typeId].filter(
+                  (entry) =>
+                    path.basename(entry.source).startsWith(MERGED_PATH) ||
+                    knownInstallationPaths.has(entry.source),
+                );
+                const dropped = before - lastDeployment[typeId].length;
+                if (dropped > 0) {
+                  log("info", "dropped orphan manifest entries", {
+                    typeId,
+                    dropped,
+                    remaining: lastDeployment[typeId].length,
+                  });
+                }
+              }
             }
 
             progress(t("Running pre-deployment events"), 2);
@@ -883,7 +918,7 @@ function genUpdateModDeployment(installManager: InstallManager) {
               stagingPath,
               modPaths,
               lastDeployment,
-              recentInstalls,
+              recentChanges,
             );
 
             progress(t("Checking for mod incompatibilities"), 25);
@@ -1845,7 +1880,16 @@ function once(api: IExtensionApi) {
       modId: string,
       cb?: (error: Error) => void,
       options?: IRemoveModOptions,
-    ) => onRemoveMod(api, getAllActivators(), gameId, modId, cb, options),
+    ) =>
+      onRemoveMod(
+        api,
+        getAllActivators(),
+        installManager,
+        gameId,
+        modId,
+        cb,
+        options,
+      ),
   );
 
   api.events.on(
@@ -1856,7 +1900,15 @@ function once(api: IExtensionApi) {
       cb?: (error: Error) => void,
       options?: IRemoveModOptions,
     ) => {
-      onRemoveMods(api, getAllActivators(), gameId, modIds, cb, options);
+      onRemoveMods(
+        api,
+        getAllActivators(),
+        installManager,
+        gameId,
+        modIds,
+        cb,
+        options,
+      );
     },
   );
 

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -856,40 +856,6 @@ function genUpdateModDeployment(installManager: InstallManager) {
               lastDeployment[typeId] = deployedFiles;
             }
 
-            // Drop manifest entries whose source mod is no longer in Redux
-            // state. These are orphans from a prior remove (or any operation
-            // that failed to clean up the manifest synchronously) and would
-            // otherwise surface as srcdeleted/refchange against the user
-            // dialog on every subsequent deploy — including across restarts,
-            // when the in-memory recentChanges allow-list is empty. Merged
-            // entries are preserved: they belong to the merge step, not to
-            // any specific mod.
-            if (Object.keys(mods).length > 0) {
-              const knownInstallationPaths = new Set<string>(
-                Object.values(mods)
-                  .map((mod) => mod.installationPath)
-                  .filter(
-                    (p): p is string => typeof p === "string" && p.length > 0,
-                  ),
-              );
-              for (const typeId of Object.keys(lastDeployment)) {
-                const before = lastDeployment[typeId].length;
-                lastDeployment[typeId] = lastDeployment[typeId].filter(
-                  (entry) =>
-                    path.basename(entry.source).startsWith(MERGED_PATH) ||
-                    knownInstallationPaths.has(entry.source),
-                );
-                const dropped = before - lastDeployment[typeId].length;
-                if (dropped > 0) {
-                  log("info", "dropped orphan manifest entries", {
-                    typeId,
-                    dropped,
-                    remaining: lastDeployment[typeId].length,
-                  });
-                }
-              }
-            }
-
             progress(t("Running pre-deployment events"), 2);
             await api.emitAndAwait(
               "will-deploy",

--- a/src/renderer/src/extensions/mod_management/util/externalChanges.ts
+++ b/src/renderer/src/extensions/mod_management/util/externalChanges.ts
@@ -264,7 +264,11 @@ export function dealWithExternalChanges(
   stagingPath: string,
   modPaths: { [typeId: string]: string },
   lastDeployment: { [typeId: string]: IDeployedFile[] },
-  recentInstalls?: Set<string>,
+  // Installation paths whose mods Vortex itself just installed or removed.
+  // change.source is set from mod.installationPath (see LinkingDeployment),
+  // so we match against installation paths, not mod IDs — these can differ in
+  // the update-via-replace flow.
+  recentChanges?: Set<string>,
 ) {
   return checkForExternalChanges(
     api,
@@ -289,7 +293,7 @@ export function dealWithExternalChanges(
               return prevInner;
             }
             if (isInstallingCollection
-                || recentInstalls?.has(change.source)) {
+                || recentChanges?.has(change.source)) {
               prevInner.autoResolved.push(change);
               return prevInner;
             }


### PR DESCRIPTION
- Track mod.installationPath (not mod.id) in InstallManager's recent-changes allow-list so it matches IDeployedFile.source. Fixes the update-via-replace case where modId is reassigned to the existing mod's id.
- Add markRecentRemoval, wired into onRemoveMods, so removed mods' manifest entries get auto-resolved on the next deploy.

fixes https://linear.app/nexus-mods/issue/APP-397
fixes https://github.com/Nexus-Mods/Vortex/issues/22799 fixes https://github.com/Nexus-Mods/Vortex/issues/22498

probably others too.