### PR TITLE
Changed: Refresh NixOS dev shell for Node 24 and Electron 41

### DIFF
--- a/docs/install-instructions/nixos.md
+++ b/docs/install-instructions/nixos.md
@@ -1,7 +1,7 @@
 # NixOS Setup
 
-NixOS `flake.nix` provides all the dependencies you need out of the box,
-skipping the Volta and Corepack flow.
+NixOS `flake.nix` provides all deps out of box, matching repo Node/Electron.
+It skips Volta/Corepack flow.
 
 Validated on 13 April 2026. If any step is out of date, please open a [PR] or [issue].
 

--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -16,7 +16,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @nexusmods/adaptor-api | link:../../packages/adaptor-api |
 | @nexusmods/fomod-installer-ipc | 0.13.1 |
 | @nexusmods/fomod-installer-native | 0.13.1 |
-| @nexusmods/nexus-api | 1.5.2 |
+| @nexusmods/nexus-api | 1.6.0 |
 | @opentelemetry/api | 1.9.1 |
 | @opentelemetry/context-async-hooks | 2.6.1 |
 | @opentelemetry/context-zone | 2.7.0 |

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             # Node.js and package managers
-            nodejs_22
+            nodejs_24
             pnpm
             yarn
 
@@ -43,7 +43,7 @@
             dotnetCorePackages.sdk_9_0
 
             # Electron (wrapped with GTK dependencies)
-            electron_39
+            electron_41
 
             # GTK dependencies for Electron runtime
             gtk3
@@ -66,7 +66,7 @@
             ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
             # Point to Nix-provided Electron
-            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_39.dist}";
+            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_41.dist}";
 
             # Make the dotnet runtime available
             DOTNET_ROOT = "${pkgs.dotnetCorePackages.runtime_9_0}/share/dotnet";
@@ -84,7 +84,7 @@
             export GDK_PIXBUF_MODULE_FILE="${pkgs.librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 
             # Chromium sandbox
-            export CHROME_DEVEL_SANDBOX="${pkgs.electron_39}/libexec/electron/chrome-sandbox"
+            export CHROME_DEVEL_SANDBOX="${pkgs.electron_41}/libexec/electron/chrome-sandbox"
 
           '';
         };


### PR DESCRIPTION
- Bump flake shell from `nodejs_22` to `nodejs_24`
- Bump Electron from `electron_39` to `electron_41`
- Refresh `flake.lock` to newer nixpkgs
- Update NixOS setup docs to match repo Node/Electron