### PR TITLE
Pin dependency versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,10 +213,10 @@ catalogs:
       specifier: 7.12.1
       version: 7.12.1
     '@babel/preset-env':
-      specifier: ^7.25.4
+      specifier: 7.29.2
       version: 7.29.2
     '@babel/preset-react':
-      specifier: ^7.24.4
+      specifier: 7.28.5
       version: 7.28.5
     '@babel/preset-typescript':
       specifier: 7.16.7
@@ -225,16 +225,16 @@ catalogs:
       specifier: 7.16.8
       version: 7.16.8
     '@cyclonedx/cyclonedx-library':
-      specifier: ^10.0.0
+      specifier: 10.0.0
       version: 10.0.0
     '@duckdb/node-api':
       specifier: 1.5.1-r.1
       version: 1.5.1-r.1
     '@electron/rebuild':
-      specifier: ^4.0.4
+      specifier: 4.0.4
       version: 4.0.4
     '@electron/remote':
-      specifier: ^2.0.12
+      specifier: 2.1.3
       version: 2.1.3
     '@eslint-react/eslint-plugin':
       specifier: 3.0.0
@@ -243,328 +243,328 @@ catalogs:
       specifier: 10.0.1
       version: 10.0.1
     '@headlessui/react':
-      specifier: ^1.7.19
+      specifier: 1.7.19
       version: 1.7.19
     '@hot-updater/bsdiff':
-      specifier: ^0.30.6
+      specifier: 0.30.6
       version: 0.30.6
     '@iarna/toml':
-      specifier: ^2.2.5
+      specifier: 2.2.5
       version: 2.2.5
     '@mdi/js':
       specifier: 7.4.47
       version: 7.4.47
     '@microsoft/api-extractor':
-      specifier: ^7.58.7
+      specifier: 7.58.7
       version: 7.58.7
     '@msgpack/msgpack':
-      specifier: ^2.7.0
+      specifier: 2.8.0
       version: 2.8.0
     '@nexusmods/fomod-installer-ipc':
-      specifier: ^0.13.1
+      specifier: 0.13.1
       version: 0.13.1
     '@nexusmods/fomod-installer-native':
-      specifier: ^0.13.1
+      specifier: 0.13.1
       version: 0.13.1
     '@nexusmods/nexus-api':
       specifier: git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
       version: 1.6.1
     '@opentelemetry/api':
-      specifier: ^1.9.0
+      specifier: 1.9.1
       version: 1.9.1
     '@opentelemetry/context-async-hooks':
-      specifier: ^2.5.1
+      specifier: 2.6.1
       version: 2.6.1
     '@opentelemetry/context-zone':
-      specifier: ^2.5.1
+      specifier: 2.7.0
       version: 2.7.0
     '@opentelemetry/exporter-trace-otlp-http':
-      specifier: ^0.57.0
+      specifier: 0.57.2
       version: 0.57.2
     '@opentelemetry/resources':
-      specifier: ^1.30.0
+      specifier: 1.30.1
       version: 1.30.1
     '@opentelemetry/sdk-trace-base':
-      specifier: ^1.30.0
+      specifier: 1.30.1
       version: 1.30.1
     '@opentelemetry/semantic-conventions':
-      specifier: ^1.30.0
+      specifier: 1.40.0
       version: 1.40.0
     '@playwright/test':
-      specifier: ^1.58.2
+      specifier: 1.58.2
       version: 1.58.2
     '@stylistic/eslint-plugin':
       specifier: 5.10.0
       version: 5.10.0
     '@tailwindcss/cli':
-      specifier: ^4.1.17
+      specifier: 4.2.2
       version: 4.2.2
     '@testing-library/dom':
-      specifier: ^10.4.1
+      specifier: 10.4.1
       version: 10.4.1
     '@testing-library/jest-dom':
-      specifier: ^6.9.1
+      specifier: 6.9.1
       version: 6.9.1
     '@testing-library/react':
-      specifier: ^12.1.5
+      specifier: 12.1.5
       version: 12.1.5
     '@testing-library/user-event':
-      specifier: ^14.6.1
+      specifier: 14.6.1
       version: 14.6.1
     '@types/babel__preset-env':
-      specifier: ~7.10.0
+      specifier: 7.10.0
       version: 7.10.0
     '@types/babel__register':
-      specifier: ~7.17.3
+      specifier: 7.17.3
       version: 7.17.3
     '@types/bbcode-to-react':
-      specifier: ~0.2.4
+      specifier: 0.2.4
       version: 0.2.4
     '@types/big.js':
-      specifier: ~6.2.2
+      specifier: 6.2.2
       version: 6.2.2
     '@types/bluebird':
       specifier: 3.5.20
       version: 3.5.20
     '@types/content-disposition':
-      specifier: ~0.5.9
+      specifier: 0.5.9
       version: 0.5.9
     '@types/content-type':
-      specifier: ^1.1.3
+      specifier: 1.1.9
       version: 1.1.9
     '@types/copyfiles':
-      specifier: ~2.4.4
+      specifier: 2.4.4
       version: 2.4.4
     '@types/d3':
-      specifier: ~7.4.3
+      specifier: 7.4.3
       version: 7.4.3
     '@types/draggabilly':
       specifier: 2.1.3
       version: 2.1.3
     '@types/encoding-down':
-      specifier: ~5.0.5
+      specifier: 5.0.5
       version: 5.0.5
     '@types/feedparser':
-      specifier: ~2.2.8
+      specifier: 2.2.8
       version: 2.2.8
     '@types/fs-extra':
-      specifier: ~11.0.4
+      specifier: 11.0.4
       version: 11.0.4
     '@types/graphlib':
-      specifier: ~2.1.12
+      specifier: 2.1.12
       version: 2.1.12
     '@types/i18next':
-      specifier: ^12.1.0
+      specifier: 12.1.0
       version: 12.1.0
     '@types/iconv-lite':
-      specifier: ^0.0.1
+      specifier: 0.0.1
       version: 0.0.1
     '@types/js-yaml':
-      specifier: ^4.0.9
+      specifier: 4.0.9
       version: 4.0.9
     '@types/json-socket':
-      specifier: ~0.1.21
+      specifier: 0.1.21
       version: 0.1.21
     '@types/jsonwebtoken':
