### PR TITLE
fix collections bsdiff crash in renderer by using a DOM Worker

### DIFF
--- a/extensions/collections/build.mjs
+++ b/extensions/collections/build.mjs
@@ -10,8 +10,16 @@ const output = path.resolve(extensionPath, "dist", "index.cjs");
 const config = createConfig(entryPoint, output);
 await bundle(config);
 
-// bsdiff worker — runs in a separate thread, needs its own bundle
-const workerEntry = path.resolve(extensionPath, "src", "util", "bsdiffWorker.ts");
-const workerOutput = path.resolve(extensionPath, "dist", "bsdiffWorker.cjs");
-const workerConfig = createConfig(workerEntry, workerOutput);
-await bundle(workerConfig);
+// bsdiff workers — run in a separate thread, need their own bundles.
+// The .dom variant is what production uses (DOM Worker in the renderer);
+// the worker_threads variant is kept for vitest, which runs in Node.
+const workers = [
+  { entry: "bsdiffWorker.ts", output: "bsdiffWorker.cjs" },
+  { entry: "bsdiffWorker.dom.ts", output: "bsdiffWorker.dom.cjs" },
+];
+for (const w of workers) {
+  const workerEntry = path.resolve(extensionPath, "src", "util", w.entry);
+  const workerOutput = path.resolve(extensionPath, "dist", w.output);
+  const workerConfig = createConfig(workerEntry, workerOutput);
+  await bundle(workerConfig);
+}

