### PR TITLE
Upgrade Downloads Graph Dependencies

### DIFF
--- a/flatpak/generated-sources.json
+++ b/flatpak/generated-sources.json
@@ -19911,20 +19911,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-2.3.0.tgz#57bad1ae26a28a62a2ddb678ba6ffdf8fa2b599c",
-    "sha512": "a0201d7445967855981f914070774161c663030f5f3334542bdb164b1e96bd248e3d5471707779cd3206cbf98ebacf8084dfeee93e133225b1beaefd3f2c2725",
-    "dest-filename": "react-resize-detector-2.3.0.tgz",
-    "dest": "flatpak-node/yarn-mirror"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-4.2.3.tgz#7df258668a30bdfd88e655bbdb27db7fd7b23127",
-    "sha512": "e00792ea5c5dcf628e80365a395b7576ea031eb6d8c12ad45f7d8a78cf63eadf484b246986825b4d108c4b568f17164716a70218b4f580c977944712599356d0",
-    "dest-filename": "react-resize-detector-4.2.3.tgz",
-    "dest": "flatpak-node/yarn-mirror"
-  },
-  {
-    "type": "file",
     "url": "https://registry.yarnpkg.com/react-select/-/react-select-1.3.0.tgz#1828ad5bf7f3e42a835c7e2d8cb13b5c20714876",
     "sha512": "83f4005351d9af349fc64c0c028ff0ce2ebf7b3756c9edf4d911997afb004de734ee123f892c5ca41d617a3148a7b57adc327c9b0ba2827e8a981dd58dd9629d",
     "dest-filename": "react-select-1.3.0.tgz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,9 +604,6 @@ catalogs:
     react-redux:
       specifier: ^7.1.3
       version: 7.2.9
-    react-resize-detector:
-      specifier: ^4.2.1
-      version: 4.2.3
     react-select:
       specifier: ^1.2.1
       version: 1.3.0
@@ -617,8 +614,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     recharts:
-      specifier: ^1.8.5
-      version: 1.8.6
+      specifier: ^2.15.4
+      version: 2.15.4
     redux:
       specifier: ^4.0.4
       version: 4.2.1
@@ -4188,9 +4185,6 @@ importers:
       react-redux:
         specifier: 'catalog:'
         version: 7.2.9(react-dom@16.14.0)(react@16.14.0)
-      react-resize-detector:
-        specifier: 'catalog:'
-        version: 4.2.3(react-dom@16.14.0)(react@16.14.0)
       react-select:
         specifier: 'catalog:'
         version: 1.3.0(react-dom@16.14.0)(react@16.14.0)
@@ -4199,7 +4193,7 @@ importers:
         version: 2.8.0(react-dnd@14.0.5)(react-dom@16.14.0)(react@16.14.0)
       recharts:
         specifier: 'catalog:'
-        version: 1.8.6(react-dom@16.14.0)(react@16.14.0)
+        version: 2.15.4(react-dom@16.14.0)(react@16.14.0)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4823,9 +4817,6 @@ importers:
       react-redux:
         specifier: 'catalog:'
         version: 7.2.9(react-dom@16.14.0)(react@16.14.0)
-      react-resize-detector:
-        specifier: 'catalog:'
-        version: 4.2.3(react-dom@16.14.0)(react@16.14.0)
       react-select:
         specifier: 'catalog:'
         version: 1.3.0(react-dom@16.14.0)(react@16.14.0)
@@ -4834,7 +4825,7 @@ importers:
         version: 2.8.0(react-dnd@14.0.5)(react-dom@16.14.0)(react@16.14.0)
       recharts:
         specifier: 'catalog:'
-        version: 1.8.6(react-dom@16.14.0)(react@16.14.0)
+        version: 2.15.4(react-dom@16.14.0)(react@16.14.0)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -7896,9 +7887,6 @@ packages:
   bail@1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
 
-  balanced-match@0.4.2:
-    resolution: {integrity: sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -8164,6 +8152,10 @@ packages:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   code-point-at@1.1.0:
     resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
     engines: {node: '>=0.10.0'}
@@ -8278,9 +8270,6 @@ packages:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
 
-  core-js@3.49.0:
-    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
-
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -8375,6 +8364,10 @@ packages:
   d3-array@1.2.4:
     resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
   d3-axis@1.0.12:
     resolution: {integrity: sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==}
 
@@ -8406,6 +8399,10 @@ packages:
   d3-ease@1.0.7:
     resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
 
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
   d3-fetch@1.2.0:
     resolution: {integrity: sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==}
 
@@ -8424,8 +8421,16 @@ packages:
   d3-interpolate@1.4.0:
     resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
 
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
 
   d3-polygon@1.0.6:
     resolution: {integrity: sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==}
@@ -8442,11 +8447,19 @@ packages:
   d3-scale@2.2.2:
     resolution: {integrity: sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==}
 
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@1.4.2:
     resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
 
   d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
 
   d3-time-format@2.3.0:
     resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
@@ -8454,8 +8467,16 @@ packages:
   d3-time@1.1.0:
     resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
 
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   d3-timer@1.0.10:
     resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   d3-transition@1.3.2:
     resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
@@ -9089,6 +9110,9 @@ packages:
   ev-emitter@1.1.1:
     resolution: {integrity: sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -9149,6 +9173,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -9706,6 +9734,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -10406,9 +10438,6 @@ packages:
 
   material-colors@1.2.6:
     resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
-
-  math-expression-evaluator@1.4.0:
-    resolution: {integrity: sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -11137,9 +11166,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  raf-schd@4.0.3:
-    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
-
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
 
@@ -11272,6 +11298,9 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
@@ -11321,28 +11350,17 @@ packages:
       react-native:
         optional: true
 
-  react-resize-detector@2.3.0:
-    resolution: {integrity: sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==}
-    peerDependencies:
-      react: ^0.14.7 || ^15.0.0 || ^16.0.0
-
-  react-resize-detector@4.2.3:
-    resolution: {integrity: sha512-4AeS6lxdz2KOgDZaOVt1duoDHrbYwSrUX32KeM9j6t9ISyRphoJbTRCMS1aPFxZHFqcCGLT1gMl3lEcSWZNW0A==}
-    peerDependencies:
-      react: ^16.0.0
-      react-dom: ^16.0.0
-
   react-select@1.3.0:
     resolution: {integrity: sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==}
     peerDependencies:
       react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
       react-dom: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
 
-  react-smooth@1.0.6:
-    resolution: {integrity: sha512-B2vL4trGpNSMSOzFiAul9kFAsxTukL9Wyy9EXtkQy3GJr6sZqW9e1nShdVOJ3hRYamPZ94O17r3Q0bjSw3UYtg==}
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
-      react: ^15.0.0 || ^16.0.0
-      react-dom: ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-sortable-tree-theme-file-explorer@2.0.0:
     resolution: {integrity: sha512-44U3pl56Ucy5Zv1xOEKshFHJU085cO1XZ3w9j2fA/ga15aQ6PzlaNdNfFIeyrhb9J8aem7SvCLiCBNEzhkF0Uw==}
@@ -11368,6 +11386,12 @@ packages:
     peerDependencies:
       react: '>=15.0.0'
       react-dom: '>=15.0.0'
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react-virtualized@9.22.6:
     resolution: {integrity: sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==}
@@ -11408,11 +11432,12 @@ packages:
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
-  recharts@1.8.6:
-    resolution: {integrity: sha512-UlfSEOnZRAxxaH33Fc86yHEcqN+IRauPP31NfVvlGudtwVZEIb2RFI5b1J3npQo7XyoSnkUodg3Ha6EupkV+SQ==}
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
     peerDependencies:
-      react: ^15.0.0 || ^16.0.0
-      react-dom: ^15.0.0 || ^16.0.0
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -11421,12 +11446,6 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  reduce-css-calc@1.3.0:
-    resolution: {integrity: sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==}
-
-  reduce-function-call@1.0.3:
-    resolution: {integrity: sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==}
 
   redux-act@1.8.0:
     resolution: {integrity: sha512-xW3FIco/VwJGMW3eCD3JGAxyozNC4k35qrWM5lEQf9T2pfv3leDC+3vQ8WdHZjcrol/jjWAeJ+ULqrscuDqlKg==}
@@ -11513,9 +11532,6 @@ packages:
 
   reselect@4.1.8:
     resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
-
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -12083,6 +12099,9 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -12498,6 +12517,9 @@ packages:
 
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-plugin-doctest@2.0.0:
     resolution: {integrity: sha512-YHfRtwwTKAB+iG/oR9BvEnEfpHJFswiwizEeNV5ZlZjI3X3UrUdX8cRYhIfMwuJuOOLE25SX0SpUWEw5C3vEFw==}
@@ -16068,8 +16090,6 @@ snapshots:
 
   bail@1.0.5: {}
 
-  balanced-match@0.4.2: {}
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -16406,6 +16426,8 @@ snapshots:
 
   clsx@1.2.1: {}
 
+  clsx@2.1.1: {}
+
   code-point-at@1.1.0: {}
 
   color-convert@1.9.3:
@@ -16497,8 +16519,6 @@ snapshots:
       browserslist: 4.28.1
 
   core-js@2.6.12: {}
-
-  core-js@3.49.0: {}
 
   core-util-is@1.0.2: {}
 
@@ -16607,6 +16627,10 @@ snapshots:
 
   d3-array@1.2.4: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
   d3-axis@1.0.12: {}
 
   d3-brush@1.1.6:
@@ -16645,6 +16669,8 @@ snapshots:
 
   d3-ease@1.0.7: {}
 
+  d3-ease@3.0.1: {}
+
   d3-fetch@1.2.0:
     dependencies:
       d3-dsv: 1.2.0
@@ -16668,7 +16694,13 @@ snapshots:
     dependencies:
       d3-color: 1.4.1
 
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 1.4.1
+
   d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
 
   d3-polygon@1.0.6: {}
 
@@ -16690,11 +16722,23 @@ snapshots:
       d3-time: 1.1.0
       d3-time-format: 2.3.0
 
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 1.4.5
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 2.3.0
+
   d3-selection@1.4.2: {}
 
   d3-shape@1.3.7:
     dependencies:
       d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
 
   d3-time-format@2.3.0:
     dependencies:
@@ -16702,7 +16746,13 @@ snapshots:
 
   d3-time@1.1.0: {}
 
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   d3-timer@1.0.10: {}
+
+  d3-timer@3.0.1: {}
 
   d3-transition@1.3.2:
     dependencies:
@@ -17639,6 +17689,8 @@ snapshots:
 
   ev-emitter@1.1.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -17735,6 +17787,8 @@ snapshots:
   eyes@0.1.8: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -18364,6 +18418,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   interpret@3.1.1: {}
 
@@ -19067,8 +19123,6 @@ snapshots:
   markdown-ast@0.2.1: {}
 
   material-colors@1.2.6: {}
-
-  math-expression-evaluator@1.4.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -19834,8 +19888,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  raf-schd@4.0.3: {}
-
   raf@3.4.1:
     dependencies:
       performance-now: 2.1.0
@@ -20016,6 +20068,8 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-is@18.3.1: {}
+
   react-lifecycles-compat@3.0.4: {}
 
   react-markdown@6.0.3(@types/react@16.14.69)(react@16.14.0):
@@ -20095,24 +20149,6 @@ snapshots:
     optionalDependencies:
       react-dom: 16.14.0(react@16.14.0)
 
-  react-resize-detector@2.3.0(react@16.14.0):
-    dependencies:
-      lodash.debounce: 4.0.8
-      lodash.throttle: 4.1.1
-      prop-types: 15.8.1
-      react: 16.14.0
-      resize-observer-polyfill: 1.5.1
-
-  react-resize-detector@4.2.3(react-dom@16.14.0)(react@16.14.0):
-    dependencies:
-      lodash: 4.17.23
-      lodash-es: 4.17.23
-      prop-types: 15.8.1
-      raf-schd: 4.0.3
-      react: 16.14.0
-      react-dom: 16.14.0(react@16.14.0)
-      resize-observer-polyfill: 1.5.1
-
   react-select@1.3.0(react-dom@16.14.0)(react@16.14.0):
     dependencies:
       classnames: 2.5.1
@@ -20121,14 +20157,13 @@ snapshots:
       react-dom: 16.14.0(react@16.14.0)
       react-input-autosize: 2.2.2(react@16.14.0)
 
-  react-smooth@1.0.6(react-dom@16.14.0)(react@16.14.0):
+  react-smooth@4.0.4(react-dom@16.14.0)(react@16.14.0):
     dependencies:
-      lodash: 4.17.23
+      fast-equals: 5.4.0
       prop-types: 15.8.1
-      raf: 3.4.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
-      react-transition-group: 2.9.0(react-dom@16.14.0)(react@16.14.0)
+      react-transition-group: 4.4.5(react-dom@16.14.0)(react@16.14.0)
 
   react-sortable-tree-theme-file-explorer@2.0.0(react-dom@16.14.0)(react-sortable-tree@2.8.0)(react@16.14.0):
     dependencies:
@@ -20170,6 +20205,15 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
       react-lifecycles-compat: 3.0.4
+
+  react-transition-group@4.4.5(react-dom@16.14.0)(react@16.14.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
 
   react-virtualized@9.22.6(react-dom@16.14.0)(react@16.14.0):
     dependencies:
@@ -20235,21 +20279,18 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@1.8.6(react-dom@16.14.0)(react@16.14.0):
+  recharts@2.15.4(react-dom@16.14.0)(react@16.14.0):
     dependencies:
-      classnames: 2.5.1
-      core-js: 3.49.0
-      d3-interpolate: 1.4.0
-      d3-scale: 2.2.2
-      d3-shape: 1.3.7
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
       lodash: 4.17.23
-      prop-types: 15.8.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
-      react-resize-detector: 2.3.0(react@16.14.0)
-      react-smooth: 1.0.6(react-dom@16.14.0)(react@16.14.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@16.14.0)(react@16.14.0)
       recharts-scale: 0.4.5
-      reduce-css-calc: 1.3.0
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   rechoir@0.8.0:
     dependencies:
@@ -20259,16 +20300,6 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-
-  reduce-css-calc@1.3.0:
-    dependencies:
-      balanced-match: 0.4.2
-      math-expression-evaluator: 1.4.0
-      reduce-function-call: 1.0.3
-
-  reduce-function-call@1.0.3:
-    dependencies:
-      balanced-match: 1.0.2
 
   redux-act@1.8.0: {}
 
@@ -20388,8 +20419,6 @@ snapshots:
     optional: true
 
   reselect@4.1.8: {}
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -21051,6 +21080,8 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinycolor2@1.6.0: {}
@@ -21515,6 +21546,23 @@ snapshots:
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-doctest@2.0.0(typescript@5.9.3)(vite@8.0.3)(vitest@4.1.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -230,11 +230,10 @@ catalog:
   react-markdown: ^6.0.2
   react-overlays: ^1.2.0
   react-redux: ^7.1.3
-  react-resize-detector: ^4.2.1
   react-select: ^1.2.1
   react-sortable-tree: ^2.6.2
   react-sortable-tree-theme-file-explorer: ^2.0.0
-  recharts: ^1.8.5
+  recharts: ^2.15.4
   redux: ^4.0.4
   redux-act: ^1.8.0
   redux-batched-actions: ^0.5.0

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -104,7 +104,6 @@
     "react-markdown": "catalog:",
     "react-overlays": "catalog:",
     "react-redux": "catalog:",
-    "react-resize-detector": "catalog:",
     "react-select": "catalog:",
     "react-sortable-tree": "catalog:",
     "recharts": "catalog:",

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -148,7 +148,6 @@
     "react-markdown": "catalog:",
     "react-overlays": "catalog:",
     "react-redux": "catalog:",
-    "react-resize-detector": "catalog:",
     "react-select": "catalog:",
     "react-sortable-tree": "catalog:",
     "recharts": "catalog:",

--- a/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resizeObserverInstances: MockResizeObserver[] = [];
+
+class MockResizeObserver {
+  public callback: ResizeObserverCallback;
+  public observe = vi.fn();
+  public disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    resizeObserverInstances.push(this);
+  }
+}
+
+vi.mock("../../../controls/ErrorBoundary", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("react-redux", () => ({
+  connect: () => (component: React.ComponentType<Record<string, unknown>>) => component,
+}));
+
+vi.mock("react-i18next", () => ({
+  withTranslation: () => (component: unknown) => component,
+  translate: () => (component: unknown) => component,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("recharts", () => ({
+  Area: () => null,
+  AreaChart: ({ children, height, width }: any) => (
+    <div data-testid="download-graph-chart" data-height={String(height)} data-width={String(width)}>
+      {children}
+    </div>
+  ),
+  CartesianGrid: () => null,
+  Label: ({ value }: { value: string }) => <span>{value}</span>,
+  ReferenceLine: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="download-graph-limit">{children}</div>
+  ),
+  YAxis: () => null,
+}));
+
+import DownloadGraph from "./DownloadGraph";
+
+const Graph = DownloadGraph as unknown as React.ComponentType<{
+  t: (key: string) => string;
+  maxBandwidth: number;
+  speeds: number[];
+}>;
+
+const t = (key: string) => key;
+
+afterEach(() => {
+  cleanup();
+  resizeObserverInstances.length = 0;
+  delete (globalThis as any).ResizeObserver;
+});
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => 320,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => 120,
+  });
+  (globalThis as any).ResizeObserver = MockResizeObserver;
+});
+
+describe("DownloadGraph", () => {
+  it("updates the chart width when ResizeObserver reports a new size", async () => {
+    const { unmount } = render(<Graph t={t} maxBandwidth={0} speeds={[1, 2, 3]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("download-graph-chart")).toHaveAttribute("data-width", "320");
+    });
+
+    const observer = resizeObserverInstances[0];
+    expect(observer.observe).toHaveBeenCalledTimes(1);
+
+    observer.callback([{ contentRect: { width: 512, height: 120 } }] as any, observer as any);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("download-graph-chart")).toHaveAttribute("data-width", "512");
+    });
+
+    unmount();
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the bandwidth limit label when maxBandwidth constrains the graph", () => {
+    render(<Graph t={t} maxBandwidth={100} speeds={[120, 140]} />);
+
+    expect(screen.getByTestId("download-graph-limit")).toHaveTextContent(
+      "Bandwidth Limit (see Settings)",
+    );
+  });
+});

