### PR TITLE
fixed inability to apply group rules when filter is defined

### DIFF
--- a/extensions/mod-dependency-manager/src/views/ConflictEditor.tsx
+++ b/extensions/mod-dependency-manager/src/views/ConflictEditor.tsx
@@ -629,24 +629,14 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     }
 
     let newRules = { ...rules };
-    const hasAppliedFilters = hideResolved || !!filterValue;
-    const refIds = hasAppliedFilters
-      ? Object.keys(rules[modId]).filter((refId) => {
-          if (mods[refId] === undefined) {
-            return false;
-          }
-          const modName = util.renderModName(mods[refId]);
-          let matchesFilter = false;
-          if (modName !== undefined) {
-            const refModName = modName.toLowerCase();
-            matchesFilter = refModName.includes(filterValue.toLowerCase());
-          }
-          return (
-            (!!filterValue && matchesFilter) ||
-            (hideResolved && this.isUnresolved(mods, modId, refId, rules, hideResolved))
-          );
-        })
-      : Object.keys(rules[modId]);
+    // Reuse the dialog's visibility predicate so the rule applies to exactly
+    // the conflict rows the user sees in this group.
+    const refIds = (conflicts[modId] ?? [])
+      .filter((conflict) =>
+        this.applyFilter(conflict, mods, modId, filterValue, rules, hideResolved),
+      )
+      .map((conflict) => conflict.otherMod.id)
+      .filter((refId) => rules[modId]?.[refId] !== undefined);
     const unassignedRefIds = refIds.filter((refId) => {
       const currentModRule = rules[modId]?.[refId]?.type;
       const currentRefRule = rules[refId]?.[modId]?.type;

--- a/extensions/mod-dependency-manager/src/views/ConflictEditor.tsx
+++ b/extensions/mod-dependency-manager/src/views/ConflictEditor.tsx
@@ -1,25 +1,6 @@
-/* eslint-disable */
-import { IBiDirRule } from "../types/IBiDirRule";
-import { IConflict } from "../types/IConflict";
-
-import { setConflictDialog, setFileOverrideDialog } from "../actions";
-
-import { RuleChoice } from "../util/getRuleTypes";
-
-import ConflictEditorTips from "./ConflictEditorTips";
-
-import { NAMESPACE } from "../statics";
-
 import memoizeOne from "memoize-one";
 import * as React from "react";
-import {
-  Button,
-  FormControl,
-  Modal,
-  OverlayTrigger,
-  Popover,
-  Table,
-} from "react-bootstrap";
+import { Button, FormControl, Modal, OverlayTrigger, Popover, Table } from "react-bootstrap";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { connect } from "react-redux";
 import * as Redux from "redux";
@@ -39,6 +20,14 @@ import {
   util,
   VisibilityProxy,
 } from "vortex-api";
+
+import { setConflictDialog, setFileOverrideDialog } from "../actions";
+import { NAMESPACE } from "../statics";
+/* eslint-disable */
+import { IBiDirRule } from "../types/IBiDirRule";
+import { IConflict } from "../types/IConflict";
+import { RuleChoice } from "../util/getRuleTypes";
+import ConflictEditorTips from "./ConflictEditorTips";
 import { IPathTools } from "./OverrideEditor";
 
 interface IBaseProps {
@@ -120,11 +109,7 @@ function nop() {
 
 interface IVisibilityProxyWrapProps {
   entry: { id: string; name: string; numConflicts: number };
-  content: (
-    modId: string,
-    name: string,
-    ref: React.RefObject<HTMLDivElement>,
-  ) => JSX.Element;
+  content: (modId: string, name: string, ref: React.RefObject<HTMLDivElement>) => JSX.Element;
   container: HTMLElement;
 }
 
@@ -183,8 +168,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
   private getModEntriesMemo = memoizeOne(this.getModEntries);
   private getFilteredEntriesMemo = memoizeOne(this.getFilteredEntries);
   private mRef = React.createRef<HTMLDivElement>();
-  private mBaselineRules: { [modId: string]: { [refId: string]: IRuleSpec } } =
-    {};
+  private mBaselineRules: { [modId: string]: { [refId: string]: IRuleSpec } } = {};
 
   constructor(props: IProps) {
     super(props);
@@ -248,10 +232,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
       ) : hasConflicts ? (
         this.renderConflicts()
       ) : (
-        <EmptyPlaceholder
-          icon="conflict"
-          text={t("You have no file conflicts. Wow!")}
-        />
+        <EmptyPlaceholder icon="conflict" text={t("You have no file conflicts. Wow!")} />
       );
 
     const renderButton = (clickFunc: () => void, text: string) =>
@@ -271,22 +252,12 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
 
     const tips = <ConflictEditorTips />;
     return (
-      <Modal
-        id="conflict-editor-dialog"
-        show={modIds !== undefined}
-        onHide={nop}
-      >
+      <Modal id="conflict-editor-dialog" show={modIds !== undefined} onHide={nop}>
         <Modal.Header>
           <FlexLayout type="column">
-            <FlexLayout.Fixed
-              style={{ justifyContent: "space-between", display: "flex" }}
-            >
+            <FlexLayout.Fixed style={{ justifyContent: "space-between", display: "flex" }}>
               <Modal.Title>{modName}</Modal.Title>
-              <tooltip.Icon
-                id="dialog-info"
-                name="dialog-info"
-                tooltip={tips}
-              />
+              <tooltip.Icon id="dialog-info" name="dialog-info" tooltip={tips} />
             </FlexLayout.Fixed>
           </FlexLayout>
         </Modal.Header>
@@ -315,19 +286,9 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     const currentRules = this.state.rules;
     const baselineRules = this.mBaselineRules;
     this.nextState.rules = (props.modIds || []).reduce(
-      (
-        prev: { [modId: string]: { [refId: string]: IRuleSpec } },
-        modId: string,
-      ) => {
-        const persisted = getRuleSpec(
-          modId,
-          props.mods,
-          props.conflicts?.[modId],
-        );
-        if (
-          currentRules[modId] !== undefined &&
-          baselineRules[modId] !== undefined
-        ) {
+      (prev: { [modId: string]: { [refId: string]: IRuleSpec } }, modId: string) => {
+        const persisted = getRuleSpec(modId, props.mods, props.conflicts?.[modId]);
+        if (currentRules[modId] !== undefined && baselineRules[modId] !== undefined) {
           // preserve local edits: if the user changed a rule from its baseline,
           // keep the user's version
           const merged: { [refId: string]: IRuleSpec } = {};
@@ -337,8 +298,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
             const wasEdited =
               local !== undefined &&
               baseline !== undefined &&
-              (local.type !== baseline.type ||
-                local.version !== baseline.version);
+              (local.type !== baseline.type || local.version !== baseline.version);
             merged[refId] = wasEdited ? local : persisted[refId];
           }
           prev[modId] = merged;
@@ -350,10 +310,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
       {},
     );
     this.mBaselineRules = (props.modIds || []).reduce(
-      (
-        prev: { [modId: string]: { [refId: string]: IRuleSpec } },
-        modId: string,
-      ) => {
+      (prev: { [modId: string]: { [refId: string]: IRuleSpec } }, modId: string) => {
         prev[modId] = getRuleSpec(modId, props.mods, props.conflicts?.[modId]);
         return prev;
       },
@@ -381,19 +338,14 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
             const batchedActions: Redux.Action[] = [];
             for (const modId of modIds || []) {
               if (Array.isArray(this.props.mods[modId]?.fileOverrides)) {
-                batchedActions.push(
-                  vortexActions.setFileOverride(this.props.gameId, modId, []),
-                );
+                batchedActions.push(vortexActions.setFileOverride(this.props.gameId, modId, []));
               }
             }
             if (batchedActions.length > 0) {
               this.props.onBatchDispatch(batchedActions);
             }
             this.nextState.rules = (modIds || []).reduce(
-              (
-                prev: { [modId: string]: { [refId: string]: IRuleSpec } },
-                modId: string,
-              ) => {
+              (prev: { [modId: string]: { [refId: string]: IRuleSpec } }, modId: string) => {
                 const res: { [modId: string]: IRuleSpec } = {};
                 (conflicts[modId] || []).forEach((conflict) => {
                   res[conflict.otherMod.id] = {
@@ -441,19 +393,14 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
           label: "Use Suggested",
           action: () => {
             this.nextState.rules = (modIds || []).reduce(
-              (
-                prev: { [modId: string]: { [refId: string]: IRuleSpec } },
-                modId: string,
-              ) => {
-                const modRules =
-                  mods[modId] !== undefined ? mods[modId].rules || [] : [];
+              (prev: { [modId: string]: { [refId: string]: IRuleSpec } }, modId: string) => {
+                const modRules = mods[modId] !== undefined ? mods[modId].rules || [] : [];
 
                 const res: { [modId: string]: IRuleSpec } = {};
                 (conflicts[modId] || []).forEach((conflict) => {
                   const existingRule = modRules.find(
                     (rule) =>
-                      ["before", "after", "conflicts"].indexOf(rule.type) !==
-                        -1 &&
+                      ["before", "after", "conflicts"].indexOf(rule.type) !== -1 &&
                       util.testModReference(conflict.otherMod, rule.reference),
                   );
 
@@ -464,10 +411,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
                         : "after"
                       : undefined;
 
-                  if (
-                    prev[conflict.otherMod.id]?.[modId]?.type ===
-                    reverseSuggestion
-                  ) {
+                  if (prev[conflict.otherMod.id]?.[modId]?.type === reverseSuggestion) {
                     // This rule is already set on the other mod.
                     res[conflict.otherMod.id] = {
                       type: undefined,
@@ -480,17 +424,13 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
                             type: conflict.suggestion,
                             version:
                               existingRule !== undefined
-                                ? importVersion(
-                                    existingRule.reference.versionMatch,
-                                  )
+                                ? importVersion(existingRule.reference.versionMatch)
                                 : "any",
                           }
                         : existingRule !== undefined
                           ? {
                               type: existingRule.type as any,
-                              version: importVersion(
-                                existingRule.reference.versionMatch,
-                              ),
+                              version: importVersion(existingRule.reference.versionMatch),
                             }
                           : { type: undefined, version: "any" };
                   }
@@ -549,16 +489,13 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
       return false;
     }
 
-    const isMatch = (val: string) =>
-      val.toLowerCase().includes(filterValue.toLowerCase());
+    const isMatch = (val: string) => val.toLowerCase().includes(filterValue.toLowerCase());
     const modName: string = util.renderModName(mods[modId]);
     const otherModName: string = util.renderModName(mods[conflict.otherMod.id]);
-    const testFilterMatch = () =>
-      filterValue ? isMatch(modName) || isMatch(otherModName) : true;
+    const testFilterMatch = () => (filterValue ? isMatch(modName) || isMatch(otherModName) : true);
 
     return (
-      testFilterMatch() &&
-      this.isUnresolved(mods, modId, conflict.otherMod.id, rules, hideResolved)
+      testFilterMatch() && this.isUnresolved(mods, modId, conflict.otherMod.id, rules, hideResolved)
     );
   };
 
@@ -572,14 +509,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
   ): { [modId: string]: IConflict[] } {
     return modEntries.reduce((prev, entry) => {
       prev[entry.id] = (conflicts[entry.id] || []).filter((conflict) =>
-        this.applyFilter(
-          conflict,
-          mods,
-          entry.id,
-          filterValue,
-          rules,
-          hideResolved,
-        ),
+        this.applyFilter(conflict, mods, entry.id, filterValue, rules, hideResolved),
       );
       return prev;
     }, {});
@@ -628,41 +558,23 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
         />
       ) : null;
 
-    const renderModEntry = (
-      modId: string,
-      name: string,
-      ref: React.RefObject<HTMLDivElement>,
-    ) => {
+    const renderModEntry = (modId: string, name: string, ref: React.RefObject<HTMLDivElement>) => {
       const filtered = filteredEntries[modId];
       return filtered.length > 0 ? (
-        <div
-          id={`content-${modId}`}
-          key={`mod-conflict-element-${modId}`}
-          ref={ref}
-        >
+        <div id={`content-${modId}`} key={`mod-conflict-element-${modId}`} ref={ref}>
           <div className="mod-conflict-group-header">
             <label>{util.renderModName(mods[modId])}</label>
-            <a
-              data-modid={modId}
-              data-action="before_all"
-              onClick={this.applyGroupRule}
-            >
+            <a data-modid={modId} data-action="before_all" onClick={this.applyGroupRule}>
               {t("Before All")}
             </a>
             <span className="link-action-seperator">&nbsp; | &nbsp;</span>
-            <a
-              data-modid={modId}
-              data-action="after_all"
-              onClick={this.applyGroupRule}
-            >
+            <a data-modid={modId} data-action="after_all" onClick={this.applyGroupRule}>
               {t("After All")}
             </a>
           </div>
           <Table className="mod-conflict-list">
             <tbody>
-              {filtered.map((conf: IConflict) =>
-                this.renderConflict(modId, name, conf),
-              )}
+              {filtered.map((conf: IConflict) => this.renderConflict(modId, name, conf))}
             </tbody>
           </Table>
         </div>
@@ -684,11 +596,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     ) : null;
   };
 
-  private confirmGroupRule = (
-    modId: string,
-    refIds: string[],
-    apply: () => void,
-  ) => {
+  private confirmGroupRule = (modId: string, refIds: string[], apply: () => void) => {
     const { t } = this.props;
     this.context.api.showDialog(
       "question",
@@ -716,10 +624,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     const { rules, hideResolved, filterValue } = this.state;
     const action = evt.currentTarget.getAttribute("data-action");
     const modId = evt.currentTarget.getAttribute("data-modid");
-    if (
-      ["after_all", "before_all"].indexOf(action) === -1 ||
-      conflicts === undefined
-    ) {
+    if (["after_all", "before_all"].indexOf(action) === -1 || conflicts === undefined) {
       return;
     }
 
@@ -738,8 +643,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
           }
           return (
             (!!filterValue && matchesFilter) ||
-            (hideResolved &&
-              this.isUnresolved(mods, modId, refId, rules, hideResolved))
+            (hideResolved && this.isUnresolved(mods, modId, refId, rules, hideResolved))
           );
         })
       : Object.keys(rules[modId]);
@@ -767,15 +671,11 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
           });
 
     const applyRule = () => {
-      const refrencedModIds =
-        unassignedRefIds.length > 0 ? unassignedRefIds : refIds;
+      const refrencedModIds = unassignedRefIds.length > 0 ? unassignedRefIds : refIds;
       refrencedModIds.forEach((refId) => {
         // Remove any existing rules from the referenced modIds.
         const refRules = getRuleSpec(refId, mods, conflicts[refId]);
-        if (
-          refRules?.[modId]?.type !== undefined ||
-          rules[refId]?.[modId]?.type !== undefined
-        ) {
+        if (refRules?.[modId]?.type !== undefined || rules[refId]?.[modId]?.type !== undefined) {
           removeRefRule(refId);
         }
 
@@ -793,11 +693,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     }
   };
 
-  private renderConflict = (
-    modId: string,
-    name: string,
-    conflict: IConflict,
-  ) => {
+  private renderConflict = (modId: string, name: string, conflict: IConflict) => {
     const { t, modRules, mods, pathTool, discovery } = this.props;
     const { rules } = this.state;
 
@@ -812,10 +708,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
 
     const toRelPath = (lhs: string, rhs: string) => pathTool.relative(lhs, rhs);
     const popover = (
-      <Popover
-        className="conflict-popover"
-        id={`conflict-popover-${conflict.otherMod.id}`}
-      >
+      <Popover className="conflict-popover" id={`conflict-popover-${conflict.otherMod.id}`}>
         {conflict.files
           .slice(0)
           .sort()
@@ -885,14 +778,10 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
           >
             <option value="norule">???</option>
             <option value="before">
-              {conflict.suggestion === "before"
-                ? t("before (suggested)")
-                : t("before")}
+              {conflict.suggestion === "before" ? t("before (suggested)") : t("before")}
             </option>
             <option value="after">
-              {conflict.suggestion === "after"
-                ? t("after (suggested)")
-                : t("after")}
+              {conflict.suggestion === "after" ? t("after (suggested)") : t("after")}
             </option>
             <option value="conflicts">{t("never together with")}</option>
           </FormControl>
@@ -905,12 +794,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
                   version: true,
                 })}
               </div>
-              <OverlayTrigger
-                trigger="click"
-                rootClose
-                placement="right"
-                overlay={popover}
-              >
+              <OverlayTrigger trigger="click" rootClose placement="right" overlay={popover}>
                 <a>
                   {t("{{ count }} conflicting file", {
                     count: conflict.files.length,
@@ -932,8 +816,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
             disabled={reverseRule !== undefined}
           >
             <option value="any">{t("Any version")}</option>
-            {conflict.otherMod.version &&
-            semver.valid(conflict.otherMod.version) ? (
+            {conflict.otherMod.version && semver.valid(conflict.otherMod.version) ? (
               <option value="compatible">{t("Compatible version")}</option>
             ) : null}
             {conflict.otherMod.version ? (
@@ -941,9 +824,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
             ) : null}
           </FormControl>
         </td>
-        <td style={{ width: "5em" }}>
-          {this.renderReverseRule(modId, reverseRule)}
-        </td>
+        <td style={{ width: "5em" }}>{this.renderReverseRule(modId, reverseRule)}</td>
       </tr>
     );
   };
@@ -958,10 +839,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
       <div>
         {t("{{ otherMod }} has a rule referencing {{ thisMod }}", {
           replace: {
-            otherMod: util.renderModReference(
-              rule.reference,
-              mods[rule.reference.id],
-            ),
+            otherMod: util.renderModReference(rule.reference, mods[rule.reference.id]),
             thisMod: util.renderModReference(rule.source, mods[rule.source.id]),
           },
         })}
@@ -991,9 +869,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
       "question",
       t("Confirm"),
       {
-        text: t(
-          "This will remove the existing rule so you can set a new one on this mod.",
-        ),
+        text: t("This will remove the existing rule so you can set a new one on this mod."),
       },
       [
         { label: "Cancel" },
@@ -1026,9 +902,7 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     const refId = evt.currentTarget.getAttribute("data-refid");
     if (this.nextState.rules[modId][refId] !== undefined) {
       this.nextState.rules[modId][refId].type =
-        evt.currentTarget.value === "norule"
-          ? undefined
-          : evt.currentTarget.value;
+        evt.currentTarget.value === "norule" ? undefined : evt.currentTarget.value;
     }
   };
 
@@ -1108,33 +982,21 @@ const emptyObj = {};
 function mapStateToProps(state): IConnectedProps {
   const dialog = state.session.dependencies.conflictDialog || emptyObj;
   const discovery =
-    dialog?.gameId !== undefined
-      ? selectors.discoveryByGame(state, dialog.gameId)
-      : emptyObj;
+    dialog?.gameId !== undefined ? selectors.discoveryByGame(state, dialog.gameId) : emptyObj;
   return {
     gameId: dialog.gameId,
     modIds: dialog.modIds,
-    conflicts: util.getSafe(
-      state,
-      ["session", "dependencies", "conflicts"],
-      undefined,
-    ),
-    mods:
-      dialog.gameId !== undefined
-        ? state.persistent.mods[dialog.gameId]
-        : emptyObj,
+    conflicts: util.getSafe(state, ["session", "dependencies", "conflicts"], undefined),
+    mods: dialog.gameId !== undefined ? state.persistent.mods[dialog.gameId] : emptyObj,
     modRules: dialog.modRules,
     discovery,
   };
 }
 
-function mapDispatchToProps(
-  dispatch: ThunkDispatch<any, null, Redux.Action>,
-): IActionProps {
+function mapDispatchToProps(dispatch: ThunkDispatch<any, null, Redux.Action>): IActionProps {
   return {
     onClose: () => dispatch(setConflictDialog(undefined, undefined, undefined)),
-    onAddRule: (gameId, modId, rule) =>
-      dispatch(vortexActions.addModRule(gameId, modId, rule)),
+    onAddRule: (gameId, modId, rule) => dispatch(vortexActions.addModRule(gameId, modId, rule)),
     onOverrideDialog: (gameId: string, modId: string) =>
       dispatch(setFileOverrideDialog(gameId, modId)),
     onBatchDispatch: (actions: Redux.Action[]) => dispatch(batch(actions)),


### PR DESCRIPTION
The conflict editor had two filter predicates that disagreed: the display
(applyFilter) matched a row if either source or referenced mod name contained
the filter, but applyGroupRule only checked the referenced mod name. When the
user filtered by the source mod's name to narrow to one group, the group was
still rendered with all its conflict rows, but "Before All" / "After All"
silently did nothing because the apply path computed an empty ref set.

Reuse applyFilter inside applyGroupRule so the rule applies to exactly the
rows the user sees, regardless of which side of the conflict the filter
matched.

(actual code is in commit d07ecc41a54f85a43d3fe8979a7f1fbdafb8ea2b)

Fixes APP-451
Fixes https://github.com/Nexus-Mods/Vortex/issues/23124