### PR TITLE
surface real 7z extraction errors during extension install

### DIFF
--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -301,6 +301,31 @@ function installExtension(
             () => undefined,
             () => undefined,
           )
+          .then((result: { code: number; errors: string[] }) => {
+            // node-7z can resolve (not reject) with a non-zero exit code or
+            // a populated errors array on partial/failed extraction. Without
+            // this check, validateInstall runs against an empty or partial
+            // tempPath and we surface a misleading "needs index.js and
+            // info.json on top-level" error instead of the real cause
+            // (locked file, AV quarantine, corrupt download, etc.).
+            const code = result?.code ?? 0;
+            const errors = result?.errors ?? [];
+            if (code !== 0 || errors.length > 0) {
+              log(code !== 0 ? "error" : "warn", "extension extraction reported issues", {
+                archivePath,
+                tempPath,
+                code,
+                errors: errors.join("; "),
+              });
+            }
+            if (code !== 0) {
+              const detail = errors.length > 0 ? errors.join("; ") : `exit code ${code}`;
+              return PromiseBB.reject(
+                new DataInvalid(`Failed to extract extension archive: ${detail}`),
+              );
+            }
+            return PromiseBB.resolve();
+          })
           .then(() => validateInstall(tempPath, info).then((guessedType) => (type = guessedType)))
           .then(() => readExtensionInfo(tempPath, false, info))
           // merge the caller-provided info with the stuff parsed from the info.json file because there


### PR DESCRIPTION
node-7z's extractFull can resolve (not reject) with code !== 0 or a populated errors[] on partial/failed extraction (file-in-use, AV quarantine, corrupt download). The renderer install path ignored both, so validation ran against an empty tempPath and surfaced "Extension needs to include index.js and info.json on top-level" regardless of the real cause.

Inspect the extract result, log code/errors when non-empty, and reject with DataInvalid carrying the actual 7z error text so the existing "Invalid Extension" notification shows what really failed. Mirrors the pattern already used in InstallManager.extractWithRetry.

fixes APP-463.
fixes fingerprint 687d2f9a