### PR TITLE
flake: upgrade to Electron 42

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1779111042,
+        "narHash": "sha256-Sikx/sVTJAbNNjaOTDvOv8Ht+fmEFyD94gNTvc/RVDI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "3a6b1f28b459dfc413a7d84bf26ef7b446c8fb45",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Vortex development environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:NixOS/flake-compat";
@@ -43,7 +43,7 @@
             dotnetCorePackages.sdk_9_0
 
             # Electron (wrapped with GTK dependencies)
-            electron_42
+            electron_42-bin
 
             # GTK dependencies for Electron runtime
             gtk3
@@ -66,7 +66,7 @@
             ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
             # Point to Nix-provided Electron
-            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_41.dist}";
+            ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_42-bin.dist}";
 
             # Make the dotnet runtime available
             DOTNET_ROOT = "${pkgs.dotnetCorePackages.runtime_9_0}/share/dotnet";
@@ -84,7 +84,7 @@
             export GDK_PIXBUF_MODULE_FILE="${pkgs.librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 
             # Chromium sandbox
-            export CHROME_DEVEL_SANDBOX="${pkgs.electron_41}/libexec/electron/chrome-sandbox"
+            export CHROME_DEVEL_SANDBOX="${pkgs.electron_42-bin}/libexec/electron/chrome-sandbox"
 
           '';
         };


### PR DESCRIPTION
Personal flake update to get electron 42 via [nixpkgs#517263](https://github.com/NixOS/nixpkgs/pull/517263).

- nixpkgs pinned to `master` (`electron_42` not yet in any channel)
- `electron_42-bin` replaces `electron_41` (packages + env vars)
- from-source `electron_42` compiles all of Chromium; `-bin` is faster for now.

> **Note:** Lock points to nixpkgs `master` commit since no channel includes `electron_42` yet. Revert to `nixos-unstable` once it catches up.