### PR TITLE
guard tracked-mods fetch when nexus client lacks OAuth config

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/util/tracking.tsx
+++ b/src/renderer/src/extensions/nexus_integration/util/tracking.tsx
@@ -52,7 +52,7 @@ class Tracking {
       description: laterT("Tracked on Nexus"),
       icon: "track",
       customRenderer: (mod: IMod, detail: boolean, t: TFunction) =>
-        mod.attributes?.source === "nexus" ? <TrackedIcon t={t} mod={mod} /> : null,
+        mod.attributes?.source === "nexus" ? <TrackedIcon mod={mod} t={t} /> : null,
       calc: (mod: IMod) => {
         if (mod.attributes?.source === "nexus") {
           const gameMode = activeGameId(this.mApi.getState());
@@ -124,12 +124,12 @@ class Tracking {
 
       return (
         <IconButton
-          icon="track"
           className="btn-embed"
-          stroke={!this.mTrackedMods[nexusId]?.has?.(mod.attributes?.modId?.toString())}
-          hollow={!this.mTrackedMods[nexusId]?.has?.(mod.attributes?.modId?.toString())}
-          tooltip={t("Mod Tracked")}
           data-modid={mod.attributes?.modId}
+          hollow={!this.mTrackedMods[nexusId]?.has?.(mod.attributes?.modId?.toString())}
+          icon="track"
+          stroke={!this.mTrackedMods[nexusId]?.has?.(mod.attributes?.modId?.toString())}
+          tooltip={t("Mod Tracked")}
           onClick={this.toggleTracked}
         />
       );
@@ -137,7 +137,7 @@ class Tracking {
   }
 
   private fetch() {
-    if (this.mNexus.getValidationResult() === null) {
+    if (this.mNexus.getValidationResult() == null) {
       return;
     }
 


### PR DESCRIPTION
Only actual change is at the bottom.

fixes APP-457