-      specifier: ~9.0.10
+      specifier: 9.0.10
       version: 9.0.10
     '@types/libxmljs':
-      specifier: ^0.18.4
+      specifier: 0.18.13
       version: 0.18.13
     '@types/lodash':
-      specifier: ~4.17.24
+      specifier: 4.17.24
       version: 4.17.24
     '@types/minimatch':
-      specifier: ^2.0.29
+      specifier: 2.0.29
       version: 2.0.29
     '@types/minimist':
-      specifier: ~1.2.5
+      specifier: 1.2.5
       version: 1.2.5
     '@types/node':
-      specifier: ^24
+      specifier: 24.12.2
       version: 24.12.2
     '@types/node-7z':
-      specifier: ~2.1.11
+      specifier: 2.1.11
       version: 2.1.11
     '@types/numeral':
-      specifier: ~2.0.5
+      specifier: 2.0.5
       version: 2.0.5
     '@types/packery':
-      specifier: ~1.4.37
+      specifier: 1.4.37
       version: 1.4.37
     '@types/prop-types':
-      specifier: ~15.7.15
+      specifier: 15.7.15
       version: 15.7.15
     '@types/react-bootstrap':
-      specifier: ^0.32.20
+      specifier: 0.32.37
       version: 0.32.37
     '@types/react-color':
-      specifier: ^2.14.0
+      specifier: 2.17.12
       version: 2.17.12
     '@types/react-datepicker':
-      specifier: ^2.9.4
+      specifier: 2.11.1
       version: 2.11.1
     '@types/react-faux-dom':
-      specifier: ^4.1.1
+      specifier: 4.1.8
       version: 4.1.8
     '@types/react-redux':
-      specifier: ^7.1.9
+      specifier: 7.1.34
       version: 7.1.34
     '@types/react-router':
-      specifier: ^2.0.41
+      specifier: 2.0.61
       version: 2.0.61
     '@types/react-select':
-      specifier: ^1.2.0
+      specifier: 1.3.6
       version: 1.3.6
     '@types/react-sortable-tree':
-      specifier: ^0.3.11
+      specifier: 0.3.23
       version: 0.3.23
     '@types/react-transition-group':
-      specifier: ^4.2.3
+      specifier: 4.4.12
       version: 4.4.12
     '@types/redux':
-      specifier: ^3.6.0
+      specifier: 3.6.0
       version: 3.6.0
     '@types/redux-devtools-log-monitor':
-      specifier: ^1.0.34
+      specifier: 1.0.35
       version: 1.0.35
     '@types/redux-thunk':
-      specifier: ^2.1.0
+      specifier: 2.1.0
       version: 2.1.0
     '@types/relaxed-json':
-      specifier: ~1.0.4
+      specifier: 1.0.4
       version: 1.0.4
     '@types/resolve':
-      specifier: ~1.20.6
+      specifier: 1.20.6
       version: 1.20.6
     '@types/rimraf':
-      specifier: ^2.0.3
+      specifier: 2.0.5
       version: 2.0.5
     '@types/semver':
-      specifier: ~7.7.1
+      specifier: 7.7.1
       version: 7.7.1
     '@types/shortid':
-      specifier: ~2.2.0
+      specifier: 2.2.0
       version: 2.2.0
     '@types/source-map-support':
-      specifier: ~0.5.10
+      specifier: 0.5.10
       version: 0.5.10
     '@types/string-template':
-      specifier: ~1.0.7
+      specifier: 1.0.7
       version: 1.0.7
     '@types/tmp':
-      specifier: ~0.1.0
+      specifier: 0.1.0
       version: 0.1.0
     '@types/universal-analytics':
-      specifier: ~0.4.8
+      specifier: 0.4.8
       version: 0.4.8
     '@types/uuid':
-      specifier: ^3.4.6
+      specifier: 3.4.13
       version: 3.4.13
     '@types/webpack-node-externals':
-      specifier: ~3.0.4
+      specifier: 3.0.4
       version: 3.0.4
     '@types/which':
-      specifier: ^1.3.1
+      specifier: 1.3.2
       version: 1.3.2
     '@types/write-file-atomic':
-      specifier: ~3.0.3
+      specifier: 3.0.3
       version: 3.0.3
     '@types/ws':
-      specifier: ~7.4.7
+      specifier: 7.4.7
       version: 7.4.7
     '@types/xml2js':
-      specifier: ~0.4.14
+      specifier: 0.4.14
       version: 0.4.14
     '@typescript-eslint/utils':
       specifier: 8.59.3
       version: 8.59.3
     '@vitejs/plugin-react':
-      specifier: ^6.0.1
+      specifier: 6.0.1
       version: 6.0.1
     '@vitest/coverage-v8':
-      specifier: ^4.1.0
+      specifier: 4.1.2
       version: 4.1.2
     '@vitest/ui':
       specifier: 4.1.0
       version: 4.1.0
     '@welldone-software/why-did-you-render':
-      specifier: ^10.0.1
+      specifier: 10.0.1
       version: 10.0.1
     bbcode-to-react:
       specifier: git+https://github.com/TanninOne/bbcode-to-react#c67356006470e5066ea447e04a3968dca367339d
       version: 0.2.11
     big.js:
-      specifier: ^5.2.2
+      specifier: 5.2.2
       version: 5.2.2
     bluebird:
-      specifier: ^3.7.2
+      specifier: 3.7.2
       version: 3.7.2
     bootstrap-sass:
-      specifier: ^3.4.1
+      specifier: 3.4.3
       version: 3.4.3
     bs58:
-      specifier: ^4.0.1
+      specifier: 4.0.1
       version: 4.0.1
     bsatk:
       specifier: git+https://github.com/Nexus-Mods/node-bsatk#5a3d15fae2177bfb0a42b794d3afb21eda563c59
       version: 2.1.0
     classnames:
-      specifier: ^2.2.6
+      specifier: 2.5.1
       version: 2.5.1
     cli-table3:
-      specifier: ^0.6.5
+      specifier: 0.6.5
       version: 0.6.5
     commander:
-      specifier: ^4.0.1
+      specifier: 4.1.1
       version: 4.1.1
     content-disposition:
