### PR TITLE
extend webview teardown mitigation to SplashScreen

### DIFF
--- a/src/main/src/SplashScreen.ts
+++ b/src/main/src/SplashScreen.ts
@@ -37,6 +37,19 @@ class SplashScreen {
     await delay(500);
 
     if (!this.mWindow?.isDestroyed()) {
+      // hide() before close(): same workaround as MainWindow.ts. Aura's
+      // close/destroy teardown synthesizes a Win32 mouse move that
+      // SendMessage's WM_NCHITTEST back into FramelessView::NonClientHitTest,
+      // which dereferences a null InspectableWebContents mid-teardown and
+      // faults inside electron::InspectableWebContents::GetView. Hiding
+      // first takes us out of screen hit-test so the message routes
+      // elsewhere. Repros as STATUS_FATAL_USER_CALLBACK_EXCEPTION
+      // (0xC000041D) at electron.exe + 0x398fe0. See GH#23176.
+      try {
+        this.mWindow?.hide();
+      } catch {
+        // webContents may already be gone
+      }
       this.mWindow?.close();
     }
 


### PR DESCRIPTION
Same access-violation as the 2.0.2 MainWindow fix, on the splash window. Splash close drives aura's visibility-change handler, a synthesized WM_NCHITTEST reaches WebContentsView::NonClientHitTest, which derefs a null InspectableWebContents and faults at GetView.

The bug is only present in Electron 39-41

Mitigation: hide() before close() in SplashScreen.fadeOut(), mirroring MainWindow.on("close"). Repro: 2/15 baseline crashes (exit 0xC000041D), 0/30 with the fix.

Dead code in `master` and `v2.1` (which is why we're not cherry-picking the fix)

closes APP-459
fixes #23176