--- a/extensions/collections/src/util/bsdiff.regression.test.ts
+++ b/extensions/collections/src/util/bsdiff.regression.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test for APP-461: `new Worker(...)` from `node:worker_threads`
+ * crashes in the Electron renderer ("The V8 platform used by this instance
+ * of Node does not support creating Workers"). The dispatcher in bsdiff.ts
+ * must pick the DOM Worker variant whenever a DOM `Worker` global exists.
+ *
+ * This test simulates a renderer environment in vitest (which normally runs
+ * with `environment: "node"`) by defining `globalThis.Worker` and a stub for
+ * `fs.existsSync` that pretends the bundled `hdiff.wasm` is on disk. Then we
+ * import `bsdiff` fresh, kick off a patch op, and assert the dispatcher
+ * constructed the DOM Worker (and only the DOM Worker).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// getWasmPath() in bsdiff.ts probes `fs.existsSync` to find a bundled hdiff.wasm.
+// We can't spy on fs (ESM namespace is non-configurable) so we vi.mock the
+// module wholesale, keeping every other export intact.
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    default: actual,
+    existsSync: (p: import("fs").PathLike) =>
+      String(p).endsWith("hdiff.wasm") ? true : actual.existsSync(p),
+  };
+});
+
+describe("bsdiff renderer dispatch (regression for APP-461)", () => {
+  let originalWorker: typeof globalThis.Worker | undefined;
+  let workerSpy: ReturnType<typeof vi.fn>;
+  let workerThreadsTouched: boolean;
+
+  beforeEach(() => {
+    originalWorker = (globalThis as { Worker?: typeof Worker }).Worker;
+
+    workerThreadsTouched = false;
+    workerSpy = vi.fn();
+    const recordUrl = workerSpy;
+
+    class MockWorker {
+      private listeners = new Map<string, ((evt: { data: unknown }) => void)[]>();
+      constructor(public url: string) {
+        recordUrl(url);
+      }
+      postMessage(msg: { id: number }): void {
+        // Echo a fake successful response so the public API resolves.
+        queueMicrotask(() => {
+          for (const l of this.listeners.get("message") ?? []) {
+            l({ data: { id: msg.id, result: new Uint8Array([0xbe, 0xef]) } });
+          }
+        });
+      }
+      addEventListener(type: string, listener: (evt: { data: unknown }) => void): void {
+        const list = this.listeners.get(type) ?? [];
+        list.push(listener);
+        this.listeners.set(type, list);
+      }
+    }
+    (globalThis as { Worker?: unknown }).Worker = MockWorker as unknown as typeof Worker;
+
+    // Tripwire: if anything in the bsdiff dispatcher ever falls back to
+    // node:worker_threads in this environment, this flag flips and the test
+    // fails. This is the actual regression we're guarding against.
+    vi.doMock("worker_threads", () => {
+      workerThreadsTouched = true;
+      return {
+        Worker: class {
+          constructor() {
+            workerThreadsTouched = true;
+            throw new Error("regression: bsdiff used worker_threads when DOM Worker was available");
+          }
+        },
+      };
+    });
+
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (globalThis as { Worker?: unknown }).Worker = originalWorker;
+    vi.restoreAllMocks();
+    vi.doUnmock("worker_threads");
+  });
+
+  it("constructs a DOM Worker (not node:worker_threads) when globalThis.Worker is defined", async () => {
+    const bsdiff = await import("./bsdiff");
+
+    const result = await bsdiff.createPatch(new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6]));
+
+    expect(workerSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = workerSpy.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toMatch(/^file:/);
+    expect(calledUrl).toMatch(/bsdiffWorker\.dom/);
+    expect(calledUrl).toContain("wasmPath=");
+    expect(workerThreadsTouched).toBe(false);
+    expect(result).toEqual(new Uint8Array([0xbe, 0xef]));
+  });
+
+  it("reuses the same DOM Worker across calls", async () => {
+    const bsdiff = await import("./bsdiff");
+
+    await bsdiff.createPatch(new Uint8Array([1]), new Uint8Array([2]));
+    await bsdiff.applyPatch(new Uint8Array([1]), new Uint8Array([2]));
+
+    expect(workerSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/collections/src/util/bsdiff.ts
+++ b/extensions/collections/src/util/bsdiff.ts
@@ -1,60 +1,94 @@
 /**
  * BSDIFF40-compatible binary diff and patch using WASM.
  *
- * The WASM computation runs in a worker thread to avoid blocking the
- * Electron main/renderer thread. A single long-lived worker is spawned
- * on first use and reused for all subsequent calls.
+ * Production (Electron renderer) runs the WASM in a DOM Worker —
+ * Electron's renderer does not support `node:worker_threads`, so the
+ * Web Worker is the only viable off-thread option. Tests (vitest in
+ * node environment) fall back to `worker_threads`. The WASM logic
+ * itself is shared via bsdiffWasm.ts.
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { Worker } from "worker_threads";
+import { pathToFileURL } from "url";
 
-import type { BsdiffRequest, BsdiffResponse } from "./bsdiffWorker";
+import type { BsdiffRequest, BsdiffResponse } from "./bsdiffWasm";
+
+const IS_RENDERER = typeof Worker !== "undefined";
 
 // --- Path resolution ---
 
 function getWasmPath(): string {
-  const bundledPath = path.join(__dirname, "hdiff.wasm");
-  if (fs.existsSync(bundledPath)) {
-    return bundledPath;
-  }
+  const bundled = path.join(__dirname, "hdiff.wasm");
+  if (fs.existsSync(bundled)) return bundled;
   const nodeEntry = require.resolve("@hot-updater/bsdiff");
-  const pkgDir = path.resolve(nodeEntry, "..", "..");
-  return path.join(pkgDir, "assets", "hdiff.wasm");
+  return path.join(path.resolve(nodeEntry, "..", ".."), "assets", "hdiff.wasm");
 }
 
-function getWorkerPath(): string {
-  const bundledPath = path.join(__dirname, "bsdiffWorker.cjs");
-  if (fs.existsSync(bundledPath)) {
-    return bundledPath;
-  }
-  return path.join(__dirname, "bsdiffWorker.ts");
+function resolveWorkerScript(stem: string): { path: string; isTsSource: boolean } {
+  const bundled = path.join(__dirname, `${stem}.cjs`);
+  if (fs.existsSync(bundled)) return { path: bundled, isTsSource: false };
+  return { path: path.join(__dirname, `${stem}.ts`), isTsSource: true };
+}
+
+// --- Worker handle abstraction ---
+
+interface WorkerHandle {
+  post(msg: BsdiffRequest, transfer: ArrayBuffer[]): void;
+  onMessage(cb: (msg: BsdiffResponse) => void): void;
+  onError(cb: (err: Error) => void): void;
+}
+
+function spawnDomWorker(): WorkerHandle {
+  const { path: scriptPath } = resolveWorkerScript("bsdiffWorker.dom");
+  const url = `${pathToFileURL(scriptPath).href}?wasmPath=${encodeURIComponent(getWasmPath())}`;
+  const w = new Worker(url);
+  return {
+    post: (msg, transfer) => w.postMessage(msg, transfer),
+    onMessage: (cb) => w.addEventListener("message", (e) => cb(e.data as BsdiffResponse)),
+    onError: (cb) =>
+      w.addEventListener("error", (e: ErrorEvent) =>
+        cb(e.error instanceof Error ? e.error : new Error(e.message)),
+      ),
+  };
+}
+
+function spawnNodeWorker(): WorkerHandle {
+  const { path: scriptPath, isTsSource } = resolveWorkerScript("bsdiffWorker");
+  // Lazy require keeps this branch sync (`await import` would force the whole
+  // postToWorker chain to become async) and avoids touching worker_threads
+  // from the renderer's module-load path, where it isn't needed.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Worker: NodeWorker } = require("worker_threads") as typeof import("worker_threads");
+  const w = new NodeWorker(scriptPath, {
+    workerData: { wasmPath: getWasmPath() },
+    // When running the .ts source directly (tests), use Node's built-in
+    // TypeScript stripping (available in Node >= 22.6).
+    ...(isTsSource ? { execArgv: ["--experimental-strip-types"] } : {}),
+  });
+  w.unref();
+  return {
+    post: (msg, transfer) => w.postMessage(msg, transfer),
+    onMessage: (cb) => w.on("message", cb),
+    onError: (cb) => w.on("error", cb),
+  };
 }
 
 // --- Worker management ---
 
-let worker: Worker | undefined;
+let worker: WorkerHandle | undefined;
 let nextId = 0;
 const pending = new Map<
   number,
   { resolve: (buf: Uint8Array) => void; reject: (err: Error) => void }
 >();
 
-function getWorker(): Worker {
+function getWorker(): WorkerHandle {
   if (worker !== undefined) return worker;
 
-  const workerPath = getWorkerPath();
-  const isTsSource = workerPath.endsWith(".ts");
+  worker = IS_RENDERER ? spawnDomWorker() : spawnNodeWorker();
 
-  worker = new Worker(workerPath, {
-    workerData: { wasmPath: getWasmPath() },
-    // When running the .ts source directly (tests), use Node's built-in
-    // TypeScript stripping (available in Node >= 22.6).
-    ...(isTsSource ? { execArgv: ["--experimental-strip-types"] } : {}),
-  });
-
-  worker.on("message", (msg: BsdiffResponse) => {
+  worker.onMessage((msg) => {
     const entry = pending.get(msg.id);
     if (entry === undefined) return;
     pending.delete(msg.id);
@@ -65,17 +99,11 @@ function getWorker(): Worker {
     }
   });
 
-  worker.on("error", (err) => {
-    // Reject all pending requests
-    for (const entry of pending.values()) {
-      entry.reject(err);
-    }
+  worker.onError((err) => {
+    for (const entry of pending.values()) entry.reject(err);
     pending.clear();
     worker = undefined;
   });
-
-  // Don't keep the process alive just for the worker
-  worker.unref();
 
   return worker;
 }
@@ -88,7 +116,7 @@ function postToWorker(
   return new Promise((resolve, reject) => {
     const id = nextId++;
     pending.set(id, { resolve, reject });
-    getWorker().postMessage({ id, op, left, right } satisfies BsdiffRequest, [
+    getWorker().post({ id, op, left, right }, [
       left.buffer as ArrayBuffer,
       right.buffer as ArrayBuffer,
     ]);
@@ -97,25 +125,17 @@ function postToWorker(
 
 // --- Public API ---
 
-/**
- * Create a BSDIFF40 patch from two buffers.
- * Runs in a worker thread — does not block the caller.
- */
+/** Create a BSDIFF40 patch from two buffers. Runs off-thread. */
 export async function createPatch(oldBuf: Uint8Array, newBuf: Uint8Array): Promise<Uint8Array> {
   return postToWorker("create_patch", new Uint8Array(oldBuf), new Uint8Array(newBuf));
 }
 
-/**
- * Apply a BSDIFF40 patch to a buffer.
- * Runs in a worker thread — does not block the caller.
- */
+/** Apply a BSDIFF40 patch to a buffer. Runs off-thread. */
 export async function applyPatch(oldBuf: Uint8Array, patchBuf: Uint8Array): Promise<Uint8Array> {
   return postToWorker("apply_patch", new Uint8Array(oldBuf), new Uint8Array(patchBuf));
 }
 
-/**
- * Create a BSDIFF40 patch file from two files.
- */
+/** Create a BSDIFF40 patch file from two files. */
 export async function diffFiles(
   oldPath: string,
   newPath: string,
@@ -123,13 +143,10 @@ export async function diffFiles(
 ): Promise<void> {
   const oldBuf = await fs.promises.readFile(oldPath);
   const newBuf = await fs.promises.readFile(newPath);
-  const patch = await createPatch(oldBuf, newBuf);
-  await fs.promises.writeFile(patchPath, patch);
+  await fs.promises.writeFile(patchPath, await createPatch(oldBuf, newBuf));
 }
 
-/**
- * Apply a BSDIFF40 patch file.
- */
+/** Apply a BSDIFF40 patch file. */
 export async function patchFiles(
   oldPath: string,
   outputPath: string,
@@ -137,6 +154,5 @@ export async function patchFiles(
 ): Promise<void> {
   const oldBuf = await fs.promises.readFile(oldPath);
   const patchBuf = await fs.promises.readFile(patchPath);
-  const result = await applyPatch(oldBuf, patchBuf);
-  await fs.promises.writeFile(outputPath, result);
+  await fs.promises.writeFile(outputPath, await applyPatch(oldBuf, patchBuf));
 }

--- a/extensions/collections/src/util/bsdiff.ts
+++ b/extensions/collections/src/util/bsdiff.ts
@@ -1,60 +1,91 @@
 /**
  * BSDIFF40-compatible binary diff and patch using WASM.
  *
- * The WASM computation runs in a worker thread to avoid blocking the
- * Electron main/renderer thread. A single long-lived worker is spawned
- * on first use and reused for all subsequent calls.
+ * Production (Electron renderer) runs the WASM in a DOM Worker —
+ * Electron's renderer does not support `node:worker_threads`, so the
+ * Web Worker is the only viable off-thread option. Tests (vitest in
+ * node environment) fall back to `worker_threads`. The WASM logic
+ * itself is shared via bsdiffWasm.ts.
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { Worker } from "worker_threads";
+import { pathToFileURL } from "url";
 
-import type { BsdiffRequest, BsdiffResponse } from "./bsdiffWorker";
+import type { BsdiffRequest, BsdiffResponse } from "./bsdiffWasm";
+
+const IS_RENDERER = typeof Worker !== "undefined";
 
 // --- Path resolution ---
 
 function getWasmPath(): string {
-  const bundledPath = path.join(__dirname, "hdiff.wasm");
-  if (fs.existsSync(bundledPath)) {
-    return bundledPath;
-  }
+  const bundled = path.join(__dirname, "hdiff.wasm");
+  if (fs.existsSync(bundled)) return bundled;
   const nodeEntry = require.resolve("@hot-updater/bsdiff");
-  const pkgDir = path.resolve(nodeEntry, "..", "..");
-  return path.join(pkgDir, "assets", "hdiff.wasm");
+  return path.join(path.resolve(nodeEntry, "..", ".."), "assets", "hdiff.wasm");
 }
 
-function getWorkerPath(): string {
-  const bundledPath = path.join(__dirname, "bsdiffWorker.cjs");
-  if (fs.existsSync(bundledPath)) {
-    return bundledPath;
-  }
-  return path.join(__dirname, "bsdiffWorker.ts");
+function resolveWorkerScript(stem: string): { path: string; isTsSource: boolean } {
+  const bundled = path.join(__dirname, `${stem}.cjs`);
+  if (fs.existsSync(bundled)) return { path: bundled, isTsSource: false };
+  return { path: path.join(__dirname, `${stem}.ts`), isTsSource: true };
+}
+
+// --- Worker handle abstraction ---
+
+interface WorkerHandle {
+  post(msg: BsdiffRequest, transfer: ArrayBuffer[]): void;
+  onMessage(cb: (msg: BsdiffResponse) => void): void;
+  onError(cb: (err: Error) => void): void;
+}
+
+function spawnDomWorker(): WorkerHandle {
+  const { path: scriptPath } = resolveWorkerScript("bsdiffWorker.dom");
+  const url = `${pathToFileURL(scriptPath).href}?wasmPath=${encodeURIComponent(getWasmPath())}`;
+  const w = new Worker(url);
+  return {
+    post: (msg, transfer) => w.postMessage(msg, transfer),
+    onMessage: (cb) => w.addEventListener("message", (e) => cb(e.data as BsdiffResponse)),
+    onError: (cb) =>
+      w.addEventListener("error", (e: ErrorEvent) =>
+        cb(e.error instanceof Error ? e.error : new Error(e.message)),
+      ),
+  };
+}
+
+function spawnNodeWorker(): WorkerHandle {
+  const { path: scriptPath, isTsSource } = resolveWorkerScript("bsdiffWorker");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Worker: NodeWorker } = require("worker_threads") as typeof import("worker_threads");
+  const w = new NodeWorker(scriptPath, {
+    workerData: { wasmPath: getWasmPath() },
+    // When running the .ts source directly (tests), use Node's built-in
+    // TypeScript stripping (available in Node >= 22.6).
+    ...(isTsSource ? { execArgv: ["--experimental-strip-types"] } : {}),
+  });
+  w.unref();
+  return {
+    post: (msg, transfer) => w.postMessage(msg, transfer),
+    onMessage: (cb) => w.on("message", cb),
+    onError: (cb) => w.on("error", cb),
+  };
 }
 
 // --- Worker management ---
 
-let worker: Worker | undefined;
+let worker: WorkerHandle | undefined;
 let nextId = 0;
 const pending = new Map<
   number,
   { resolve: (buf: Uint8Array) => void; reject: (err: Error) => void }
 >();
 
-function getWorker(): Worker {
+function getWorker(): WorkerHandle {
   if (worker !== undefined) return worker;
 
-  const workerPath = getWorkerPath();
-  const isTsSource = workerPath.endsWith(".ts");
+  worker = IS_RENDERER ? spawnDomWorker() : spawnNodeWorker();
 
-  worker = new Worker(workerPath, {
-    workerData: { wasmPath: getWasmPath() },
-    // When running the .ts source directly (tests), use Node's built-in
-    // TypeScript stripping (available in Node >= 22.6).
-    ...(isTsSource ? { execArgv: ["--experimental-strip-types"] } : {}),
-  });
-
-  worker.on("message", (msg: BsdiffResponse) => {
+  worker.onMessage((msg) => {
     const entry = pending.get(msg.id);
     if (entry === undefined) return;
     pending.delete(msg.id);
@@ -65,17 +96,11 @@ function getWorker(): Worker {
     }
   });
 
-  worker.on("error", (err) => {
-    // Reject all pending requests
-    for (const entry of pending.values()) {
-      entry.reject(err);
-    }
+  worker.onError((err) => {
+    for (const entry of pending.values()) entry.reject(err);
     pending.clear();
     worker = undefined;
   });
-
-  // Don't keep the process alive just for the worker
-  worker.unref();
 
   return worker;
 }
@@ -88,7 +113,7 @@ function postToWorker(
   return new Promise((resolve, reject) => {
     const id = nextId++;
     pending.set(id, { resolve, reject });
-    getWorker().postMessage({ id, op, left, right } satisfies BsdiffRequest, [
+    getWorker().post({ id, op, left, right }, [
       left.buffer as ArrayBuffer,
       right.buffer as ArrayBuffer,
     ]);
@@ -97,25 +122,17 @@ function postToWorker(
 
 // --- Public API ---
 
-/**
- * Create a BSDIFF40 patch from two buffers.
- * Runs in a worker thread — does not block the caller.
- */
+/** Create a BSDIFF40 patch from two buffers. Runs off-thread. */
 export async function createPatch(oldBuf: Uint8Array, newBuf: Uint8Array): Promise<Uint8Array> {
   return postToWorker("create_patch", new Uint8Array(oldBuf), new Uint8Array(newBuf));
 }
 
-/**
- * Apply a BSDIFF40 patch to a buffer.
- * Runs in a worker thread — does not block the caller.
- */
+/** Apply a BSDIFF40 patch to a buffer. Runs off-thread. */
 export async function applyPatch(oldBuf: Uint8Array, patchBuf: Uint8Array): Promise<Uint8Array> {
   return postToWorker("apply_patch", new Uint8Array(oldBuf), new Uint8Array(patchBuf));
 }
 
-/**
- * Create a BSDIFF40 patch file from two files.
- */
+/** Create a BSDIFF40 patch file from two files. */
 export async function diffFiles(
   oldPath: string,
   newPath: string,
@@ -123,13 +140,10 @@ export async function diffFiles(
 ): Promise<void> {
   const oldBuf = await fs.promises.readFile(oldPath);
   const newBuf = await fs.promises.readFile(newPath);
-  const patch = await createPatch(oldBuf, newBuf);
-  await fs.promises.writeFile(patchPath, patch);
+  await fs.promises.writeFile(patchPath, await createPatch(oldBuf, newBuf));
 }
 
-/**
- * Apply a BSDIFF40 patch file.
- */
+/** Apply a BSDIFF40 patch file. */
 export async function patchFiles(
   oldPath: string,
   outputPath: string,
@@ -137,6 +151,5 @@ export async function patchFiles(
 ): Promise<void> {
   const oldBuf = await fs.promises.readFile(oldPath);
   const patchBuf = await fs.promises.readFile(patchPath);
-  const result = await applyPatch(oldBuf, patchBuf);
-  await fs.promises.writeFile(outputPath, result);
+  await fs.promises.writeFile(outputPath, await applyPatch(oldBuf, patchBuf));
 }

--- a/extensions/collections/src/util/bsdiffWasm.ts
+++ b/extensions/collections/src/util/bsdiffWasm.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure bsdiff WASM helpers. No worker, no I/O — safe to use from any
+ * context (renderer, Node worker_threads worker, DOM Worker).
+ */
+
+export interface BsdiffWasmExports {
+  memory: WebAssembly.Memory;
+  alloc(size: number): number;
+  dealloc(ptr: number, size: number): void;
+  create_patch(basePtr: number, baseLen: number, nextPtr: number, nextLen: number): number;
+  apply_patch(basePtr: number, baseLen: number, patchPtr: number, patchLen: number): number;
+  output_ptr(): number;
+  output_len(): number;
+  free_output(): void;
+}
+
+export const BSDIFF_OK = 0;
+
+export function loadWasm(wasmBytes: Uint8Array): BsdiffWasmExports {
+  const wasmModule = new WebAssembly.Module(wasmBytes as unknown as BufferSource);
+  const instance = new WebAssembly.Instance(wasmModule);
+  return instance.exports as unknown as BsdiffWasmExports;
+}
+
+export function runBinaryOp(
+  wasm: BsdiffWasmExports,
+  left: Uint8Array,
+  right: Uint8Array,
+  op: (lPtr: number, lLen: number, rPtr: number, rLen: number) => number,
+): number {
+  const lPtr = wasm.alloc(left.byteLength);
+  const rPtr = wasm.alloc(right.byteLength);
+  try {
+    if (left.byteLength > 0) {
+      new Uint8Array(wasm.memory.buffer, lPtr, left.byteLength).set(left);
+    }
+    if (right.byteLength > 0) {
+      new Uint8Array(wasm.memory.buffer, rPtr, right.byteLength).set(right);
+    }
+    return op(lPtr, left.byteLength, rPtr, right.byteLength);
+  } finally {
+    if (left.byteLength > 0) wasm.dealloc(lPtr, left.byteLength);
+    if (right.byteLength > 0) wasm.dealloc(rPtr, right.byteLength);
+  }
+}
+
+export function readOutput(wasm: BsdiffWasmExports): Uint8Array {
+  const ptr = wasm.output_ptr();
+  const len = wasm.output_len();
+  if (len === 0) {
+    wasm.free_output();
+    return new Uint8Array();
+  }
+  const result = new Uint8Array(new Uint8Array(wasm.memory.buffer, ptr, len));
+  wasm.free_output();
+  return result;
+}
+
+export interface BsdiffRequest {
+  id: number;
+  op: "create_patch" | "apply_patch";
+  left: Uint8Array;
+  right: Uint8Array;
+}
+
+export interface BsdiffResponse {
+  id: number;
+  result?: Uint8Array;
+  error?: string;
+}
+
+export function processRequest(wasm: BsdiffWasmExports, msg: BsdiffRequest): BsdiffResponse {
+  try {
+    const op = msg.op === "create_patch" ? wasm.create_patch : wasm.apply_patch;
+    const status = runBinaryOp(wasm, msg.left, msg.right, op);
+    if (status !== BSDIFF_OK) {
+      return { id: msg.id, error: `bsdiff ${msg.op} failed with status ${status}` };
+    }
+    return { id: msg.id, result: readOutput(wasm) };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { id: msg.id, error: message };
+  }
+}

--- a/extensions/collections/src/util/bsdiffWorker.dom.ts
+++ b/extensions/collections/src/util/bsdiffWorker.dom.ts
@@ -1,0 +1,36 @@
+/**
+ * DOM Worker used inside the Electron renderer. Relies on
+ * `nodeIntegrationInWorker: true` for `fs` access (configured on
+ * MainWindow). Wasm path is passed via the worker URL's query string so
+ * we don't need a separate init handshake.
+ */
+
+import * as fs from "fs";
+
+import type { BsdiffRequest, BsdiffWasmExports } from "./bsdiffWasm";
+import { loadWasm, processRequest } from "./bsdiffWasm";
+
+interface WorkerSelf {
+  location: { search: string };
+  addEventListener(type: "message", listener: (evt: MessageEvent<BsdiffRequest>) => void): void;
+  postMessage(message: unknown, transfer: ArrayBuffer[]): void;
+}
+declare const self: WorkerSelf;
+
+let wasmExports: BsdiffWasmExports | undefined;
+
+function getWasm(): BsdiffWasmExports {
+  if (wasmExports !== undefined) return wasmExports;
+  const wasmPath = new URLSearchParams(self.location.search).get("wasmPath");
+  if (wasmPath === null) {
+    throw new Error("bsdiff worker started without wasmPath query parameter");
+  }
+  wasmExports = loadWasm(fs.readFileSync(wasmPath));
+  return wasmExports;
+}
+
+self.addEventListener("message", (evt) => {
+  const response = processRequest(getWasm(), evt.data);
+  const transfer = response.result ? [response.result.buffer as ArrayBuffer] : [];
+  self.postMessage(response, transfer);
+});

--- a/extensions/collections/src/util/bsdiffWorker.ts
+++ b/extensions/collections/src/util/bsdiffWorker.ts
@@ -1,116 +1,28 @@
 /**
- * Worker thread that loads the bsdiff WASM module and processes
- * diff/patch requests. Runs the blocking WASM computation off
- * the main thread.
+ * Node `worker_threads` worker used for tests (which run under vitest's
+ * node environment). Production / Electron renderer uses the DOM worker
+ * variant in bsdiffWorker.dom.ts.
  */
 
 import * as fs from "fs";
 import { parentPort, workerData } from "worker_threads";
 
-// --- WASM interface ---
-
-interface BsdiffWasmExports {
-  memory: WebAssembly.Memory;
-  alloc(size: number): number;
-  dealloc(ptr: number, size: number): void;
-  create_patch(basePtr: number, baseLen: number, nextPtr: number, nextLen: number): number;
-  apply_patch(basePtr: number, baseLen: number, patchPtr: number, patchLen: number): number;
-  output_ptr(): number;
-  output_len(): number;
-  free_output(): void;
-}
-
-const BSDIFF_OK = 0;
+// .ts extension is required so Node's --experimental-strip-types can resolve
+// this import when vitest runs the worker source directly.
+import type { BsdiffRequest, BsdiffWasmExports } from "./bsdiffWasm.ts";
+import { loadWasm, processRequest } from "./bsdiffWasm.ts";
 
 let wasmExports: BsdiffWasmExports | undefined;
 
-function loadWasm(): BsdiffWasmExports {
+function getWasm(): BsdiffWasmExports {
   if (wasmExports !== undefined) return wasmExports;
   const wasmPath: string = (workerData as { wasmPath: string }).wasmPath;
-  const wasmBuf = fs.readFileSync(wasmPath);
-  const wasmModule = new WebAssembly.Module(wasmBuf);
-  const instance = new WebAssembly.Instance(wasmModule);
-  wasmExports = instance.exports as unknown as BsdiffWasmExports;
+  wasmExports = loadWasm(fs.readFileSync(wasmPath));
   return wasmExports;
 }
 
-function runBinaryOp(
-  wasm: BsdiffWasmExports,
-  left: Uint8Array,
-  right: Uint8Array,
-  op: (lPtr: number, lLen: number, rPtr: number, rLen: number) => number,
-): number {
-  const lPtr = wasm.alloc(left.byteLength);
-  const rPtr = wasm.alloc(right.byteLength);
-  try {
-    if (left.byteLength > 0) {
-      new Uint8Array(wasm.memory.buffer, lPtr, left.byteLength).set(left);
-    }
-    if (right.byteLength > 0) {
-      new Uint8Array(wasm.memory.buffer, rPtr, right.byteLength).set(right);
-    }
-    return op(lPtr, left.byteLength, rPtr, right.byteLength);
-  } finally {
-    if (left.byteLength > 0) wasm.dealloc(lPtr, left.byteLength);
-    if (right.byteLength > 0) wasm.dealloc(rPtr, right.byteLength);
-  }
-}
-
-function readOutput(wasm: BsdiffWasmExports): Uint8Array {
-  const ptr = wasm.output_ptr();
-  const len = wasm.output_len();
-  if (len === 0) {
-    wasm.free_output();
-    return new Uint8Array();
-  }
-  const result = new Uint8Array(new Uint8Array(wasm.memory.buffer, ptr, len));
-  wasm.free_output();
-  return result;
-}
-
-// --- Message handling ---
-
-export interface BsdiffRequest {
-  id: number;
-  op: "create_patch" | "apply_patch";
-  left: Uint8Array;
-  right: Uint8Array;
-}
-
-export interface BsdiffResponse {
-  id: number;
-  result?: Uint8Array;
-  error?: string;
-}
-
 parentPort!.on("message", (msg: BsdiffRequest) => {
-  try {
-    const wasm = loadWasm();
-    let status: number;
-    if (msg.op === "create_patch") {
-      status = runBinaryOp(wasm, msg.left, msg.right, (bp, bl, np, nl) =>
-        wasm.create_patch(bp, bl, np, nl),
-      );
-    } else {
-      status = runBinaryOp(wasm, msg.left, msg.right, (bp, bl, pp, pl) =>
-        wasm.apply_patch(bp, bl, pp, pl),
-      );
-    }
-    if (status !== BSDIFF_OK) {
-      parentPort!.postMessage({
-        id: msg.id,
-        error: `bsdiff ${msg.op} failed with status ${status}`,
-      } as BsdiffResponse);
-      return;
-    }
-    const output = readOutput(wasm);
-    parentPort!.postMessage({ id: msg.id, result: output } as BsdiffResponse, [
-      output.buffer as ArrayBuffer,
-    ]);
-  } catch (err: any) {
-    parentPort!.postMessage({
-      id: msg.id,
-      error: err?.message ?? String(err),
-    } as BsdiffResponse);
-  }
+  const response = processRequest(getWasm(), msg);
+  const transfer = response.result ? [response.result.buffer as ArrayBuffer] : [];
+  parentPort!.postMessage(response, transfer);
 });

--- a/extensions/collections/tsconfig.json
+++ b/extensions/collections/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig.json",
   "extends": "../tsconfig.extensions.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": ["src"]
 }


### PR DESCRIPTION
Electron renderers do not register V8 with worker support, so `new Worker(...)` from `node:worker_threads` throws "The V8 platform used by this instance of Node does not support creating Workers" the first time a collection with binary patches is installed.

Split the worker into two entry points sharing pure WASM helpers (bsdiffWasm.ts): bsdiffWorker.dom.ts for the renderer (DOM Worker, relies on nodeIntegrationInWorker for fs access; wasm path passed via URL query) and bsdiffWorker.ts kept for the vitest node environment. bsdiff.ts dispatches between them based on whether a DOM Worker global exists.

Adds a regression test that stubs globalThis.Worker and traps any use of node:worker_threads to guard against re-introducing the crash.

fixes APP-461