-      specifier: ^0.5.3
+      specifier: 0.5.4
       version: 0.5.4
     content-type:
-      specifier: ^1.0.4
+      specifier: 1.0.5
       version: 1.0.5
     copyfiles:
-      specifier: ^2.4.1
+      specifier: 2.4.1
       version: 2.4.1
     crc-32:
-      specifier: ^1.2.1
+      specifier: 1.2.2
       version: 1.2.2
     cross-env:
-      specifier: ^10.1.0
+      specifier: 10.1.0
       version: 10.1.0
     cross-fetch:
-      specifier: ^3.1.5
+      specifier: 3.2.0
       version: 3.2.0
     csstype:
       specifier: 3.2.3
       version: 3.2.3
     cytoscape:
-      specifier: ^3.6.0
+      specifier: 3.33.1
       version: 3.33.1
     cytoscape-cose-bilkent:
-      specifier: ^4.1.0
+      specifier: 4.1.0
       version: 4.1.0
     cytoscape-edgehandles:
-      specifier: ^3.5.1
+      specifier: 3.6.0
       version: 3.6.0
     d3:
-      specifier: ^5.14.1
+      specifier: 5.16.0
       version: 5.16.0
     date-fns:
-      specifier: ^2.8.0
+      specifier: 2.30.0
       version: 2.30.0
     dayjs:
-      specifier: ^1.11.10
+      specifier: 1.11.20
       version: 1.11.20
     dequal:
-      specifier: ^2.0.3
+      specifier: 2.0.3
       version: 2.0.3
     dnd-core:
-      specifier: ^9.4.0
+      specifier: 9.5.1
       version: 9.5.1
     draggabilly:
-      specifier: ^2.2.0
+      specifier: 2.4.1
       version: 2.4.1
     drivelist:
       specifier: git+https://github.com/TanninOne/drivelist#720d1890db11482ec05fc0f6aa176cfa6e6844dd
@@ -576,19 +576,19 @@ catalogs:
       specifier: 24.13.3
       version: 24.13.3
     electron-context-menu:
-      specifier: ^3.1.1
+      specifier: 3.6.1
       version: 3.6.1
     electron-extension-installer:
-      specifier: ^2.0.1
+      specifier: 2.0.1
       version: 2.0.1
     electron-redux:
       specifier: git+https://github.com/TanninOne/electron-redux#66bbd9d389579806e8c4ebd87bd513a668cc64a8
       version: 1.4.9-sync
     electron-updater:
-      specifier: ^4.2.0
+      specifier: 4.6.5
       version: 4.6.5
     encoding-down:
-      specifier: ^6.3.0
+      specifier: 6.3.0
       version: 6.3.0
     eslint:
       specifier: 10.4.0
@@ -609,70 +609,70 @@ catalogs:
       specifier: 5.9.0
       version: 5.9.0
     feedparser:
-      specifier: ^2.2.9
+      specifier: 2.3.0
       version: 2.3.0
     font-scanner:
-      specifier: ^0.2.1
+      specifier: 0.2.1
       version: 0.2.1
     fork-ts-checker-webpack-plugin:
-      specifier: ^9.0.2
+      specifier: 9.1.0
       version: 9.1.0
     fs-extra:
-      specifier: ^9.1.0
+      specifier: 9.1.0
       version: 9.1.0
     fuzzball:
-      specifier: ^1.3.0
+      specifier: 1.4.0
       version: 1.4.0
     glob:
-      specifier: ^11.0.3
+      specifier: 11.1.0
       version: 11.1.0
     globals:
-      specifier: ^17.3.0
+      specifier: 17.4.0
       version: 17.4.0
     got:
       specifier: 15.0.2
       version: 15.0.2
     graphlib:
-      specifier: ^2.1.7
+      specifier: 2.1.8
       version: 2.1.8
     happy-dom:
-      specifier: ^20.8.3
+      specifier: 20.8.8
       version: 20.8.8
     husky:
-      specifier: ^9.1.7
+      specifier: 9.1.7
       version: 9.1.7
     i18next:
-      specifier: ^19.0.1
+      specifier: 19.9.2
       version: 19.9.2
     i18next-fs-backend:
-      specifier: ^2.1.1
+      specifier: 2.6.1
       version: 2.6.1
     iconv-lite:
-      specifier: ^0.5.0
+      specifier: 0.5.2
       version: 0.5.2
     immutability-helper:
-      specifier: ^3.0.1
+      specifier: 3.1.1
       version: 3.1.1
     ini:
-      specifier: ^6.0.0
+      specifier: 6.0.0
       version: 6.0.0
     interweave:
-      specifier: ^12.9.0
+      specifier: 12.9.0
       version: 12.9.0
     is-admin:
-      specifier: ^3.0.0
+      specifier: 3.0.0
       version: 3.0.0
     js-yaml:
-      specifier: ^4.1.0
+      specifier: 4.1.1
       version: 4.1.1
     json-loader:
-      specifier: ^0.5.7
+      specifier: 0.5.7
       version: 0.5.7
     json-socket:
       specifier: git+https://github.com/foi/node-json-socket#d56c8e2938fa4284c4001b815d9b6e4a92b5c07b
       version: 0.3.0
     jsonwebtoken:
-      specifier: ^9.0.0
+      specifier: 9.0.3
       version: 9.0.3
     leveldown:
       specifier: 5.6.0
@@ -681,34 +681,34 @@ catalogs:
       specifier: 4.4.0
       version: 4.4.0
     limiter:
-      specifier: ^3.0.0
+      specifier: 3.0.0
       version: 3.0.0
     lint-staged:
-      specifier: ^15.5.0
+      specifier: 15.5.2
       version: 15.5.2
     lodash:
-      specifier: ^4.17.21
+      specifier: 4.17.23
       version: 4.17.23
     loot:
       specifier: git+https://github.com/Nexus-Mods/node-loot#7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d
       version: 6.2.2
     lru-cache:
-      specifier: ^11.2.6
+      specifier: 11.2.7
       version: 11.2.7
     markdown-ast:
-      specifier: ^0.2.1
+      specifier: 0.2.1
       version: 0.2.1
     memoize-one:
-      specifier: ^5.1.1
+      specifier: 5.2.1
       version: 5.2.1
     minimatch:
