### PR TITLE
False Positive Env Issues Reported

### DIFF
--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -8,7 +8,7 @@ import {
   SpanStatusCode,
   trace,
 } from "@opentelemetry/api";
-import { unknownToError } from "@vortex/shared";
+import { isEnvironmentalError, unknownToError } from "@vortex/shared";
 import { recordErrorOnSpan } from "@vortex/shared/telemetry";
 import { ipcRenderer } from "electron";
 import * as fs from "fs-extra";
@@ -516,6 +516,9 @@ export function withTrackedActivity<T>(
       const result = await fun(
         (key, value) => span.setAttribute(key, value),
         (error) => {
+          if (isEnvironmentalError(error)) {
+            return;
+          }
           hasError = true;
           recordError(error);
         },
@@ -526,11 +529,15 @@ export function withTrackedActivity<T>(
       return result;
     } catch (unknownErr) {
       const err = unknownToError(unknownErr);
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: err?.message,
-      });
-      recordError(err);
+      // Environmental errors (write-protected folders, disk full, etc.) leave
+      // the span status UNSET so RingBufferSpanProcessor doesn't flush the trace.
+      if (!isEnvironmentalError(err)) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err?.message,
+        });
+        recordError(err);
+      }
       throw err;
     } finally {
       span.end();
@@ -567,6 +574,9 @@ export function recordErrorSpan(
   error: Error,
   attributes?: Record<string, string | number | boolean>,
 ): void {
+  if (isEnvironmentalError(error)) {
+    return;
+  }
   const activeSpan = trace.getSpan(context.active());
 
   if (activeSpan !== undefined) {

--- a/src/renderer/src/util/message.ts
+++ b/src/renderer/src/util/message.ts
@@ -388,7 +388,7 @@ function prettifyNodeErrorMessageInner(
   if (decoded !== undefined) {
     return {
       message: decoded.message,
-      replace: { path: err.path ?? err.filename },
+      replace: { filePath: err.path ?? err.filename },
       allowReport: false,
     };
   }

--- a/src/renderer/src/util/nativeErrors.ts
+++ b/src/renderer/src/util/nativeErrors.ts
@@ -38,7 +38,7 @@ export function decodeSystemError(
     return {
       title: `I/O Error (${code})`,
       message:
-        'Accessing "{{filePath}} failed with an error that indicates ' +
+        'Accessing "{{filePath}}" failed with an error that indicates ' +
         "file system corruption. If this isn't a temporary problem " +
         "you may want to run chkdsk or similar software to check for problems. " +
         "It may also help to reinstall the software that this file belongs to.",

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { computeErrorFingerprint, sanitizeFramePath } from "./errors";
+import {
+  computeErrorFingerprint,
+  isEnvironmentalError,
+  sanitizeFramePath,
+} from "./errors";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -396,5 +400,48 @@ describe("computeErrorFingerprint", () => {
         computeErrorFingerprint(b, VERSION),
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEnvironmentalError
+// ---------------------------------------------------------------------------
+
+describe("isEnvironmentalError", () => {
+  const withCode = (code: string): Error =>
+    Object.assign(new Error(code), { code });
+
+  it.each(["EPERM", "EACCES", "ENOSPC", "EROFS"])(
+    "returns true for %s",
+    (code) => {
+      expect(isEnvironmentalError(withCode(code))).toBe(true);
+    },
+  );
+
+  it("returns false for unrelated error codes", () => {
+    expect(isEnvironmentalError(withCode("ENOENT"))).toBe(false);
+    expect(isEnvironmentalError(withCode("ETIMEDOUT"))).toBe(false);
+    expect(isEnvironmentalError(withCode("EBUSY"))).toBe(false);
+  });
+
+  it("returns false for plain Error without code", () => {
+    expect(isEnvironmentalError(new Error("boom"))).toBe(false);
+  });
+
+  it("returns true when allowReport is explicitly false", () => {
+    const err = Object.assign(new Error("boom"), { allowReport: false });
+    expect(isEnvironmentalError(err)).toBe(true);
+  });
+
+  it("ignores allowReport when not strictly false", () => {
+    const err = Object.assign(new Error("boom"), { allowReport: true });
+    expect(isEnvironmentalError(err)).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isEnvironmentalError("EPERM")).toBe(false);
+    expect(isEnvironmentalError(undefined)).toBe(false);
+    expect(isEnvironmentalError(null)).toBe(false);
+    expect(isEnvironmentalError({ code: "EPERM" })).toBe(false);
   });
 });

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -80,6 +80,35 @@ export function getErrorNativeCode(err: unknown): number | bigint | null {
   return null;
 }
 
+/**
+ * Error codes that indicate a user-environment problem (write-protected
+ * folder, disk full, file locked by another process) rather than a Vortex
+ * bug. Telemetry export filters these out — exporting them spams our error
+ * tracking with issues we cannot fix in code.
+ */
+const ENVIRONMENTAL_ERROR_CODES = new Set([
+  "EPERM", // Operation not permitted (e.g. write-protected Program Files folder)
+  "EACCES", // Permission denied (filesystem ACL or process lacks rights)
+  "ENOSPC", // No space left on the device (disk full)
+  "EROFS", // Read-only filesystem (mount option or hardware switch)
+]);
+
+/**
+ * Returns true if the error represents a user-environment problem rather
+ * than a Vortex bug. Honors an explicit `allowReport === false` flag set
+ * by `prettifyNodeErrorMessage`, falling back to a code-based check.
+ */
+export function isEnvironmentalError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  if ((err as { allowReport?: boolean }).allowReport === false) {
+    return true;
+  }
+  const code = getErrorCode(err);
+  return code !== null && ENVIRONMENTAL_ERROR_CODES.has(code);
+}
+
 type ErrorWithSystemCode = Error & { systemCode: number | bigint };
 
 /** Extracts the system code property from a potential error object */


### PR DESCRIPTION
We have a leaky flow that enables Vortex to report user environment caused errors like EPERM/EACCESS/ENOSPC/EROFS
We need to make sure they are excluded from the reporting process
Also fixed a typo in prettifyNodeErrorMessageInner and decodeSystemError

Fixes fingerprints 0d68b85c 30a965b1 31211fe9 4ca1d30f 62e0d031 6cb325df 27f07735 e3343ea5 5d31dd78 e2093fb3 abfa4354 cbf6cd2f 0a84dded affd9aab b4d2699f 1fb3a595 4bfc1843 08fbbc3d eba31a95 01e3cbb9 029137a0 0e3fbe94 005a4009 ff691123 2161f793 4961ee0c 5b68cc64 3504ec1f 30487235 d0d78361 1bb56f28
Closes APP-435