### PR TITLE
coalesce persistence writes to reduce LevelDB stalls

### DIFF
--- a/AGENTS-DEBUGGING.md
+++ b/AGENTS-DEBUGGING.md
@@ -7,3 +7,16 @@
 
 > sewer note: This will be replaced with better .vscode config down the road.
 > am just keeping this as a leftover note for now.
+
+## Diagnostic environment variables
+
+- `VORTEX_TRACE_DB_WRITES=1` - turns on per-write breadcrumb logging in
+  `LevelPersist`. Every persistence write (`setItem`, `removeItem`,
+  `bulkSetItem`, `bulkRemoveItem`) emits a `level_pivot Write enter`
+  line at debug level before the call and a `level_pivot Write exit`
+  line after, with `method`, `alias`, `count`, and `elapsedMs`. Useful
+  for diagnosing indefinite shutdown hangs in the persist queue (the
+  last enter line with no matching exit pinpoints the wedged call).
+  Off by default. With the env var unset, the same code path still
+  emits a `level_pivot slow Write` warning when a single write exceeded
+  250 ms (`SLOW_WRITE_THRESHOLD_MS` in `LevelPersist.ts`).

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -804,8 +804,9 @@ class Application {
       );
     }
 
-    // Wrap all operations in a single transaction to avoid concurrent
-    // BEGIN TRANSACTION calls from individual setItem/removeItem calls.
+    // Wrap all operations in a single transaction so the import is atomic;
+    // a partial backup restore on failure would leave state in a confusing
+    // mixed-version condition.
     await persistor.beginTransaction();
     try {
       for (const [hive, hiveData] of Object.entries(backupData)) {

--- a/src/main/src/store/LevelPersist.test.ts
+++ b/src/main/src/store/LevelPersist.test.ts
@@ -1,0 +1,411 @@
+import type { DuckDBConnection } from "@duckdb/node-api";
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logging", () => ({ log: vi.fn() }));
+
+import { log } from "../logging";
+
+import LevelPersist from "./LevelPersist";
+
+const SEPARATOR = "###";
+
+function createMockConnection() {
+  return {
+    run: vi.fn().mockResolvedValue(undefined),
+    runAndReadAll: vi.fn().mockResolvedValue({ getRows: () => [] }),
+  };
+}
+
+function createPersist() {
+  const connection = createMockConnection();
+  const persist = new LevelPersist(
+    connection as unknown as DuckDBConnection,
+    "db",
+  );
+  return { persist, connection };
+}
+
+describe("LevelPersist.setItem", () => {
+  it("issues a single INSERT (no SELECT-then-branch)", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.setItem(["settings", "window", "x"], "42");
+
+    expect(connection.runAndReadAll).not.toHaveBeenCalled();
+    expect(connection.run).toHaveBeenCalledTimes(1);
+    expect(connection.run).toHaveBeenCalledWith(
+      "INSERT INTO db.kv VALUES ($1, $2)",
+      [`settings${SEPARATOR}window${SEPARATOR}x`, "42"],
+    );
+  });
+
+  it("does not begin or commit a transaction internally", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.setItem(["a"], "v");
+
+    const sqls = connection.run.mock.calls.map((c) => c[0] as string);
+    expect(sqls).not.toContainEqual(expect.stringMatching(/BEGIN/i));
+    expect(sqls).not.toContainEqual(expect.stringMatching(/COMMIT/i));
+  });
+
+  it("propagates connection errors", async () => {
+    const { persist, connection } = createPersist();
+    connection.run.mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(persist.setItem(["a"], "v")).rejects.toThrow("disk full");
+  });
+});
+
+describe("LevelPersist.removeItem", () => {
+  it("issues a single DELETE", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.removeItem(["settings", "window", "x"]);
+
+    expect(connection.run).toHaveBeenCalledTimes(1);
+    expect(connection.run).toHaveBeenCalledWith(
+      "DELETE FROM db.kv WHERE key = $1",
+      [`settings${SEPARATOR}window${SEPARATOR}x`],
+    );
+  });
+});
+
+describe("LevelPersist.bulkSetItem", () => {
+  it("is a no-op for an empty list", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkSetItem([]);
+
+    expect(connection.run).not.toHaveBeenCalled();
+  });
+
+  it("emits a single multi-row INSERT with positional params", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkSetItem([
+      { key: ["a"], value: "1" },
+      { key: ["b"], value: "2" },
+      { key: ["c"], value: "3" },
+    ]);
+
+    expect(connection.run).toHaveBeenCalledTimes(1);
+    const [sql, params] = connection.run.mock.calls[0];
+    expect(sql).toBe(
+      "INSERT INTO db.kv VALUES ($1, $2), ($3, $4), ($5, $6)",
+    );
+    expect(params).toEqual(["a", "1", "b", "2", "c", "3"]);
+  });
+
+  it("joins compound key paths with the separator", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkSetItem([
+      { key: ["settings", "window", "x"], value: "42" },
+    ]);
+
+    const params = connection.run.mock.calls[0][1] as string[];
+    expect(params[0]).toBe(`settings${SEPARATOR}window${SEPARATOR}x`);
+  });
+
+  it("scales placeholder count linearly with item count", async () => {
+    const { persist, connection } = createPersist();
+
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      key: [`k${i}`],
+      value: `v${i}`,
+    }));
+    await persist.bulkSetItem(items);
+
+    const sql = connection.run.mock.calls[0][0] as string;
+    const placeholders = sql.match(/\$\d+/g) ?? [];
+    expect(placeholders.length).toBe(200); // 2 per item
+
+    const params = connection.run.mock.calls[0][1] as string[];
+    expect(params.length).toBe(200);
+    expect(params[0]).toBe("k0");
+    expect(params[1]).toBe("v0");
+    expect(params[198]).toBe("k99");
+    expect(params[199]).toBe("v99");
+  });
+});
+
+describe("LevelPersist.bulkRemoveItem", () => {
+  it("is a no-op for an empty list", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkRemoveItem([]);
+
+    expect(connection.run).not.toHaveBeenCalled();
+  });
+
+  it("emits a single DELETE … WHERE key IN (…)", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkRemoveItem([["a"], ["b"], ["c"]]);
+
+    expect(connection.run).toHaveBeenCalledTimes(1);
+    const [sql, params] = connection.run.mock.calls[0];
+    expect(sql).toBe("DELETE FROM db.kv WHERE key IN ($1, $2, $3)");
+    expect(params).toEqual(["a", "b", "c"]);
+  });
+
+  it("joins compound key paths with the separator", async () => {
+    const { persist, connection } = createPersist();
+
+    await persist.bulkRemoveItem([["settings", "window"]]);
+
+    const params = connection.run.mock.calls[0][1] as string[];
+    expect(params).toEqual([`settings${SEPARATOR}window`]);
+  });
+});
+
+describe("LevelPersist transaction state", () => {
+  it("inTransaction is false before BEGIN", () => {
+    const { persist } = createPersist();
+    expect(persist.inTransaction).toBe(false);
+  });
+
+  it("inTransaction becomes true after a successful BEGIN", async () => {
+    const { persist } = createPersist();
+
+    await persist.beginTransaction();
+
+    expect(persist.inTransaction).toBe(true);
+  });
+
+  it("inTransaction stays false if BEGIN throws", async () => {
+    const { persist, connection } = createPersist();
+    connection.run.mockRejectedValueOnce(new Error("already in transaction"));
+
+    await expect(persist.beginTransaction()).rejects.toThrow();
+
+    expect(persist.inTransaction).toBe(false);
+  });
+
+  it("inTransaction is cleared after a successful COMMIT", async () => {
+    const { persist } = createPersist();
+    await persist.beginTransaction();
+
+    await persist.commitTransaction();
+
+    expect(persist.inTransaction).toBe(false);
+  });
+
+  it("inTransaction is cleared even if COMMIT throws", async () => {
+    const { persist, connection } = createPersist();
+    await persist.beginTransaction();
+    connection.run.mockRejectedValueOnce(new Error("commit failed"));
+
+    await expect(persist.commitTransaction()).rejects.toThrow("commit failed");
+
+    expect(persist.inTransaction).toBe(false);
+  });
+
+  it("inTransaction is cleared even if ROLLBACK throws", async () => {
+    const { persist, connection } = createPersist();
+    await persist.beginTransaction();
+    connection.run.mockRejectedValueOnce(new Error("nothing to roll back"));
+
+    await expect(persist.rollbackTransaction()).rejects.toThrow();
+
+    expect(persist.inTransaction).toBe(false);
+  });
+});
+
+describe("LevelPersist write timing breadcrumbs", () => {
+  const logMock = log as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    logMock.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // Returns a Date.now spy primed to advance by `elapsedMs` between the
+  // first and second call, so a single timed write computes that elapsed.
+  function fakeElapsed(elapsedMs: number) {
+    const spy = vi.spyOn(Date, "now");
+    let call = 0;
+    spy.mockImplementation(() => (call++ === 0 ? 1_000 : 1_000 + elapsedMs));
+    return spy;
+  }
+
+  it("does not log when a write completes under the slow threshold", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(50);
+
+    await persist.setItem(["a"], "v");
+
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when a write exceeds SLOW_WRITE_THRESHOLD_MS", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(300);
+
+    await persist.setItem(["settings", "window", "x"], "42");
+
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock).toHaveBeenCalledWith(
+      "warn",
+      "level_pivot slow Write",
+      expect.objectContaining({
+        method: "setItem",
+        alias: "db",
+        count: 1,
+        elapsedMs: 300,
+      }),
+    );
+  });
+
+  it("does not warn for an exactly-on-threshold write (strict greater-than)", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(250);
+
+    await persist.setItem(["a"], "v");
+
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates the rejection but still emits the warning when a slow write fails", async () => {
+    const { persist, connection } = createPersist();
+    connection.run.mockRejectedValueOnce(new Error("disk error"));
+    fakeElapsed(400);
+
+    await expect(persist.setItem(["a"], "v")).rejects.toThrow("disk error");
+
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock).toHaveBeenCalledWith(
+      "warn",
+      "level_pivot slow Write",
+      expect.objectContaining({ method: "setItem", elapsedMs: 400 }),
+    );
+  });
+
+  it("reports the row count from bulkSetItem", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(500);
+
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      key: [`k${i}`],
+      value: `v${i}`,
+    }));
+    await persist.bulkSetItem(items);
+
+    expect(logMock).toHaveBeenCalledWith(
+      "warn",
+      "level_pivot slow Write",
+      expect.objectContaining({
+        method: "bulkSetItem",
+        count: 100,
+        elapsedMs: 500,
+      }),
+    );
+  });
+
+  it("reports the key count from bulkRemoveItem", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(500);
+
+    const keys = Array.from({ length: 7 }, (_, i) => [`k${i}`]);
+    await persist.bulkRemoveItem(keys);
+
+    expect(logMock).toHaveBeenCalledWith(
+      "warn",
+      "level_pivot slow Write",
+      expect.objectContaining({
+        method: "bulkRemoveItem",
+        count: 7,
+        elapsedMs: 500,
+      }),
+    );
+  });
+
+  it("does not log for an empty bulk call (no Write actually issued)", async () => {
+    const { persist } = createPersist();
+    fakeElapsed(10_000);
+
+    await persist.bulkSetItem([]);
+    await persist.bulkRemoveItem([]);
+
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  describe("trace mode (VORTEX_TRACE_DB_WRITES=1)", () => {
+    beforeEach(() => {
+      vi.stubEnv("VORTEX_TRACE_DB_WRITES", "1");
+    });
+
+    it("emits enter and exit at debug level even when fast", async () => {
+      const { persist } = createPersist();
+      fakeElapsed(5);
+
+      await persist.setItem(["a"], "v");
+
+      expect(logMock).toHaveBeenCalledTimes(2);
+      expect(logMock).toHaveBeenNthCalledWith(
+        1,
+        "debug",
+        "level_pivot Write enter",
+        expect.objectContaining({ method: "setItem", alias: "db", count: 1 }),
+      );
+      expect(logMock).toHaveBeenNthCalledWith(
+        2,
+        "debug",
+        "level_pivot Write exit",
+        expect.objectContaining({
+          method: "setItem",
+          alias: "db",
+          count: 1,
+          elapsedMs: 5,
+        }),
+      );
+    });
+
+    it("does not double-log: trace mode suppresses the warn path", async () => {
+      const { persist } = createPersist();
+      fakeElapsed(500);
+
+      await persist.setItem(["a"], "v");
+
+      expect(logMock).toHaveBeenCalledTimes(2);
+      const levels = logMock.mock.calls.map((c) => c[0]);
+      expect(levels).toEqual(["debug", "debug"]);
+      expect(levels).not.toContain("warn");
+    });
+
+    it("still emits the exit line on rejection", async () => {
+      const { persist, connection } = createPersist();
+      connection.run.mockRejectedValueOnce(new Error("io fail"));
+      fakeElapsed(400);
+
+      await expect(persist.setItem(["a"], "v")).rejects.toThrow("io fail");
+
+      expect(logMock).toHaveBeenCalledTimes(2);
+      expect(logMock).toHaveBeenNthCalledWith(
+        2,
+        "debug",
+        "level_pivot Write exit",
+        expect.objectContaining({ elapsedMs: 400 }),
+      );
+    });
+
+    it("ignores any value other than the literal '1'", async () => {
+      vi.stubEnv("VORTEX_TRACE_DB_WRITES", "true");
+      const { persist } = createPersist();
+      fakeElapsed(5);
+
+      await persist.setItem(["a"], "v");
+
+      // Fast write + trace not enabled -> no logging at all.
+      expect(logMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/src/store/LevelPersist.test.ts
+++ b/src/main/src/store/LevelPersist.test.ts
@@ -376,7 +376,7 @@ describe("LevelPersist write timing breadcrumbs", () => {
       await persist.setItem(["a"], "v");
 
       expect(logMock).toHaveBeenCalledTimes(2);
-      const levels = logMock.mock.calls.map((c) => c[0]);
+      const levels = logMock.mock.calls.map((c): unknown => c[0]);
       expect(levels).toEqual(["debug", "debug"]);
       expect(levels).not.toContain("warn");
     });

--- a/src/main/src/store/LevelPersist.ts
+++ b/src/main/src/store/LevelPersist.ts
@@ -1,17 +1,28 @@
-import type { IPersistor } from "@vortex/shared/state";
-
 import type { DuckDBConnection } from "@duckdb/node-api";
+import type { IPersistor } from "@vortex/shared/state";
 
 import { unknownToError } from "@vortex/shared";
 import { DataInvalid } from "@vortex/shared/errors";
-
 import * as path from "node:path";
 
-import { log } from "../logging";
 import { getVortexPath } from "../getVortexPath";
+import { log } from "../logging";
 import DuckDBSingleton from "./DuckDBSingleton";
 
 const SEPARATOR: string = "###";
+
+// Threshold (in milliseconds) above which a successful write is logged as
+// a warning. Picked to be silent under healthy operation while still
+// surfacing meaningful stalls in field log captures.
+const SLOW_WRITE_THRESHOLD_MS = 250;
+
+// When VORTEX_TRACE_DB_WRITES=1 is set in the environment, every persistence
+// write logs an enter/exit pair at debug level so the "last enter without an
+// exit" marks the wedged call. Read per-call so tests (and live operators)
+// can flip it via vi.stubEnv / a relaunch without rebuilding.
+function traceWritesEnabled(): boolean {
+  return process.env.VORTEX_TRACE_DB_WRITES === "1";
+}
 
 export class DatabaseLocked extends Error {
   constructor() {
@@ -115,6 +126,52 @@ class LevelPersist implements IPersistor {
     return this.#mConnection;
   }
 
+  public get inTransaction(): boolean {
+    return this.#mInTransaction;
+  }
+
+  // Times a write through the connection. Default behaviour: silent on
+  // success, warns when the call exceeded SLOW_WRITE_THRESHOLD_MS. With
+  // VORTEX_TRACE_DB_WRITES=1 set in the environment, also emits an enter
+  // line before the await and an exit line after - so an indefinite hang
+  // (where the exit line never appears in vortex.log) pinpoints the
+  // wedged call.
+  private async timedWrite<T>(
+    method: string,
+    count: number,
+    op: () => Promise<T>,
+  ): Promise<T> {
+    const trace = traceWritesEnabled();
+    const start = Date.now();
+    if (trace) {
+      log("debug", "level_pivot Write enter", {
+        method,
+        alias: this.#mAlias,
+        count,
+      });
+    }
+    try {
+      return await op();
+    } finally {
+      const elapsedMs = Date.now() - start;
+      if (trace) {
+        log("debug", "level_pivot Write exit", {
+          method,
+          alias: this.#mAlias,
+          count,
+          elapsedMs,
+        });
+      } else if (elapsedMs > SLOW_WRITE_THRESHOLD_MS) {
+        log("warn", "level_pivot slow Write", {
+          method,
+          alias: this.#mAlias,
+          count,
+          elapsedMs,
+        });
+      }
+    }
+  }
+
   public async close(): Promise<void> {
     await DuckDBSingleton.getInstance().detachDatabase(this.#mAlias);
   }
@@ -184,54 +241,87 @@ class LevelPersist implements IPersistor {
   }
 
   public async setItem(statePath: string[], newState: string): Promise<void> {
-    const key = statePath.join(SEPARATOR);
-    // level_pivot tables don't support UNIQUE indexes, so ON CONFLICT
-    // upserts aren't possible.  UPDATE … RETURNING is also unreliable:
-    // level_pivot's EmitRowCount unconditionally emits a single-row chunk
-    // (the "rows affected" count), which DuckDB's RETURNING pipeline
-    // surfaces as the query result — so RETURNING always reports 1 row
-    // regardless of whether any row was matched.  Use SELECT to check
-    // existence, then UPDATE or INSERT accordingly.
-    const ownTransaction = !this.#mInTransaction;
-    if (ownTransaction) {
-      await this.beginTransaction();
-    }
-    try {
-      const exists = await this.#mConnection.runAndReadAll(
-        `SELECT 1 FROM ${this.#mAlias}.kv WHERE key = $1`,
-        [key],
-      );
-      if (exists.getRows().length > 0) {
-        await this.#mConnection.run(
-          `UPDATE ${this.#mAlias}.kv SET value = $2 WHERE key = $1`,
-          [key, newState],
-        );
-      } else {
-        await this.#mConnection.run(
-          `INSERT INTO ${this.#mAlias}.kv VALUES ($1, $2)`,
-          [key, newState],
-        );
-      }
-      if (ownTransaction) {
-        await this.commitTransaction();
-      }
-    } catch (err) {
-      if (ownTransaction) {
-        await this.rollbackTransaction();
-      }
-      throw err;
-    }
+    // No internal BEGIN/COMMIT here. The previous implementation issued
+    // three statements (SELECT-then-UPDATE-or-INSERT) and self-wrapped in a
+    // transaction to keep them atomic against concurrent writers to the
+    // same key. The new shape is a single statement - raw-mode level_pivot
+    // tables have no UNIQUE constraint and the Sink unconditionally calls
+    // batch.put, so plain INSERT already overwrites an existing row, and
+    // DuckDB's auto-commit makes a one-statement INSERT atomic on its own.
+    // Pinned by the upsert tests in the level_pivot extension's
+    // level_pivot.test. Callers that need to batch multiple setItem /
+    // removeItem calls atomically wrap them in beginTransaction /
+    // commitTransaction explicitly (see ReduxPersistorIPC.processOperations
+    // and Application.importBackup).
+    await this.timedWrite("setItem", 1, () =>
+      this.#mConnection.run(`INSERT INTO ${this.#mAlias}.kv VALUES ($1, $2)`, [
+        statePath.join(SEPARATOR),
+        newState,
+      ]),
+    );
   }
 
   public async removeItem(statePath: string[]): Promise<void> {
-    await this.#mConnection.run(
-      `DELETE FROM ${this.#mAlias}.kv WHERE key = $1`,
-      [statePath.join(SEPARATOR)],
+    await this.timedWrite("removeItem", 1, () =>
+      this.#mConnection.run(
+        `DELETE FROM ${this.#mAlias}.kv WHERE key = $1`,
+        [statePath.join(SEPARATOR)],
+      ),
     );
   }
 
   /**
-   * Begin a transaction on this connection.
+   * Bulk variant of setItem: a single multi-row INSERT covering every item.
+   * Relies on the same upsert behaviour as setItem. The caller is expected
+   * to chunk large diffs to bound failure granularity (see
+   * ReduxPersistorIPC.processOperations).
+   */
+  public async bulkSetItem(
+    items: ReadonlyArray<{ key: string[]; value: string }>,
+  ): Promise<void> {
+    if (items.length === 0) {
+      return;
+    }
+    // Build "VALUES ($1, $2), ($3, $4), ..." with positional params.
+    const placeholders: string[] = [];
+    const params: string[] = [];
+    for (let i = 0; i < items.length; i++) {
+      placeholders.push(`($${2 * i + 1}, $${2 * i + 2})`);
+      params.push(items[i].key.join(SEPARATOR), items[i].value);
+    }
+    await this.timedWrite("bulkSetItem", items.length, () =>
+      this.#mConnection.run(
+        `INSERT INTO ${this.#mAlias}.kv VALUES ${placeholders.join(", ")}`,
+        params,
+      ),
+    );
+  }
+
+  /**
+   * Bulk variant of removeItem: a single DELETE … WHERE key IN (…) statement
+   * covering every key. The caller is expected to chunk large lists.
+   */
+  public async bulkRemoveItem(keys: ReadonlyArray<string[]>): Promise<void> {
+    if (keys.length === 0) {
+      return;
+    }
+    const placeholders: string[] = [];
+    const params: string[] = [];
+    for (let i = 0; i < keys.length; i++) {
+      placeholders.push(`$${i + 1}`);
+      params.push(keys[i].join(SEPARATOR));
+    }
+    await this.timedWrite("bulkRemoveItem", keys.length, () =>
+      this.#mConnection.run(
+        `DELETE FROM ${this.#mAlias}.kv WHERE key IN (${placeholders.join(", ")})`,
+        params,
+      ),
+    );
+  }
+
+  /**
+   * Begin a transaction on this connection. The in-transaction flag is only
+   * set if BEGIN succeeds.
    */
   public async beginTransaction(): Promise<void> {
     await this.#mConnection.run("BEGIN TRANSACTION");
@@ -242,16 +332,22 @@ class LevelPersist implements IPersistor {
    * Commit the current transaction.
    */
   public async commitTransaction(): Promise<void> {
-    await this.#mConnection.run("COMMIT");
-    this.#mInTransaction = false;
+    try {
+      await this.#mConnection.run("COMMIT");
+    } finally {
+      this.#mInTransaction = false;
+    }
   }
 
   /**
    * Rollback the current transaction.
    */
   public async rollbackTransaction(): Promise<void> {
-    await this.#mConnection.run("ROLLBACK");
-    this.#mInTransaction = false;
+    try {
+      await this.#mConnection.run("ROLLBACK");
+    } finally {
+      this.#mInTransaction = false;
+    }
   }
 
   /**

--- a/src/main/src/store/ReduxPersistorIPC.test.ts
+++ b/src/main/src/store/ReduxPersistorIPC.test.ts
@@ -17,6 +17,8 @@ vi.mock("../logging", () => ({
   log: vi.fn(),
 }));
 
+import type LevelPersist from "./LevelPersist";
+import type QueryInvalidator from "./QueryInvalidator";
 import ReduxPersistorIPC from "./ReduxPersistorIPC";
 
 type MockPersistor = IPersistor & {
@@ -79,10 +81,8 @@ async function setupIPC(persistor: IPersistor) {
   const levelPersist = createMockLevelPersist();
   const invalidator = createMockInvalidator();
   ipc.setQueryInvalidator(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    levelPersist as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    invalidator as any,
+    levelPersist as unknown as LevelPersist,
+    invalidator as unknown as QueryInvalidator,
   );
   await ipc.insertPersistor("test", persistor);
   return { ipc, levelPersist, invalidator };
@@ -132,10 +132,12 @@ describe("ReduxPersistorIPC: run grouping", () => {
     // Record the dispatch order via a shared call log rather than reading
     // it back out of two separate mock-call lists.
     const callLog: Array<"set" | "remove"> = [];
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     persistor.bulkSetItem.mockImplementation((): Promise<void> => {
       callLog.push("set");
       return Promise.resolve();
     });
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     persistor.bulkRemoveItem.mockImplementation((): Promise<void> => {
       callLog.push("remove");
       return Promise.resolve();
@@ -400,6 +402,7 @@ describe(
       const blocker = new Promise<void>((resolve) => {
         release = resolve;
       });
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       persistor.bulkSetItem.mockImplementationOnce(() => blocker);
 
       const { ipc } = await setupIPC(persistor);

--- a/src/main/src/store/ReduxPersistorIPC.test.ts
+++ b/src/main/src/store/ReduxPersistorIPC.test.ts
@@ -1,0 +1,432 @@
+import type { DiffOperation } from "@vortex/shared/ipc";
+import type { IPersistor, PersistorKey } from "@vortex/shared/state";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub terminate so a faulted processOperations doesn't try to show a dialog.
+// Re-throwing keeps the same control flow as the real terminate (synchronous
+// throw caught by the outer queue catch).
+vi.mock("../errorHandling", () => ({
+  terminate: (err: Error) => {
+    throw err;
+  },
+}));
+
+// Suppress log noise from the queue's catch handler.
+vi.mock("../logging", () => ({
+  log: vi.fn(),
+}));
+
+import ReduxPersistorIPC from "./ReduxPersistorIPC";
+
+type MockPersistor = IPersistor & {
+  bulkSetItem: ReturnType<typeof vi.fn>;
+  bulkRemoveItem: ReturnType<typeof vi.fn>;
+  setItem: ReturnType<typeof vi.fn>;
+  removeItem: ReturnType<typeof vi.fn>;
+};
+
+function createBulkPersistor(): MockPersistor {
+  return {
+    setResetCallback: vi.fn(),
+    getItem: vi.fn().mockResolvedValue(""),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+    getAllKeys: vi.fn().mockResolvedValue([]),
+    getAllKVs: vi.fn().mockResolvedValue([]),
+    bulkSetItem: vi.fn().mockResolvedValue(undefined),
+    bulkRemoveItem: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createNonBulkPersistor(): IPersistor & {
+  setItem: ReturnType<typeof vi.fn>;
+  removeItem: ReturnType<typeof vi.fn>;
+} {
+  return {
+    setResetCallback: vi.fn(),
+    getItem: vi.fn().mockResolvedValue(""),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+    getAllKeys: vi.fn().mockResolvedValue([]),
+    getAllKVs: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockLevelPersist() {
+  return {
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commitTransaction: vi.fn().mockResolvedValue(undefined),
+    rollbackTransaction: vi.fn().mockResolvedValue(undefined),
+    getDirtyTables: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockInvalidator() {
+  return { notifyDirtyTables: vi.fn() };
+}
+
+function set(path: PersistorKey, value: unknown): DiffOperation {
+  return { type: "set", path, value };
+}
+
+function remove(path: PersistorKey): DiffOperation {
+  return { type: "remove", path };
+}
+
+async function setupIPC(persistor: IPersistor) {
+  const ipc = new ReduxPersistorIPC();
+  const levelPersist = createMockLevelPersist();
+  const invalidator = createMockInvalidator();
+  ipc.setQueryInvalidator(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    levelPersist as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    invalidator as any,
+  );
+  await ipc.insertPersistor("test", persistor);
+  return { ipc, levelPersist, invalidator };
+}
+
+describe("ReduxPersistorIPC: run grouping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("collapses a uniform set run into one bulkSetItem call", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    ipc.applyDiffOperations("test", [
+      set(["a"], "1"),
+      set(["b"], "2"),
+      set(["c"], "3"),
+    ]);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkSetItem).toHaveBeenCalledTimes(1);
+    expect(persistor.bulkRemoveItem).not.toHaveBeenCalled();
+
+    const items = persistor.bulkSetItem.mock.calls[0][0] as Array<{
+      key: PersistorKey;
+      value: string;
+    }>;
+    expect(items.map((i) => i.key)).toEqual([["a"], ["b"], ["c"]]);
+  });
+
+  it("collapses a uniform remove run into one bulkRemoveItem call", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    ipc.applyDiffOperations("test", [
+      remove(["a"]),
+      remove(["b"]),
+      remove(["c"]),
+    ]);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkRemoveItem).toHaveBeenCalledTimes(1);
+    expect(persistor.bulkSetItem).not.toHaveBeenCalled();
+  });
+
+  it("preserves order across type boundaries (set, remove, set)", async () => {
+    const persistor = createBulkPersistor();
+    // Record the dispatch order via a shared call log rather than reading
+    // it back out of two separate mock-call lists.
+    const callLog: Array<"set" | "remove"> = [];
+    persistor.bulkSetItem.mockImplementation((): Promise<void> => {
+      callLog.push("set");
+      return Promise.resolve();
+    });
+    persistor.bulkRemoveItem.mockImplementation((): Promise<void> => {
+      callLog.push("remove");
+      return Promise.resolve();
+    });
+    const { ipc } = await setupIPC(persistor);
+
+    ipc.applyDiffOperations("test", [
+      set(["a"], "1"),
+      set(["b"], "2"),
+      remove(["c"]),
+      remove(["d"]),
+      set(["e"], "5"),
+    ]);
+    await ipc.finalizeWrite();
+
+    expect(callLog).toEqual(["set", "remove", "set"]);
+    expect(persistor.bulkSetItem).toHaveBeenCalledTimes(2);
+    expect(persistor.bulkRemoveItem).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ReduxPersistorIPC: chunking at BULK_CHUNK_SIZE (256)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("emits a single bulk call for exactly 256 set operations", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    const ops = Array.from({ length: 256 }, (_, i) => set([`k${i}`], `v${i}`));
+    ipc.applyDiffOperations("test", ops);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkSetItem).toHaveBeenCalledTimes(1);
+    const items = persistor.bulkSetItem.mock.calls[0][0] as Array<unknown>;
+    expect(items.length).toBe(256);
+  });
+
+  it("splits 257 ops into chunks of 256 + 1", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    const ops = Array.from({ length: 257 }, (_, i) => set([`k${i}`], `v${i}`));
+    ipc.applyDiffOperations("test", ops);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkSetItem).toHaveBeenCalledTimes(2);
+    expect(
+      (persistor.bulkSetItem.mock.calls[0][0] as Array<unknown>).length,
+    ).toBe(256);
+    expect(
+      (persistor.bulkSetItem.mock.calls[1][0] as Array<unknown>).length,
+    ).toBe(1);
+  });
+
+  it("splits a 1002-op set run into 4 chunks (256+256+256+234)", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    const ops = Array.from({ length: 1002 }, (_, i) => set([`k${i}`], `v${i}`));
+    ipc.applyDiffOperations("test", ops);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkSetItem).toHaveBeenCalledTimes(4);
+    const sizes = persistor.bulkSetItem.mock.calls.map(
+      (c) => (c[0] as Array<unknown>).length,
+    );
+    expect(sizes).toEqual([256, 256, 256, 234]);
+
+    // First key of each chunk advances by 256, last chunk has the tail.
+    const firstKeys = persistor.bulkSetItem.mock.calls.map((c) => {
+      const items = c[0] as Array<{ key: PersistorKey }>;
+      return items[0].key[0];
+    });
+    expect(firstKeys).toEqual(["k0", "k256", "k512", "k768"]);
+  });
+
+  it("chunks remove runs with the same boundary", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    const ops = Array.from({ length: 300 }, (_, i) => remove([`k${i}`]));
+    ipc.applyDiffOperations("test", ops);
+    await ipc.finalizeWrite();
+
+    expect(persistor.bulkRemoveItem).toHaveBeenCalledTimes(2);
+    const sizes = persistor.bulkRemoveItem.mock.calls.map(
+      (c) => (c[0] as Array<unknown>).length,
+    );
+    expect(sizes).toEqual([256, 44]);
+  });
+});
+
+describe("ReduxPersistorIPC: fallback when bulk methods are absent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("falls back to per-op setItem when persistor lacks bulkSetItem", async () => {
+    const persistor = createNonBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    ipc.applyDiffOperations("test", [
+      set(["a"], "1"),
+      set(["b"], "2"),
+      set(["c"], "3"),
+    ]);
+    await ipc.finalizeWrite();
+
+    expect(persistor.setItem).toHaveBeenCalledTimes(3);
+    expect(persistor.setItem).toHaveBeenNthCalledWith(1, ["a"], '"1"');
+    expect(persistor.setItem).toHaveBeenNthCalledWith(2, ["b"], '"2"');
+    expect(persistor.setItem).toHaveBeenNthCalledWith(3, ["c"], '"3"');
+  });
+
+  it("falls back to per-op removeItem when persistor lacks bulkRemoveItem", async () => {
+    const persistor = createNonBulkPersistor();
+    const { ipc } = await setupIPC(persistor);
+
+    ipc.applyDiffOperations("test", [remove(["a"]), remove(["b"])]);
+    await ipc.finalizeWrite();
+
+    expect(persistor.removeItem).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ReduxPersistorIPC: transaction wrapping and dirty-table notify", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("wraps each diff in BEGIN…COMMIT and notifies dirty tables", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc, levelPersist, invalidator } = await setupIPC(persistor);
+    levelPersist.getDirtyTables.mockResolvedValue([
+      { database: "db", table: "kv", type: "raw" },
+    ]);
+
+    ipc.applyDiffOperations("test", [set(["a"], "1")]);
+    await ipc.finalizeWrite();
+
+    expect(levelPersist.beginTransaction).toHaveBeenCalledTimes(1);
+    expect(levelPersist.getDirtyTables).toHaveBeenCalledTimes(1);
+    expect(levelPersist.commitTransaction).toHaveBeenCalledTimes(1);
+    expect(invalidator.notifyDirtyTables).toHaveBeenCalledWith([
+      { database: "db", table: "kv", type: "raw" },
+    ]);
+    expect(levelPersist.rollbackTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not notify dirty tables when none changed", async () => {
+    const persistor = createBulkPersistor();
+    const { ipc, levelPersist, invalidator } = await setupIPC(persistor);
+    levelPersist.getDirtyTables.mockResolvedValue([]);
+
+    ipc.applyDiffOperations("test", [set(["a"], "1")]);
+    await ipc.finalizeWrite();
+
+    expect(invalidator.notifyDirtyTables).not.toHaveBeenCalled();
+  });
+});
+
+describe(
+  "ReduxPersistorIPC: atomicity under partial failure (force-close simulation)",
+  () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // What this test models:
+    //
+    // The renderer pushes a multi-chunk diff while the user force-closes the
+    // app (or the OS / disk introduces a write error). We can't actually
+    // SIGKILL inside the test, so we simulate the failure point by making
+    // one of the bulk writes throw - the same shape the queue would
+    // observe if a LevelDB Write reported an error mid-transaction.
+    //
+    // We assert two recovery properties:
+    //   1. ROLLBACK is issued for the in-flight DuckDB transaction so a
+    //      stale BEGIN can't block a future caller.
+    //   2. Bulk calls *after* the failure point do not run, bounding
+    //      worst-case data loss to one chunk's worth of writes (256 ops
+    //      with the current BULK_CHUNK_SIZE).
+    //
+    // Note: at the LevelDB layer, each chunk's batch.commit is its own
+    // atomic Write - so chunks the persistor *did* successfully apply
+    // before the failure are durable independently of the DuckDB
+    // ROLLBACK. This test verifies that the queue stops dispatching
+    // additional chunks rather than charging on through the rest.
+
+    it("rolls back and stops dispatch when a bulk chunk fails mid-transaction", async () => {
+      const persistor = createBulkPersistor();
+
+      // Succeed on the first chunk, fail on the second, never reach the third.
+      persistor.bulkSetItem
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("simulated mid-transaction failure"))
+        .mockResolvedValueOnce(undefined);
+
+      const { ipc, levelPersist, invalidator } = await setupIPC(persistor);
+
+      // 700 ops -> 256 + 256 + 188 chunks
+      const ops = Array.from({ length: 700 }, (_, i) =>
+        set([`k${i}`], `v${i}`),
+      );
+      ipc.applyDiffOperations("test", ops);
+      await ipc.finalizeWrite();
+
+      // Exactly two chunks attempted: chunk #1 succeeded, chunk #2 threw,
+      // chunk #3 never ran.
+      expect(persistor.bulkSetItem).toHaveBeenCalledTimes(2);
+
+      // The transaction was rolled back rather than committed.
+      expect(levelPersist.beginTransaction).toHaveBeenCalledTimes(1);
+      expect(levelPersist.rollbackTransaction).toHaveBeenCalledTimes(1);
+      expect(levelPersist.commitTransaction).not.toHaveBeenCalled();
+
+      // Dirty-table notifications must not fire on a failed transaction -
+      // consumers would otherwise observe phantom invalidations for state
+      // that didn't actually commit.
+      expect(invalidator.notifyDirtyTables).not.toHaveBeenCalled();
+    });
+
+    it("survives a rollback that itself fails - queue continues", async () => {
+      const persistor = createBulkPersistor();
+      persistor.bulkSetItem.mockRejectedValueOnce(new Error("write failed"));
+
+      const { ipc, levelPersist } = await setupIPC(persistor);
+      levelPersist.rollbackTransaction.mockRejectedValueOnce(
+        new Error("rollback failed"),
+      );
+
+      // First diff fails.
+      ipc.applyDiffOperations("test", [set(["a"], "1")]);
+
+      // Subsequent diff must still drain - the queue's catch handler must
+      // not let the rejection propagate and block the chain.
+      ipc.applyDiffOperations("test", [set(["b"], "2")]);
+
+      await expect(ipc.finalizeWrite()).resolves.toBeUndefined();
+
+      // Both diffs were attempted (the second one's bulkSetItem ran fine).
+      expect(persistor.bulkSetItem).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not partially apply ops after the failure point within the same diff", async () => {
+      const persistor = createBulkPersistor();
+      // Fail on the very first chunk.
+      persistor.bulkSetItem.mockRejectedValueOnce(new Error("disk error"));
+
+      const { ipc } = await setupIPC(persistor);
+
+      const ops = Array.from({ length: 600 }, (_, i) =>
+        set([`k${i}`], `v${i}`),
+      );
+      ipc.applyDiffOperations("test", ops);
+      await ipc.finalizeWrite();
+
+      // 600 ops would be 3 chunks (256+256+88) on success. After the first
+      // chunk throws, no further chunks may run.
+      expect(persistor.bulkSetItem).toHaveBeenCalledTimes(1);
+    });
+
+    it("queue stays in order: a later diff is not processed before an earlier one finishes", async () => {
+      const persistor = createBulkPersistor();
+      // Hold the first bulk call in flight via a deferred promise so we can
+      // observe ordering.
+      let release: () => void = () => undefined;
+      const blocker = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      persistor.bulkSetItem.mockImplementationOnce(() => blocker);
+
+      const { ipc } = await setupIPC(persistor);
+
+      ipc.applyDiffOperations("test", [set(["first"], "1")]);
+      ipc.applyDiffOperations("test", [set(["second"], "2")]);
+
+      // Give microtasks a chance to drain. Only the first diff's bulk call
+      // should have been issued so far - the second is queued behind it.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(persistor.bulkSetItem).toHaveBeenCalledTimes(1);
+      expect(
+        (persistor.bulkSetItem.mock.calls[0][0] as Array<{
+          key: PersistorKey;
+        }>)[0].key[0],
+      ).toBe("first");
+
+      release();
+      await ipc.finalizeWrite();
+
+      expect(persistor.bulkSetItem).toHaveBeenCalledTimes(2);
+      expect(
+        (persistor.bulkSetItem.mock.calls[1][0] as Array<{
+          key: PersistorKey;
+        }>)[0].key[0],
+      ).toBe("second");
+    });
+  },
+);

--- a/src/main/src/store/ReduxPersistorIPC.ts
+++ b/src/main/src/store/ReduxPersistorIPC.ts
@@ -186,9 +186,22 @@ class ReduxPersistorIPC {
       });
   }
 
+  // Maximum operations bundled into a single bulk INSERT or DELETE.
+  // Bounds failure granularity (a Write failure loses at most this many
+  // operations of progress) while still collapsing typical Redux diffs
+  // into a small number of LevelDB writes. Each set chunk uses 2*N
+  // positional parameters; each remove chunk uses N. 256 keeps both
+  // comfortably below any reasonable parameter limit.
+  private static readonly BULK_CHUNK_SIZE = 256;
+
   /**
    * Process a batch of diff operations for a hive.
-   * Operations are processed sequentially to maintain order.
+   *
+   * Consecutive operations of the same type are coalesced into multi-row
+   * INSERT or DELETE statements (chunked at BULK_CHUNK_SIZE) when the
+   * persistor supports the optional bulk methods. Order is preserved across
+   * type boundaries - a set->remove->set sequence on the same key still
+   * resolves last-write-wins.
    */
   private async processOperations(
     hive: string,
@@ -205,10 +218,7 @@ class ReduxPersistorIPC {
         await levelPersist.beginTransaction();
       }
 
-      // Process operations sequentially to maintain order
-      for (const op of operations) {
-        await this.applyOperation(persistor, op);
-      }
+      await this.applyOperationsInRuns(persistor, operations);
 
       if (useTransaction) {
         // Check dirty tables BEFORE commit (while transaction is active)
@@ -258,18 +268,77 @@ class ReduxPersistorIPC {
   }
 
   /**
-   * Apply a single diff operation to the persistor.
+   * Walk the operation list, grouping consecutive same-type ops into runs
+   * and dispatching each run to the bulk path when available.
    */
-  private applyOperation(
+  private async applyOperationsInRuns(
     persistor: IPersistor,
-    operation: DiffOperation,
+    operations: DiffOperation[],
   ): Promise<void> {
-    if (operation.type === "set") {
-      return Promise.resolve(
-        persistor.setItem(operation.path, this.serialize(operation.value)),
-      );
+    let i = 0;
+    while (i < operations.length) {
+      const opType = operations[i].type;
+      let runEnd = i + 1;
+      while (
+        runEnd < operations.length &&
+        operations[runEnd].type === opType
+      ) {
+        runEnd++;
+      }
+      const run = operations.slice(i, runEnd);
+      if (opType === "set") {
+        await this.applySetRun(persistor, run);
+      } else {
+        await this.applyRemoveRun(persistor, run);
+      }
+      i = runEnd;
+    }
+  }
+
+  private async applySetRun(
+    persistor: IPersistor,
+    run: DiffOperation[],
+  ): Promise<void> {
+    if (persistor.bulkSetItem !== undefined) {
+      const bulk = persistor.bulkSetItem.bind(persistor);
+      for (
+        let start = 0;
+        start < run.length;
+        start += ReduxPersistorIPC.BULK_CHUNK_SIZE
+      ) {
+        const chunk = run.slice(start, start + ReduxPersistorIPC.BULK_CHUNK_SIZE);
+        await bulk(
+          chunk.map((op) => ({
+            key: op.path,
+            value: this.serialize(op.value),
+          })),
+        );
+      }
     } else {
-      return Promise.resolve(persistor.removeItem(operation.path));
+      for (const op of run) {
+        await persistor.setItem(op.path, this.serialize(op.value));
+      }
+    }
+  }
+
+  private async applyRemoveRun(
+    persistor: IPersistor,
+    run: DiffOperation[],
+  ): Promise<void> {
+    if (persistor.bulkRemoveItem !== undefined) {
+      const bulk = persistor.bulkRemoveItem.bind(persistor);
+      for (
+        let start = 0;
+        start < run.length;
+        start += ReduxPersistorIPC.BULK_CHUNK_SIZE
+      ) {
+        const chunk = run.slice(start, start + ReduxPersistorIPC.BULK_CHUNK_SIZE);
+        await bulk(chunk.map((op) => op.path));
+      }
+    } else {
+      for (const op of run) {
+        await persistor.removeItem(op.path);
+      }
     }
   }
 

--- a/src/main/src/store/SubPersistor.test.ts
+++ b/src/main/src/store/SubPersistor.test.ts
@@ -1,0 +1,139 @@
+import type { IPersistor, PersistorKey } from "@vortex/shared/state";
+
+import { describe, it, expect, vi } from "vitest";
+
+import SubPersistor from "./SubPersistor";
+
+function createWrappedWithBulk(): IPersistor {
+  return {
+    setResetCallback: vi.fn(),
+    getItem: vi.fn().mockResolvedValue("value"),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+    getAllKeys: vi.fn().mockResolvedValue([]),
+    getAllKVs: vi.fn().mockResolvedValue([]),
+    bulkSetItem: vi.fn().mockResolvedValue(undefined),
+    bulkRemoveItem: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createWrappedWithoutBulk(): IPersistor {
+  return {
+    setResetCallback: vi.fn(),
+    getItem: vi.fn().mockResolvedValue("value"),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+    getAllKeys: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe("SubPersistor key prefixing (single-item)", () => {
+  it("setItem prepends the hive to the key path", async () => {
+    const wrapped = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "settings");
+
+    await sub.setItem(["window", "x"], "42");
+
+    expect(wrapped.setItem).toHaveBeenCalledWith(
+      ["settings", "window", "x"],
+      "42",
+    );
+  });
+
+  it("removeItem prepends the hive to the key path", async () => {
+    const wrapped = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "settings");
+
+    await sub.removeItem(["window", "x"]);
+
+    expect(wrapped.removeItem).toHaveBeenCalledWith([
+      "settings",
+      "window",
+      "x",
+    ]);
+  });
+});
+
+describe("SubPersistor.bulkSetItem", () => {
+  it("is exposed when the wrapped persistor exposes it", () => {
+    const sub = new SubPersistor(createWrappedWithBulk(), "settings");
+    expect(typeof sub.bulkSetItem).toBe("function");
+  });
+
+  it("is undefined when the wrapped persistor does not expose it", () => {
+    const sub = new SubPersistor(createWrappedWithoutBulk(), "settings");
+    expect(sub.bulkSetItem).toBeUndefined();
+  });
+
+  it("prepends the hive to every item's key path", async () => {
+    const wrapped = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "app");
+
+    await sub.bulkSetItem!([
+      { key: ["extensions", "ext1", "remove"], value: "true" },
+      { key: ["extensions", "ext2", "remove"], value: "true" },
+    ]);
+
+    expect(wrapped.bulkSetItem).toHaveBeenCalledTimes(1);
+    expect(wrapped.bulkSetItem).toHaveBeenCalledWith([
+      { key: ["app", "extensions", "ext1", "remove"], value: "true" },
+      { key: ["app", "extensions", "ext2", "remove"], value: "true" },
+    ]);
+  });
+
+  it("does not mutate the input array", async () => {
+    const wrapped = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "settings");
+    const items = [{ key: ["window"], value: "1" }];
+    const snapshot: typeof items = JSON.parse(JSON.stringify(items));
+
+    await sub.bulkSetItem!(items);
+
+    expect(items).toEqual(snapshot);
+  });
+});
+
+describe("SubPersistor.bulkRemoveItem", () => {
+  it("is exposed when the wrapped persistor exposes it", () => {
+    const sub = new SubPersistor(createWrappedWithBulk(), "settings");
+    expect(typeof sub.bulkRemoveItem).toBe("function");
+  });
+
+  it("is undefined when the wrapped persistor does not expose it", () => {
+    const sub = new SubPersistor(createWrappedWithoutBulk(), "settings");
+    expect(sub.bulkRemoveItem).toBeUndefined();
+  });
+
+  it("prepends the hive to every key path", async () => {
+    const wrapped = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "app");
+
+    await sub.bulkRemoveItem!([["extensions", "a"], ["extensions", "b"]]);
+
+    expect(wrapped.bulkRemoveItem).toHaveBeenCalledTimes(1);
+    expect(wrapped.bulkRemoveItem).toHaveBeenCalledWith([
+      ["app", "extensions", "a"],
+      ["app", "extensions", "b"],
+    ]);
+  });
+});
+
+describe("SubPersistor.getAllKVs filtering", () => {
+  it("only returns rows that match the hive prefix and strips it", async () => {
+    const wrapped = createWrappedWithBulk();
+    const mixed: Array<{ key: PersistorKey; value: string }> = [
+      { key: ["settings", "window", "x"], value: "1" },
+      { key: ["app", "extensions", "ext1"], value: "2" },
+      { key: ["settings", "language"], value: "en" },
+    ];
+    (wrapped.getAllKVs as ReturnType<typeof vi.fn>).mockResolvedValue(mixed);
+
+    const sub = new SubPersistor(wrapped, "settings");
+    const result = await sub.getAllKVs!();
+
+    expect(result).toEqual([
+      { key: ["window", "x"], value: "1" },
+      { key: ["language"], value: "en" },
+    ]);
+  });
+});

--- a/src/main/src/store/SubPersistor.test.ts
+++ b/src/main/src/store/SubPersistor.test.ts
@@ -4,17 +4,23 @@ import { describe, it, expect, vi } from "vitest";
 
 import SubPersistor from "./SubPersistor";
 
-function createWrappedWithBulk(): IPersistor {
-  return {
+function createWrappedWithBulk() {
+  const setItem = vi.fn().mockResolvedValue(undefined);
+  const removeItem = vi.fn().mockResolvedValue(undefined);
+  const getAllKVs = vi.fn().mockResolvedValue([]);
+  const bulkSetItem = vi.fn().mockResolvedValue(undefined);
+  const bulkRemoveItem = vi.fn().mockResolvedValue(undefined);
+  const wrapped: IPersistor = {
     setResetCallback: vi.fn(),
     getItem: vi.fn().mockResolvedValue("value"),
-    setItem: vi.fn().mockResolvedValue(undefined),
-    removeItem: vi.fn().mockResolvedValue(undefined),
+    setItem,
+    removeItem,
     getAllKeys: vi.fn().mockResolvedValue([]),
-    getAllKVs: vi.fn().mockResolvedValue([]),
-    bulkSetItem: vi.fn().mockResolvedValue(undefined),
-    bulkRemoveItem: vi.fn().mockResolvedValue(undefined),
+    getAllKVs,
+    bulkSetItem,
+    bulkRemoveItem,
   };
+  return { wrapped, setItem, removeItem, getAllKVs, bulkSetItem, bulkRemoveItem };
 }
 
 function createWrappedWithoutBulk(): IPersistor {
@@ -29,34 +35,28 @@ function createWrappedWithoutBulk(): IPersistor {
 
 describe("SubPersistor key prefixing (single-item)", () => {
   it("setItem prepends the hive to the key path", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped, setItem } = createWrappedWithBulk();
     const sub = new SubPersistor(wrapped, "settings");
 
     await sub.setItem(["window", "x"], "42");
 
-    expect(wrapped.setItem).toHaveBeenCalledWith(
-      ["settings", "window", "x"],
-      "42",
-    );
+    expect(setItem).toHaveBeenCalledWith(["settings", "window", "x"], "42");
   });
 
   it("removeItem prepends the hive to the key path", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped, removeItem } = createWrappedWithBulk();
     const sub = new SubPersistor(wrapped, "settings");
 
     await sub.removeItem(["window", "x"]);
 
-    expect(wrapped.removeItem).toHaveBeenCalledWith([
-      "settings",
-      "window",
-      "x",
-    ]);
+    expect(removeItem).toHaveBeenCalledWith(["settings", "window", "x"]);
   });
 });
 
 describe("SubPersistor.bulkSetItem", () => {
   it("is exposed when the wrapped persistor exposes it", () => {
-    const sub = new SubPersistor(createWrappedWithBulk(), "settings");
+    const { wrapped } = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "settings");
     expect(typeof sub.bulkSetItem).toBe("function");
   });
 
@@ -66,28 +66,28 @@ describe("SubPersistor.bulkSetItem", () => {
   });
 
   it("prepends the hive to every item's key path", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped, bulkSetItem } = createWrappedWithBulk();
     const sub = new SubPersistor(wrapped, "app");
 
-    await sub.bulkSetItem!([
+    await sub.bulkSetItem([
       { key: ["extensions", "ext1", "remove"], value: "true" },
       { key: ["extensions", "ext2", "remove"], value: "true" },
     ]);
 
-    expect(wrapped.bulkSetItem).toHaveBeenCalledTimes(1);
-    expect(wrapped.bulkSetItem).toHaveBeenCalledWith([
+    expect(bulkSetItem).toHaveBeenCalledTimes(1);
+    expect(bulkSetItem).toHaveBeenCalledWith([
       { key: ["app", "extensions", "ext1", "remove"], value: "true" },
       { key: ["app", "extensions", "ext2", "remove"], value: "true" },
     ]);
   });
 
   it("does not mutate the input array", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped } = createWrappedWithBulk();
     const sub = new SubPersistor(wrapped, "settings");
     const items = [{ key: ["window"], value: "1" }];
     const snapshot: typeof items = JSON.parse(JSON.stringify(items));
 
-    await sub.bulkSetItem!(items);
+    await sub.bulkSetItem(items);
 
     expect(items).toEqual(snapshot);
   });
@@ -95,7 +95,8 @@ describe("SubPersistor.bulkSetItem", () => {
 
 describe("SubPersistor.bulkRemoveItem", () => {
   it("is exposed when the wrapped persistor exposes it", () => {
-    const sub = new SubPersistor(createWrappedWithBulk(), "settings");
+    const { wrapped } = createWrappedWithBulk();
+    const sub = new SubPersistor(wrapped, "settings");
     expect(typeof sub.bulkRemoveItem).toBe("function");
   });
 
@@ -105,13 +106,13 @@ describe("SubPersistor.bulkRemoveItem", () => {
   });
 
   it("prepends the hive to every key path", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped, bulkRemoveItem } = createWrappedWithBulk();
     const sub = new SubPersistor(wrapped, "app");
 
-    await sub.bulkRemoveItem!([["extensions", "a"], ["extensions", "b"]]);
+    await sub.bulkRemoveItem([["extensions", "a"], ["extensions", "b"]]);
 
-    expect(wrapped.bulkRemoveItem).toHaveBeenCalledTimes(1);
-    expect(wrapped.bulkRemoveItem).toHaveBeenCalledWith([
+    expect(bulkRemoveItem).toHaveBeenCalledTimes(1);
+    expect(bulkRemoveItem).toHaveBeenCalledWith([
       ["app", "extensions", "a"],
       ["app", "extensions", "b"],
     ]);
@@ -120,16 +121,16 @@ describe("SubPersistor.bulkRemoveItem", () => {
 
 describe("SubPersistor.getAllKVs filtering", () => {
   it("only returns rows that match the hive prefix and strips it", async () => {
-    const wrapped = createWrappedWithBulk();
+    const { wrapped, getAllKVs } = createWrappedWithBulk();
     const mixed: Array<{ key: PersistorKey; value: string }> = [
       { key: ["settings", "window", "x"], value: "1" },
       { key: ["app", "extensions", "ext1"], value: "2" },
       { key: ["settings", "language"], value: "en" },
     ];
-    (wrapped.getAllKVs as ReturnType<typeof vi.fn>).mockResolvedValue(mixed);
+    getAllKVs.mockResolvedValue(mixed);
 
     const sub = new SubPersistor(wrapped, "settings");
-    const result = await sub.getAllKVs!();
+    const result = await sub.getAllKVs();
 
     expect(result).toEqual([
       { key: ["window", "x"], value: "1" },

--- a/src/main/src/store/SubPersistor.ts
+++ b/src/main/src/store/SubPersistor.ts
@@ -37,7 +37,9 @@ class SubPersistor implements IPersistor {
     }
 
     if (this.mWrapped.bulkSetItem) {
-      const wrappedBulkSet = this.mWrapped.bulkSetItem.bind(this.mWrapped);
+      const wrappedBulkSet: (
+        items: ReadonlyArray<{ key: PersistorKey; value: string }>,
+      ) => PromiseLike<void> = this.mWrapped.bulkSetItem.bind(this.mWrapped);
       this.bulkSetItem = (items) =>
         wrappedBulkSet(
           items.map((it) => ({ key: [hive, ...it.key], value: it.value })),
@@ -45,7 +47,9 @@ class SubPersistor implements IPersistor {
     }
 
     if (this.mWrapped.bulkRemoveItem) {
-      const wrappedBulkRemove = this.mWrapped.bulkRemoveItem.bind(
+      const wrappedBulkRemove: (
+        keys: ReadonlyArray<PersistorKey>,
+      ) => PromiseLike<void> = this.mWrapped.bulkRemoveItem.bind(
         this.mWrapped,
       );
       this.bulkRemoveItem = (keys) =>

--- a/src/main/src/store/SubPersistor.ts
+++ b/src/main/src/store/SubPersistor.ts
@@ -4,6 +4,16 @@ class SubPersistor implements IPersistor {
   public getAllKVs:
     | (() => PromiseLike<Array<{ key: string[]; value: string }>>)
     | undefined = undefined;
+  // Bulk variants are exposed only when the wrapped persistor exposes them,
+  // so callers can feature-detect via a simple presence check.
+  public bulkSetItem:
+    | ((
+        items: ReadonlyArray<{ key: PersistorKey; value: string }>,
+      ) => PromiseLike<void>)
+    | undefined = undefined;
+  public bulkRemoveItem:
+    | ((keys: ReadonlyArray<PersistorKey>) => PromiseLike<void>)
+    | undefined = undefined;
 
   private mWrapped: IPersistor;
   private mHive: string;
@@ -24,6 +34,22 @@ class SubPersistor implements IPersistor {
               value: kv.value,
             })),
         ) ?? Promise.resolve([]);
+    }
+
+    if (this.mWrapped.bulkSetItem) {
+      const wrappedBulkSet = this.mWrapped.bulkSetItem.bind(this.mWrapped);
+      this.bulkSetItem = (items) =>
+        wrappedBulkSet(
+          items.map((it) => ({ key: [hive, ...it.key], value: it.value })),
+        );
+    }
+
+    if (this.mWrapped.bulkRemoveItem) {
+      const wrappedBulkRemove = this.mWrapped.bulkRemoveItem.bind(
+        this.mWrapped,
+      );
+      this.bulkRemoveItem = (keys) =>
+        wrappedBulkRemove(keys.map((k) => [hive, ...k]));
     }
   }
 

--- a/src/shared/src/types/state.ts
+++ b/src/shared/src/types/state.ts
@@ -58,6 +58,13 @@ export interface IPersistor {
   getAllKVs?(
     prefix?: string,
   ): PromiseLike<Array<{ key: PersistorKey; value: string }>>;
+  // Optional bulk variants. When present, callers should prefer them for
+  // diff-style writes - they collapse N round-trips and N LevelDB writes
+  // into a small number of multi-row statements.
+  bulkSetItem?(
+    items: ReadonlyArray<{ key: PersistorKey; value: string }>,
+  ): PromiseLike<void>;
+  bulkRemoveItem?(keys: ReadonlyArray<PersistorKey>): PromiseLike<void>;
 }
 
 export interface IPosition {


### PR DESCRIPTION
The persist queue used to call setItem once per Redux diff entry, and each setItem issued ~3 DuckDB statements (SELECT to check existence, then UPDATE or INSERT). The SELECT was a read; the UPDATE or INSERT produced one LevelDB Write via the Sink's batch.commit. A 1000-op Redux diff (heavy plugin sort, collection install, bulk rule edit) therefore went through ~2000 DuckDB statements and ~1000 sequential LevelDB Writes through LevelDB's single write thread - long enough to provoke force-quits.

Three changes:

- Drop the SELECT-then-branch in setItem. Raw-mode level_pivot tables have no UNIQUE constraint and the insert Sink calls batch.put unconditionally, so plain INSERT already overwrites. One statement per setItem instead of three. Pinned upstream by the level_pivot upsert tests on the [Nexus-Mods/duckdb-level-pivot fix/app-429 branch](https://github.com/Nexus-Mods/duckdb-level-pivot/pull/2).
- Add optional bulkSetItem / bulkRemoveItem to IPersistor and a matching SubPersistor delegation that prefixes the hive. LevelPersist implements them as a single multi-row INSERT or DELETE ... WHERE key IN (...).
- Rewrite ReduxPersistorIPC.processOperations to group consecutive same-type ops into runs and dispatch each run through the bulk path, chunked at 256 rows. A 1000-op diff is now ~4 multi-row statements (~4 LevelDB Writes) total instead of ~2000 statements / ~1000 Writes. The 256 chunk cap preserves recovery granularity: any single Write failure can lose at most 256 ops of progress.

Adds breadcrumb logging in LevelPersist: any successful write that exceeds 250 ms is logged at warn level, and setting VORTEX_TRACE_DB_WRITES=1 in the environment turns on enter/exit pairs at debug level for every persistence write so an indefinite hang is identifiable from vortex.log. Documented in AGENTS-DEBUGGING.md.

Adds vitest coverage for the bulk methods, run-grouping, chunking, fallback path when bulk methods are absent, transaction-state correctness (including stale-flag handling on COMMIT/ROLLBACK failures), and a force-quit-style atomicity test that injects a mid-transaction write failure and asserts the queue rolls back rather than continuing.

part of https://linear.app/nexus-mods/issue/APP-429