### PR TITLE
fix v2.0 elevation chain failing "Deployment interrupted"

### DIFF
--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -60,6 +60,7 @@
     "bundledPlugins",
     "node_modules/7z-bin",
     "node_modules/bootstrap-sass/assets/stylesheets",
+    "node_modules/json-socket",
     "node_modules/react-select/scss",
     "node_modules/@nexusmods/fomod-installer-native/dist/*.dll",
     "node_modules/@nexusmods/fomod-installer-ipc/dist/*.exe",

--- a/src/main/src/main.ts
+++ b/src/main/src/main.ts
@@ -30,6 +30,7 @@ import {
 import { app, dialog } from "electron";
 import i18next from "i18next";
 import child_process from "node:child_process";
+import { appendFileSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import os from "os";
@@ -174,6 +175,32 @@ const handleError = (error: Error) => {
 async function main(): Promise<void> {
   // important: The following has to be synchronous!
   const mainArgs = parseCommandline(process.argv, false);
+
+  // Elevation diagnostics (issue #23043). Uses synchronous fs.appendFileSync
+  // (not winston) because the elevated Vortex.exe app.quit()s immediately
+  // after the --run handler spawns the inner Node child; winston's buffered
+  // writes can be lost in that window, and winston itself isn't initialised
+  // until later in Application's constructor.
+  const traceElevation = (
+    stage: string,
+    data?: Record<string, unknown>,
+  ): void => {
+    try {
+      const line =
+        new Date().toISOString() +
+        " [DEBG] [MAIN] [elevation-trace] " +
+        stage +
+        " " +
+        JSON.stringify({ pid: process.pid, ...(data || {}) }) +
+        "\n";
+      appendFileSync(path.join(app.getPath("userData"), "vortex.log"), line);
+    } catch {
+      // diagnostics must never throw
+    }
+  };
+
+  traceElevation("main entry", { argv: process.argv });
+
   if (mainArgs.report) {
     return sendReportFile(mainArgs.report)
       .catch((err: unknown) => {
@@ -184,39 +211,15 @@ async function main(): Promise<void> {
       .then(() => app.quit());
   }
 
-  const NODE_OPTIONS = process.env.NODE_OPTIONS || "";
-  process.env.NODE_OPTIONS =
-    NODE_OPTIONS +
-    ` --max-http-header-size=${HTTP_HEADER_SIZE}` +
-    " --no-force-async-hooks-checks";
-
-  if (mainArgs.disableGPU) {
-    app.disableHardwareAcceleration();
-    app.commandLine.appendSwitch("--disable-software-rasterizer");
-    app.commandLine.appendSwitch("--disable-gpu");
-  }
-
-  app.commandLine.appendSwitch("disable-features", "WidgetLayering");
-  app.commandLine.appendSwitch(
-    "disable-features",
-    "UseEcoQoSForBackgroundProcess",
-  );
-
-  createMainTelemetryProvider();
-
-  // Now that telemetry is available, swap in the proper error handler
-  // that supports crash reporting
-  process.removeListener("uncaughtException", earlyErrHandler);
-  process.removeListener("unhandledRejection", earlyErrHandler);
-  process.on("uncaughtException", handleError);
-  process.on("unhandledRejection", handleError);
-
-  initIpcHandlers();
-  initTelemetryIpcHandler();
-  StylesheetCompiler.init();
-
-  // --run has to be evaluated *before* we request the single instance lock!
+  // --run is the entry point for the elevated helper chain (see
+  // src/renderer/src/util/elevated.ts). The renderer-side monitorConsent
+  // watchdog is tight, so this must run before the telemetry / IPC /
+  // stylesheet init below; in v2.0 those steps burned the budget and broke
+  // deployment elevation (issue #23043).
   if (mainArgs.run !== undefined) {
+    traceElevation("--run detected, spawning inner Node child", {
+      tmpScript: mainArgs.run,
+    });
     const appAsar = `${path.sep}app.asar${path.sep}`;
     const execPath = process.execPath.replace(
       appAsar,
@@ -264,14 +267,47 @@ async function main(): Promise<void> {
         detached: true,
       })
       .on("error", (err) => {
+        traceElevation("inner child spawn error", { error: err.message });
         // TODO: In practice we have practically no information about what we're running
         //       at this point
         dialog.showErrorBox("Failed to run script", err.message);
       });
+    traceElevation("inner child spawn issued, quitting");
     // quit this process, the new one is detached
     app.quit();
     return;
   }
+
+  const NODE_OPTIONS = process.env.NODE_OPTIONS || "";
+  process.env.NODE_OPTIONS =
+    NODE_OPTIONS +
+    ` --max-http-header-size=${HTTP_HEADER_SIZE}` +
+    " --no-force-async-hooks-checks";
+
+  if (mainArgs.disableGPU) {
+    app.disableHardwareAcceleration();
+    app.commandLine.appendSwitch("--disable-software-rasterizer");
+    app.commandLine.appendSwitch("--disable-gpu");
+  }
+
+  app.commandLine.appendSwitch("disable-features", "WidgetLayering");
+  app.commandLine.appendSwitch(
+    "disable-features",
+    "UseEcoQoSForBackgroundProcess",
+  );
+
+  createMainTelemetryProvider();
+
+  // Now that telemetry is available, swap in the proper error handler
+  // that supports crash reporting
+  process.removeListener("uncaughtException", earlyErrHandler);
+  process.removeListener("unhandledRejection", earlyErrHandler);
+  process.on("uncaughtException", handleError);
+  process.on("unhandledRejection", handleError);
+
+  initIpcHandlers();
+  initTelemetryIpcHandler();
+  StylesheetCompiler.init();
 
   if (process.env.VORTEX_E2E === "1") {
     // Skip single-instance lock in e2e tests — each test worker runs its

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -1226,7 +1226,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
     const didRegister: boolean = await api.registerProtocol(
       "nxm",
       def !== false,
-      void makeNXMLinkCallback(api),
+      makeNXMLinkCallback(api),
     );
     if (didRegister) {
       api.sendNotification({

--- a/src/renderer/src/extensions/symlink_activator_elevate/index.ts
+++ b/src/renderer/src/extensions/symlink_activator_elevate/index.ts
@@ -484,6 +484,7 @@ class DeploymentMethod extends LinkingDeployment {
 
     return new PromiseBB<void>((resolve, reject) => {
       let elevating = false;
+      const tStart = Date.now();
 
       if (this.mQuitTimer !== undefined) {
         log("debug", "reusing symlink process");
@@ -492,12 +493,17 @@ class DeploymentMethod extends LinkingDeployment {
         return resolve();
       }
       log("debug", "starting symlink process", ipcPath);
+      log("debug", "[elevation-trace] symlink elevation start", { ipcPath });
 
       this.mIPCServer = startIPCServer(
         ipcPath,
         (conn: JsonSocket, message: string, payload: any) => {
           if (message === "initialised") {
             const { pid } = payload;
+            log("debug", "[elevation-trace] initialised received", {
+              pid,
+              elapsedMs: Date.now() - tStart,
+            });
             log("debug", "ipc connected", { pid });
             this.mElevatedClient = conn;
             this.api.store.dispatch(clearUIBlocker("elevating"));
@@ -548,6 +554,14 @@ class DeploymentMethod extends LinkingDeployment {
           if (elevating) {
             // this is called if consent.exe disappeared but none of our "regular" code paths ran
             // which would have cancelled this timeout
+            log(
+              "warn",
+              "[elevation-trace] watchdog fired, no initialised IPC",
+              {
+                elapsedMs: Date.now() - tStart,
+                ipcPath,
+              },
+            );
             this.api.store.dispatch(clearUIBlocker("elevating"));
             this.endIPC("no init");
             /*

--- a/src/renderer/src/util/elevated.ts
+++ b/src/renderer/src/util/elevated.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as tmp from "tmp";
 import * as winapi from "winapi-bindings";
 
+import { log } from "../logging";
 import { getRealNodeModulePaths } from "./webpack-hacks";
 
 declare const __non_webpack_require__: NodeJS.Require;
@@ -31,6 +32,39 @@ function elevatedMain(
   main: (ipc: IElevatedIpc, req: NodeJS.Require) => void | PromiseLike<void>,
 ) {
   let client;
+
+  // stderr from the elevated child goes nowhere visible (issue #23043), so
+  // failures need to land in vortex.log to be diagnosable. userData comes
+  // from ELECTRON_USERDATA, set by the outer elevated Vortex.exe when
+  // spawning this inner Node child.
+  const logError = (message: string, error: unknown) => {
+    try {
+      const fs = __non_webpack_require__("fs");
+      const path = __non_webpack_require__("path");
+      const userData = process.env.ELECTRON_USERDATA;
+      if (!userData) return;
+      const detail =
+        error instanceof Error
+          ? {
+              name: error.name,
+              message: error.message,
+              stack: error.stack,
+              code: (error as { code?: unknown }).code,
+            }
+          : { value: String(error) };
+      const line =
+        new Date().toISOString() +
+        " [ERROR] [ELEVATED] " +
+        message +
+        " " +
+        JSON.stringify({ pid: process.pid, ipcPath, ...detail }) +
+        "\n";
+      fs.appendFileSync(path.join(userData, "vortex.log"), line);
+    } catch {
+      // diagnostics must never throw
+    }
+  };
+
   const syntaxErrors = ["ReferenceError"];
   const handleError = (error: any) => {
     const testIfScriptInvalid = () => {
@@ -41,7 +75,7 @@ function elevatedMain(
         }
       });
     };
-    console.error("Elevated code failed", error.stack);
+    logError("Elevated code failed", error);
     if (client !== undefined) {
       testIfScriptInvalid();
     }
@@ -73,7 +107,7 @@ function elevatedMain(
     })
     .on("error", (err) => {
       if (err.code !== "EPIPE") {
-        console.error("Connection failed", err.message);
+        logError("Connection failed", err);
       }
     });
 }
@@ -119,6 +153,21 @@ export function runElevated(
           p.split("\\").join("/"),
         );
 
+        // In production builds the elevated Node child runs with
+        // ELECTRON_RUN_AS_NODE, which disables Electron's asar resolution.
+        // Asar-unpacked deps (e.g. json-socket) live under
+        // resources/app.asar.unpacked/node_modules and must be on the
+        // require search path explicitly. In dev the path doesn't exist
+        // and is harmless. See issue #23043.
+        if (process.resourcesPath) {
+          modulePaths.unshift(
+            path
+              .join(process.resourcesPath, "app.asar.unpacked", "node_modules")
+              .split("\\")
+              .join("/"),
+          );
+        }
+
         let mainBody = elevatedMain.toString();
         mainBody = mainBody.slice(
           mainBody.indexOf("{") + 1,
@@ -158,11 +207,9 @@ export function runElevated(
               try {
                 cleanup();
               } catch (cleanupErr) {
-                const errorMessage = getErrorMessageOrDefault(cleanupErr);
-                console.error(
-                  "failed to clean up temporary script",
-                  errorMessage,
-                );
+                log("warn", "failed to clean up temporary script", {
+                  error: getErrorMessageOrDefault(cleanupErr),
+                });
               }
               return reject(writeErr);
             }


### PR DESCRIPTION
- Fixes "Deployment interrupted" on elevated symlink deploys. Three root causes addressed: (1) `--run` moved to top of `main()` so it runs before the renderer's watchdog expires, (2) `node_modules/json-socket` re-added to `asarUnpack`, (3) `<resourcesPath>/app.asar.unpacked/node_modules` prepended to the elevated tmp script's `moduleRoot` since `ELECTRON_RUN_AS_NODE` disables Electron's asar redirect.
- Replaces `console.error` in `elevatedMain` (lost in detached elevated process) with a `logError` helper that writes to `vortex.log`. Adds `[elevation-trace]` entries so future failures have a grep-able fingerprint.
- Drive-by: fixes nxm protocol handler being registered with `undefined` due to a stray `void` operator (regression from d443c0e77).

fixes APP-444
fixes #23043
fixes #23073