### PR TITLE
wait for discovery before activating on `--game` restart/relaunch

### DIFF
--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -1110,7 +1110,14 @@ function init(context: IExtensionContext): boolean {
           );
 
           if (game !== undefined) {
-            manageGame(context.api, game.id);
+            // Wait for discovery to populate before deciding undiscovered vs
+            // discovered; otherwise this races the fire-and-forget
+            // startQuickDiscovery in gamemode_management.once() and pops the
+            // "Game not discovered" dialog even though discovery would have
+            // succeeded.
+            context.api
+              .emitAndAwait("discover-game", game.id)
+              .then(() => manageGame(context.api, game.id));
           } else {
             log("warn", "game specified on command line not found", {
               game: commandLine.game,


### PR DESCRIPTION
Clicking a game tile for an extension that isn't installed yet installs the extension, relaunches with --game <gameId>, and runs discovery. The --game cmdline handler in profile_management.once() called manageGame() immediately, which read
state.settings.gameMode.discovered[gameId].path and fell through to manageGameUndiscovered() when the path was still undefined, popping the "Game not discovered" dialog even though the asynchronous startQuickDiscovery() in gamemode_management.once() would have populated the path moments later. The game then activated correctly anyway, leaving the dialog as a misleading false positive.

Emit and await discover-game (which runs startQuickDiscovery([game]) for the target game) before calling manageGame, matching the existing pattern in the game-unmanaged-buttons tile-click handler.

closes APP-462