### PR TITLE
Package inline issue fixes

### DIFF
--- a/docs/install-instructions/windows.md
+++ b/docs/install-instructions/windows.md
@@ -67,6 +67,35 @@ Some native build pieces need CMake during local builds.
 winget install --id Microsoft.DotNet.SDK.9 -e
 ```
 
+## Enable Windows Settings
+
+The following Windows settings must be enabled. Both require an
+**Administrator** PowerShell session and a sign-out (or reboot) to take effect.
+
+### Enable Long Paths
+
+Vortex and its native modules produce paths longer than the legacy 260-character
+`MAX_PATH` limit. Enable long path support in Windows and Git:
+
+```powershell
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+    -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+git config --system core.longpaths true
+```
+
+### Enable Windows Developer Mode
+
+Developer Mode allows symlink creation without elevation, which `pnpm` and some
+native build steps rely on.
+
+```powershell
+New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" `
+    -Name "AllowDevelopmentWithoutDevLicense" -Value 1 -PropertyType DWORD -Force
+```
+
+Alternatively, enable it via **Settings → System → For developers → Developer
+Mode**.
+
 ## Verify Install
 
 ```powershell

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3981,6 +3981,9 @@ importers:
       '@types/uuid':
         specifier: 'catalog:'
         version: 3.4.13
+      '@welldone-software/why-did-you-render':
+        specifier: 'catalog:'
+        version: 10.0.1(react@16.14.0)
       bbcode-to-react:
         specifier: 'catalog:'
         version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@16.14.0)
@@ -4005,6 +4008,9 @@ importers:
       content-type:
         specifier: 'catalog:'
         version: 1.0.5
+      csstype:
+        specifier: 'catalog:'
+        version: 3.2.3
       d3:
         specifier: 'catalog:'
         version: 5.16.0
@@ -4194,6 +4200,9 @@ importers:
       redux-batched-actions:
         specifier: 'catalog:'
         version: 0.5.0(redux@4.2.1)
+      redux-freeze:
+        specifier: 'catalog:'
+        version: 0.1.7
       redux-thunk:
         specifier: 'catalog:'
         version: 2.4.2(redux@4.2.1)
@@ -4375,9 +4384,6 @@ importers:
       '@vortex/shared':
         specifier: workspace:*
         version: link:../shared
-      '@welldone-software/why-did-you-render':
-        specifier: 'catalog:'
-        version: 10.0.1(react@16.14.0)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -4390,9 +4396,6 @@ importers:
       electron-devtools-installer:
         specifier: 'catalog:'
         version: 3.2.1
-      redux-freeze:
-        specifier: 'catalog:'
-        version: 0.1.7
 
   src/preload:
     dependencies:

--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/electron-userland/electron-builder/raw/refs/tags/v24.13.3/packages/app-builder-lib/scheme.json",
   "appId": "com.nexusmods.vortex",
-  "includeSubNodeModules": false,
+  "includeSubNodeModules": true,
   "directories": {
     "buildResources": "./nsis",
     "app": "./build",

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm vitest run --config ./vitest.config.ts",
     "test:downloader": "pnpm vitest run --config ./vitest.downloader.config.ts",
     "test:adaptor": "pnpm vitest run --config ./vitest.integration.config.ts",
-    "publish": "pnpm exec rimraf ./dist && pnpm -F @vortex/main deploy ./dist && node ./dist/prepare-dist-package.mjs",
+    "publish": "pnpm exec rimraf ./dist && pnpm -F @vortex/main deploy ./dist && node ./dist/prepare-dist-package.mjs && pnpm install --dir=./dist --prod --node-linker=hoisted",
     "package": "cd ./dist && pnpm electron-builder --config ./electron-builder.config.json --config.win.forceCodeSigning=true --config.win.sign=./sign.cjs --publish never",
     "package:nosign": "cd ./dist && pnpm electron-builder --config ./electron-builder.config.json --publish never"
   },
@@ -141,6 +141,7 @@
     "@tailwindcss/cli": "catalog:",
     "@types/bluebird": "catalog:",
     "@types/uuid": "catalog:",
+    "@welldone-software/why-did-you-render": "catalog:",
     "@nexusmods/adaptor-api": "workspace:*",
     "bbcode-to-react": "catalog:",
     "big.js": "catalog:",