--- a/src/renderer/src/extensions/download_management/views/DownloadGraph.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadGraph.tsx
@@ -1,13 +1,12 @@
 import type { TFunction } from "i18next";
 import * as React from "react";
-import ResizeDetector from "react-resize-detector";
 import * as recharts from "recharts";
 
 import { setSettingsPage } from "../../../actions/session";
 import { ComponentEx, connect } from "../../../controls/ComponentEx";
 import ErrorBoundary from "../../../controls/ErrorBoundary";
 import type { IState } from "../../../types/IState";
-import { bytesToString, truthy } from "../../../util/util";
+import { bytesToString } from "../../../util/util";
 import { NUM_SPEED_DATA_POINTS } from "../reducers/state";
 
 interface IBaseProps {
@@ -29,6 +28,9 @@ interface IComponentState {
  * download speed dashlet
  */
 class DownloadGraph extends ComponentEx<IProps, IComponentState> {
+  private chartContainer?: HTMLDivElement;
+  private resizeObserver?: ResizeObserver;
+
   constructor(props: IProps) {
     super(props);
     this.initState({ width: 800 });
@@ -36,6 +38,16 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
 
   public componentDidMount() {
     this.forceUpdate();
+    if (this.chartContainer) {
+      this.resizeObserver = new ResizeObserver(([entry]) => {
+        this.onResize(entry.contentRect.width, entry.contentRect.height);
+      });
+      this.resizeObserver.observe(this.chartContainer);
+    }
+  }
+
+  public componentWillUnmount() {
+    this.resizeObserver?.disconnect();
   }
 
   public render(): JSX.Element {
@@ -80,7 +92,7 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
             {showLimit ? (
               <ReferenceLine y={maxBandwidth} strokeDasharray="6 2">
                 <Label
-                  value={t("Bandwidth Limit (see Settings)")}
+                  value={t("Bandwidth Limit (see Settings)") as string}
                   position="top"
                   onClick={this.openSettings}
                 />
@@ -95,9 +107,6 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
             /> */
             }
           </AreaChart>
-        </ErrorBoundary>
-        <ErrorBoundary>
-          <ResizeDetector handleWidth handleHeight onResize={this.onResize} />
         </ErrorBoundary>
       </div>
     );
@@ -120,8 +129,9 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
     return Math.ceil(input / roundVal) * roundVal;
   }
 
-  private setRef = (ref: HTMLDivElement) => {
-    if (truthy(ref)) {
+  private setRef = (ref: HTMLDivElement | null) => {
+    this.chartContainer = ref ?? undefined;
+    if (ref) {
       this.onResize(ref.clientWidth, ref.clientHeight);
     }
   };

--- a/src/stylesheets/vortex/charts.scss
+++ b/src/stylesheets/vortex/charts.scss
@@ -13,13 +13,10 @@
 }
 
 .download-chart .recharts-area {
-    // unfortunately stroke and area are two separate groups that
-    // are indistinguishable by class/id so we have to rely on their order
-    // here (which is an implementation detail)
-    :first-child {
+    .recharts-area-area {
         fill: url(#graph-gradient);
     }
-    :last-child {
+    .recharts-area-curve {
         stroke: $brand-clickable;
         stroke-width: 1.2px;
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     projects: [
       "./src/**/vitest.config.ts",
+      "./src/**/vitest.config.mts",
       "./src/main/vitest.downloader.config.ts",
       "./packages/**/vitest.config.ts",
       "./extensions/**/vitest.config.ts",


### PR DESCRIPTION
fixes LAZ-199

## Summary

`DownloadGraph` blocks the React 17 migration because it depends on 
`react-resize-detector@4.2.3` and `recharts@1.8.6`, both of which only support
React 16 as a peer dependency.

This PR updates/replaces those dependencies without changing Downloads page
behaviour (expand/collapse, resize handling, recent speed history, bandwidth-limit line).

See LAZ-199 for details.

## Changes

### Dependency updates
- **Remove** `react-resize-detector` from catalog, `src/main/package.json`, and `src/renderer/package.json`
- **Upgrade** `recharts` from `^1.8.5` → `^2.15.4` (React 17 support since 2.0.3)

### `DownloadGraph.tsx`
- Replace `react-resize-detector` with native `ResizeObserver`
- Update `setRef` to store container ref and observe resize via `ResizeObserver`
- Remove `truthy` import (no longer needed)

### `charts.scss`
- Update `.recharts-area` selectors: use `.recharts-area-area` / `.recharts-area-curve` class names instead of `:first-child` / `:last-child` pseudo-selectors (recharts 2.x changed markup structure)

### Test coverage
- Add `DownloadGraph.test.tsx` covering:
  - `ResizeObserver` triggers chart width update
  - `disconnect()` called on unmount
  - Bandwidth limit label rendered when `maxBandwidth` constrains the graph

### Config
- Add `vitest.config.mts` glob to `vitest.config.ts` projects

## Acceptance criteria

- [x] No active dependency path for the Downloads graph uses `react-resize-detector@4.2.3` or `recharts@1.8.6`
- [x] Graph still renders above the downloads table, expands/collapses, resizes with container, updates from `speedHistory`, shows bandwidth-limit line
- [x] Current no-animation behaviour preserved
- [x] Build, test, lint, format pass
- [x] Manual smoke-test of Downloads page graph