-      specifier: ^3.0.5
+      specifier: 3.1.5
       version: 3.1.5
     minimist:
-      specifier: ^1.2.8
+      specifier: 1.2.8
       version: 1.2.8
     mixpanel-browser:
-      specifier: ^2.71.0
+      specifier: 2.77.0
       version: 2.77.0
     modmeta-db:
       specifier: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
@@ -723,118 +723,118 @@ catalogs:
       specifier: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
       version: 0.8.1
     normalize-url:
-      specifier: ^6.0.1
+      specifier: 6.1.0
       version: 6.1.0
     numeral:
-      specifier: ^2.0.6
+      specifier: 2.0.6
       version: 2.0.6
     nx:
-      specifier: ^22.7.1
+      specifier: 22.7.1
       version: 22.7.1
     oxfmt:
-      specifier: ^0.41.0
+      specifier: 0.41.0
       version: 0.41.0
     p-limit:
-      specifier: ^7.3.0
+      specifier: 7.3.0
       version: 7.3.0
     p-queue:
-      specifier: ^9.1.0
+      specifier: 9.1.0
       version: 9.1.0
     packery:
-      specifier: ^2.1.2
+      specifier: 2.1.2
       version: 2.1.2
     permissions:
       specifier: git+https://github.com/Nexus-Mods/node-permissions#7c1b6f1d6437f2238be51316de823b0fbd63e4c0
       version: 2.1.0
     playwright:
-      specifier: ^1.58.2
+      specifier: 1.58.2
       version: 1.58.2
     prop-types:
-      specifier: ^15.7.2
+      specifier: 15.8.1
       version: 15.8.1
     ps-list:
-      specifier: ^7.2.0
+      specifier: 7.2.0
       version: 7.2.0
     re-reselect:
       specifier: 4.0.1
       version: 4.0.1
     re-resizable:
-      specifier: ^6.9.9
+      specifier: 6.11.2
       version: 6.11.2
     react:
-      specifier: ^16.12.0
+      specifier: 16.14.0
       version: 16.14.0
     react-bootstrap:
-      specifier: ^0.33.0
+      specifier: 0.33.1
       version: 0.33.1
     react-color:
-      specifier: ^2.17.0
+      specifier: 2.19.3
       version: 2.19.3
     react-datepicker:
-      specifier: ^3.3.0
+      specifier: 3.8.0
       version: 3.8.0
     react-dnd:
-      specifier: ^14.0.5
+      specifier: 14.0.5
       version: 14.0.5
     react-dnd-html5-backend:
-      specifier: ^14.0.5
+      specifier: 14.1.0
       version: 14.1.0
     react-dom:
-      specifier: ^16.12.0
+      specifier: 16.14.0
       version: 16.14.0
     react-hot-toast:
-      specifier: ^2.6.0
+      specifier: 2.6.0
       version: 2.6.0
     react-i18next:
-      specifier: ^11.11.0
+      specifier: 11.18.6
       version: 11.18.6
     react-markdown:
-      specifier: ^6.0.2
+      specifier: 6.0.3
       version: 6.0.3
     react-overlays:
-      specifier: ^1.2.0
+      specifier: 1.2.0
       version: 1.2.0
     react-redux:
-      specifier: ^7.1.3
+      specifier: 7.2.9
       version: 7.2.9
     react-resize-detector:
-      specifier: ^4.2.1
+      specifier: 4.2.3
       version: 4.2.3
     react-select:
-      specifier: ^1.2.1
+      specifier: 1.3.0
       version: 1.3.0
     react-sortable-tree:
-      specifier: ^2.6.2
+      specifier: 2.8.0
       version: 2.8.0
     react-sortable-tree-theme-file-explorer:
-      specifier: ^2.0.0
+      specifier: 2.0.0
       version: 2.0.0
     recharts:
-      specifier: ^1.8.5
+      specifier: 1.8.6
       version: 1.8.6
     redux:
-      specifier: ^4.0.4
+      specifier: 4.2.1
       version: 4.2.1
     redux-act:
-      specifier: ^1.8.0
+      specifier: 1.8.0
       version: 1.8.0
     redux-batched-actions:
-      specifier: ^0.5.0
+      specifier: 0.5.0
       version: 0.5.0
     redux-freeze:
       specifier: 0.1.7
       version: 0.1.7
     redux-thunk:
-      specifier: ^2.3.0
+      specifier: 2.4.2
       version: 2.4.2
     relaxed-json:
-      specifier: ^1.0.3
+      specifier: 1.0.3
       version: 1.0.3
     reselect:
-      specifier: ^4.1.7
+      specifier: 4.1.8
       version: 4.1.8
     resolve:
-      specifier: ^1.12.0
+      specifier: 1.22.11
       version: 1.22.11
     rimraf:
       specifier: git+https://github.com/TanninOne/rimraf#7b8b70d4e8783cd233fca3283cf1f930af4e39c2
@@ -846,58 +846,58 @@ catalogs:
       specifier: 1.97.3
       version: 1.97.3
     semver:
-      specifier: ^7.6.0
+      specifier: 7.7.4
       version: 7.7.4
     shortid:
       specifier: 2.2.17
       version: 2.2.17
     simple-git:
-      specifier: ^3.7.1
+      specifier: 3.33.0
       version: 3.33.0
     simple-vdf:
       specifier: git+https://github.com/Nexus-Mods/vdf-parser#df279ff89cb480597544d3029e12f90cb8c79464
       version: 1.1.3
     source-map-loader:
-      specifier: ^5.0.0
+      specifier: 5.0.0
       version: 5.0.0
     source-map-support:
-      specifier: ^0.5.16
+      specifier: 0.5.21
       version: 0.5.21
     string-template:
-      specifier: ^1.0.0
+      specifier: 1.0.0
       version: 1.0.0
     tailwindcss:
-      specifier: ^4.1.17
+      specifier: 4.2.2
       version: 4.2.2
     terser-webpack-plugin:
-      specifier: ^5.3.10
+      specifier: 5.4.0
       version: 5.4.0
     tmp:
-      specifier: ^0.1.0
+      specifier: 0.1.0
       version: 0.1.0
     tough-cookie:
