### PR TITLE
restored Redux DevTools in dev builds

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,9 +376,9 @@ catalogs:
     electron-context-menu:
       specifier: ^3.1.1
       version: 3.6.1
-    electron-devtools-installer:
-      specifier: ^3.2.0
-      version: 3.2.1
+    electron-extension-installer:
+      specifier: ^2.0.1
+      version: 2.0.1
     electron-redux:
       specifier: git+https://github.com/TanninOne/electron-redux#66bbd9d389579806e8c4ebd87bd513a668cc64a8
       version: 1.4.9-sync
@@ -4399,9 +4399,9 @@ importers:
       electron-builder:
         specifier: 'catalog:'
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
-      electron-devtools-installer:
+      electron-extension-installer:
         specifier: 'catalog:'
-        version: 3.2.1
+        version: 2.0.1(electron@42.0.0)
       redux-freeze:
         specifier: 'catalog:'
         version: 0.1.7
@@ -8703,12 +8703,14 @@ packages:
   electron-context-menu@3.6.1:
     resolution: {integrity: sha512-lcpO6tzzKUROeirhzBjdBWNqayEThmdW+2I2s6H6QMrwqTVyT3EK47jW3Nxm60KTxl5/bWfEoIruoUNn57/QkQ==}
 
-  electron-devtools-installer@3.2.1:
-    resolution: {integrity: sha512-FaCi+oDCOBTw0gJUsuw5dXW32b2Ekh5jO8lI1NRCQigo3azh2VogsIi0eelMVrP1+LkN/bewyH3Xoo1USjO0eQ==}
-
   electron-dl@3.5.2:
     resolution: {integrity: sha512-i104cl+u8yJ0lhpRAtUWfeGuWuL1PL6TBiw2gLf0MMIBjfgE485Ags2mcySx4uWU9P9uj/vsD3jd7X+w1lzZxw==}
     engines: {node: '>=12'}
+
+  electron-extension-installer@2.0.1:
+    resolution: {integrity: sha512-pFdtmilltpZrjt568an4cwRZ0NPPLSiC0noZ3Bj9dE2O07jvDhFLNQZop4BudNJBhVSnlDHj4LznV3Y+9Q+tug==}
+    peerDependencies:
+      electron: '>=36.0.0'
 
   electron-is-dev@2.0.0:
     resolution: {integrity: sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==}
