### PR TITLE
fix: persist state repairs by using prefix-delete for subtree removal

### DIFF
--- a/src/main/src/store/LevelPersist.ts
+++ b/src/main/src/store/LevelPersist.ts
@@ -213,8 +213,10 @@ class LevelPersist implements IPersistor {
   }
 
   public async removeItem(statePath: string[]): Promise<void> {
-    await this.#mConnection.run(`DELETE FROM ${this.#mAlias}.kv WHERE key = $1`, [
-      statePath.join(SEPARATOR),
+    const key = statePath.join(SEPARATOR);
+    await this.#mConnection.run(`DELETE FROM ${this.#mAlias}.kv WHERE key = $1 OR key LIKE $2`, [
+      key,
+      key + SEPARATOR + "%",
     ]);
   }
 

--- a/src/renderer/src/store/stateDiff.ts
+++ b/src/renderer/src/store/stateDiff.ts
@@ -48,8 +48,13 @@ export function computeStateDiff<T>(
       const currentPath = [...path, key];
 
       if (newState[key] === undefined) {
-        // Key was removed - collect all remove operations for this subtree
-        operations.push(...collectRemoveOperations(currentPath, oldState[key]));
+        // Key was removed — emit a remove at this path (prefix-delete handles
+        // any children stored separately) plus leaf removes for keys that may
+        // be stored deeper than this level.
+        operations.push({ type: "remove", path: currentPath });
+        if (isObject(oldState[key])) {
+          operations.push(...collectRemoveOperations(currentPath, oldState[key]));
+        }
       } else if (oldState[key] !== newState[key]) {
         // Key exists in both but value changed - recurse
         operations.push(...computeStateDiff(oldState[key], newState[key], currentPath));
@@ -77,13 +82,11 @@ export function computeStateDiff<T>(
         operations.push({ type: "set", path, value: newState });
       }
     } else {
-      // Value was removed
+      // Value was removed — always emit remove at this path
+      operations.push({ type: "remove", path });
       if (isObject(oldState)) {
-        // Old value was an object - remove all its leaf values
+        // Old value was an object - also remove leaf keys stored separately
         operations.push(...collectRemoveOperations(path, oldState));
-      } else {
-        // Old value was a primitive
-        operations.push({ type: "remove", path });
       }
     }
   }


### PR DESCRIPTION
## Problem

Clicking **Repair** in the "Application State Corrupted" dialog removes corrupted entries from the in-memory Redux state, but the removal never persists to the database. On next startup the corrupted entries are reloaded and the dialog reappears — creating an infinite repair loop.

## Root Cause

A mismatch between how `computeStateDiff` generates remove operations and how `removeItem` deletes from DuckDB:

1. **`setItem`** sometimes stores data as a JSON blob at an intermediate path (e.g. `files###id###failCause` → `{"payload":{"code":404}}`).
2. **`computeStateDiff`** emits remove ops only for leaf paths (e.g. `files###id###failCause###payload###code`).
3. **`removeItem`** uses exact key matching (`WHERE key = $1`), so the leaf-path deletes miss the intermediate-path blob entirely.

Result: the corrupted data survives every repair attempt.

## Reproduction Steps

1. Start a download in Vortex (any game, any mod)
2. Force-kill Vortex mid-download (or simulate network failure) so the download entry has only a `failCause` field and no `game` field
3. Restart Vortex — the "Application State Corrupted" dialog appears
4. Click **Repair**
5. Restart Vortex again — the dialog reappears (the repair did not persist)
6. Repeat steps 4–5 indefinitely — the loop never resolves

**Alternate reproduction (faster):** Manually insert a malformed entry into the `persistent###downloads###files` hive in the DuckDB kv table where the value is a JSON blob stored at an intermediate path rather than decomposed leaf keys.

## Fix

Two changes:

### `LevelPersist.ts` — prefix-delete in `removeItem`

```sql
-- Before: exact match only
DELETE FROM kv WHERE key = $1

-- After: match key itself OR any children
DELETE FROM kv WHERE key = $1 OR key LIKE $2
-- where $2 = key + "###%"
```

This ensures that removing a path also removes any data stored under it, regardless of storage depth.

### `stateDiff.ts` — emit container-path removes in `computeStateDiff`

Previously only leaf removes were emitted. Now a remove is also emitted at the container path when a key is deleted, covering the case where data was stored as a blob at that level rather than decomposed into leaf keys.

## Testing

- Reproduced the infinite repair loop before the fix
- After the fix, Repair persists correctly — corrupted entries are removed from the DB and do not reappear on restart
- Normal set/get operations unaffected (prefix-delete on a leaf key with no children reduces to the original exact-match behavior)
- No new dependencies introduced