-      specifier: ^6.0.1
+      specifier: 6.0.1
       version: 6.0.1
     ts-loader:
-      specifier: ^9.5.1
+      specifier: 9.5.4
       version: 9.5.4
     ts-v-gen:
-      specifier: ^1.0.1
+      specifier: 1.0.3
       version: 1.0.3
     tsconfig-paths-webpack-plugin:
-      specifier: ^4.2.0
+      specifier: 4.2.0
       version: 4.2.0
     tsdown:
       specifier: 0.21.0-beta.1
       version: 0.21.0-beta.1
     tsx:
-      specifier: ^4.22.0
+      specifier: 4.22.0
       version: 4.22.0
     turbowalk:
       specifier: git+https://github.com/Nexus-Mods/node-turbowalk#3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
       version: 3.1.1
     typed-binary:
-      specifier: ^4.3.3
+      specifier: 4.3.3
       version: 4.3.3
     typescript:
       specifier: 6.0.3
@@ -906,34 +906,34 @@ catalogs:
       specifier: 8.59.3
       version: 8.59.3
     universal-analytics:
-      specifier: ^0.4.23
+      specifier: 0.4.23
       version: 0.4.23
     uuid:
-      specifier: ^3.3.3
+      specifier: 3.4.0
       version: 3.4.0
     vite:
-      specifier: ^8.0.0
+      specifier: 8.0.3
       version: 8.0.3
     vite-plugin-doctest:
-      specifier: ^2.0.0
+      specifier: 2.0.0
       version: 2.0.0
     vitest:
-      specifier: ^4.1.0
+      specifier: 4.1.2
       version: 4.1.2
     vortex-parse-ini:
       specifier: git+https://github.com/Nexus-Mods/vortex-parse-ini#2425af99d1cff2331ccf3aacfa892c314e99e18d
       version: 0.4.0
     webpack:
-      specifier: ^5.94.0
+      specifier: 5.105.4
       version: 5.105.4
     webpack-cli:
-      specifier: ^5.1.4
+      specifier: 5.1.4
       version: 5.1.4
     webpack-node-externals:
-      specifier: ^3.0.0
+      specifier: 3.0.0
       version: 3.0.0
     which:
-      specifier: ^1.3.1
+      specifier: 1.3.1
       version: 1.3.1
     wholocks:
       specifier: git+https://github.com/Nexus-Mods/node-wholocks#28da3bcf312312e577d7c636799a59011998b4af
@@ -942,22 +942,22 @@ catalogs:
       specifier: git+https://github.com/Nexus-Mods/node-winapi-bindings#faa92afe3320731e98abc15b3f5f19c60896d7c1
       version: 2.7.3
     winston:
-      specifier: ^2.4.3
+      specifier: 2.4.7
       version: 2.4.7
     write-file-atomic:
-      specifier: ^3.0.1
+      specifier: 3.0.3
       version: 3.0.3
     ws:
-      specifier: ^7.4.6
+      specifier: 7.5.10
       version: 7.5.10
     xml2js:
-      specifier: ^0.5.0
+      specifier: 0.5.0
       version: 0.5.0
     xxhash-addon:
-      specifier: ^2.0.3
+      specifier: 2.1.0
       version: 2.1.0
     zod:
-      specifier: ^4.3.5
+      specifier: 4.3.6
       version: 4.3.6
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,262 +33,261 @@ allowBuilds:
 catalog:
   7z-bin: git+https://github.com/Nexus-Mods/7z-bin#3298c42e69e3220dc39694bc2f610c077c3e213a
   "@babel/polyfill": 7.12.1
-  "@babel/preset-env": ^7.25.4
-  "@babel/preset-react": ^7.24.4
+  "@babel/preset-env": 7.29.2
+  "@babel/preset-react": 7.28.5
   "@babel/preset-typescript": 7.16.7
   "@babel/register": 7.16.8
-  "@cyclonedx/cyclonedx-library": ^10.0.0
+  "@cyclonedx/cyclonedx-library": 10.0.0
   "@duckdb/node-api": 1.5.1-r.1
-  "@electron/rebuild": ^4.0.4
-  "@electron/remote": ^2.0.12
+  "@electron/rebuild": 4.0.4
+  "@electron/remote": 2.1.3
   "@eslint-react/eslint-plugin": 3.0.0
   "@eslint/js": 10.0.1
-  "@headlessui/react": ^1.7.19
-  "@hot-updater/bsdiff": ^0.30.6
-  "@iarna/toml": ^2.2.5
+  "@headlessui/react": 1.7.19
+  "@hot-updater/bsdiff": 0.30.6
+  "@iarna/toml": 2.2.5
   "@mdi/js": 7.4.47
-  "@microsoft/api-extractor": ^7.58.7
-  "@msgpack/msgpack": ^2.7.0
-  "@nexusmods/fomod-installer-ipc": ^0.13.1
-  "@nexusmods/fomod-installer-native": ^0.13.1
+  "@microsoft/api-extractor": 7.58.7
+  "@msgpack/msgpack": 2.8.0
+  "@nexusmods/fomod-installer-ipc": 0.13.1
+  "@nexusmods/fomod-installer-native": 0.13.1
   "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
-  "@opentelemetry/api": ^1.9.0
-  "@opentelemetry/context-async-hooks": ^2.5.1
-  "@opentelemetry/context-zone": ^2.5.1
-  "@opentelemetry/exporter-trace-otlp-http": ^0.57.0
-  "@opentelemetry/resources": ^1.30.0
-  "@opentelemetry/sdk-trace-base": ^1.30.0
-  "@opentelemetry/semantic-conventions": ^1.30.0
-  "@playwright/test": ^1.58.2
+  "@opentelemetry/api": 1.9.1
+  "@opentelemetry/context-async-hooks": 2.6.1
+  "@opentelemetry/context-zone": 2.7.0
+  "@opentelemetry/exporter-trace-otlp-http": 0.57.2
+  "@opentelemetry/resources": 1.30.1
+  "@opentelemetry/sdk-trace-base": 1.30.1
+  "@opentelemetry/semantic-conventions": 1.40.0
+  "@playwright/test": 1.58.2
   "@stylistic/eslint-plugin": 5.10.0