@@ -10459,10 +10461,6 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -11537,11 +11535,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@https://codeload.github.com/TanninOne/rimraf/tar.gz/7b8b70d4e8783cd233fca3283cf1f930af4e39c2:
     resolution: {gitHosted: true, tarball: https://codeload.github.com/TanninOne/rimraf/tar.gz/7b8b70d4e8783cd233fca3283cf1f930af4e39c2}
     version: 2.6.2
@@ -12367,9 +12360,6 @@ packages:
     resolution: {integrity: sha512-BMiNwJbuWmqCpAM1FqxCTD7lXF97AvfQC8Kr/DIeA6VtvhJaMDupZ82+inbjl5yVP44PcxOuCSxye1QMS0wZyg==}
     engines: {node: '>=8'}
 
-  unzip-crx-3@0.2.0:
-    resolution: {integrity: sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==}
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -12697,9 +12687,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yaku@0.16.7:
-    resolution: {integrity: sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -16842,18 +16829,16 @@ snapshots:
       electron-dl: 3.5.2
       electron-is-dev: 2.0.0
 
-  electron-devtools-installer@3.2.1:
-    dependencies:
-      rimraf: 3.0.2
-      semver: 7.7.4
-      tslib: 2.8.1
-      unzip-crx-3: 0.2.0
-
   electron-dl@3.5.2:
     dependencies:
       ext-name: 5.0.0
       pupa: 2.1.1
       unused-filename: 2.1.0
+
+  electron-extension-installer@2.0.1(electron@42.0.0):
+    dependencies:
+      electron: 42.0.0
+      jszip: 3.10.1
 
   electron-is-dev@2.0.0: {}
 
@@ -18773,10 +18758,6 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-
   mkdirp@1.0.4: {}
 
   modify-filename@1.1.0: {}
@@ -20033,10 +20014,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@https://codeload.github.com/TanninOne/rimraf/tar.gz/7b8b70d4e8783cd233fca3283cf1f930af4e39c2:
     dependencies:
       glob: 7.2.3
@@ -20996,12 +20973,6 @@ snapshots:
       modify-filename: 1.1.0
       path-exists: 4.0.0
 
-  unzip-crx-3@0.2.0:
-    dependencies:
-      jszip: 3.10.1
-      mkdirp: 0.5.6
-      yaku: 0.16.7
-
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -21374,8 +21345,6 @@ snapshots:
       node-gyp-build: 4.8.4
 
   y18n@5.0.8: {}
-
-  yaku@0.16.7: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -156,7 +156,7 @@ catalog:
   electron: 42.0.0
   electron-builder: 24.13.3
   electron-context-menu: ^3.1.1
-  electron-devtools-installer: ^3.2.0
+  electron-extension-installer: ^2.0.1
   electron-redux: git+https://github.com/TanninOne/electron-redux#66bbd9d389579806e8c4ebd87bd513a668cc64a8
   electron-updater: ^4.2.0
   encoding-down: ^6.3.0

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -290,7 +290,7 @@
     "cross-env": "catalog:",
     "electron": "catalog:",
     "electron-builder": "catalog:",
-    "electron-devtools-installer": "catalog:",
+    "electron-extension-installer": "catalog:",
     "redux-freeze": "catalog:"
   }
 }

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -468,6 +468,12 @@ class Application {
     log("debug", "checking if migration is required");
     await this.migrateIfNecessary(this.mAppMetadata.version);
 
+    // Install dev tools extensions before creating the main window so the
+    // extension content scripts are registered on the session before the
+    // renderer navigates — otherwise window.__REDUX_DEVTOOLS_EXTENSION__
+    // is undefined when the renderer builds its store enhancer.
+    await this.initDevel();
+
     log("debug", "starting user interface");
     await this.initMainWindow();
 
@@ -481,8 +487,6 @@ class Application {
     process.removeAllListeners("unhandledRejection");
     process.on("uncaughtException", handleError);
     process.on("unhandledRejection", handleError);
-
-    await this.initDevel();
 
     this.setupContextMenu();
 

--- a/src/main/src/devel.ts
+++ b/src/main/src/devel.ts
@@ -10,32 +10,13 @@ export async function installDevelExtensions(): Promise<void> {
   if (process.env.NODE_ENV !== "development") return;
   if (process.env.VORTEX_E2E === "1") return;
 
-  const {
-    default: install,
-    REACT_DEVELOPER_TOOLS,
-    REDUX_DEVTOOLS,
-  } = await import("electron-devtools-installer");
-
-  const options = {
-    loadExtensionOptions: { allowFileAccess: true },
-  };
+  const { installExtension, REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } =
+    await import("electron-extension-installer");
 
   try {
-    // Cast needed: TS resolves `default` from dynamic CJS import as the module
-    // namespace rather than the actual default export (the install function).
-    // Alternatively we could just use double default import, but meh.
-    type ExtensionRef = { id: string; electron: string };
-    type InstallFn = (
-      ref: ExtensionRef | string | Array<ExtensionRef | string>,
-      options?:
-        | {
-            forceDownload?: boolean;
-            loadExtensionOptions?: Record<string, unknown>;
-          }
-        | boolean,
-    ) => Promise<string>;
-    await (install as unknown as InstallFn)(REACT_DEVELOPER_TOOLS, options);
-    await (install as unknown as InstallFn)(REDUX_DEVTOOLS, options);
+    await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS], {
+      loadExtensionOptions: { allowFileAccess: true },
+    });
   } catch (err) {
     log("error", "error installing dev tools", getErrorMessageOrDefault(err));
   }


### PR DESCRIPTION
Swap abandoned electron-devtools-installer for electron-extension-installer, and run installDevelExtensions() before initMainWindow() so the extension is registered on the session before the renderer builds its store.

fixes app-474