### PR TITLE
convert unauthenticated download 401 errors to login notification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ catalogs:
       specifier: ^0.13.1
       version: 0.13.1
     '@nexusmods/nexus-api':
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
-      version: 1.6.1
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+      version: 1.6.2
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.1
@@ -512,8 +512,8 @@ catalogs:
       specifier: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
       version: 0.9.3
     nexus-api:
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
-      version: 1.6.1
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+      version: 1.6.2
     node:
       specifier: runtime:24.15.0
       version: 24.15.0
@@ -972,7 +972,7 @@ importers:
         version: 0.30.6
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -2284,7 +2284,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
@@ -2609,7 +2609,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3554,7 +3554,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/3298c42e69e3220dc39694bc2f610c077c3e213a
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3581,7 +3581,7 @@ importers:
         version: 4.17.23
       nexus-api:
         specifier: 'catalog:'
-        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7'
+        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835'
       react:
         specifier: 'catalog:'
         version: 16.14.0
@@ -3893,7 +3893,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@types/react':
         specifier: '16'
         version: 16.14.69
@@ -3959,7 +3959,7 @@ importers:
         version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -4456,7 +4456,7 @@ importers:
         version: 0.13.1
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -5856,9 +5856,9 @@ packages:
     resolution: {integrity: sha512-6fcow0nDO8I4KFYG1ffa5z9FcKkZsW/D1Axjkb5ebmV47JKg10nJALv8sVkd0hCrKCW8oJZEEvgHKOkF2Pn9ww==}
     engines: {node: '>=22'}
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7}
-    version: 1.6.1
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835':
+    resolution: {gitHosted: true, integrity: sha512-Q/2lKCGUM4QSf4uSQU06sIUS8VW+E98wZjucZTg0AXRG0bbMMx8SHHuYHg6TDJCrE/wxwfzL/QJJ1Owk+r+IqQ==, tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835}
+    version: 1.6.2
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -14002,7 +14002,7 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7':
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835':
     dependencies:
       form-data: 4.0.5
       jsonwebtoken: 9.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalog:
   "@msgpack/msgpack": ^2.7.0
   "@nexusmods/fomod-installer-ipc": ^0.13.1
   "@nexusmods/fomod-installer-native": ^0.13.1
-  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
   "@opentelemetry/api": ^1.9.0
   "@opentelemetry/context-async-hooks": ^2.5.1
   "@opentelemetry/context-zone": ^2.5.1
@@ -201,7 +201,7 @@ catalog:
   minimist: ^1.2.8
   mixpanel-browser: ^2.71.0
   modmeta-db: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
-  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
+  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
   node: runtime:24.15.0
   node-7z: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
   normalize-url: ^6.0.1

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -1637,6 +1637,21 @@ function makeNXMProtocol(api: IExtensionApi, onAwaitLink: AwaitLinkCB) {
         newError.stack = err.stack;
         return PromiseBB.reject(newError);
       })
+      .catch(HTTPError, (err) => {
+        // A 401 here means the Nexus client could not authenticate the
+        // request and could not (or did not) refresh its token. Reachable
+        // when persisted state says we have OAuth credentials but the live
+        // Nexus instance does not (e.g. updateToken never ran on startup,
+        // forced-logout migration path), when the refresh token has been
+        // revoked server-side, or on a resume after logout. Surface as a
+        // ProcessCanceled so reportDownloadError shows a friendly,
+        // non-reportable notification instead of letting the raw 401 fall
+        // through to the generic else branch with the Report button.
+        if (err.statusCode === 401) {
+          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
+        }
+        return PromiseBB.reject(err);
+      })
       .catch(RateLimitError, (err) => {
         api.showErrorNotification("Rate limit exceeded", err, {
           allowReport: false,


### PR DESCRIPTION
The front-door `ensureLoggedIn` at `index.tsx:770` already gates user-forwarded `nxm://` URLs and the login dialog pops correctly in the standard logged-out flow. The bug surfaces in cases where Redux state and the live Nexus instance disagree on auth (forced-logout migration, startup race where `updateToken` did not run, server-side token revocation, download resume after logout). In all of those `sel.isLoggedIn(state)` still returns true, so an `isLoggedIn` check at the top of `resolveFunc` would never fire. Catching the 401 itself covers every scenario.

- Bumps `@nexusmods/nexus-api` to 1.6.2 ([Nexus-Mods/node-nexus-api#37](https://github.com/Nexus-Mods/node-nexus-api/pull/37)), which guards the reactive JWT refresh path. An unauthenticated 401 now surfaces as `HTTPError(401)` instead of a `TypeError` on undefined OAuth config.
- Catches that 401 in the NXM resolver's existing PromiseBB `.catch` chain and converts it to a `ProcessCanceled` with a user-facing message, so the user sees a single non-reportable "You are not logged in to Nexus Mods!" notification instead of a reportable TypeError stack.

Upstream PR: https://github.com/Nexus-Mods/node-nexus-api/pull/37

Fixes fingerptint cf367ac7
closes APP-475