-  "@tailwindcss/cli": ^4.1.17
-  "@testing-library/dom": ^10.4.1
-  "@testing-library/jest-dom": ^6.9.1
-  "@testing-library/react": ^12.1.5
-  "@testing-library/user-event": ^14.6.1
-  "@types/babel__preset-env": ~7.10.0
-  "@types/babel__register": ~7.17.3
-  "@types/bbcode-to-react": ~0.2.4
-  "@types/big.js": ~6.2.2
+  "@tailwindcss/cli": 4.2.2
+  "@testing-library/dom": 10.4.1
+  "@testing-library/jest-dom": 6.9.1
+  "@testing-library/react": 12.1.5
+  "@testing-library/user-event": 14.6.1
+  "@types/babel__preset-env": 7.10.0
+  "@types/babel__register": 7.17.3
+  "@types/bbcode-to-react": 0.2.4
+  "@types/big.js": 6.2.2
   "@types/bluebird": 3.5.20
-  "@types/content-disposition": ~0.5.9
-  "@types/content-type": ^1.1.3
-  "@types/copyfiles": ~2.4.4
-  "@types/d3": ~7.4.3
+  "@types/content-disposition": 0.5.9
+  "@types/content-type": 1.1.9
+  "@types/copyfiles": 2.4.4
+  "@types/d3": 7.4.3
   "@types/draggabilly": 2.1.3
-  "@types/encoding-down": ~5.0.5
-  "@types/feedparser": ~2.2.8
-  "@types/fs-extra": ~11.0.4
-  "@types/graphlib": ~2.1.12
-  "@types/i18next": ^12.1.0
-  "@types/iconv-lite": ^0.0.1
-  "@types/js-yaml": ^4.0.9
-  "@types/json-socket": ~0.1.21
-  "@types/jsonwebtoken": ~9.0.10
-  "@types/libxmljs": ^0.18.4
-  "@types/lodash": ~4.17.24
-  "@types/minimatch": ^2.0.29
-  "@types/minimist": ~1.2.5
-  "@types/node": ^24
-  "@types/node-7z": ~2.1.11
-  "@types/numeral": ~2.0.5
-  "@types/packery": ~1.4.37
-  "@types/prop-types": ~15.7.15
+  "@types/encoding-down": 5.0.5
+  "@types/feedparser": 2.2.8
+  "@types/fs-extra": 11.0.4
+  "@types/graphlib": 2.1.12
+  "@types/i18next": 12.1.0
+  "@types/iconv-lite": 0.0.1
+  "@types/js-yaml": 4.0.9
+  "@types/json-socket": 0.1.21
+  "@types/jsonwebtoken": 9.0.10
+  "@types/libxmljs": 0.18.13
+  "@types/lodash": 4.17.24
+  "@types/minimatch": 2.0.29
+  "@types/minimist": 1.2.5
+  "@types/node": 24.12.2
+  "@types/node-7z": 2.1.11
+  "@types/numeral": 2.0.5
+  "@types/packery": 1.4.37
+  "@types/prop-types": 15.7.15
   "@types/react": ^16.14.66
-  "@types/react-bootstrap": ^0.32.20
-  "@types/react-color": ^2.14.0
-  "@types/react-datepicker": ^2.9.4
+  "@types/react-bootstrap": 0.32.37
+  "@types/react-color": 2.17.12
+  "@types/react-datepicker": 2.11.1
   "@types/react-dom": ~19.2.3
-  "@types/react-faux-dom": ^4.1.1
-  "@types/react-redux": ^7.1.9
-  "@types/react-router": ^2.0.41
-  "@types/react-select": ^1.2.0
-  "@types/react-sortable-tree": ^0.3.11
-  "@types/react-transition-group": ^4.2.3
-  "@types/redux": ^3.6.0
-  "@types/redux-devtools-log-monitor": ^1.0.34
-  "@types/redux-thunk": ^2.1.0
-  "@types/relaxed-json": ~1.0.4
-  "@types/resolve": ~1.20.6
-  "@types/rimraf": ^2.0.3
-  "@types/semver": ~7.7.1
-  "@types/shortid": ~2.2.0
-  "@types/source-map-support": ~0.5.10
-  "@types/string-template": ~1.0.7
-  "@types/tmp": ~0.1.0
-  "@types/universal-analytics": ~0.4.8
-  "@types/uuid": ^3.4.6
-  "@types/webpack-node-externals": ~3.0.4
-  "@types/which": ^1.3.1
-  "@types/write-file-atomic": ~3.0.3
-  "@types/ws": ~7.4.7
-  "@types/xml2js": ~0.4.14
+  "@types/react-faux-dom": 4.1.8
+  "@types/react-redux": 7.1.34
+  "@types/react-router": 2.0.61
+  "@types/react-select": 1.3.6
+  "@types/react-sortable-tree": 0.3.23
+  "@types/react-transition-group": 4.4.12
+  "@types/redux": 3.6.0
+  "@types/redux-devtools-log-monitor": 1.0.35
+  "@types/redux-thunk": 2.1.0
+  "@types/relaxed-json": 1.0.4
+  "@types/resolve": 1.20.6
+  "@types/rimraf": 2.0.5
+  "@types/semver": 7.7.1
+  "@types/shortid": 2.2.0
+  "@types/source-map-support": 0.5.10
+  "@types/string-template": 1.0.7
+  "@types/tmp": 0.1.0
+  "@types/universal-analytics": 0.4.8
+  "@types/uuid": 3.4.13
+  "@types/webpack-node-externals": 3.0.4
+  "@types/which": 1.3.2
+  "@types/write-file-atomic": 3.0.3
+  "@types/ws": 7.4.7
+  "@types/xml2js": 0.4.14
   "@typescript-eslint/utils": 8.59.3
-  "@vitejs/plugin-react": ^6.0.1
-  "@vitest/coverage-v8": ^4.1.0
+  "@vitejs/plugin-react": 6.0.1
+  "@vitest/coverage-v8": 4.1.2
   "@vitest/ui": 4.1.0
-  "@welldone-software/why-did-you-render": ^10.0.1
+  "@welldone-software/why-did-you-render": 10.0.1
   bbcode-to-react: git+https://github.com/TanninOne/bbcode-to-react#c67356006470e5066ea447e04a3968dca367339d