@@ -150,6 +151,7 @@
     "commander": "catalog:",
     "content-disposition": "catalog:",
     "content-type": "catalog:",
+    "csstype": "catalog:",
     "d3": "catalog:",
     "date-fns": "catalog:",
     "dayjs": "catalog:",
@@ -213,6 +215,7 @@
     "redux": "catalog:",
     "redux-act": "catalog:",
     "redux-batched-actions": "catalog:",
+    "redux-freeze": "catalog:",
     "redux-thunk": "catalog:",
     "relaxed-json": "catalog:",
     "reselect": "catalog:",
@@ -275,11 +278,9 @@
     "@types/ws": "catalog:",
     "@types/xml2js": "catalog:",
     "@vortex/shared": "workspace:*",
-    "@welldone-software/why-did-you-render": "catalog:",
     "cross-env": "catalog:",
     "electron": "catalog:",
     "electron-builder": "catalog:",
-    "electron-devtools-installer": "catalog:",
-    "redux-freeze": "catalog:"
+    "electron-devtools-installer": "catalog:"
   }
 }

--- a/src/main/prepare-dist-package.mjs
+++ b/src/main/prepare-dist-package.mjs
@@ -1,30 +1,125 @@
-import { createWriteStream } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createWriteStream, existsSync } from "node:fs";
+import { glob, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 const MAIN_DIR = resolve(import.meta.dirname);
+const ROOT_DIR = resolve(MAIN_DIR, "..", "..", "..");
 const MAIN_PACKAGE_PATH = resolve(MAIN_DIR, "package.json");
 const DIST_DIR = resolve(MAIN_DIR, "build");
 const DIST_PACKAGE_PATH = resolve(DIST_DIR, "package.json");
+const NODE_MODULES_DIR = resolve(MAIN_DIR, "node_modules");
+const WORKSPACE_YAML_PATH = resolve(MAIN_DIR, "pnpm-workspace.yaml");
+const ROOT_WORKSPACE_YAML_PATH = resolve(ROOT_DIR, "pnpm-workspace.yaml");
 
-async function resolveDepVersions(deps, nodeModulesDir) {
+// Build a map of workspace-package-name → absolute source directory, by reading the
+// root pnpm-workspace.yaml's `packages:` field and globbing it. Used to translate
+// `workspace:*` deps into `file:<absolute-path>` pointing at the workspace source —
+// NOT at the pnpm-deploy'd copy under .pnpm/, which is about to be wiped.
+async function buildWorkspacePackageMap() {
+  const yaml = await readFile(ROOT_WORKSPACE_YAML_PATH, "utf8");
+  const block = yaml.match(/^packages:[ \t]*\n((?:[ \t]+-\s.+\n?)+)/m);
+  if (!block) return {};
+
+  const patterns = block[1]
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith("- "))
+    .map((l) =>
+      l
+        .slice(2)
+        .trim()
+        .replace(/^['"]|['"]$/g, ""),
+    );
+
+  const resolved = new Set();
+  for (const pattern of patterns) {
+    if (pattern.includes("*")) {
+      for await (const m of glob(pattern, { cwd: ROOT_DIR })) resolved.add(m);
+    } else {
+      resolved.add(pattern);
+    }
+  }
+
+  const map = {};
+  for (const relPath of resolved) {
+    const pkgDir = resolve(ROOT_DIR, relPath);
+    try {
+      const pkg = JSON.parse(await readFile(resolve(pkgDir, "package.json"), "utf8"));
+      if (pkg.name) map[pkg.name] = pkgDir;
+    } catch {
+      // skip dirs without a readable package.json
+    }
+  }
+  return map;
+}
+
+// Parse the `catalog:` block from pnpm-workspace.yaml into { pkgName: spec }. Specs
+// include git URLs (e.g. `git+https://github.com/...#<sha>`), not just semver ranges
+// — those must be preserved verbatim so the upcoming `pnpm install` can fetch them.
+function parseCatalog(yamlText) {
+  const match = yamlText.match(/^catalog:[ \t]*\n((?:[ \t]+\S.*\n?)*)/m);
+  if (!match) return {};
+  const catalog = {};
+  for (const line of match[1].split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const colon = trimmed.indexOf(":");
+    if (colon === -1) continue;
+    const key = trimmed
+      .slice(0, colon)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
+    const value = trimmed
+      .slice(colon + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
+    if (key && value) catalog[key] = value;
+  }
+  return catalog;
+}
+
+// Resolve `catalog:` → the raw catalog spec (preserves git URLs!) and
+// `workspace:*` → `file:<absolute-path>` (the workspace source dir from `wsMap`).
+// Used so the re-install below has a self-contained package.json with no pnpm-specific
+// protocols, which lets it run with a shadowed (non-strict) pnpm-workspace.yaml.
+async function resolveDepVersions(deps, catalog, wsMap) {
   if (!deps) return deps;
   const resolved = { ...deps };
   for (const [name, version] of Object.entries(deps)) {
-    if (version === "catalog:" || version.startsWith("workspace:")) {
-      try {
-        const pkgJson = JSON.parse(
-          await readFile(resolve(nodeModulesDir, name, "package.json"), "utf8"),
-        );
-        resolved[name] = pkgJson.version;
-      } catch {
-        // leave as-is if not found in node_modules
-      }
+    if (version === "catalog:" && catalog[name]) {
+      resolved[name] = catalog[name];
+    } else if (version.startsWith("workspace:") && wsMap[name]) {
+      resolved[name] = `file:${wsMap[name]}`;
     }
   }
   return resolved;
+}
+
+// Extract `^<name>:` block (and its indented body) from a YAML file. Returns null if
+// the block isn't present. Tolerates blank lines inside the block (root yaml has them
+// for visual grouping); stops only at the next top-level (non-indented) key.
+function extractYamlBlock(yamlText, blockName) {
+  const re = new RegExp(`^${blockName}:[ \\t]*\\n((?:[ \\t]+\\S.*\\n?|\\s*\\n)*)`, "m");
+  const match = yamlText.match(re);
+  return match ? match[0].trimEnd() : null;
+}
+
+// Shadow the root pnpm-workspace.yaml. The root config has `catalogMode: strict` and
+// `forceLegacyDeploy: true`, which both interfere with re-installing inside the deploy
+// dir. The shadow keeps just the blocks that affect resolution/native-build outcomes.
+async function writeShadowWorkspaceYaml() {
+  const rootYaml = await readFile(ROOT_WORKSPACE_YAML_PATH, "utf8");
+  const parts = [];
+  // No `packages:` key — pnpm treats this as a single-package project (the dist itself).
+  // Carry over `overrides` and `allowBuilds` so transitive resolution and native-module
+  // build scripts behave the same as in the workspace.
+  for (const block of ["overrides", "allowBuilds"]) {
+    const text = extractYamlBlock(rootYaml, block);
+    if (text) parts.push(text);
+  }
+  await writeFile(WORKSPACE_YAML_PATH, parts.join("\n\n") + "\n");
 }
 
 async function downloadFile(url, dest) {
@@ -47,19 +142,39 @@ async function prepareWin() {
 }
 
 async function main() {
-  const json = await readFile(MAIN_PACKAGE_PATH, "utf8");
-  const mainPkg = JSON.parse(json);
+  // Read the original src/main/package.json (with `catalog:` / `workspace:*` protocols
+  // intact). pnpm deploy already wrote dist/package.json with its own resolution, which
+  // turns git-URL catalog entries into raw versions that don't exist on npm — useless
+  // for the upcoming `pnpm install`. We resolve from source instead.
+  const mainPkg = JSON.parse(
+    await readFile(resolve(ROOT_DIR, "src", "main", "package.json"), "utf8"),
+  );
 
-  mainPkg["name"] = "Vortex";
-  mainPkg["main"] = mainPkg.main.replace(/^build\//, "");
-  mainPkg["version"] = process.env.VORTEX_VERSION || "1.0.0";
+  mainPkg.name = "Vortex";
+  mainPkg.main = mainPkg.main.replace(/^build\//, "");
+  mainPkg.version = process.env.VORTEX_VERSION || "1.0.0";
 
-  // NOTE(erri120): this is the minimal amount of bullshit required to get the piece of shit software called "electron-builder" to work with PNPM.
-  const nodeModulesDir = resolve(MAIN_DIR, "node_modules");
-  mainPkg.dependencies = await resolveDepVersions(mainPkg.dependencies, nodeModulesDir);
-  mainPkg.devDependencies = await resolveDepVersions(mainPkg.devDependencies, nodeModulesDir);
+  const rootYaml = await readFile(ROOT_WORKSPACE_YAML_PATH, "utf8");
+  const catalog = parseCatalog(rootYaml);
+  const wsMap = await buildWorkspacePackageMap();
+  mainPkg.dependencies = await resolveDepVersions(mainPkg.dependencies, catalog, wsMap);
+  mainPkg.devDependencies = await resolveDepVersions(mainPkg.devDependencies, catalog, wsMap);
 
-  await writeFile(DIST_PACKAGE_PATH, JSON.stringify(mainPkg, null, 2) + "\n", "utf8");
+  const serialized = JSON.stringify(mainPkg, null, 2) + "\n";
+  await mkdir(DIST_DIR, { recursive: true });
+  // Write to dist/package.json so the upcoming `pnpm install` sees resolved specs, and
+  // to dist/build/package.json so electron-builder reads the same thing.
+  await writeFile(MAIN_PACKAGE_PATH, serialized);
+  await writeFile(DIST_PACKAGE_PATH, serialized);
+
+  await writeShadowWorkspaceYaml();
+
+  // pnpm deploy produced an isolated layout that electron-builder 24.x can't traverse.
+  // Wipe it so the follow-up `pnpm install --node-linker=hoisted` rebuilds with the
+  // proper hoist+nest layout that electron-builder understands.
+  if (existsSync(NODE_MODULES_DIR)) {
+    await rm(NODE_MODULES_DIR, { recursive: true, force: true });
+  }
 
   if (process.platform === "win32") {
     await prepareWin();

--- a/src/shared/tsconfig.json
+++ b/src/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig.json",
   "extends": "../../tsconfig.strict.json",
-  "include": ["**/*", "../../typings.custom/promise.d.ts"],
+  "include": ["src/**/*", "../../typings.custom/promise.d.ts"],
   "compilerOptions": {
     "composite": true,
     "noEmit": true,


### PR DESCRIPTION
# Fix: packaged installer crashes at startup with "Cannot find module" errors

## Problem

After the recent NX + `pnpm deploy` migration, the packaged installer launches but the main process (and then the renderer) crash at startup with a cascading sequence of `Cannot find module` errors:

```
Error: Cannot find module '@babel/runtime/helpers/typeof'
  required by app.asar/node_modules/i18next/dist/cjs/i18next.js

Error: Cannot find module 'source-map'
  required by app.asar/node_modules/source-map-support/source-map-support.js

SyntaxError: The requested module 'is-stream' does not provide an export named 'isReadableStream'

Error: Cannot find module 'redux-freeze'
  required by app.asar/renderer.js
```

## Root cause

`pnpm deploy` (with `forceLegacyDeploy: true`) produces an **isolated** `node_modules` layout where direct deps are top-level symlinks and transitives only live under `.pnpm/<shard>/node_modules/`. electron-builder 24.x doesn't traverse the `.pnpm` virtual store, so 98+ transitive packages reachable from main's runtime imports never make it into `app.asar`.

A separate but related issue: the renderer is webpack-bundled with `nodeExternals({ allowlist: [/@vortex\/shared/] })`, which marks **every** dep as an external runtime `require()`. Those externals need to live in `@vortex/main`'s production dependencies (since `renderer.js` lives inside `app.asar`, governed by main's `package.json`).

## Approaches considered

| # | Approach | Verdict |
|---|---|---|
| 1 | Declare missing transitives explicitly in main's `dependencies` | Tried with `@babel/runtime` — audit revealed **98 missing transitives** (`source-map`, `js-yaml`, `keyv`, `tldts`, `chokidar`, `graceful-fs`, …). Whack-a-mole with new failures every dep update. Rejected. |
| 2 | Post-deploy in-house hoister (walk `.pnpm/`, create top-level junctions) | Got us further but hit a hard wall on **version conflicts**: three versions of `is-stream` in the tree, only one can sit at the top, picked the wrong one. Flat hoisting can't faithfully represent multi-version graphs. Rejected. |
| 3 | **Post-deploy `pnpm install --node-linker=hoisted`** — let pnpm do the hoist+nest itself | Adopted. pnpm correctly puts compatible versions at the top and nests conflicts under their consumer (e.g. top-level `is-stream@4` for `got`, `execa/node_modules/is-stream@1` for `execa`). |

## Solution

After `pnpm deploy` produces the (isolated) dist, a follow-up `pnpm install --prod --node-linker=hoisted` re-lays out `dist/node_modules` in npm-style hoisted-with-nesting. electron-builder's `includeSubNodeModules` is flipped to `true` so the nested copies (for conflict versions) also make it into the asar.

For the install to succeed in `dist/` (which is outside the workspace), `prepare-dist-package.mjs`:
- Resolves `catalog:` deps via the **raw catalog spec** from the root `pnpm-workspace.yaml` (so git-URL catalog entries like `bbcode-to-react: git+https://...` are preserved verbatim — `pnpm deploy`'s resolution turns them into internal version numbers that don't exist on npm).
- Resolves `workspace:*` deps to `file:<absolute-path>` pointing at the workspace **source** (parsed from the workspace's `packages:` glob), not at the about-to-be-wiped pnpm-deploy copy under `.pnpm/`.
- Writes a shadow `dist/pnpm-workspace.yaml` carrying just `overrides` and `allowBuilds` from root (so transitive version overrides and native-module build-script approvals survive). The shadow exists so pnpm stops walking up at `dist/` and doesn't pick up the root's `catalogMode: strict` / `forceLegacyDeploy` settings.
- Wipes `dist/node_modules` so the follow-up install rebuilds it cleanly.

## Files changed

### [`src/main/prepare-dist-package.mjs`](src/main/prepare-dist-package.mjs)
Rewritten to:
- Read the **source** `src/main/package.json` (preserves `catalog:`/`workspace:*` protocols intact).
- Parse the root `pnpm-workspace.yaml` for the `catalog:` block and `packages:` glob.
- Resolve `catalog:` → raw catalog spec, `workspace:*` → `file:<absolute-path>`.
- Write the resolved `package.json` to both `dist/package.json` and `dist/build/package.json`.
- Write a shadow `dist/pnpm-workspace.yaml` with `overrides` + `allowBuilds`.
- Wipe `dist/node_modules`.

### [`src/main/package.json`](src/main/package.json)
- `publish` script appends `&& pnpm install --dir=./dist --prod --node-linker=hoisted` after the existing `rimraf` + `pnpm deploy` + `prepare-dist-package.mjs` chain.
- Moved `@welldone-software/why-did-you-render` and `redux-freeze` from `devDependencies` → `dependencies` (renderer externals require them at runtime).
- Added `csstype` to `dependencies` (renderer external, previously not declared anywhere in main).

### [`src/main/electron-builder.config.json`](src/main/electron-builder.config.json)
- `includeSubNodeModules: false` → `true`. Required so nested `node_modules/<pkg>/node_modules/<dep>` directories (which pnpm/npm produce on version conflicts) are bundled into the asar.

### [`src/shared/tsconfig.json`](src/shared/tsconfig.json)
- `"include": ["**/*"]` → `"include": ["src/**/*"]`. Drive-by fix for a pre-existing nx parallelism race that surfaced when this PR invalidated the build cache: `tsdown` rewrites content-hashed `dist/*` files while `tsc` is reading them, producing intermittent `TS6053: File not found` errors. Matches the pattern used by `src/main`, `src/preload`, and `packages/adaptor-api`.

## Verification

Locally, after the changes:

- `pnpm install --prod --node-linker=hoisted` in `dist/` completes in ~47s with all native modules (winapi-bindings, xxhash-addon, leveldown, protobufjs, drivelist) successfully building via `allowBuilds`.
- `is-stream@4` sits at top level (satisfies `isReadableStream` consumers via `got`), `is-stream@1` nested under `execa` (satisfies execa's `^1.1.0`).
- All previously-missing transitives — `@babel/runtime`, `source-map`, `chokidar`, `keyv`, `js-yaml`, `graceful-fs`, `colors`, `tldts`, etc. — resolve at top level.
- Workspace deps `@nexusmods/adaptor-api` and `exe-version` install from their workspace source via `file:`.
- `pnpm nx run-many -t build lint typecheck` clean.