### PR TITLE
yet another fix for BG3 pak-read failure spam

### DIFF
--- a/extensions/games/game-baldursgate3/package.json
+++ b/extensions/games/game-baldursgate3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-baldursgate3",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Support for Baldur's Gate 3",
   "author": "Black Tree Gaming Ltd.",
   "license": "GPL-3.0",

--- a/extensions/games/game-baldursgate3/src/divineWrapper.ts
+++ b/extensions/games/game-baldursgate3/src/divineWrapper.ts
@@ -9,17 +9,24 @@ import { getLatestLSLibMod, logError } from './util';
 import {
   DEFAULT_TIMEOUT_MS,
   DivineAborted,
+  DivineExecMissing,
   DivineMissingDotNet,
+  DivinePakInvalid,
   IDivineRunOptions,
   parsePackageListOutput,
   runDivineCore,
 } from './divineCore';
 
-// Run 5 concurrent Divine processes - retry each process 5 times if it fails,
-// but do not retry aborted operations — they should fail fast.
+// Run 5 concurrent Divine processes. Retry on transient failures, but fail
+// fast for deterministic ones — retrying a missing exe, a missing .NET
+// runtime, or a malformed pak just multiplies log volume without changing
+// the outcome.
 const concurrencyLimiter: util.ConcurrencyLimiter = new util.ConcurrencyLimiter(
   5,
-  (err: Error) => !(err instanceof DivineAborted));
+  (err: Error) => !(err instanceof DivineAborted)
+               && !(err instanceof DivineExecMissing)
+               && !(err instanceof DivineMissingDotNet)
+               && !(err instanceof DivinePakInvalid));
 
 // Module-level AbortController lets callers cancel all in-flight and queued
 // divine operations at once (e.g. when switching games). Replaced after each

--- a/extensions/games/game-baldursgate3/src/loadOrder.ts
+++ b/extensions/games/game-baldursgate3/src/loadOrder.ts
@@ -634,6 +634,26 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
     return [];
   }
 
+  // Pre-check: if divine.exe is missing on disk (corrupted install, AV
+  // quarantine), bail with a single notification rather than fanning out one
+  // failed call per pak through the retry-on-error concurrency limiter.
+  const stagingFolder = selectors.installPathForGame(state, GAME_ID);
+  const divineExePath = path.join(stagingFolder, lsLib.installationPath, 'tools', 'divine.exe');
+  try {
+    await fs.statAsync(divineExePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      api.showErrorNotification('Divine executable is missing',
+        'The installed copy of LSLib/Divine is corrupted - please '
+        + 'delete the existing LSLib mod entry and re-install it. Make sure to '
+        + 'disable or add any necessary exceptions to your security software to '
+        + 'ensure it does not interfere with Vortex/LSLib file operations.',
+        { id: 'bg3-divine-missing', allowReport: false });
+      return [];
+    }
+    throw err;
+  }
+
   const paks = await readPAKList(api);
 
   // logDebug('paks', paks);
@@ -662,7 +682,9 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
             : undefined;
 
           const pakPath = path.join(modsPath(), fileName);
-          return cache.getCacheEntry(api, pakPath, mod);
+          // `return await` (not bare `return`) so this try/catch sees the
+          // promise rejection — without await, the catch is dead code.
+          return await cache.getCacheEntry(api, pakPath, mod);
         } catch (err) {
           // Game switched (or similar) while we were reading paks — bail out
           // without notifying the user; the new game context will re-scan.
@@ -681,8 +703,9 @@ async function readPAKs(api: types.IExtensionApi) : Promise<Array<ICacheEntry>> 
               + 'delete the existing LSLib mod entry and re-install it. Make sure to '
               + 'disable or add any necessary exceptions to your security software to '
               + 'ensure it does not interfere with Vortex/LSLib file operations.';
+            // Stable id so parallel pak failures collapse into one notification.
             api.showErrorNotification('Divine executable is missing', message,
-              { allowReport: false });
+              { id: 'bg3-divine-missing', allowReport: false });
             return undefined;
           }
           api.showErrorNotification('Failed to read pak. Please make sure you are using the latest version of LSLib by using the "Re-install LSLib/Divine" toolbar button on the Mods page.', err, {


### PR DESCRIPTION
A deterministic failure in BG3 pak parsing was fanning out into N×retries error spans per load-order change. Pre-check divine.exe before the parallel fanout, drop deterministic errors from the retry predicate, and add the missing await so the per-pak try/catch actually catches.

fixes fingerprint e957147c
fixes fingerprint 0d124ed7
fixes fingerprint 73bec7b7
fixes fingerprint eb5a70d5
fixes fingerprint 6f5a76c6
fixes fingerprint a2143502
fixes fingerprint 58ddb7f3

fixes https://linear.app/nexus-mods/issue/APP-418