-  big.js: ^5.2.2
-  bluebird: ^3.7.2
-  bootstrap-sass: ^3.4.1
-  bs58: ^4.0.1
+  big.js: 5.2.2
+  bluebird: 3.7.2
+  bootstrap-sass: 3.4.3
+  bs58: 4.0.1
   bsatk: git+https://github.com/Nexus-Mods/node-bsatk#5a3d15fae2177bfb0a42b794d3afb21eda563c59
-  classnames: ^2.2.6
-  cli-table3: ^0.6.5
-  commander: ^4.0.1
-  content-disposition: ^0.5.3
-  content-type: ^1.0.4
-  copyfiles: ^2.4.1
-  crc-32: ^1.2.1
-  cross-env: ^10.1.0
-  cross-fetch: ^3.1.5
+  classnames: 2.5.1
+  cli-table3: 0.6.5
+  commander: 4.1.1
+  content-disposition: 0.5.4
+  content-type: 1.0.5
+  copyfiles: 2.4.1
+  crc-32: 1.2.2
+  cross-env: 10.1.0
+  cross-fetch: 3.2.0
   csstype: 3.2.3
-  cytoscape: ^3.6.0
-  cytoscape-cose-bilkent: ^4.1.0
-  cytoscape-edgehandles: ^3.5.1
-  d3: ^5.14.1
-  date-fns: ^2.8.0
-  dayjs: ^1.11.10
-  dequal: ^2.0.3
-  dnd-core: ^9.4.0
-  draggabilly: ^2.2.0
+  cytoscape: 3.33.1
+  cytoscape-cose-bilkent: 4.1.0
+  cytoscape-edgehandles: 3.6.0
+  d3: 5.16.0
+  date-fns: 2.30.0
+  dayjs: 1.11.20
+  dequal: 2.0.3
+  dnd-core: 9.5.1
+  draggabilly: 2.4.1
   drivelist: git+https://github.com/TanninOne/drivelist#720d1890db11482ec05fc0f6aa176cfa6e6844dd
   electron: 42.0.0
   electron-builder: 24.13.3
-  electron-context-menu: ^3.1.1
-  electron-extension-installer: ^2.0.1
+  electron-context-menu: 3.6.1
+  electron-extension-installer: 2.0.1
   electron-redux: git+https://github.com/TanninOne/electron-redux#66bbd9d389579806e8c4ebd87bd513a668cc64a8
-  electron-updater: ^4.2.0
-  encoding-down: ^6.3.0
+  electron-updater: 4.6.5
+  encoding-down: 6.3.0
   eslint: 10.4.0
   eslint-config-prettier: 10.1.8
   eslint-import-resolver-typescript: 4.4.4
   eslint-plugin-better-tailwindcss: 4.5.0
   eslint-plugin-import: 2.32.0
   eslint-plugin-perfectionist: 5.9.0
-  feedparser: ^2.2.9
-  font-scanner: ^0.2.1
-  fork-ts-checker-webpack-plugin: ^9.0.2
-  fs-extra: ^9.1.0
-  fuzzball: ^1.3.0
-  glob: ^11.0.3
-  globals: ^17.3.0
+  feedparser: 2.3.0
+  font-scanner: 0.2.1
+  fork-ts-checker-webpack-plugin: 9.1.0
+  fs-extra: 9.1.0
+  fuzzball: 1.4.0
+  glob: 11.1.0
+  globals: 17.4.0
   got: 15.0.2
-  graphlib: ^2.1.7
-  happy-dom: ^20.8.3
-  husky: ^9.1.7
-  i18next: ^19.0.1
-  i18next-fs-backend: ^2.1.1
-  iconv-lite: ^0.5.0
-  immutability-helper: ^3.0.1
-  ini: ^6.0.0
-  interweave: ^12.9.0
-  is-admin: ^3.0.0
-  js-yaml: ^4.1.0
-  json-loader: ^0.5.7
+  graphlib: 2.1.8
+  happy-dom: 20.8.8
+  husky: 9.1.7
+  i18next: 19.9.2
+  i18next-fs-backend: 2.6.1
+  iconv-lite: 0.5.2
+  immutability-helper: 3.1.1
+  ini: 6.0.0
+  interweave: 12.9.0
+  is-admin: 3.0.0
+  js-yaml: 4.1.1
+  json-loader: 0.5.7
   json-socket: git+https://github.com/foi/node-json-socket#d56c8e2938fa4284c4001b815d9b6e4a92b5c07b
-  jsonwebtoken: ^9.0.0
+  jsonwebtoken: 9.0.3
   leveldown: 5.6.0
   levelup: 4.4.0
-  limiter: ^3.0.0
-  lint-staged: ^15.5.0
-  lodash: ^4.17.21
+  limiter: 3.0.0
+  lint-staged: 15.5.2
+  lodash: 4.17.23
   loot: git+https://github.com/Nexus-Mods/node-loot#7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d
-  lru-cache: ^11.2.6
-  markdown-ast: ^0.2.1
-  memoize-one: ^5.1.1
-  minimatch: ^3.0.5
-  minimist: ^1.2.8
-  mixpanel-browser: ^2.71.0
+  lru-cache: 11.2.7
+  markdown-ast: 0.2.1
+  memoize-one: 5.2.1
+  minimatch: 3.1.5
+  minimist: 1.2.8
+  mixpanel-browser: 2.77.0
   modmeta-db: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
   nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#2d92fd2bdc4aa6b9813a1e7043d412e13f4aa1d7
   node: runtime:24.15.0
   node-7z: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
-  normalize-url: ^6.0.1
-  numeral: ^2.0.6
-  nx: ^22.7.1
-  oxfmt: ^0.41.0
-  p-limit: ^7.3.0
-  p-queue: ^9.1.0
-  packery: ^2.1.2
+  normalize-url: 6.1.0
+  numeral: 2.0.6
+  nx: 22.7.1
+  oxfmt: 0.41.0
+  p-limit: 7.3.0
+  p-queue: 9.1.0
+  packery: 2.1.2
   permissions: git+https://github.com/Nexus-Mods/node-permissions#7c1b6f1d6437f2238be51316de823b0fbd63e4c0
