### PR TITLE
add ECD diagnostic logging

### DIFF
--- a/src/renderer/src/extensions/mod_management/util/externalChanges.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/externalChanges.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  IDeployedFile,
+  IDeploymentMethod,
+  IExtensionApi,
+  IFileChange,
+} from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+import { MERGED_PATH } from "../modMerging";
+
+// Mock fs. applyFileActions inside dealWithExternalChanges calls into it
+// whenever any auto-resolved changes are present. Real fs ops would fail in a
+// unit test, so make every call a no-op.
+vi.mock("../../../util/fs", () => ({
+  removeAsync: vi.fn(() => Promise.resolve()),
+  moveAsync: vi.fn(() => Promise.resolve()),
+  statAsync: vi.fn(() => Promise.resolve({ mtime: new Date(0) })),
+  lstatAsync: vi.fn(() => Promise.resolve({ mtime: new Date(0) })),
+}));
+
+vi.mock("../../../logging", () => {
+  const log = vi.fn();
+  return { default: log, log };
+});
+
+// Required mocks for the real InstallManager imported below. The integration
+// test at the bottom builds a real InstallManager so it can drive the
+// markRecentInstall / markRecentRemoval / consumeRecentChanges flow against
+// the live implementation (rather than re-stating the resulting Set inline).
+vi.mock("../util/dependencies");
+vi.mock("../../../util/api");
+
+// Capture every payload passed to showExternalChanges so each test can assert
+// what would have been surfaced to the user.
+const showExternalChangesCalls: Array<{ [typeId: string]: IFileChange[] }> = [];
+// externalChanges.ts only imports `showExternalChanges` from this module, so
+// stubbing that one export is sufficient. The returned thunk resolves with
+// [] (simulating the user clicking Confirm without overriding any default
+// action); downstream applyFileActions is still exercised but is a no-op
+// given mocked fs.
+vi.mock("../actions/session", () => ({
+  showExternalChanges: vi.fn((changes: { [typeId: string]: IFileChange[] }) => {
+    return () => {
+      showExternalChangesCalls.push(changes);
+      return Promise.resolve([]);
+    };
+  }),
+}));
+
+import InstallManager from "../InstallManager";
+import { dealWithExternalChanges } from "./externalChanges";
+
+function makeRefchange(source: string, filePath: string): IFileChange {
+  return {
+    filePath,
+    source,
+    sourceTime: new Date(0),
+    destTime: new Date(0),
+    changeType: "refchange",
+  };
+}
+
+function makeApi(opts: { externalChanges: IFileChange[]; activeSession?: unknown }): {
+  api: IExtensionApi;
+  activator: IDeploymentMethod;
+} {
+  const state = {
+    persistent: {
+      profiles: {
+        "test-profile": {
+          id: "test-profile",
+          gameId: "skyrimse",
+        },
+      },
+    },
+    session: {
+      collections: { activeSession: opts.activeSession ?? undefined },
+    },
+    settings: {
+      profiles: { activeProfileId: "test-profile" },
+    },
+  } as unknown as IState;
+
+  const api: IExtensionApi = {
+    store: {
+      getState: () => state,
+      dispatch: vi.fn((action: unknown) => {
+        // Honour thunks (functions). That's how showExternalChanges resolves.
+        if (typeof action === "function") {
+          return (action as (d: unknown) => unknown)(vi.fn());
+        }
+        return action;
+      }),
+    },
+    events: {
+      emit: vi.fn(),
+    },
+  } as unknown as IExtensionApi;
+
+  const activator: IDeploymentMethod = {
+    externalChanges: vi.fn(() => Promise.resolve(opts.externalChanges)),
+  } as unknown as IDeploymentMethod;
+
+  return { api, activator };
+}
+
+const FAKE_STAGING = "C:\\staging";
+const FAKE_MOD_PATHS = { "": "C:\\game\\Data" };
+// dealWithExternalChanges iterates over lastDeployment keys (modTypes) to
+// dispatch applyFileActions; the per-entry contents don't matter once changes
+// are produced by the (mocked) activator.
+const FAKE_LAST_DEPLOYMENT: { [typeId: string]: IDeployedFile[] } = { "": [] };
+
+describe("dealWithExternalChanges", () => {
+  beforeEach(() => {
+    showExternalChangesCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("auto-resolves __merged changes regardless of recentChanges", async () => {
+    const { api, activator } = makeApi({
+      externalChanges: [makeRefchange(`${MERGED_PATH}_skyrim`, "Data/merged.esp")],
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      new Set(),
+    );
+
+    expect(showExternalChangesCalls).toHaveLength(0);
+  });
+
+  it("auto-resolves every change during a collection install", async () => {
+    const { api, activator } = makeApi({
+      externalChanges: [
+        makeRefchange("some-mod-A", "Data/a.bsa"),
+        makeRefchange("some-mod-B", "Data/b.bsa"),
+      ],
+      activeSession: { collectionSlug: "fake-collection", state: "installing" },
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      new Set(),
+    );
+
+    expect(showExternalChangesCalls).toHaveLength(0);
+  });
+
+  it("treats an undefined recentChanges as 'nothing recently touched'", async () => {
+    const { api, activator } = makeApi({
+      externalChanges: [makeRefchange("any-mod", "Data/file.esp")],
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      undefined,
+    );
+
+    expect(showExternalChangesCalls).toHaveLength(1);
+    expect(showExternalChangesCalls[0][""]?.[0].source).toBe("any-mod");
+  });
+
+  // A deployment cycle consumes the recentChanges snapshot ONCE at the start,
+  // then runs dealWithExternalChanges against that snapshot. If a second
+  // install completes after the snapshot is taken (e.g. parallel installers,
+  // or an install that finished while the first deployment was still in
+  // flight), its installation path is not in the local recentChanges seen
+  // by the current dealWithExternalChanges call. A refchange attributed to
+  // that just-installed mod therefore surfaces to the user, even though
+  // Vortex did install it. This is correct behavior given the input; the
+  // upstream concern is whether two install/deploy flows should overlap at
+  // all. Locks in the snapshot-at-consume-time contract between
+  // InstallManager and dealWithExternalChanges.
+  it("only auto-resolves against the recentChanges snapshot taken at consume time", async () => {
+    const gameId = "skyrimse";
+    const modA = "mod-A-installed-before-consume";
+    const modB = "mod-B-installed-after-consume";
+
+    const state = {
+      persistent: {
+        mods: {
+          [gameId]: {
+            [modA]: { id: modA, installationPath: modA },
+            [modB]: { id: modB, installationPath: modB },
+          },
+        },
+      },
+    };
+    const installManagerApi = {
+      getState: vi.fn(() => state),
+      store: { dispatch: vi.fn(), getState: vi.fn(() => state) },
+      events: { emit: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() },
+      onAsync: vi.fn(),
+      onStateChange: vi.fn(),
+      sendNotification: vi.fn(),
+      dismissNotification: vi.fn(),
+      showErrorNotification: vi.fn(),
+      translate: vi.fn((key: string) => key),
+      registerInstaller: vi.fn(),
+    } as unknown as IExtensionApi;
+    const installManager = new InstallManager(installManagerApi, vi.fn());
+
+    // Install A completes BEFORE the deployment cycle starts.
+    installManager.markRecentInstall(modA, gameId);
+
+    // Deployment cycle begins: snapshot recentChanges.
+    const snapshot = installManager.consumeRecentChanges();
+    expect(snapshot).toEqual(new Set([modA]));
+
+    // Install B completes WHILE the deployment cycle is in flight, after
+    // the snapshot has been taken. Its path goes into the next batch.
+    installManager.markRecentInstall(modB, gameId);
+
+    // The current deployment cycle calls dealWithExternalChanges with the
+    // snapshot. The activator reports a refchange attributed to mod B
+    // (a stale manifest entry, an in-flight unlink/relink, etc.).
+    const { api, activator } = makeApi({
+      externalChanges: [makeRefchange(modA, "Data/a.esp"), makeRefchange(modB, "Data/b.esp")],
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      snapshot,
+    );
+
+    // A is auto-resolved (in snapshot), B surfaces (not in snapshot).
+    expect(showExternalChangesCalls).toHaveLength(1);
+    const surfaced = showExternalChangesCalls[0][""];
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced?.[0].source).toBe(modB);
+
+    // The next deployment cycle would pick up B.
+    expect(installManager.consumeRecentChanges()).toEqual(new Set([modB]));
+  });
+});

--- a/src/renderer/src/extensions/mod_management/util/externalChanges.ts
+++ b/src/renderer/src/extensions/mod_management/util/externalChanges.ts
@@ -2,22 +2,22 @@ import * as path from "path";
 
 import { getErrorCode, unknownToError } from "@vortex/shared";
 
+import { log } from "../../../logging";
 import type {
   IDeployedFile,
   IDeploymentMethod,
   IExtensionApi,
   IFileChange,
 } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
 import { ProcessCanceled } from "../../../util/CustomErrors";
 import * as fs from "../../../util/fs";
-import { log } from "../../../util/log";
 import {
   activeGameId,
   activeProfile,
   getCollectionActiveSession,
   profileById,
 } from "../../../util/selectors";
-import { getSafe } from "../../../util/storeHelper";
 import { setdefault, truthy } from "../../../util/util";
 import { showExternalChanges } from "../actions/session";
 import { MERGED_PATH } from "../modMerging";
@@ -175,6 +175,32 @@ function defaultAction(changeType: string): FileAction {
   }
 }
 
+export type ExternalChangeBucket = "merged" | "autoResolved" | "rest";
+
+/**
+ * Decide which bucket an external file change belongs to. Pure function so the
+ * decision is testable in isolation (see externalChanges.test.ts).
+ *
+ *   - merged:       file originates from the __merged folder; always resolved
+ *                   silently via defaultInternalAction.
+ *   - autoResolved: change is expected because Vortex just touched the source
+ *                   mod (collection install, or installationPath in
+ *                   recentChanges); resolved silently.
+ *   - rest:         surfaced to the user via the external-changes dialog.
+ */
+export function classifyExternalChange(
+  change: IFileChange,
+  context: { isInstallingCollection: boolean; recentChanges?: Set<string> },
+): ExternalChangeBucket {
+  if (path.basename(change.source).startsWith(MERGED_PATH)) {
+    return "merged";
+  }
+  if (context.isInstallingCollection || context.recentChanges?.has(change.source)) {
+    return "autoResolved";
+  }
+  return "rest";
+}
+
 export function changeToEntry(modTypeId: string, change: IFileChange): IFileEntry {
   return {
     modTypeId,
@@ -188,7 +214,7 @@ export function changeToEntry(modTypeId: string, change: IFileChange): IFileEntr
 }
 
 function defaultInternalAction(typeId: string, input: IFileChange): IFileEntry {
-  // Internal changes are from mod updates/reinstalls/merges — always drop the old
+  // Internal changes are from mod updates/reinstalls/merges; always drop the old
   // deployed file so deployment recreates it from the updated staging files.
   const action: FileAction = {
     refchange: "drop",
@@ -217,12 +243,9 @@ async function checkForExternalChanges(
   // update mod state again because if the user did have to confirm,
   // it's more intuitive if we deploy the state at the time he confirmed, not when
   // the deployment was triggered
-  const state = api.store.getState();
+  const state = api.store.getState() as IState;
 
-  const profile =
-    profileId !== undefined
-      ? getSafe(state, ["persistent", "profiles", profileId], undefined)
-      : activeProfile(state);
+  const profile = profileById(state, profileId) ?? activeProfile(state);
   if (profile === undefined) {
     throw new ProcessCanceled("Profile no longer exists.");
   }
@@ -253,58 +276,48 @@ export function dealWithExternalChanges(
   lastDeployment: { [typeId: string]: IDeployedFile[] },
   // Installation paths whose mods Vortex itself just installed or removed.
   // change.source is set from mod.installationPath (see LinkingDeployment),
-  // so we match against installation paths, not mod IDs — these can differ in
+  // so we match against installation paths, not mod IDs; these can differ in
   // the update-via-replace flow.
   recentChanges?: Set<string>,
 ) {
   return checkForExternalChanges(api, activator, profileId, stagingPath, modPaths, lastDeployment)
     .then((changes: { [typeId: string]: IFileChange[] }) => {
       const automaticActions: IFileEntry[] = [];
-      const isInstallingCollection = getCollectionActiveSession(api.store.getState()) !== undefined;
-      const userChanges = Object.keys(changes).reduce((prev, typeId) => {
-        const { merged, rest, autoResolved } = changes[typeId].reduce(
-          (prevInner, change) => {
-            const isMerged = path.basename(change.source).startsWith(MERGED_PATH);
-            if (isMerged) {
-              prevInner.merged.push(change);
-              return prevInner;
-            }
-            if (isInstallingCollection || recentChanges?.has(change.source)) {
-              prevInner.autoResolved.push(change);
-              return prevInner;
-            }
+      const userChanges: { [typeId: string]: IFileChange[] } = {};
+      let count = 0;
+      const state = api.store.getState() as IState;
+      const isInstallingCollection = getCollectionActiveSession(state) !== undefined;
+      const context = { isInstallingCollection, recentChanges };
 
-            prevInner.rest.push(change);
-
-            return prevInner;
-          },
-          { merged: [], rest: [], autoResolved: [] },
-        );
-
-        if (merged.length > 0) {
-          merged.forEach((change) => automaticActions.push(defaultInternalAction(typeId, change)));
+      for (const typeId of Object.keys(changes)) {
+        for (const change of changes[typeId]) {
+          if (classifyExternalChange(change, context) === "rest") {
+            (userChanges[typeId] ??= []).push(change);
+            count++;
+          } else {
+            automaticActions.push(defaultInternalAction(typeId, change));
+          }
         }
+      }
 
-        if (autoResolved.length > 0) {
-          autoResolved.forEach((change) =>
-            automaticActions.push(defaultInternalAction(typeId, change)),
-          );
-        }
-
-        if (rest.length > 0) {
-          prev[typeId] = rest;
-        }
-        return prev;
-      }, {});
-
-      const count: number = Object.values(userChanges).reduce(
-        (prev: number, list: any[]) => prev + list.length,
-        0,
-      ) as number;
       if (count > 0) {
         log("info", "found external changes", {
           automated: automaticActions.length,
           user: count,
+        });
+        // Diagnostic: dump the surfaced changes plus the recentChanges set
+        // so update-via-replace false positives can be diagnosed from logs.
+        log("debug", "external changes diagnostic", {
+          isInstallingCollection,
+          recentChanges: Array.from(recentChanges ?? []),
+          surfaced: Object.entries(userChanges).flatMap(([typeId, list]) =>
+            list.map((change) => ({
+              typeId,
+              filePath: change.filePath,
+              source: change.source,
+              changeType: change.changeType,
+            })),
+          ),
         });
         return api.store
           .dispatch(showExternalChanges(userChanges))


### PR DESCRIPTION
Adds debug-level logging in dealWithExternalChanges that dumps the changes surfaced to the external changes dialog along with the recentChanges set used to suppress self-induced changes. Used to better diagnose claims of ECD being raised incorrectly.

Also extracts classifyExternalChange as a pure function (covered by externalChanges.test.ts) and collapses the nested-reduce bucket pass in dealWithExternalChanges into a single classify-and-route loop.

diagnostic for https://github.com/Nexus-Mods/Vortex/issues/23201