### PR TITLE
fix Tailwind source detection for renderer

### DIFF
--- a/src/stylesheets/package.json
+++ b/src/stylesheets/package.json
@@ -32,7 +32,8 @@
         "cache": true,
         "inputs": [
           "default",
-          "{projectRoot}/**/*.css"
+          "{projectRoot}/**/*.css",
+          "{workspaceRoot}/src/renderer/src/**/*.{ts,tsx,html}"
         ],
         "outputs": [
           "{projectRoot}/dist/tailwind-v4.css"

--- a/src/stylesheets/tailwind-v4.css
+++ b/src/stylesheets/tailwind-v4.css
@@ -12,6 +12,9 @@
 
 @import "tailwindcss";
 
+/* Explicit source paths so detection doesn't depend on the CLI's cwd. */
+@source "../renderer/src/**/*.{ts,tsx,html}";
+
 /* Import design system */
 @import "./ui/theme";
 @import "./ui/elements";


### PR DESCRIPTION
Tailwind v4 auto-detects sources from the CLI's cwd. After 095ed0f95 moved the output from src/main/build/assets/css/ to src/stylesheets/dist/, the scan no longer reached src/renderer/, so utility classes used in the Spine and other UIv2 components were stripped from tailwind-v4.css and the layout rendered unstyled.

Add an explicit `@source` pointing at the renderer so detection no longer depends on where the output happens to land.