-  playwright: ^1.58.2
-  prop-types: ^15.7.2
-  ps-list: ^7.2.0
+  playwright: 1.58.2
+  prop-types: 15.8.1
+  ps-list: 7.2.0
   re-reselect: 4.0.1
-  re-resizable: ^6.9.9
-  react: ^16.12.0
-  react-bootstrap: ^0.33.0
-  react-color: ^2.17.0
-  react-datepicker: ^3.3.0
-  react-dnd: ^14.0.5
-  react-dnd-html5-backend: ^14.0.5
-  react-dom: ^16.12.0
-  react-hot-toast: ^2.6.0
-  react-i18next: ^11.11.0
-  react-markdown: ^6.0.2
-  react-overlays: ^1.2.0
-  react-redux: ^7.1.3
-  react-resize-detector: ^4.2.1
-  react-select: ^1.2.1
-  react-sortable-tree: ^2.6.2
-  react-sortable-tree-theme-file-explorer: ^2.0.0
-  recharts: ^1.8.5
-  redux: ^4.0.4
-  redux-act: ^1.8.0
-  redux-batched-actions: ^0.5.0
+  re-resizable: 6.11.2
+  react: 16.14.0
+  react-bootstrap: 0.33.1
+  react-color: 2.19.3
+  react-datepicker: 3.8.0
+  react-dnd: 14.0.5
+  react-dnd-html5-backend: 14.1.0
+  react-dom: 16.14.0
+  react-hot-toast: 2.6.0
+  react-i18next: 11.18.6
+  react-markdown: 6.0.3
+  react-overlays: 1.2.0
+  react-redux: 7.2.9
+  react-resize-detector: 4.2.3
+  react-select: 1.3.0
+  react-sortable-tree: 2.8.0
+  react-sortable-tree-theme-file-explorer: 2.0.0
+  recharts: 1.8.6
+  redux: 4.2.1
+  redux-act: 1.8.0
+  redux-batched-actions: 0.5.0
   redux-freeze: 0.1.7
-  redux-thunk: ^2.3.0
-  relaxed-json: ^1.0.3
-  reselect: ^4.1.7
-  resolve: ^1.12.0
+  redux-thunk: 2.4.2
+  relaxed-json: 1.0.3
+  reselect: 4.1.8
+  resolve: 1.22.11
   rimraf: git+https://github.com/TanninOne/rimraf#7b8b70d4e8783cd233fca3283cf1f930af4e39c2
   rolldown: 1.0.0-rc.9
   sass: 1.97.3
-  semver: ^7.6.0
+  semver: 7.7.4
   shortid: 2.2.17
-  simple-git: ^3.7.1
+  simple-git: 3.33.0
   simple-vdf: git+https://github.com/Nexus-Mods/vdf-parser#df279ff89cb480597544d3029e12f90cb8c79464
-  source-map-loader: ^5.0.0
-  source-map-support: ^0.5.16
-  string-template: ^1.0.0
-  tailwindcss: ^4.1.17
-  terser-webpack-plugin: ^5.3.10
-  tmp: ^0.1.0
-  tough-cookie: ^6.0.1
-  ts-loader: ^9.5.1
-  ts-v-gen: ^1.0.1
-  tsconfig-paths-webpack-plugin: ^4.2.0
+  source-map-loader: 5.0.0
+  source-map-support: 0.5.21
+  string-template: 1.0.0
+  tailwindcss: 4.2.2
+  terser-webpack-plugin: 5.4.0
+  tmp: 0.1.0
+  tough-cookie: 6.0.1
+  ts-loader: 9.5.4
+  ts-v-gen: 1.0.3
+  tsconfig-paths-webpack-plugin: 4.2.0
   tsdown: 0.21.0-beta.1
-  tsx: ^4.22.0
+  tsx: 4.22.0
   turbowalk: git+https://github.com/Nexus-Mods/node-turbowalk#3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
-  typed-binary: ^4.3.3
+  typed-binary: 4.3.3
   typescript: 6.0.3
   typescript-eslint: 8.59.3
-  universal-analytics: ^0.4.23
-  uuid: ^3.3.3
-  vite: ^8.0.0
-  vite-plugin-doctest: ^2.0.0
-  vitest: ^4.1.0
+  universal-analytics: 0.4.23
+  uuid: 3.4.0
+  vite: 8.0.3
+  vite-plugin-doctest: 2.0.0
+  vitest: 4.1.2
   vortex-parse-ini: git+https://github.com/Nexus-Mods/vortex-parse-ini#2425af99d1cff2331ccf3aacfa892c314e99e18d
-  webpack: ^5.94.0
-  webpack-cli: ^5.1.4
-  webpack-node-externals: ^3.0.0
-  which: ^1.3.1
+  webpack: 5.105.4
+  webpack-cli: 5.1.4
+  webpack-node-externals: 3.0.0
+  which: 1.3.1
   wholocks: git+https://github.com/Nexus-Mods/node-wholocks#28da3bcf312312e577d7c636799a59011998b4af
   winapi-bindings: git+https://github.com/Nexus-Mods/node-winapi-bindings#faa92afe3320731e98abc15b3f5f19c60896d7c1
-  winston: ^2.4.3
-  write-file-atomic: ^3.0.1
-  ws: ^7.4.6
-  xml2js: ^0.5.0
-  xxhash-addon: ^2.0.3
-  zod: ^4.3.5
+  winston: 2.4.7
+  write-file-atomic: 3.0.3
+  ws: 7.5.10
+  xml2js: 0.5.0
+  xxhash-addon: 2.1.0
+  zod: 4.3.6
 
 blockExoticSubdeps: false
 catalogMode: strict
 cleanupUnusedCatalogs: true
-
 dedupePeers: true
 
 engineStrict: true
@@ -303,5 +302,6 @@ overrides:
   "@types/react-dom": "16"
   node-addon-api: 8.5.0
   node-gyp: 12.3.0
+
 patchedDependencies:
   playwright-core@1.58.2: patches/playwright-core@1.58.2.patch


### PR DESCRIPTION
Removes the `^` and `~` prefixes from version ranges and pins exact versions in our catalog as originally intended. This forces version updates to go through the catalog instead of being hidden inside the lock file which nobody checks.