### PR TITLE
[QA-113] Add profile e2e test

### DIFF
--- a/packages/e2e/selectors/navbar.ts
+++ b/packages/e2e/selectors/navbar.ts
@@ -6,6 +6,8 @@ export class NavBar {
   readonly gamesLink: Locator;
   readonly modsLink: Locator;
   readonly settingsLink: Locator;
+  readonly preferencesLink: Locator;
+  readonly profilesLink: Locator;
   readonly extensionsLink: Locator;
 
   constructor(page: Page) {
@@ -13,7 +15,11 @@ export class NavBar {
     this.gamesLink = page.getByText("Games", { exact: true }).first();
     this.homeLink = page.getByText("Dashboard", { exact: true }).first();
     this.extensionsLink = page.getByText("Extensions", { exact: true }).first();
-    this.settingsLink = page.getByText(/^(Settings|Preferences)$/).first();
+    // "Settings" is global; "Preferences" is the per-game page that also
+    // appears in the menu — keep them as separate locators.
+    this.settingsLink = page.getByRole("button", { name: "Settings", exact: true }).first();
+    this.preferencesLink = page.getByRole("button", { name: "Preferences", exact: true }).first();
+    this.profilesLink = page.getByRole("button", { name: "Profiles", exact: true }).first();
     this.modsLink = page.getByText("Mods", { exact: true }).first();
   }
 }

--- a/packages/e2e/selectors/spine.ts
+++ b/packages/e2e/selectors/spine.ts
@@ -1,0 +1,16 @@
+import type { Locator, Page } from "@playwright/test";
+
+// Spine selection (home vs per-game) decides which page group the menu shows.
+export class Spine {
+  readonly page: Page;
+  readonly homeButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.homeButton = page.getByTitle("Home", { exact: true }).first();
+  }
+
+  gameButton(gameName: string): Locator {
+    return this.page.getByTitle(gameName, { exact: true }).first();
+  }
+}

--- a/packages/e2e/tests/profile.spec.ts
+++ b/packages/e2e/tests/profile.spec.ts
@@ -1,0 +1,81 @@
+import { cleanupFakeGame, GAME_CONFIGS } from "../fixtures/game-setup/fake-game";
+/**
+ * QA-113: user can add a new profile for the currently managed game.
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { manageGame, type ManagedGame } from "../helpers/games";
+import { NavBar } from "../selectors/navbar";
+import { SettingsPage } from "../selectors/settings";
+import { Spine } from "../selectors/spine";
+
+test.describe("Profiles - Add", () => {
+  test(`[QA-113] user can add a new profile for the current game`, async ({
+    vortexApp,
+    vortexWindow,
+  }) => {
+    test.setTimeout(120_000);
+
+    const profileName = `QA-113 ${Date.now()}`;
+    let managed: ManagedGame | null = null;
+
+    try {
+      managed = await manageGame(vortexWindow, "stardewvalley");
+      const gameName = GAME_CONFIGS.stardewvalley!.gameName;
+
+      await test.step("Enable Profile Management via global Settings", async () => {
+        // Settings only appears in the home spine context, not per-game.
+        const spine = new Spine(vortexWindow);
+        await spine.homeButton.click();
+
+        const navbar = new NavBar(vortexWindow);
+        await expect(navbar.settingsLink).toBeVisible({ timeout: 10_000 });
+        await navbar.settingsLink.click();
+
+        const settings = new SettingsPage(vortexWindow);
+        await settings.interfaceTab.click();
+
+        const toggleRow = vortexWindow.locator(".toggle-container", {
+          hasText: "Enable Profile Management",
+        });
+        await expect(toggleRow).toBeVisible({ timeout: 10_000 });
+
+        const offToggle = toggleRow.locator(".toggle.toggle-off");
+        if (await offToggle.isVisible({ timeout: 1_000 }).catch(() => false)) {
+          await offToggle.click();
+        }
+      });
+
+      await test.step("Switch back to the game and open Profiles", async () => {
+        const spine = new Spine(vortexWindow);
+        await spine.gameButton(gameName).click();
+
+        const navbar = new NavBar(vortexWindow);
+        await expect(navbar.profilesLink).toBeVisible({ timeout: 10_000 });
+        await navbar.profilesLink.click();
+      });
+
+      await test.step("Click Add Profile and enter a name", async () => {
+        const addBtn = vortexWindow.getByRole("button", { name: /Add ".+" Profile/i }).first();
+        await expect(addBtn).toBeVisible({ timeout: 10_000 });
+        await addBtn.click();
+
+        const nameInput = vortexWindow.locator(".profile-edit-panel input[type=text]");
+        await expect(nameInput).toBeVisible({ timeout: 10_000 });
+        await nameInput.fill(profileName);
+
+        const saveBtn = vortexWindow.locator("#__accept");
+        await expect(saveBtn).toBeEnabled();
+        await saveBtn.click();
+      });
+
+      await test.step("Verify the new profile appears in the list", async () => {
+        const newProfile = vortexWindow.getByText(profileName).first();
+        await expect(newProfile).toBeVisible({ timeout: 15_000 });
+      });
+    } finally {
+      if (managed !== null) {
+        cleanupFakeGame(managed.basePath);
+      }
+    }
+  });
+});

--- a/src/renderer/src/views/components/Spine/index.tsx
+++ b/src/renderer/src/views/components/Spine/index.tsx
@@ -66,6 +66,7 @@ export const Spine: FC = () => {
         className="border-2"
         iconPath={mdiHome}
         isActive={selection.type === "home"}
+        title="Home"
         onClick={selectHome}
       />
 


### PR DESCRIPTION
E2E for adding a new profile to a managed game (SDV): Settings → enable Profile Management → Profiles page → add profile → verify.

Adds ``title="Home"`` to the home ``SpineButton`` (icon-only, otherwise unclickable via Playwright). Splits ``NavBar.settingsLink`` from a new ``preferencesLink`` since both labels appear in modern UI once a game is managed.

Verified locally: passes in 35-36s.