### PR TITLE
fix download failure when target game's folder is missing

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { access, rename, rm } from "node:fs/promises";
+import { access, mkdir, rename, rm } from "node:fs/promises";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
 
@@ -435,6 +435,11 @@ export class IPCDownloadAdapter {
 
     const state = this.#api.getState();
     const dlPath = downloadPathForGame(state, modInfo.game ?? activeGameId(state));
+
+    // The per-game subfolder may not exist yet - ensureDownloadsDirectory only
+    // creates the active game's folder, but downloads can target any game
+    // (SITE_ID extension downloads, compatible domains, collection downloads, etc.).
+    await mkdir(dlPath, { recursive: true });
 
     // Check for an existing file using the caller-supplied name before queuing.
     // We can only do this when a name is provided; temp-named downloads are always new.

--- a/src/renderer/src/extensions/gamemode_management/index.ts
+++ b/src/renderer/src/extensions/gamemode_management/index.ts
@@ -1076,7 +1076,18 @@ function init(context: IExtensionContext): boolean {
         .then(() => $.gameModeManager.setGameMode(oldGameId, newGameId, currentProfileId))
         .catch((err) => {
           if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
-            // nop
+            // The other branches all surface the failure via showError /
+            // sendNotification (which log themselves). UserCanceled and
+            // ProcessCanceled are intentionally silent for the user, but
+            // they still cause setNextProfile(undefined) below, so log
+            // here. Otherwise the resulting profile clear is invisible
+            // when diagnosing reports of "Vortex bounced me back to the
+            // dashboard".
+            log("info", "game mode change canceled", {
+              newGameId,
+              reason: err instanceof UserCanceled ? "UserCanceled" : "ProcessCanceled",
+              error: err.message,
+            });
           } else if (err instanceof SetupError || err instanceof DataInvalid) {
             showError(store.dispatch, "Failed to set game mode", err, {
               allowReport: false,


### PR DESCRIPTION
IPCDownloadAdapter: ensure the per-game download folder exists before queuing. Several games offer inter-version mod compatibility. (Skyrim, Enderal, Nehrim, bla bla)

The downloads folder would be missing for games that the user never managed, yet the mod itself is compatible for multiple domains.

The site domain for example is compatible with all other domains.

Why not ensure that the site downloads folder is created on startup in extension_manager you ask? because that's just one example of inter-domain name compatible mods. The only correct place for this is when the mod is getting downloaded and we just got the metadata back for it.

also added logging for failed game-mode changes when UserCanceled/ProcessCanceled errors are thrown so we can better diagnose why it was canceled based on logs

fixes APP-464