### PR TITLE
Stardew Valley Copy on hardlink deploy fail

### DIFF
--- a/extensions/games/game-stardewvalley/src/configMod/sync.ts
+++ b/extensions/games/game-stardewvalley/src/configMod/sync.ts
@@ -209,6 +209,13 @@ export async function addModConfig(
       await fs.copyAsync(file.filePath, targetPath, { overwrite: true });
       await fs.removeAsync(file.filePath);
     } catch (err) {
+      // When a mod has been deployed via hardlink, the source and target
+      // share an inode and copyAsync rejects with SelfCopyCheckError. The
+      // file is already in the config mod, so there is nothing to do.
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("are the same file")) {
+        continue;
+      }
       api.showErrorNotification?.("Failed to write mod config", err);
     }
   }


### PR DESCRIPTION
When we do hardlink deployment, the inode entry of the deployed file and the staging copy are the same. 
fs.copyAsync triggers SelfCopyCheckError on such cases, we need to ignore it


Fixes fingerprint 2dbc2319 2351f3eb
Closes APP-432