### PR TITLE
contain react-hot-toast goober render crash

### DIFF
--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -134,6 +134,7 @@ import {
   wrapExtCBSync,
 } from "./util/util";
 import { webpackRequireHack } from "./util/webpack-hacks";
+import { isToastSystemDisabled } from "./views/layout/ToastContainer";
 
 const modmeta = lazyRequire<typeof modmetaT>(() => require("modmeta-db"));
 
@@ -1680,6 +1681,9 @@ class ExtensionManager {
   };
 
   private canBeToast = (notif: INotification) => {
+    if (isToastSystemDisabled()) {
+      return false;
+    }
     const invalidToastTypes = ["activity", "warning"];
     if (
       notif.displayMS != null &&

--- a/src/renderer/src/views/layout/ToastContainer.tsx
+++ b/src/renderer/src/views/layout/ToastContainer.tsx
@@ -1,30 +1,78 @@
-import React, { memo, type FC } from "react";
+import React, { Component, memo, type FC, type ReactNode } from "react";
 import { Toaster } from "react-hot-toast";
 
-/**
- * Provides a toast container component.
- * For both layouts.
- */
+import { log } from "../../logging";
+
+const REPEAT_WINDOW_MS = 5000;
+
+let toastSystemDisabled = false;
+let lastCatchTime = 0;
+
+export const isToastSystemDisabled = (): boolean => toastSystemDisabled;
+
+interface IToastBoundaryState {
+  failed: boolean;
+}
+
+class ToastErrorBoundary extends Component<
+  { children: ReactNode },
+  IToastBoundaryState
+> {
+  public state: IToastBoundaryState = { failed: false };
+
+  public static getDerivedStateFromError(): IToastBoundaryState {
+    return { failed: true };
+  }
+
+  public componentDidCatch(error: Error) {
+    // goober (used by react-hot-toast) can throw during a render race.
+    // Treat the first crash as transient and remount; if a second crash
+    // lands within REPEAT_WINDOW_MS the issue isn't transient, so permanently
+    // disable toasts and let sendNotification fall back to standard notifications.
+    const now = Date.now();
+    const repeated = now - lastCatchTime < REPEAT_WINDOW_MS;
+    lastCatchTime = now;
+
+    log("warn", "Toast renderer crashed", {
+      message: error.message,
+      repeated,
+    });
+
+    if (repeated) {
+      toastSystemDisabled = true;
+      return;
+    }
+
+    this.setState({ failed: false });
+  }
+
+  public render(): ReactNode {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 export const ToastContainer: FC = memo(() => (
-  <Toaster
-    position="bottom-center"
-    reverseOrder={false}
-    toastOptions={{
-      className: "custom-toast",
-      success: {
-        className: "custom-toast toast-success",
-        iconTheme: {
-          primary: "var(--toast-success-primary)",
-          secondary: "var(--toast-success-secondary)",
+  <ToastErrorBoundary>
+    <Toaster
+      position="bottom-center"
+      reverseOrder={false}
+      toastOptions={{
+        className: "custom-toast",
+        success: {
+          className: "custom-toast toast-success",
+          iconTheme: {
+            primary: "var(--toast-success-primary)",
+            secondary: "var(--toast-success-secondary)",
+          },
         },
-      },
-      error: {
-        className: "custom-toast toast-error",
-        iconTheme: {
-          primary: "var(--toast-error-primary)",
-          secondary: "var(--toast-error-secondary)",
+        error: {
+          className: "custom-toast toast-error",
+          iconTheme: {
+            primary: "var(--toast-error-primary)",
+            secondary: "var(--toast-error-secondary)",
+          },
         },
-      },
-    }}
-  />
+      }}
+    />
+  </ToastErrorBoundary>
 ));


### PR DESCRIPTION
goober is buggy, and we're on the last version. So only thing left for us to do is wrap the toaster in an error boundary and disable the toast system if the error is not transient.

fixes fingerprint 601a5d43
fixes https://linear.app/nexus-mods/issue/APP-409