### PR TITLE
Remove native-errors C++ addon

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -73,7 +73,6 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | minimatch | 3.1.5 |
 | mixpanel-browser | 2.77.0 |
 | modmeta-db | 0.9.3 |
-| native-errors | 2.0.3 |
 | node-7z | 0.8.1 |
 | normalize-url | 6.1.0 |
 | numeral | 2.0.6 |

--- a/flatpak/generated-sources.json
+++ b/flatpak/generated-sources.json
@@ -317,13 +317,6 @@
     },
     {
         "type": "file",
-        "url": "https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18",
-        "sha256": "0b03c10d8d4d1627b6cd6634b4a3f6b14dd6837ff54129cdbe02c77b4cb9cee5",
-        "dest-filename": "51913db07e4c9b68a96ba7fcf741b32796758f18",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/3a8c20c7cf770c9684ce6eda58fe56b04d095906",
         "sha256": "5a7f2ae0e1af55c203db81dc68a03038404763c5e6c1ada0d0750a6f82a93dad",
         "dest-filename": "3a8c20c7cf770c9684ce6eda58fe56b04d095906",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,9 +526,6 @@ catalogs:
     modmeta-db:
       specifier: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
       version: 0.9.3
-    native-errors:
-      specifier: git+https://github.com/Nexus-Mods/node-native-errors#51913db07e4c9b68a96ba7fcf741b32796758f18
-      version: 2.0.3
     nexus-api:
       specifier: git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
       version: 1.6.0
@@ -4142,9 +4139,6 @@ importers:
       modmeta-db:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@4.1.1)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
-      native-errors:
-        specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18(bluebird@3.7.2)
       node-7z:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479
@@ -4786,9 +4780,6 @@ importers:
       modmeta-db:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@4.1.1)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
-      native-errors:
-        specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18(bluebird@3.7.2)
       node-7z:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479
@@ -10654,10 +10645,6 @@ packages:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
-
-  native-errors@https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18:
-    resolution: {tarball: https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18}
-    version: 2.0.3
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -19299,16 +19286,6 @@ snapshots:
   napi-macros@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
-
-  native-errors@https://codeload.github.com/Nexus-Mods/node-native-errors/tar.gz/51913db07e4c9b68a96ba7fcf741b32796758f18(bluebird@3.7.2):
-    dependencies:
-      autogypi: 0.2.2
-      node-addon-api: 8.5.0
-      node-gyp: 9.4.1(bluebird@3.7.2)
-      prebuild-install: 7.1.3
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
 
   natural-compare@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,6 @@ allowBuilds:
   gamebryo-savegame: true
   leveldown: true
   loot: true
-  native-errors: true
   protobufjs: true
   unrs-resolver: true
   winapi-bindings: true
@@ -208,7 +207,6 @@ catalog:
   minimist: ^1.2.8
   mixpanel-browser: ^2.71.0
   modmeta-db: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
-  native-errors: git+https://github.com/Nexus-Mods/node-native-errors#51913db07e4c9b68a96ba7fcf741b32796758f18
   nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#4dd3460c2d02d93ba8f1bbeeeb2c5fa9af039a67
   node-7z: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
   normalize-url: ^6.0.1

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -85,7 +85,6 @@
     "minimatch": "catalog:",
     "mixpanel-browser": "catalog:",
     "modmeta-db": "catalog:",
-    "native-errors": "catalog:",
     "node-7z": "catalog:",
     "normalize-url": "catalog:",
     "numeral": "catalog:",

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -129,7 +129,6 @@
     "minimatch": "catalog:",
     "mixpanel-browser": "catalog:",
     "modmeta-db": "catalog:",
-    "native-errors": "catalog:",
     "node-7z": "catalog:",
     "normalize-url": "catalog:",
     "numeral": "catalog:",

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -70,7 +70,6 @@ import {
 import Bluebird from "bluebird";
 import { ipcRenderer, webFrame } from "electron";
 import { EventEmitter } from "events";
-import * as nativeErr from "native-errors";
 import { readFile } from "node:fs/promises";
 import * as path from "path";
 import React from "react";
@@ -158,26 +157,17 @@ if (process.env.CRASH_REPORTING === "vortex") {
   });
 }
 
-// on windows, inject the native error code into "unknown" errors to help track those down
+// on windows, copy systemCode to nativeCode so downstream error handling
+// can read a consistent property name
 if (process.platform === "win32") {
-  nativeErr.InitHook();
   const oldPrep = Error.prepareStackTrace;
   Error.prepareStackTrace = (error, stack) => {
-    if (error["code"] === "UNKNOWN" && error["nativeCode"] === undefined) {
-      if (error["systemCode"] !== undefined) {
-        error["nativeCode"] = error["systemCode"];
-      } else {
-        const native = nativeErr.GetLastError();
-        // Only inject the native code if it's actually meaningful (non-zero).
-        // A code of 0 means ERROR_SUCCESS — the Win32 last-error was already
-        // cleared (e.g. by NAPI internals) before the stack trace was captured,
-        // so it doesn't reflect the real error. Injecting it would overwrite the
-        // original exception message with "The operation completed successfully."
-        if (native.code !== 0) {
-          error.message = `${native.message} (${native.code})`;
-          error["nativeCode"] = native.code;
-        }
-      }
+    if (
+      error["code"] === "UNKNOWN" &&
+      error["nativeCode"] === undefined &&
+      error["systemCode"] !== undefined
+    ) {
+      error["nativeCode"] = error["systemCode"];
     }
     return oldPrep !== undefined ? oldPrep(error, stack) : error.stack;
   };


### PR DESCRIPTION
## Summary

- Removes the `native-errors` native C++ addon (~180 lines) which hooked into libuv's error translation layer to capture Win32 error codes
- Modern Node (22+) provides `err.code`, `err.syscall`, and `err.errno` natively, making the libuv hook unnecessary
- The `Error.prepareStackTrace` override is preserved in simplified form — it still copies `systemCode` → `nativeCode` so downstream error handling (`decodeSystemError`, `getErrorNativeCode`, `fs.ts`, `message.ts`) continues to work
- Only the `GetLastError()` fallback for truly unknown errors is removed
- Removes `native-errors` from both `package.json` files, `pnpm-workspace.yaml` (catalog + allowBuilds), `flatpak/generated-sources.json`, and the dependency report

Resolves APP-404

## Test plan

- [x] All 1188 tests pass
- [x] `pnpm install` succeeds without native-errors
- [x] `nativeErrors.ts` / `decodeSystemError` / `getErrorNativeCode` still handle `systemCode` from other native modules