### PR TITLE
Replace native diskusage addon with fs.statfsSync

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -41,7 +41,6 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | date-fns | 2.30.0 |
 | dayjs | 1.11.20 |
 | dequal | 2.0.3 |
-| diskusage | 2.0.1 |
 | dnd-core | 9.5.1 |
 | draggabilly | 2.4.1 |
 | drivelist | 10.0.2 |

--- a/flatpak/generated-sources.json
+++ b/flatpak/generated-sources.json
@@ -639,13 +639,6 @@
     },
     {
         "type": "file",
-        "url": "https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d",
-        "sha256": "f0fb199589c451d184daf60011d4f5caaf29c179dcfed7b9af29f2934492b2ed",
-        "dest-filename": "eb52fd176b2c311dd3ae5f0e68ff7488c08a179d",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://codeload.github.com/TanninOne/rimraf/tar.gz/7b8b70d4e8783cd233fca3283cf1f930af4e39c2",
         "sha256": "1b6a9cd18170ff3060e65143fdb582b55bbe294e3d26f592210151b5a928ed4f",
         "dest-filename": "7b8b70d4e8783cd233fca3283cf1f930af4e39c2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,9 +367,6 @@ catalogs:
     dequal:
       specifier: ^2.0.3
       version: 2.0.3
-    diskusage:
-      specifier: git+https://github.com/TanninOne/node-diskusage#eb52fd176b2c311dd3ae5f0e68ff7488c08a179d
-      version: 2.0.1
     dnd-core:
       specifier: ^9.4.0
       version: 9.5.1
@@ -4040,9 +4037,6 @@ importers:
       dequal:
         specifier: 'catalog:'
         version: 2.0.3
-      diskusage:
-        specifier: 'catalog:'
-        version: https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d(bluebird@3.7.2)
       dnd-core:
         specifier: 'catalog:'
         version: 9.5.1
@@ -4684,9 +4678,6 @@ importers:
       dequal:
         specifier: 'catalog:'
         version: 2.0.3
-      diskusage:
-        specifier: 'catalog:'
-        version: https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d(bluebird@3.7.2)
       dnd-core:
         specifier: 'catalog:'
         version: 9.5.1
@@ -8648,10 +8639,6 @@ packages:
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
 
-  diskusage@https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d:
-    resolution: {tarball: https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d}
-    version: 2.0.1
-
   disposables@1.0.2:
     resolution: {integrity: sha512-q1XTvs/XGdfubRSemB2+QRhJjIX4PerKkSom+i8Nkw3hCv6xISNrgaN442n2BunyBI4x77Om4ZAzSlqmhM9pwA==}
 
@@ -8914,9 +8901,6 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
-
-  es6-promise@4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -16910,16 +16894,6 @@ snapshots:
 
   discontinuous-range@1.0.0: {}
 
-  diskusage@https://codeload.github.com/TanninOne/node-diskusage/tar.gz/eb52fd176b2c311dd3ae5f0e68ff7488c08a179d(bluebird@3.7.2):
-    dependencies:
-      es6-promise: 4.2.8
-      node-addon-api: 8.5.0
-      node-gyp: 9.4.1(bluebird@3.7.2)
-      prebuild-install: 7.1.3
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
   disposables@1.0.2: {}
 
   dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
@@ -17359,8 +17333,6 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
-
-  es6-promise@4.2.8: {}
 
   escalade@3.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,6 @@ allowBuilds:
   bsatk: true
   core-js: true
   crash-dump: true
-  diskusage: true
   drivelist: true
   electron: true
   esbuild: true
@@ -154,7 +153,6 @@ catalog:
   date-fns: ^2.8.0
   dayjs: ^1.11.10
   dequal: ^2.0.3
-  diskusage: git+https://github.com/TanninOne/node-diskusage#eb52fd176b2c311dd3ae5f0e68ff7488c08a179d
   dnd-core: ^9.4.0
   draggabilly: ^2.2.0
   drivelist: git+https://github.com/TanninOne/drivelist#720d1890db11482ec05fc0f6aa176cfa6e6844dd

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -53,7 +53,6 @@
     "date-fns": "catalog:",
     "dayjs": "catalog:",
     "dequal": "catalog:",
-    "diskusage": "catalog:",
     "dnd-core": "catalog:",
     "draggabilly": "catalog:",
     "drivelist": "catalog:",

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -95,7 +95,6 @@
     "date-fns": "catalog:",
     "dayjs": "catalog:",
     "dequal": "catalog:",
-    "diskusage": "catalog:",
     "dnd-core": "catalog:",
     "draggabilly": "catalog:",
     "drivelist": "catalog:",

--- a/src/renderer/src/util/transferPath.test.ts
+++ b/src/renderer/src/util/transferPath.test.ts
@@ -38,9 +38,11 @@ const diskCheckResults: Record<string, { free: number }> = {
   "": { free: 42 },
 };
 
-vi.mock("diskusage", () => ({
-  check: (checkPath: string) =>
-    diskCheckResults[checkPath] ?? diskCheckResults[""],
+vi.mock("fs", () => ({
+  statfsSync: (checkPath: string) => {
+    const result = diskCheckResults[checkPath] ?? diskCheckResults[""];
+    return { bavail: result.free, bsize: 1 };
+  },
 }));
 
 vi.mock("winapi-bindings", () => ({

--- a/src/renderer/src/util/transferPath.ts
+++ b/src/renderer/src/util/transferPath.ts
@@ -6,7 +6,7 @@ import {
   unknownToError,
 } from "@vortex/shared";
 import PromiseBB from "bluebird";
-import * as diskusage from "diskusage";
+import * as nodeFs from "fs";
 import * as path from "path";
 import turbowalk from "turbowalk";
 import * as winapi from "winapi-bindings";
@@ -107,7 +107,8 @@ export function testPathTransfer(
     .then((totalSize) => {
       totalNeededBytes = totalSize;
       try {
-        return diskusage.check(destinationRoot);
+        const stats = nodeFs.statfsSync(destinationRoot);
+        return PromiseBB.resolve({ free: stats.bavail * stats.bsize });
       } catch (err) {
         // don't report an error just because this check failed
         return PromiseBB.resolve({ free: Number.MAX_VALUE });


### PR DESCRIPTION
## Summary

- Replaces the native C++ `diskusage` addon with Node's built-in `fs.statfsSync()` (available since Node 18.15)
- Single call site in `transferPath.ts`: `diskusage.check(path)` → `fs.statfsSync(path)` with `bavail * bsize` for free bytes
- Removes `diskusage` from `pnpm-workspace.yaml` (catalog + allowBuilds), both `package.json` files, `flatpak/generated-sources.json`, and the dependency report

This is the lowest-effort native addon elimination — one function, one call site, drop-in Node built-in replacement.

Resolves APP-401

## Test plan

- [x] All 1167 tests pass (including `transferPath.test.ts` disk space checks)
- [x] `pnpm install` succeeds without diskusage