### PR TITLE
mitigate webview teardown crash and add sync renderer diagnostics

### DIFF
--- a/src/main/src/MainWindow.ts
+++ b/src/main/src/MainWindow.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from "node:fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
@@ -156,6 +157,20 @@ class MainWindow {
     this.mWindow.webContents.on(
       "render-process-gone",
       (_evt, details: Electron.RenderProcessGoneDetails) => {
+        // Winston is buffered; if main crashes in the same message-loop tick
+        // (e.g. the WebContents teardown re-entrancy that can follow
+        // render-process-gone), the buffered line is lost. Sync write first.
+        try {
+          const line =
+            new Date().toISOString() +
+            " [ERRO] [MAIN] [diag] render-process-gone " +
+            JSON.stringify({ exitCode: details.exitCode, reason: details.reason }) +
+            "\n";
+          appendFileSync(path.join(app.getPath("userData"), "vortex.log"), line);
+        } catch {
+          // diagnostics must never throw
+        }
+
         log("error", "render process gone", {
           exitCode: details.exitCode,
           reason: details.reason,
@@ -407,6 +422,17 @@ class MainWindow {
       }
       this.mWindow.webContents.send("window:event:close");
       closeAllViews(this.mWindow);
+      // hide() before destroy(): destroy's aura teardown synthesizes a Win32
+      // mouse move that SendMessage's WM_NCHITTEST back into
+      // WebContentsView::NonClientHitTest, which dereferences a null
+      // InspectableWebContents mid-teardown and faults inside
+      // electron::InspectableWebContents::GetView. ShowWindow(SW_HIDE) takes
+      // us out of screen hit-test so the message routes elsewhere.
+      try {
+        this.mWindow.hide();
+      } catch {
+        // webContents may already be gone
+      }
       this.mWindow.destroy();
     });
     this.mWindow.on("closed", () => {

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -179,12 +179,12 @@ export function init() {
   // Sync write: the caller is typically about to die, so the line must be on
   // disk before we return. Raw ipcMain because betterIpcMain has no sync
   // handler.
-  ipcMain.on("diag:fatal", (event, message: unknown) => {
+  ipcMain.on("diag:fatal", (event, message: string) => {
     try {
       const line =
         new Date().toISOString() +
         " [ERRO] [RENDERER] [diag] " +
-        String(message).replace(/\r?\n/g, "\\n") +
+        message.replace(/\r?\n/g, "\\n") +
         "\n";
       appendFileSync(path.join(app.getPath("userData"), "vortex.log"), line);
     } catch {

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -3,6 +3,7 @@
  * These handlers respond to requests from the renderer process via preload.
  */
 
+import { appendFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -23,6 +24,7 @@ import {
   clipboard,
   contentTracing,
   dialog,
+  ipcMain,
   Menu,
   powerSaveBlocker,
   WebContentsView,
@@ -172,6 +174,23 @@ export function init() {
 
   betterIpcMain.handle("app:exit", (_event: IpcMainInvokeEvent, exitCode: number) => {
     app.exit(exitCode);
+  });
+
+  // Sync write: the caller is typically about to die, so the line must be on
+  // disk before we return. Raw ipcMain because betterIpcMain has no sync
+  // handler.
+  ipcMain.on("diag:fatal", (event, message: unknown) => {
+    try {
+      const line =
+        new Date().toISOString() +
+        " [ERRO] [RENDERER] [diag] " +
+        String(message).replace(/\r?\n/g, "\\n") +
+        "\n";
+      appendFileSync(path.join(app.getPath("userData"), "vortex.log"), line);
+    } catch {
+      // diagnostics must never throw
+    }
+    event.returnValue = null;
   });
 
   // Shell

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -237,6 +237,17 @@ try {
         return () => ipcRenderer.removeListener("download:resolve", listener);
       },
     },
+
+    diag: {
+      // Raw ipcRenderer because betterIpcRenderer has no sendSync helper.
+      fatal: (message: string) => {
+        try {
+          ipcRenderer.sendSync("diag:fatal", message);
+        } catch {
+          // diagnostic must never throw
+        }
+      },
+    },
   });
 } catch (err) {
   console.error("failed to run preload code", err);

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -23,7 +23,9 @@ const earlyErrHandler = (evt: ErrorEvent | PromiseRejectionEvent) => {
     value = evt.error;
     fallbackMessage = evt.message;
   }
-  const stack = (value as Error | undefined)?.stack ?? String(value ?? fallbackMessage ?? evt.type);
+  const errLike = value as Error | undefined;
+  const valueString = typeof value === "string" ? value : errLike?.message;
+  const stack = errLike?.stack ?? valueString ?? fallbackMessage ?? evt.type;
 
   // diag.fatal is sync; the line is on disk before we exit, so it survives
   // any main-process teardown crash that would lose winston-buffered logs.

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -14,12 +14,38 @@ if (process.env.DEBUG_REACT_RENDERS === "true") {
 const requireRemap = require("./util/requireRemap").default;
 requireRemap();
 
-const earlyErrHandler = (evt: ErrorEvent) => {
-  const error = evt.error as Error | undefined;
-  // Use preload API for dialog and app access
-  void window.api.dialog.showErrorBox("Unhandled error", error?.stack ?? String(evt.error));
+const earlyErrHandler = (evt: ErrorEvent | PromiseRejectionEvent) => {
+  let value: unknown;
+  let fallbackMessage = "";
+  if (evt instanceof PromiseRejectionEvent) {
+    value = evt.reason;
+  } else {
+    value = evt.error;
+    fallbackMessage = evt.message;
+  }
+  const stack = (value as Error | undefined)?.stack ?? String(value ?? fallbackMessage ?? evt.type);
+
+  // diag.fatal is sync; the line is on disk before we exit, so it survives
+  // any main-process teardown crash that would lose winston-buffered logs.
+  try {
+    window.api.diag.fatal(`early-renderer-error type=${evt.type}: ${stack}`);
+  } catch {
+    // diagnostics must never throw
+  }
+
+  void window.api.dialog.showErrorBox("Unhandled error", stack);
   void window.api.app.exit(1);
 };
+
+// 'error' / 'unhandledrejection' don't cover clean process.exit or
+// chromium-side kills; this hook catches those.
+process.on("exit", (code: number) => {
+  try {
+    window.api.diag.fatal(`renderer-process-exit code=${code}`);
+  } catch {
+    // diagnostics must never throw
+  }
+});
 
 // turn all error logs into a single parameter. The reason is that (at least in production)
 // these only get reported by the main process and due to a "bug" only one parameter gets

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -97,6 +97,9 @@ export interface Api {
 
   /** Downloader APIs */
   downloader: DownloaderApi;
+
+  /** Diagnostic APIs */
+  diag: Diag;
 }
 
 export interface Example {
@@ -110,6 +113,13 @@ export interface Shell {
 
   /** Opens the file using the default application for the file extension */
   openFile(filePath: string): void;
+}
+
+export interface Diag {
+  /** Synchronously append one line to vortex.log. Blocks until main has
+   *  flushed the line, so it survives the caller dying or main crashing in
+   *  the same message-loop tick. Sync IPC; reserve for fatal diagnostics. */
+  fatal(message: string): void;
 }
 
 export interface Dialog {


### PR DESCRIPTION
Main-process access violation in electron's InspectableWebContents:: GetView when BrowserWindow.destroy() runs with the mouse over the window: aura teardown synthesizes a Win32 mouse move, the synchronous WM_NCHITTEST reaches WebContentsView::NonClientHitTest, and that dereferences a half-destroyed InspectableWebContents.

Mitigation: hide the window before destroy() so the synthesized hit-test lands elsewhere.

Adds a synchronous diag IPC (window.api.diag.fatal) wired into the renderer's earlyErrHandler, a new process.on("exit") hook, and main's render-process-gone handler. Writes survive teardown crashes that would otherwise lose winston-buffered logs.

part of APP-459
part of #23176