### PR TITLE
surface GraphQL error path/location/query in nexus-api logs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ catalogs:
       specifier: ^0.13.1
       version: 0.13.1
     '@nexusmods/nexus-api':
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
-      version: 1.5.2
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
+      version: 1.6.0
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.1
@@ -554,8 +554,8 @@ catalogs:
       specifier: git+https://github.com/Nexus-Mods/node-native-errors#51913db07e4c9b68a96ba7fcf741b32796758f18
       version: 2.0.3
     nexus-api:
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#d16099d8c9def488dde7b545428d4d7a04668679
-      version: 1.5.1
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
+      version: 1.6.0
     node-7z:
       specifier: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
       version: 0.8.1
@@ -990,7 +990,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/3298c42e69e3220dc39694bc2f610c077c3e213a
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -2314,7 +2314,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.15
@@ -2642,7 +2642,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3587,7 +3587,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/3298c42e69e3220dc39694bc2f610c077c3e213a
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3614,7 +3614,7 @@ importers:
         version: 4.17.23
       nexus-api:
         specifier: 'catalog:'
-        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/d16099d8c9def488dde7b545428d4d7a04668679'
+        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67'
       react:
         specifier: 'catalog:'
         version: 16.14.0
@@ -3929,7 +3929,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@types/react':
         specifier: '16'
         version: 16.14.69
@@ -3992,7 +3992,7 @@ importers:
         version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -4489,7 +4489,7 @@ importers:
         version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -6054,13 +6054,9 @@ packages:
     resolution: {integrity: sha512-6fcow0nDO8I4KFYG1ffa5z9FcKkZsW/D1Axjkb5ebmV47JKg10nJALv8sVkd0hCrKCW8oJZEEvgHKOkF2Pn9ww==}
     engines: {node: '>=22'}
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161':
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161}
-    version: 1.5.2
-
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/d16099d8c9def488dde7b545428d4d7a04668679':
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/d16099d8c9def488dde7b545428d4d7a04668679}
-    version: 1.5.1
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67':
+    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67}
+    version: 1.6.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -14961,16 +14957,7 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4192c0c9f34306c2167e258dd4fef773af406161':
-    dependencies:
-      form-data: 4.0.5
-      jsonwebtoken: 9.0.3
-      request: 2.88.2
-      set-cookie-parser: 2.7.2
-      string-template: 1.0.0
-      typed-emitter: 1.4.0
-
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/d16099d8c9def488dde7b545428d4d7a04668679':
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67':
     dependencies:
       form-data: 4.0.5
       jsonwebtoken: 9.0.3
@@ -18849,8 +18836,7 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
-  extsprintf@1.4.1:
-    optional: true
+  extsprintf@1.4.1: {}
 
   eyes@0.1.8: {}
 
@@ -23138,7 +23124,7 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
-      extsprintf: 1.3.0
+      extsprintf: 1.4.1
 
   verror@1.10.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   "@msgpack/msgpack": ^2.7.0
   "@nexusmods/fomod-installer-ipc": ^0.13.1
   "@nexusmods/fomod-installer-native": ^0.13.1
-  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#4192c0c9f34306c2167e258dd4fef773af406161
+  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
   "@opentelemetry/api": ^1.9.0
   "@opentelemetry/context-async-hooks": ^2.5.1
   "@opentelemetry/exporter-trace-otlp-http": ^0.57.0
@@ -218,7 +218,7 @@ catalog:
   mixpanel-browser: ^2.71.0
   modmeta-db: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
   native-errors: git+https://github.com/Nexus-Mods/node-native-errors#51913db07e4c9b68a96ba7fcf741b32796758f18
-  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#d16099d8c9def488dde7b545428d4d7a04668679
+  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
   node-7z: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
   normalize-url: ^6.0.1
   numeral: ^2.0.6

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -80,6 +80,7 @@ import {
   endorseDirectImpl,
   endorseThing,
   ensureLoggedIn,
+  graphErrorContext,
   nexusGamesProm,
   processErrorMessage,
   resolveGraphError,
@@ -1142,6 +1143,7 @@ export function onGetModRequirements(
           log("warn", "Failed to get mod requirements", {
             ...defaultDetails,
             ...detail,
+            ...graphErrorContext(err),
           });
         }
         return Bluebird.resolve({});

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -21,7 +21,7 @@ import type Nexus from "@nexusmods/nexus-api";
 import type { TFunction } from "i18next";
 import type * as Redux from "redux";
 
-import { NexusError, RateLimitError, TimeoutError } from "@nexusmods/nexus-api";
+import { GraphError, NexusError, RateLimitError, TimeoutError } from "@nexusmods/nexus-api";
 import {
   getErrorMessageOrDefault,
   unknownToError,
@@ -1114,6 +1114,25 @@ export function processErrorMessage(err: NexusError): IRequestError {
       stack: err.stack,
     };
   }
+}
+
+/**
+ * Extract GraphQL diagnostic context (per-error path + line/column locations,
+ * the rendered query string) from a thrown error so it can be merged into
+ * structured logs. Returns an empty object for non-GraphQL errors. Logging
+ * the query alongside the locations lets us map e.g. "column 303" back to
+ * the failing token without having to repro the request.
+ */
+export function graphErrorContext(err: unknown): Record<string, unknown> {
+  if (!(err instanceof GraphError)) {
+    return {};
+  }
+  const ctx: Record<string, unknown> = {};
+  if (err.code !== undefined) ctx.graphCode = err.code;
+  if (err.call !== undefined) ctx.graphCall = err.call;
+  if (err.entries.length > 0) ctx.graphEntries = err.entries;
+  if (err.query !== undefined) ctx.graphQuery = err.query;
+  return ctx;
 }
 
 export function resolveGraphError(


### PR DESCRIPTION
Previously a `Failed to get mod requirements` warning had only the flattened error message, with the per-error path, line/column, and the GraphQL query string itself dropped at the SDK boundary — making errors like "A name name was not found" near-impossible to diagnose without re-running the request.

- Repin @nexusmods/nexus-api to 1.6.0, which now exposes `entries` (path + locations + code per error) and `query` on `GraphError`.
- Add `graphErrorContext(err)` helper in nexus_integration/util.ts that picks those fields off a `GraphError` for structured logging.
- Merge it into the warn log in onGetModRequirements so future failures carry enough context to identify the failing field directly.

fixes fingerprint 21a33af6
fixes https://linear.app/nexus-mods/issue/APP-410