### PR TITLE
persist verifier repairs via subtree-aware kv delete

### DIFF
--- a/src/main/src/store/LevelPersist.test.ts
+++ b/src/main/src/store/LevelPersist.test.ts
@@ -59,15 +59,16 @@ describe("LevelPersist.setItem", () => {
 });
 
 describe("LevelPersist.removeItem", () => {
-  it("issues a single DELETE", async () => {
+  it("issues a single DELETE that matches the exact key and any descendants", async () => {
     const { persist, connection } = createPersist();
 
     await persist.removeItem(["settings", "window", "x"]);
 
     expect(connection.run).toHaveBeenCalledTimes(1);
+    const exact = `settings${SEPARATOR}window${SEPARATOR}x`;
     expect(connection.run).toHaveBeenCalledWith(
-      "DELETE FROM db.kv WHERE key = $1",
-      [`settings${SEPARATOR}window${SEPARATOR}x`],
+      "DELETE FROM db.kv WHERE key = $1 OR starts_with(key, $2)",
+      [exact, `${exact}${SEPARATOR}`],
     );
   });
 });
@@ -138,15 +139,26 @@ describe("LevelPersist.bulkRemoveItem", () => {
     expect(connection.run).not.toHaveBeenCalled();
   });
 
-  it("emits a single DELETE … WHERE key IN (…)", async () => {
+  it("emits a single DELETE with a subtree clause per input key", async () => {
     const { persist, connection } = createPersist();
 
     await persist.bulkRemoveItem([["a"], ["b"], ["c"]]);
 
     expect(connection.run).toHaveBeenCalledTimes(1);
     const [sql, params] = connection.run.mock.calls[0];
-    expect(sql).toBe("DELETE FROM db.kv WHERE key IN ($1, $2, $3)");
-    expect(params).toEqual(["a", "b", "c"]);
+    expect(sql).toBe(
+      "DELETE FROM db.kv WHERE key = $1 OR starts_with(key, $2) " +
+        "OR key = $3 OR starts_with(key, $4) " +
+        "OR key = $5 OR starts_with(key, $6)",
+    );
+    expect(params).toEqual([
+      "a",
+      `a${SEPARATOR}`,
+      "b",
+      `b${SEPARATOR}`,
+      "c",
+      `c${SEPARATOR}`,
+    ]);
   });
 
   it("joins compound key paths with the separator", async () => {
@@ -155,7 +167,10 @@ describe("LevelPersist.bulkRemoveItem", () => {
     await persist.bulkRemoveItem([["settings", "window"]]);
 
     const params = connection.run.mock.calls[0][1] as string[];
-    expect(params).toEqual([`settings${SEPARATOR}window`]);
+    expect(params).toEqual([
+      `settings${SEPARATOR}window`,
+      `settings${SEPARATOR}window${SEPARATOR}`,
+    ]);
   });
 });
 

--- a/src/main/src/store/LevelPersist.ts
+++ b/src/main/src/store/LevelPersist.ts
@@ -261,11 +261,22 @@ class LevelPersist implements IPersistor {
     );
   }
 
+  // Removes the exact key and any descendants (keys whose stored form is
+  // `<key>###...`). Subtree removal is needed because some persistence paths
+  // store an object as a single JSON blob at an intermediate path, while
+  // others decompose it into one row per leaf - a parent-only delete would
+  // leave the blob row orphaned (the "infinite repair loop" failure mode).
+  // starts_with is a literal prefix match, so segments containing LIKE
+  // metacharacters (`_`, `%`) - common in keys like `skyrim_se` - cannot
+  // over-match. SEPARATOR collisions are structurally impossible: keys
+  // cannot contain `###` except as a separator.
   public async removeItem(statePath: string[]): Promise<void> {
+    const key = statePath.join(SEPARATOR);
     await this.timedWrite("removeItem", 1, () =>
-      this.#mConnection.run(`DELETE FROM ${this.#mAlias}.kv WHERE key = $1`, [
-        statePath.join(SEPARATOR),
-      ]),
+      this.#mConnection.run(
+        `DELETE FROM ${this.#mAlias}.kv WHERE key = $1 OR starts_with(key, $2)`,
+        [key, `${key}${SEPARATOR}`],
+      ),
     );
   }
 
