### PR TITLE
Qa 83/login logout of vortex

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,9 @@ jobs:
         continue-on-error: true
         env:
           E2E_NEXUS_FREE_USER_USERNAME: ${{ secrets.E2E_NEXUS_FREE_USER_USERNAME }}
+          E2E_NEXUS_PREMIUM_USER_USERNAME: ${{ secrets.E2E_NEXUS_PREMIUM_USER_USERNAME }}
           E2E_NEXUS_FREE_USER_PASSWORD: ${{ secrets.E2E_NEXUS_FREE_USER_PASSWORD }}
+          E2E_NEXUS_PREMIUM_USER_PASSWORD: ${{ secrets.E2E_NEXUS_PREMIUM_USER_PASSWORD }}
         run: pnpm e2e
 
       - name: Run E2E tests (Linux)
@@ -86,7 +88,9 @@ jobs:
         continue-on-error: true
         env:
           E2E_NEXUS_FREE_USER_USERNAME: ${{ secrets.E2E_NEXUS_FREE_USER_USERNAME }}
+          E2E_NEXUS_PREMIUM_USER_USERNAME: ${{ secrets.E2E_NEXUS_PREMIUM_USER_USERNAME }}
           E2E_NEXUS_FREE_USER_PASSWORD: ${{ secrets.E2E_NEXUS_FREE_USER_PASSWORD }}
+          E2E_NEXUS_PREMIUM_USER_PASSWORD: ${{ secrets.E2E_NEXUS_PREMIUM_USER_PASSWORD }}
         run: xvfb-run pnpm e2e
 
       - name: Upload test report

