### PR TITLE
centralize GraphQL error handling in nexus_integration

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -22,11 +22,7 @@ import type {
 import type Nexus from "@nexusmods/nexus-api";
 
 import { NexusError, RateLimitError, TimeoutError } from "@nexusmods/nexus-api";
-import {
-  getErrorCode,
-  getErrorMessageOrDefault,
-  unknownToError,
-} from "@vortex/shared";
+import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import Bluebird from "bluebird";
 import * as path from "path";
 import * as semver from "semver";
@@ -78,6 +74,7 @@ import {
   endorseThing,
   ensureLoggedIn,
   graphErrorContext,
+  handleGraphError,
   nexusGamesProm,
   processErrorMessage,
   resolveGraphError,
@@ -737,13 +734,12 @@ export function onGetMyCollections(
 
       return revisions;
     } catch (err) {
-      const code = getErrorCode(err);
-      if (!["NOT_FOUND", "UNAUTHORIZED"].includes(code)) {
-        api.showErrorNotification("Failed to get list of collections", err, {
-          allowReport: !["MODEL_NOT_FOUND"].includes(code),
-        });
-      }
-      return [];
+      return handleGraphError<IRevision[]>(api, err, {
+        title: "Failed to get list of collections",
+        fallback: [],
+        skipCodes: ["NOT_FOUND", "UNAUTHORIZED"],
+        noReportCodes: ["MODEL_NOT_FOUND"],
+      });
     }
   };
 }