@@ -297,22 +308,28 @@ class LevelPersist implements IPersistor {
   }
 
   /**
-   * Bulk variant of removeItem: a single DELETE … WHERE key IN (…) statement
-   * covering every key. The caller is expected to chunk large lists.
+   * Bulk variant of removeItem: a single DELETE statement covering every
+   * key. Each input key removes the exact match and any descendants - same
+   * subtree semantics as removeItem (see comment there). The caller is
+   * expected to chunk large lists; with BULK_CHUNK_SIZE=256 the parameter
+   * count stays at 2*256=512.
    */
   public async bulkRemoveItem(keys: ReadonlyArray<string[]>): Promise<void> {
     if (keys.length === 0) {
       return;
     }
-    const placeholders: string[] = [];
+    const clauses: string[] = [];
     const params: string[] = [];
     for (let i = 0; i < keys.length; i++) {
-      placeholders.push(`$${i + 1}`);
-      params.push(keys[i].join(SEPARATOR));
+      const exact = 2 * i + 1;
+      const prefix = 2 * i + 2;
+      clauses.push(`key = $${exact} OR starts_with(key, $${prefix})`);
+      const key = keys[i].join(SEPARATOR);
+      params.push(key, `${key}${SEPARATOR}`);
     }
     await this.timedWrite("bulkRemoveItem", keys.length, () =>
       this.#mConnection.run(
-        `DELETE FROM ${this.#mAlias}.kv WHERE key IN (${placeholders.join(", ")})`,
+        `DELETE FROM ${this.#mAlias}.kv WHERE ${clauses.join(" OR ")}`,
         params,
       ),
     );

--- a/src/renderer/src/store/stateDiff.test.ts
+++ b/src/renderer/src/store/stateDiff.test.ts
@@ -125,6 +125,33 @@ describe("computeStateDiff", () => {
     expect(removeOp.type).toBe("remove");
   });
 
+  it("emits a remove at the container path when an object subtree is removed", () => {
+    // The persistence layer treats remove ops as subtree removals (key + any
+    // descendants). For that to clear a JSON blob stored at an intermediate
+    // path - which is what happens to non-plain objects in
+    // collectSetOperations - the diff must include a remove at that path,
+    // not just at deeper leaves.
+    const oldState = {
+      files: {
+        downloadId: {
+          failCause: new Error("network failed"),
+        },
+      },
+    };
+    const newState = { files: {} };
+
+    const ops = computeStateDiff(oldState, newState);
+    const removePaths = new Set(
+      ops.filter((op) => op.type === "remove").map((op) => op.path.join(".")),
+    );
+
+    // The container itself must be removed - this is what sweeps a blob
+    // stored at `files###downloadId` in the kv table.
+    expect(removePaths.has("files.downloadId")).toBe(true);
+    // And the non-plain-object child too, in case it was decomposed.
+    expect(removePaths.has("files.downloadId.failCause")).toBe(true);
+  });
+
   it("generates set operation when Date replaces a string", () => {
     // Simulates startInstallCB (string) -> finishInstallCB (Date)
     const oldState = {

--- a/src/renderer/src/store/stateDiff.ts
+++ b/src/renderer/src/store/stateDiff.ts
@@ -48,8 +48,21 @@ export function computeStateDiff<T>(
       const currentPath = [...path, key];
 
       if (newState[key] === undefined) {
-        // Key was removed - collect all remove operations for this subtree
-        operations.push(...collectRemoveOperations(currentPath, oldState[key]));
+        // Key was removed. Emit a remove at the container path first - the
+        // persistence layer treats removes as subtree removals (key + any
+        // descendants), so this single op handles the case where the value
+        // was stored as a JSON blob at the intermediate path (non-plain
+        // objects, e.g. Date or Error instances, take that branch in
+        // collectSetOperations and end up as one row at currentPath).
+        // For object subtrees, also emit leaf removes as a fallback for
+        // exact-match persistors (tests, mocks). For primitives the
+        // container-path remove already covers it.
+        operations.push({ type: "remove", path: currentPath });
+        if (isObject(oldState[key])) {
+          operations.push(
+            ...collectRemoveOperations(currentPath, oldState[key]),
+          );
+        }
       } else if (oldState[key] !== newState[key]) {
         // Key exists in both but value changed - recurse
         operations.push(
@@ -79,13 +92,13 @@ export function computeStateDiff<T>(
         operations.push({ type: "set", path, value: newState });
       }
     } else {
-      // Value was removed
+      // Value was removed. Always emit a remove at this path (see the
+      // object-key removal branch above for why the container-path remove
+      // matters under prefix-delete). For object subtrees, also emit the
+      // leaf removes as a fallback for exact-match persistors.
+      operations.push({ type: "remove", path });
       if (isObject(oldState)) {
-        // Old value was an object - remove all its leaf values
         operations.push(...collectRemoveOperations(path, oldState));
-      } else {
-        // Old value was a primitive
-        operations.push({ type: "remove", path });
       }
     }
   }


### PR DESCRIPTION
Repair removed bad entries from memory but the delete never reached DuckDB: computeStateDiff emitted only leaf removes and bulkRemoveItem matched keys exactly, so blob rows at intermediate paths (state values whose prototype is not Object.prototype - Date, Error, etc.) survived and re-hydrated next launch. Infinite repair loop.

removeItem and bulkRemoveItem now subtree-delete via "WHERE key = $1 OR starts_with(key, $2)". computeStateDiff also emits a container-path remove on object subtree removal; leaf removes stay as fallback. starts_with (not LIKE) so segments like skyrim_se can't over-match.

Original report and partial fix in PR #23100 by Alex Tabisz; that fix patched removeItem, but the production path goes through bulkRemoveItem.

Co-Authored-By: Alex Tabisz <alex@tabisz.org> @atabisz

fixes APP-446