### PR TITLE
fixed notification suppress action icon showing a "cog/gear"

### DIFF
--- a/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
@@ -1,4 +1,4 @@
-import { mdiCogOutline, mdiClose } from "@mdi/js";
+import { mdiEyeOff, mdiClose } from "@mdi/js";
 import React, { type FC, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -30,7 +30,7 @@ export const NotificationControls: FC<NotificationControlsProps> = ({
       {allowSuppress && (
         <Button
           buttonType="tertiary"
-          leftIconPath={mdiCogOutline}
+          leftIconPath={mdiEyeOff}
           size="xs"
           title={t("Never show again")}
           onClick={onSuppress}


### PR DESCRIPTION
suppressible notifications will currently show the suppress action as a cog/gear - this is misleading users as the globally accepted meaning of a cog/gear means to show settings, not suppress.

fixes APP-454