### PR TITLE
[QA-92][QA-93] Header badges tests

### DIFF
--- a/packages/e2e/helpers/login.ts
+++ b/packages/e2e/helpers/login.ts
@@ -65,7 +65,7 @@ export async function loginToNexus(
       await expect(nexusLoginPage.authLoginHeading).toBeVisible();
     });
 
-    await test.step("Login with FreeUser credentials", async () => {
+    await test.step("Login with Nexus Mods credentials", async () => {
       if (authPage === null) {
         throw new Error("Auth page was not available for login.");
       }

--- a/packages/e2e/helpers/users.ts
+++ b/packages/e2e/helpers/users.ts
@@ -17,3 +17,12 @@ export const freeUser: NexusUser = {
     return requireEnvVar("E2E_NEXUS_FREE_USER_PASSWORD");
   },
 };
+
+export const premiumUser: NexusUser = {
+  get username() {
+    return requireEnvVar("E2E_NEXUS_PREMIUM_USER_USERNAME");
+  },
+  get password() {
+    return requireEnvVar("E2E_NEXUS_PREMIUM_USER_PASSWORD");
+  },
+};

--- a/packages/e2e/selectors/header.ts
+++ b/packages/e2e/selectors/header.ts
@@ -1,0 +1,11 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class Header {
+  readonly page: Page;
+  readonly premiumIndicator: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.premiumIndicator = page.getByTestId("premium-indicator");
+  }
+}

--- a/packages/e2e/tests/account.spec.ts
+++ b/packages/e2e/tests/account.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * QA-92 + QA-93: free user must NOT see the header Premium badge;
+ * premium user MUST see it. Pure login + header assertion — no website
+ * navigation, no game management.
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { loginToNexus } from "../helpers/login";
+import { freeUser, premiumUser, type NexusUser } from "../helpers/users";
+import { Header } from "../selectors/header";
+
+const TIERS = [
+  {
+    id: "QA-92",
+    tier: "free",
+    user: freeUser,
+    expectBadge: false,
+  },
+  {
+    id: "QA-93",
+    tier: "premium",
+    user: premiumUser,
+    expectBadge: true,
+  },
+] as const satisfies readonly {
+  id: string;
+  tier: string;
+  user: NexusUser;
+  expectBadge: boolean;
+}[];
+
+test.describe("Account - Header Premium badge", () => {
+  test.describe.configure({ mode: "parallel" });
+
+  for (const { id, tier, user, expectBadge } of TIERS) {
+    const verb = expectBadge ? "sees" : "does NOT see";
+    test(`[${id}] ${tier} user ${verb} the Premium badge in the header`, async ({
+      vortexApp,
+      vortexWindow,
+    }) => {
+      test.setTimeout(120_000);
+
+      await loginToNexus(vortexApp, vortexWindow, user);
+
+      const header = new Header(vortexWindow);
+      if (expectBadge) {
+        await expect(header.premiumIndicator).toBeVisible({ timeout: 15_000 });
+        await expect(header.premiumIndicator).toHaveText(/premium/i);
+      } else {
+        await expect(header.premiumIndicator).toBeHidden({ timeout: 15_000 });
+      }
+    });
+  }
+});

--- a/src/renderer/src/views/components/Header/PremiumIndicator.tsx
+++ b/src/renderer/src/views/components/Header/PremiumIndicator.tsx
@@ -31,7 +31,11 @@ export const PremiumIndicator: FC = () => {
 
   if (premium) {
     return (
-      <Typography appearance="moderate" typographyType="title-sm">
+      <Typography
+        appearance="moderate"
+        typographyType="title-sm"
+        data-testid="premium-indicator"
+      >
         {t("Premium")}
       </Typography>
     );


### PR DESCRIPTION
Pure login + header assertion — covers free user must NOT see the Premium indicator and premium user must see it. Adds a `data-testid` to the PremiumIndicator Typography so the e2e test can reliably distinguish the header indicator from other "Premium" text on the page (DashboardBanner, LoginIcon).

Also adds `premiumUser` to helpers/users.ts mirroring `freeUser`.