@@ -787,14 +783,16 @@ export function onGetNexusCollection(
 export function onGetNexusCollections(
   api: IExtensionApi,
   nexus: Nexus,
-): (gameId: string) => Bluebird<ICollection[]> {
-  return (gameId: string): Bluebird<ICollection[]> =>
+): (gameId: string) => Bluebird<Partial<ICollection>[] | undefined> {
+  return (gameId: string) =>
     Bluebird.resolve(
       nexus.getCollectionListGraph(FULL_COLLECTION_INFO, gameId),
-    ).catch((err) => {
-      api.showErrorNotification("Failed to get list of collections", err);
-      return Bluebird.resolve(undefined);
-    });
+    ).catch((err) =>
+      handleGraphError<Partial<ICollection>[] | undefined>(api, err, {
+        title: "Failed to get list of collections",
+        fallback: undefined,
+      }),
+    );
 }
 
 /**
@@ -820,10 +818,12 @@ export function onResolveCollectionUrl(
   nexus: Nexus,
 ): (apiLink: string) => Bluebird<IDownloadURL[]> {
   return (apiLink: string): Bluebird<IDownloadURL[]> =>
-    Bluebird.resolve(nexus.getCollectionDownloadLink(apiLink)).catch((err) => {
-      api.showErrorNotification("Failed to get list of collections", err);
-      return Bluebird.resolve([]);
-    });
+    Bluebird.resolve(nexus.getCollectionDownloadLink(apiLink)).catch((err) =>
+      handleGraphError<IDownloadURL[]>(api, err, {
+        title: "Failed to get list of collections",
+        fallback: [],
+      }),
+    );
 }
 
 export function onGetNexusCollectionRevision(
@@ -984,12 +984,13 @@ export function onGetModFiles(
       nexus.getModFiles(modId, nexusGameId(game, gameId) || gameId),
     )
       .then((result) => result.files)
-      .catch((err) => {
-        api.showErrorNotification("Failed to get list of mod files", err, {
-          allowReport: false,
-        });
-        return Bluebird.resolve([]);
-      });
+      .catch((err) =>
+        handleGraphError<IFileInfo[]>(api, err, {
+          title: "Failed to get list of mod files",
+          fallback: [],
+          doNotReport: true,
+        }),
+      );
   };
 }
 
@@ -1005,12 +1006,13 @@ export function onModFileContents(
   ) => {
     return Bluebird.resolve(
       nexus.modFileContents(query, filter, offset, count),
-    ).catch((err) => {
-      api.showErrorNotification("Failed to get mod file contents", err, {
-        allowReport: false,
-      });
-      return Bluebird.resolve({});
-    });
+    ).catch((err) =>
+      handleGraphError(api, err, {
+        title: "Failed to get mod file contents",
+        fallback: {},
+        doNotReport: true,
+      }),
+    );
   };
 }
 
@@ -1026,12 +1028,13 @@ export function onGetModInfo(
     const game = gameById(state, gameId);
     return Bluebird.resolve(
       nexus.getModInfo(modId, nexusGameId(game, gameId) || gameId),
-    ).catch((err) => {
-      api.showErrorNotification("Failed to get mod info", err, {
-        allowReport: false,
-      });
-      return Bluebird.resolve({});
-    });
+    ).catch((err) =>
+      handleGraphError(api, err, {
+        title: "Failed to get mod info",
+        fallback: {},
+        doNotReport: true,
+      }),
+    );
   };
 }
 
@@ -1176,12 +1179,13 @@ export function onGetPreferences(
   nexus: Nexus,
 ): (...args: any[]) => Promise<Partial<IPreference>> {
   return (query: IPreferenceQuery) => {
-    return Promise.resolve(nexus.getPreferences(query)).catch((err) => {
-      api.showErrorNotification("Failed to get preferences", err, {
-        allowReport: false,
-      });
-      return Promise.resolve({});
-    });
+    return Promise.resolve(nexus.getPreferences(query)).catch((err) =>
+      handleGraphError(api, err, {
+        title: "Failed to get preferences",
+        fallback: {},
+        doNotReport: true,
+      }),
+    );
   };
 }
 

--- a/src/renderer/src/extensions/nexus_integration/types/INexusAPIExtension.ts
+++ b/src/renderer/src/extensions/nexus_integration/types/INexusAPIExtension.ts
@@ -34,7 +34,9 @@ export interface INexusAPIExtension {
     allowInstall?: boolean,
   ) => PromiseLike<string>;
   nexusGetCollection?: (slug: string) => PromiseLike<ICollection>;
-  nexusGetCollections?: (gameId: string) => PromiseLike<ICollection[]>;
+  nexusGetCollections?: (
+    gameId: string,
+  ) => PromiseLike<Partial<ICollection>[] | undefined>;
   nexusSearchCollections?: (
     options: ICollectionSearchOptions,
   ) => PromiseLike<ICollectionSearchResult>;

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -27,7 +27,12 @@ import {
   RateLimitError,
   TimeoutError,
 } from "@nexusmods/nexus-api";
-import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
+import {
+  getErrorCode,
+  getErrorMessage,
+  getErrorMessageOrDefault,
+  unknownToError,
+} from "@vortex/shared";
 import BluebirdPromise from "bluebird";
 import jwt from "jsonwebtoken";
 import * as _ from "lodash";
@@ -1137,6 +1142,59 @@ export function graphErrorContext(err: unknown): Record<string, unknown> {
   return ctx;
 }
 
+export interface IHandleGraphErrorOptions<T> {
+  // Notification title shown to the user when the error isn't skipped.
+  title: string;
+  // Value returned when an error is handled, so callers can `return handleGraphError(...)`.
+  fallback: T;
+  // Some errors are expected and shouldn't notify the user at all.
+  doNotReport?: boolean;
+  // Codes that should be silently ignored (no notification, no report).
+  skipCodes?: readonly string[];
+  // Codes that should still notify but suppress the report button.
+  noReportCodes?: readonly string[];
+  // Default report behavior when no code-specific override applies. Defaults to true.
+  allowReport?: boolean;
+  // Notification id, e.g. to collapse repeated failures into a single toast.
+  notificationId?: string;
+}
+
+/**
+ * Shared catch-handler for endpoints that hit the Nexus GraphQL API.
+ * Pulls the error code and diagnostic context out via graphErrorContext,
+ * decides whether to surface a notification (and whether that notification
+ * permits a bug report), and returns the caller-supplied fallback so the
+ * chain recovers with a sensible default. Graph diagnostics are also logged
+ * so bug reports carry the failing call / query / path locations.
+ */
+export function handleGraphError<T>(
+  api: IExtensionApi,
+  err: unknown,
+  opts: IHandleGraphErrorOptions<T>,
+): T {
+  const ctx = graphErrorContext(err);
+  if (opts.doNotReport) {
+    log("warn", opts.title, { ...ctx, message: getErrorMessage(err) });
+    return opts.fallback;
+  }
+  const code = ctx.graphCode as string | undefined;
+  if (code !== undefined && (opts.skipCodes?.includes(code) ?? false)) {
+    return opts.fallback;
+  }
+  const noReport =
+    code !== undefined && (opts.noReportCodes?.includes(code) ?? false);
+  const allowReport = (opts.allowReport ?? true) && !noReport;
+  if (Object.keys(ctx).length > 0) {
+    log("warn", opts.title, ctx);
+  }
+  const notifyOpts: { allowReport: boolean; id?: string } = { allowReport };
+  if (opts.notificationId !== undefined) {
+    notifyOpts.id = opts.notificationId;
+  }
+  api.showErrorNotification(opts.title, unknownToError(err), notifyOpts);
+  return opts.fallback;
+}
+
 export function resolveGraphError(
   t: TFunction,
   isLoggedIn: boolean,
@@ -1147,6 +1205,7 @@ export function resolveGraphError(
     return t("You can't endorse a mod that has no version set.");
   }
 
+  const errCode = getErrorCode(err);
   const msg = {
     NOT_DOWNLOADED_MOD: "You have not downloaded this mod from Nexus Mods yet.",
     TOO_SOON_AFTER_DOWNLOAD:
@@ -1156,7 +1215,7 @@ export function resolveGraphError(
     UNAUTHORIZED: isLoggedIn
       ? "You cannot interact with this collection because you have been blocked by the curator."
       : "You have to be logged in to vote.",
-  }[err["code"]];
+  }[errCode];
 
   return msg;
 }


### PR DESCRIPTION
Adds handleGraphError<T> in nexus_integration/util.ts that reuses graphErrorContext to extract the error code and diagnostic context, logs that context before surfacing the notification, and returns the caller's fallback. Skip-codes, no-report-codes, allowReport, and notification id are configurable.

Migrates the simple / skip-on-code catches: onGetMyCollections, onGetNexusCollections, onResolveCollectionUrl, onGetModFiles, onModFileContents, onGetModInfo, onGetPreferences. Endpoints with bespoke per-code branching are left as-is.

Also fixes nexusGetCollections in INexusAPIExtension.ts, which declared PromiseLike<ICollection[]> but actually returned Partial<ICollection>[] | undefined.

fixes https://linear.app/nexus-mods/issue/APP-443
fixes https://github.com/Nexus-Mods/Vortex/issues/23077