### PR TITLE
CI: fix pnpm node-gyp permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+      - name: Fix pnpm node-gyp permissions
+        run: find "$PNPM_HOME" -path '*/node-gyp/gyp/gyp_main.py' -exec chmod +x {} \;
       # NOTE(erri120): fontconfig required by font-scanner required by theme-switcher
       - name: Install fontconfig
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           cache: true
 
+      - name: Fix pnpm node-gyp permissions
+        if: runner.os == 'Linux'
+        run: find "$PNPM_HOME" -path '*/node-gyp/gyp/gyp_main.py' -exec chmod +x {} \;
+
       # NOTE(erri120): fontconfig required by font-scanner required by theme-switcher
       - name: Install fontconfig
         if: runner.os == 'Linux'


### PR DESCRIPTION
Fixes [LAZ-410](https://linear.app/nexus-mods/issue/LAZ-410/flaky-linux-ci-permission-failure-in-formatbuild)

## Summary

Fix Linux CI native installs failing when `pnpm/action-setup` restores `node-gyp/gyp/gyp_main.py` without executable permission.

## Change

After `pnpm/action-setup@v6`, run:

```sh
find "$PNPM_HOME" -path '*/node-gyp/gyp/gyp_main.py' -exec chmod +x {} \;
```

in:

- `.github/workflows/main.yml` - Linux only (`if: runner.os == 'Linux'`)
- `.github/workflows/format.yml` - Ubuntu runner (no condition needed)

## Why

`pnpm/action-setup` with caching can restore `node-gyp`'s `gyp_main.py` without the executable bit set. When native dependencies trigger `node-gyp`, the Python script fails:

```
/home/runner/.../node-gyp/gyp/gyp_main.py: Permission denied
```

Observed failure (fork CI run): https://github.com/Sewer56/Vortex/actions/runs/26098248254

## Validation

Fork CI passed on both workflows after the fix:

- Main: https://github.com/Sewer56/Vortex/actions/runs/26115728043
- Format: https://github.com/Sewer56/Vortex/actions/runs/26115728037
