### PR TITLE
fix: add missing sidebar and help menu icons (LAZ-240)

### DIFF
--- a/src/renderer/src/views/components/Header/HelpSection.tsx
+++ b/src/renderer/src/views/components/Header/HelpSection.tsx
@@ -1,9 +1,11 @@
 import { Menu } from "@headlessui/react";
 import {
+  mdiBugOutline,
   mdiFileDocumentOutline,
   mdiHelpCircleOutline,
   mdiInformationOutline,
   mdiPuzzle,
+  mdiThumbsUpDownOutline,
 } from "@mdi/js";
 import React, { type FC, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,6 +20,13 @@ import { DropdownItem } from "../../../ui/components/dropdown/DropdownItem";
 import { DropdownItems } from "../../../ui/components/dropdown/DropdownItems";
 import { IconButton } from "./IconButton";
 import { useGlobalIconActions } from "./useGlobalIconActions";
+
+// Actions from built-in extensions that should render in the main help menu
+// with their own icons, rather than under the "extension provided" puzzle section.
+const builtInActionIcons: Record<string, string> = {
+  feedback: mdiThumbsUpDownOutline,
+  bug: mdiBugOutline,
+};
 
 export const HelpSection: FC = () => {
   const dispatch = useDispatch();
@@ -39,6 +48,11 @@ export const HelpSection: FC = () => {
 
   const globalIconActions = useGlobalIconActions(extensions);
 
+  const builtInActions = globalIconActions.filter((action) => action.icon in builtInActionIcons);
+  const extensionActions = globalIconActions.filter(
+    (action) => !(action.icon in builtInActionIcons),
+  );
+
   const handleGlobalIconAction = useCallback((action: IActionDefinition) => {
     return () => {
       if (action.action) {
@@ -52,7 +66,7 @@ export const HelpSection: FC = () => {
       <Menu.Button as={IconButton} iconPath={mdiHelpCircleOutline} title={t("Help")} />
 
       <DropdownItems>
-        {globalIconActions.map((action) => (
+        {extensionActions.map((action) => (
           <DropdownItem
             key={`${action.icon}-${action.title}`}
             leftIconPath={mdiPuzzle}
@@ -62,7 +76,7 @@ export const HelpSection: FC = () => {
           </DropdownItem>
         ))}
 
-        {globalIconActions.length > 0 && <DropdownDivider />}
+        {extensionActions.length > 0 && <DropdownDivider />}
 
         <DropdownItem leftIconPath={mdiHelpCircleOutline} onClick={handleHelpCentre}>
           {t("Help centre")}
@@ -71,6 +85,16 @@ export const HelpSection: FC = () => {
         <DropdownItem leftIconPath={mdiFileDocumentOutline} onClick={handleDiagnosticFiles}>
           {t("View logs")}
         </DropdownItem>
+
+        {builtInActions.map((action) => (
+          <DropdownItem
+            key={`${action.icon}-${action.title}`}
+            leftIconPath={builtInActionIcons[action.icon]}
+            onClick={handleGlobalIconAction(action)}
+          >
+            {t(action.title, { ns: action.options?.namespace })}
+          </DropdownItem>
+        ))}
 
         <DropdownItem leftIconPath={mdiInformationOutline} onClick={handleAbout}>
           {t("About")}

--- a/src/renderer/src/views/components/iconMap.ts
+++ b/src/renderer/src/views/components/iconMap.ts
@@ -1,6 +1,7 @@
 import {
   mdiCog,
   mdiCommentTextOutline,
+  mdiContentSave,
   mdiDownload,
   mdiEye,
   mdiGamepadSquare,
@@ -9,6 +10,7 @@ import {
   mdiInformationOutline,
   mdiMenu,
   mdiPalette,
+  mdiPowerPlug,
   mdiPuzzle,
   mdiShapeOutline,
   mdiTune,
@@ -32,6 +34,8 @@ const iconMap: Record<string, string> = {
   feedback: mdiCommentTextOutline,
   nexus: mdiWeb,
   palette: mdiPalette,
+  plugins: mdiPowerPlug,
+  savegame: mdiContentSave,
   tools: mdiWrench,
   tune: mdiTune,
 };


### PR DESCRIPTION
Map the legacy icon names "plugins" and "savegame" to MDI paths so the Modern UI sidebar renders proper icons for Bethesda plugins and save games pages, which previously fell back to the generic shape outline.

In the help menu, render built-in feedback/bug actions as regular menu items with thumbs-up-down and bug icons, instead of grouping them under the "extension provided" puzzle section reserved for third-party extensions.