### PR TITLE
[QA-96] upgrade-to-premium e2e test

### DIFF
--- a/packages/e2e/E2E-BEST-PRACTICES.md
+++ b/packages/e2e/E2E-BEST-PRACTICES.md
@@ -332,14 +332,23 @@ pnpm -F @vortex/e2e run test:report
 
 Do not add code comments unless ABSOLUTELY needed for explaining vague code. If you want to add a comment, try to rewrite the code to be understandable without one.
 
-Run formatter, lint, and tests on the e2e package before committing:
+**Run these BEFORE every commit. The CI `format` job will block your PR if you skip them.**
 
 ```bash
-# Format (oxfmt) — config at oxfmtrc.json. Run on the files you touched.
-pnpm oxfmt packages/e2e/<paths-you-changed>
+# 1. Format every file you touched (oxfmt — config at oxfmtrc.json).
+#    Source files outside packages/e2e count too if you changed any.
+pnpm exec oxfmt <paths-you-changed>
 
-# Or format every staged file in one shot:
-pnpm run format:staged
+# 2. Verify nothing is still unformatted. This is what CI runs.
+pnpm run format:check
+
+# 3. Type-check the e2e package.
+pnpm -F @vortex/e2e exec tsc --noEmit
+
+# 4. Run the test you added/changed locally.
+pnpm -F @vortex/e2e exec playwright test <your-spec> --workers=1
+```
+
+If `format:check` reports any file, run `pnpm exec oxfmt <that-file>` and amend the commit. Don't push and rely on CI to tell you — it's a slow feedback loop.
 
 The repo formats with **oxfmt**, not prettier. There is no `.prettierrc`. oxfmt's default is double-quoted strings; some older files in this package still have single quotes from before the formatter switch — when you edit one of those files, oxfmt will convert it. Don't fight it.
-```

--- a/packages/e2e/tests/upgrade-to-premium.spec.ts
+++ b/packages/e2e/tests/upgrade-to-premium.spec.ts
@@ -18,9 +18,7 @@ test.describe("Account - Upgrade to Premium", () => {
 
     await test.step("Wait for userInfo and force Dashboard re-render", async () => {
       await vortexWindow.keyboard.press("Escape").catch(() => undefined);
-      const headerGoPremium = vortexWindow
-        .getByRole("button", { name: /Go premium/i })
-        .first();
+      const headerGoPremium = vortexWindow.getByRole("button", { name: /Go premium/i }).first();
       await expect(headerGoPremium).toBeVisible({ timeout: 60_000 });
 
       const navbar = new NavBar(vortexWindow);
@@ -47,9 +45,7 @@ test.describe("Account - Upgrade to Premium", () => {
 
     await test.step("Verify the captured URL points to the premium page", async () => {
       const captured = await vortexApp.evaluate(
-        () =>
-          (global as unknown as { __capturedOpenUrls?: string[] })
-            .__capturedOpenUrls ?? [],
+        () => (global as unknown as { __capturedOpenUrls?: string[] }).__capturedOpenUrls ?? [],
       );
       expect(captured.length).toBeGreaterThan(0);
 

--- a/packages/e2e/tests/upgrade-to-premium.spec.ts
+++ b/packages/e2e/tests/upgrade-to-premium.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * QA-96: free user clicks the Dashboard "Go Premium" button and is taken to
+ * the premium upgrade URL.
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { loginToNexus } from "../helpers/login";
+import { freeUser } from "../helpers/users";
+import { NavBar } from "../selectors/navbar";
+
+test.describe("Account - Upgrade to Premium", () => {
+  test(`[QA-96] free user clicking Go Premium opens the upgrade URL`, async ({
+    vortexApp,
+    vortexWindow,
+  }) => {
+    test.setTimeout(120_000);
+
+    await loginToNexus(vortexApp, vortexWindow, freeUser);
+
+    await test.step("Wait for userInfo and force Dashboard re-render", async () => {
+      await vortexWindow.keyboard.press("Escape").catch(() => undefined);
+      const headerGoPremium = vortexWindow
+        .getByRole("button", { name: /Go premium/i })
+        .first();
+      await expect(headerGoPremium).toBeVisible({ timeout: 60_000 });
+
+      const navbar = new NavBar(vortexWindow);
+      await navbar.gamesLink.click();
+      await navbar.homeLink.click();
+    });
+
+    await test.step("Stub shell.openExternal", async () => {
+      await vortexApp.evaluate(({ shell }) => {
+        const slot = global as unknown as { __capturedOpenUrls?: string[] };
+        slot.__capturedOpenUrls = [];
+        shell.openExternal = (url: string) => {
+          slot.__capturedOpenUrls?.push(url);
+          return Promise.resolve();
+        };
+      });
+    });
+
+    await test.step("Click the Go Premium dashlet button", async () => {
+      const goPremiumBtn = vortexWindow.locator(".dashlet-premium-button");
+      await expect(goPremiumBtn).toBeVisible({ timeout: 30_000 });
+      await goPremiumBtn.click();
+    });
+
+    await test.step("Verify the captured URL points to the premium page", async () => {
+      const captured = await vortexApp.evaluate(
+        () =>
+          (global as unknown as { __capturedOpenUrls?: string[] })
+            .__capturedOpenUrls ?? [],
+      );
+      expect(captured.length).toBeGreaterThan(0);
+
+      const url = new URL(captured[0]!);
+      expect(url.hostname).toContain("nexusmods.com");
+      expect(url.pathname).toContain("account/billing/premium");
+      expect(url.searchParams.get("utm_source")).toBe("vortex");
+      expect(url.searchParams.get("utm_campaign")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Logs in as free user, waits for the Header "Go premium" button (proxy for userInfo loaded), navigates Games → Home to remount Dashboard so the Go Premium dashlet picks up the now-loaded userInfo, stubs shell.openExternal in the main process, clicks the dashlet button, asserts the captured URL is on nexusmods.com, path account/billing/premium, with utm_source=vortex and a utm_campaign.