### PR TITLE
fixed missing extension dependencies leave games un-manageable

### DIFF
--- a/extensions/modtype-enb/src/index.ts
+++ b/extensions/modtype-enb/src/index.ts
@@ -50,6 +50,9 @@ function install(
 
 function gameSupported(gameId: string) {
   const game = util.getGame(gameId);
+  if (game === undefined) {
+    return false;
+  }
   if (game.compatible?.deployToGameDirectory === false || game.compatible?.enb === false) {
     return false;
   }

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -6,7 +6,7 @@ import * as _ from "lodash";
 import type ZipT from "node-7z";
 import rimraf from "rimraf";
 
-import { removeExtension } from "../../actions";
+import { forgetExtension, removeExtension } from "../../actions";
 import ExtensionManager from "../../ExtensionManager";
 import { log } from "../../logging";
 import type { ExtensionType, IExtension } from "../../types/extensions";
@@ -72,15 +72,32 @@ function installExtensionDependencies(api: IExtensionApi, extPath: string): Prom
 
     const state: IState = api.store.getState();
 
+    const { installed, available } = state.session.extensions;
+
     return PromiseBB.map(handler.dependencies, (depId) => {
-      if (state.session.extensions.installed[depId] !== undefined) {
+      if (installed[depId] !== undefined) {
         return;
       }
-      const ext = state.session.extensions.available.find(
+
+      const ext = available.find(
         (iter) => !iter.type && (iter.name === depId || iter.id === depId),
       );
 
+      // Direct key lookup can miss when the dependent calls
+      // requireExtension(<Nexus display name>) but the installed map is
+      // keyed by info.json `id` (or folder basename). UEMI is the canonical
+      // case: published as "Unreal Engine Mod Installer", but its info.json
+      // name is "Unreal Engine Game Library", so neither key nor name match.
+      // Cross-reference via the Nexus available manifest and compare modId,
+      // which is populated on every Nexus install.
       if (ext !== undefined) {
+        const alreadyInstalled = Object.values(installed).some(
+          (entry) =>
+            (ext.modId !== undefined && entry.modId === ext.modId) || entry.name === ext.name,
+        );
+        if (alreadyInstalled) {
+          return;
+        }
         return api.emitAndAwait("install-extension", ext);
       } else {
         return PromiseBB.resolve();
@@ -107,7 +124,7 @@ function sanitize(input: string): string {
   }
 }
 
-function removeOldVersion(api: IExtensionApi, info: IExtension): PromiseBB<void> {
+function removeOldVersion(api: IExtensionApi, info: IExtension): PromiseBB<string[]> {
   const state: IState = api.store.getState();
   const { installed } = state.session.extensions;
 
@@ -128,7 +145,7 @@ function removeOldVersion(api: IExtensionApi, info: IExtension): PromiseBB<void>
   }
 
   previousVersions.forEach((key) => api.store.dispatch(removeExtension(key)));
-  return PromiseBB.resolve();
+  return PromiseBB.resolve(previousVersions);
 }
 
 /**
@@ -283,6 +300,11 @@ function installExtension(
   let type: ExtensionType;
 
   let extName: string;
+  // Keys whose previous-version state entries were marked for removal during
+  // this install. Cleared after the rename succeeds so the next launch's
+  // state-flag-driven removal path in ExtensionManager doesn't wipe the
+  // just-installed folder (#19527).
+  let removedKeys: string[] = [];
   return PromiseBB.resolve(
     withTrackedActivity(
       "vortex.extension-manager",
@@ -370,10 +392,17 @@ function installExtension(
             }
             return removeOldVersion(api, manifestInfo.info);
           })
-          // we don't actually expect the output directory to exist
-          .then(() => fs.removeAsync(destPath))
+          .then((keys) => {
+            removedKeys = keys;
+            // we don't actually expect the output directory to exist
+            return fs.removeAsync(destPath);
+          })
           .then(() => fs.renameAsync(tempPath, destPath))
           .then(() => {
+            // New files are in place. Clear the `remove: true` flags
+            // dispatched by removeOldVersion so the next ExtensionManager
+            // construction doesn't wipe the freshly-installed folder.
+            removedKeys.forEach((key) => api.store.dispatch(forgetExtension(key)));
             if (type === "translation") {
               return fs
                 .readdirAsync(destPath)

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -676,11 +676,16 @@ function manageGameUndiscovered(api: IExtensionApi, gameId: string): PromiseBB<v
 }
 
 function manageGame(api: IExtensionApi, gameId: string): PromiseLike<void> {
-  const state: IState = api.store.getState();
-  const discoveredGames = state.settings.gameMode?.discovered || {};
+  const state = api.store.getState() as IState;
   const profiles = state.persistent.profiles || {};
 
-  if (getSafe(discoveredGames, [gameId, "path"], undefined) !== undefined) {
+  // Discovery state outlives the registering extension. If the extension
+  // didn't load (missing dependency, exception, disabled) getGame is
+  // undefined and activating would create an orphan profile.
+  if (
+    state.settings.gameMode?.discovered?.[gameId]?.path !== undefined &&
+    getGame(gameId) !== undefined
+  ) {
     const profile = Object.values(profiles).find((prof) => prof.gameId === gameId);
     if (profile !== undefined) {
       return activateGame(api.store, gameId);
@@ -897,8 +902,11 @@ function init(context: IExtensionContext): boolean {
         .then(() => checkOverridden(context.api, gameId))
         .then(() => {
           const state = context.api.getState();
+          // Mirrors the guard in manageGame: discovery can outlive the
+          // registering extension.
           const manageFunc =
-            state.settings.gameMode.discovered[gameId]?.path !== undefined
+            state.settings.gameMode.discovered[gameId]?.path !== undefined &&
+            getGame(gameId) !== undefined
               ? manageGameDiscovered
               : manageGameUndiscovered;
 
@@ -1007,7 +1015,14 @@ function init(context: IExtensionContext): boolean {
 
   context.registerActionCheck("SET_NEXT_PROFILE", (state: IState, action: any) => {
     const { profileId } = action.payload;
-    context.api.dismissAllNotifications();
+    // Only clear notifications on a real transition between two
+    // different profiles. Startup restores SET_NEXT_PROFILE from
+    // undefined, and re-activation targets the current profile; both
+    // would otherwise wipe warnings the user hasn't yet seen.
+    const activeProfileId = state.settings.profiles.activeProfileId;
+    if (profileId !== undefined && activeProfileId !== undefined && activeProfileId !== profileId) {
+      context.api.dismissAllNotifications();
+    }
     if (profileId === undefined) {
       // resetting must always work
       return undefined;

--- a/src/renderer/src/views/NotificationButton.tsx
+++ b/src/renderer/src/views/NotificationButton.tsx
@@ -50,6 +50,13 @@ const displayTime = (item: INotification): number | null => {
     return item.displayMS;
   }
 
+  // A notification with actions but no explicit displayMS requires the
+  // user to choose. Auto-hiding it would silently strand the choice
+  // (see INotification displayMS contract).
+  if (item.actions !== undefined && item.actions.length > 0) {
+    return null;
+  }
+
   return NOTIFICATION_TIMEOUTS[item.type] ?? 10000;
 };
 

--- a/src/renderer/src/views/components/Header/Notifications/index.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/index.tsx
@@ -26,7 +26,10 @@ const NotificationsContent: React.FC<{ popoverOpen: boolean }> = ({ popoverOpen 
     [notifications],
   );
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const prevIdsRef = useRef(new Set(notifications.map((n) => n.id)));
+  // Empty seed so notifications already present at mount (dispatched
+  // before this component rendered, e.g. during startup) count as new
+  // on the first effect run and trigger the auto-open.
+  const prevIdsRef = useRef<Set<string>>(new Set());
 
   const [expand, setExpand] = useState<string | undefined>(undefined);
 

--- a/src/renderer/src/views/components/Header/Notifications/useNotificationFiltering.ts
+++ b/src/renderer/src/views/components/Header/Notifications/useNotificationFiltering.ts
@@ -22,6 +22,13 @@ const displayTime = (item: INotification): number | null => {
     return item.displayMS;
   }
 
+  // A notification with actions but no explicit displayMS requires the
+  // user to choose. Auto-hiding it would silently strand the choice
+  // (see INotification displayMS contract).
+  if (item.actions !== undefined && item.actions.length > 0) {
+    return null;
+  }
+
   return NOTIFICATION_TIMEOUTS[item.type] ?? 10000;
 };
 


### PR DESCRIPTION
When a game extension's required dependency is missing (uninstalled or load-failed), several cascading failures previously left users with no clear path to recover. This addresses each link in that chain:

- installExtension: when resolving recursive dependencies, dedup against the installed map by modId and name in addition to the direct key lookup. Fixes the UEMI canonical case where the Nexus display name differs from the info.json name, which previously queued a redundant install and forced a second restart (Nexus-Mods/Vortex#19527).

- profile_management: gate manageGame and the Manage action handler on getGame() in addition to the discovered path. Discovery state outlives the registering extension; without this guard, clicking Manage on a game whose extension didn't load created an orphan profile that the switch handler then rejected with "Game no longer supported" (Nexus-Mods/Vortex#20692, Nexus-Mods/Vortex#23188).

- profile_management: scope the SET_NEXT_PROFILE action check's dismissAllNotifications() to real profile-to-profile transitions. It was firing on startup restore and on every Manage click, silently wiping the missing-dependency warning before the user could act on it.

- notifications (classic + UIV2): honor the documented INotification contract that a notification with actions but no explicit displayMS should persist until acted on or dismissed. Both display-time filters previously applied a default 10s timeout.

- UIV2 notifications: seed the auto-open "previously seen" set empty so notifications already in state when the bell component mounts (anything dispatched during startup) count as new on the first effect run and trigger the popover. Otherwise they only show as a bell badge.

- modtype-enb: defensive null check around util.getGame() in gameSupported. An orphan activeProfileId pointing at an unregistered gameId would otherwise crash the renderer on first render via the mod-types table options filter.

fixes app-468
fixes Nexus-Mods/Vortex#20692
fixes Nexus-Mods/Vortex#23188
fixes Nexus-Mods/Vortex#19527