--- a/packages/e2e/fixtures/vortex-app-isolated.ts
+++ b/packages/e2e/fixtures/vortex-app-isolated.ts
@@ -1,0 +1,205 @@
+import {
+  test as base,
+  _electron as electron,
+  expect,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { createRequire } from "node:module";
+
+/** Package root (packages/e2e/) — used for resolving node_modules. */
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+
+/** Repo root directory. */
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, "..", "..");
+
+// createRequire from the package root so pnpm-linked electron resolves correctly
+const require = createRequire(path.join(PACKAGE_ROOT, "package.json"));
+
+function resolveMainDir(): string {
+  return path.resolve(REPO_ROOT, "src", "main");
+}
+
+function resolveElectronBinary(): string {
+  return require("electron") as unknown as string;
+}
+
+function safeRemoveDir(dir: string): void {
+  try {
+    fs.rmSync(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
+  } catch {
+    // Best-effort cleanup: Windows can keep file handles briefly.
+  }
+}
+
+/**
+ * Build a clean env for the Electron process.
+ * Removes ELECTRON_RUN_AS_NODE (set by pnpm) and isolates user data.
+ */
+function buildElectronEnv(userDataDir: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key !== "ELECTRON_RUN_AS_NODE" && value !== undefined) {
+      env[key] = value;
+    }
+  }
+  env.NODE_ENV = "development";
+  const appDataDir = path.join(userDataDir, "appData");
+  const userDataSubDir = path.join(userDataDir, "userData");
+  const appNameDir = path.join(appDataDir, "@vortex", "main");
+  fs.mkdirSync(appNameDir, { recursive: true });
+  fs.mkdirSync(userDataSubDir, { recursive: true });
+  env.ELECTRON_USERDATA = userDataSubDir;
+  env.ELECTRON_APPDATA = appDataDir;
+  env.VORTEX_E2E = "1";
+  if (!process.env.PWDEBUG) {
+    env.VORTEX_E2E_HEADLESS = "1";
+  }
+  return env;
+}
+
+/**
+ * Wait for the main window (index.html) to appear, skipping the splash screen.
+ */
+async function waitForMainWindow(
+  vortexApp: ElectronApplication,
+): Promise<Page> {
+  const isMainWindow = (win: Page): boolean => {
+    try {
+      return win.url().includes("index.html");
+    } catch {
+      return false;
+    }
+  };
+
+  for (const win of vortexApp.windows()) {
+    if (isMainWindow(win)) {
+      await win.waitForLoadState("domcontentloaded");
+      return win;
+    }
+  }
+
+  return new Promise<Page>((resolve, reject) => {
+    const cleanup = () => {
+      clearInterval(interval);
+      vortexApp.off("window", onWindow);
+      vortexApp.process().off("exit", onExit);
+    };
+
+    const onWindow = (page: Page) => {
+      if (isMainWindow(page)) {
+        cleanup();
+        resolve(page);
+      }
+    };
+
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Vortex process exited unexpectedly with code ${code} before the main window appeared. ` +
+            `Check the app logs for 'App threw an error during load' or similar startup errors.`,
+        ),
+      );
+    };
+
+    vortexApp.on("window", onWindow);
+    vortexApp.process().on("exit", onExit);
+
+    const interval = setInterval(() => {
+      for (const win of vortexApp.windows()) {
+        if (isMainWindow(win)) {
+          cleanup();
+          resolve(win);
+          return;
+        }
+      }
+    }, 500);
+
+    setTimeout(() => {
+      cleanup();
+      const windows = vortexApp.windows();
+      const lastWindow = windows[windows.length - 1];
+      if (lastWindow) {
+        resolve(lastWindow);
+      } else {
+        reject(
+          new Error("Timed out waiting for the Vortex main window to appear."),
+        );
+      }
+    }, 120_000);
+  });
+}
+
+export type VortexTestFixtures = {
+  /** Fresh Electron app instance per test. */
+  vortexApp: ElectronApplication;
+  /** Main Vortex window for that test instance. */
+  vortexWindow: Page;
+};
+
+/**
+ * Playwright test with isolated Vortex fixtures.
+ *
+ * Launches a fresh Electron app + user data directory for every test,
+ * ensuring no state leaks between tests.
+ */
+export const test = base.extend<VortexTestFixtures>({
+  vortexApp: async ({}, use) => {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "vortex-e2e-"));
+    const mainDir = resolveMainDir();
+    const electronBinary = resolveElectronBinary();
+
+    const app = await electron.launch({
+      executablePath: electronBinary,
+      args: [mainDir, "--disable-gpu", "--disable-software-rasterizer"],
+      env: buildElectronEnv(userDataDir),
+      cwd: mainDir,
+      timeout: 120_000,
+    });
+
+    try {
+      await use(app);
+    } finally {
+      await app.close().catch(() => {});
+      safeRemoveDir(userDataDir);
+    }
+  },
+
+  vortexWindow: async ({ vortexApp }, use) => {
+    const mainWindow = await waitForMainWindow(vortexApp);
+    await mainWindow.waitForLoadState("domcontentloaded");
+
+    try {
+      await mainWindow.locator("body").first().waitFor({
+        state: "visible",
+        timeout: 60_000,
+      });
+      await use(mainWindow);
+      return;
+    } catch (error) {
+      if (!mainWindow.isClosed()) {
+        throw error;
+      }
+    }
+
+    const recoveredWindow = await waitForMainWindow(vortexApp);
+    await recoveredWindow.waitForLoadState("domcontentloaded");
+    await recoveredWindow.locator("body").first().waitFor({
+      state: "visible",
+      timeout: 60_000,
+    });
+
+    await use(recoveredWindow);
+  },
+});
+
+export { expect };

--- a/packages/e2e/helpers/login.ts
+++ b/packages/e2e/helpers/login.ts
@@ -126,6 +126,9 @@ export async function loginToNexus(
     await expect(vortexLoginPage.vortexLoginDialog).toBeHidden();
     await expect(vortexLoginPage.profileButton).toBeVisible();
     await vortexLoginPage.profileButton.click();
-    await expect(vortexLoginPage.loggedInMenuItem).toBeVisible();
+    await expect(vortexLoginPage.logOutMenuItem).toBeVisible();
+
+    await vortexWindow.keyboard.press("Escape");
+    await expect(vortexLoginPage.logOutMenuItem).toBeHidden();
   });
 }

--- a/packages/e2e/selectors/loginPage.ts
+++ b/packages/e2e/selectors/loginPage.ts
@@ -14,7 +14,7 @@ export class LoginPage {
   readonly authoriseButton: Locator;
   readonly authorisationSuccessTitle: Locator;
   readonly profileButton: Locator;
-  readonly loggedInMenuItem: Locator;
+  readonly logOutMenuItem: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -44,8 +44,6 @@ export class LoginPage {
         "button[title='Profile'], button[title='Log in'], button:has(img[alt])",
       )
       .first();
-    this.loggedInMenuItem = page
-      .getByText(/view profile on web|logout/i)
-      .first();
+    this.logOutMenuItem = page.getByText(/logout/i).first();
   }
 }

--- a/packages/e2e/tests/login.spec.ts
+++ b/packages/e2e/tests/login.spec.ts
@@ -2,13 +2,34 @@
  * Login/authentication tests.
  * Covers test cases: #3.1A, #3.3A, #5.5A-#5.7A
  */
-import { test, expect } from "../fixtures/vortex-app";
+import { test, expect } from "../fixtures/vortex-app-isolated";
 import { loginToNexus } from "../helpers/login";
 import { freeUser } from "../helpers/users";
+import { LoginPage } from "../selectors/loginPage";
 
 test.describe("Login UI", () => {
   test("Login", async ({ vortexApp, vortexWindow }) => {
     await loginToNexus(vortexApp, vortexWindow, freeUser);
+  });
+
+  test("Logout of Vortex", async ({ vortexApp, vortexWindow }) => {
+    const loginPage = new LoginPage(vortexWindow);
+
+    await test.step("Login as a free user", async () => {
+      await loginToNexus(vortexApp, vortexWindow, freeUser);
+      await expect(loginPage.profileButton).toBeVisible();
+    });
+    await test.step("Open the profile menu", async () => {
+      await loginPage.profileButton.click();
+      await expect(loginPage.logOutMenuItem).toBeVisible();
+    });
+    await test.step("Click logout", async () => {
+      await loginPage.logOutMenuItem.click();
+      await expect(loginPage.logOutMenuItem).not.toBeVisible();
+    });
+    await test.step("Verify logged out state", async () => {
+      await expect(loginPage.vortexLoginButton).toBeVisible();
+    });
   });
 
   // TODO: Implement with API key injection fixture


### PR DESCRIPTION
Adding a logout test for Vortex

Added premium user for Vortex

Because all tests need to be independent from one another. I have created a vortex-app-isolated fixture that launches a fresh Electron app and fresh user-data directory per test.