### PR TITLE
remove BrowserWindow close-handler workaround (fixed in Electron 42)

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -209,11 +209,6 @@ class Application {
             this.mTray.close();
           }
           if (process.platform !== "darwin") {
-            // All windows are already destroyed at this point (via the
-            // destroy() workaround in MainWindow), so app.quit() won't
-            // attempt to close any windows — it just fires the before-quit
-            // / will-quit lifecycle events (needed by the autoupdater) and
-            // then exits cleanly.
             app.quit();
           }
         })

--- a/src/main/src/MainWindow.ts
+++ b/src/main/src/MainWindow.ts
@@ -404,17 +404,12 @@ class MainWindow {
       return;
     }
 
-    this.mWindow.on("close", (event) => {
+    this.mWindow.on("close", () => {
       if (this.mWindow === null) {
         return;
       }
-      // Work around Electron >=39.6.1 crash on Windows where the normal
-      // WM_CLOSE destruction path triggers an access violation inside
-      // electron.exe (STATUS_FATAL_USER_CALLBACK_EXCEPTION / 0xC000041D).
-      // See: https://github.com/electron/electron/issues/50040
-      event.preventDefault();
-      // Save the renderer process PID before destroying so Application can
-      // wait for the process to fully exit and release file handles.
+      // Capture the renderer PID so Application.waitForRendererExit can wait
+      // for the process to fully release its file handles before quitting.
       try {
         this.mRendererPid = this.mWindow.webContents.getOSProcessId();
       } catch {
@@ -422,18 +417,6 @@ class MainWindow {
       }
       this.mWindow.webContents.send("window:event:close");
       closeAllViews(this.mWindow);
-      // hide() before destroy(): destroy's aura teardown synthesizes a Win32
-      // mouse move that SendMessage's WM_NCHITTEST back into
-      // WebContentsView::NonClientHitTest, which dereferences a null
-      // InspectableWebContents mid-teardown and faults inside
-      // electron::InspectableWebContents::GetView. ShowWindow(SW_HIDE) takes
-      // us out of screen hit-test so the message routes elsewhere.
-      try {
-        this.mWindow.hide();
-      } catch {
-        // webContents may already be gone
-      }
-      this.mWindow.destroy();
     });
     this.mWindow.on("closed", () => {
       this.mWindow = null;

--- a/src/main/src/cli.ts
+++ b/src/main/src/cli.ts
@@ -278,10 +278,10 @@ export function parseCommandline(argv: string[], electronIsShitHack: boolean): I
 
 export function relaunch(args?: string[]) {
   app.relaunch({ args: [...filterArgs(process.argv), ...(args || [])] });
-  // Don't call app.quit() — it sets internal quitting state before closing
-  // windows, which causes an access violation in Electron's native
-  // destruction path. Instead, close all windows normally; the
-  // window-all-closed handler will call app.quit() after cleanup.
+  // Close windows rather than calling app.quit() directly: Application's
+  // window-all-closed handler performs the async finalize / waitForRendererExit
+  // / DuckDB shutdown sequence and calls app.quit() itself at the end.
+  // Calling app.quit() here races that cleanup and hangs the relaunch.
   for (const win of BrowserWindow.getAllWindows()) {
     win.close();
   }


### PR DESCRIPTION
Electron 42 ships the fix for #50040 (UAF in NonClientHitTest during view teardown), so the preventDefault + manual destroy() in MainWindow's close handler can go. PID capture and the window:event:close IPC stay; the default close path destroys the window.

cli.ts relaunch() keeps the close-windows loop: Application's window-all-closed handler owns the async finalize + DuckDB shutdown + app.quit() sequence, and calling app.quit() directly from relaunch() races that cleanup and hangs (caught during extension-install testing).

https://github.com/electron/electron/pull/50042

closes APP-473