### PR TITLE
Vitest shared config and icon-extract test fixes

### DIFF
--- a/extensions/collections/vitest.config.ts
+++ b/extensions/collections/vitest.config.ts
@@ -1,19 +1,24 @@
 import * as path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.base.config";
 
 const mock = (name: string) => path.resolve(import.meta.dirname, `__mocks__/${name}.ts`);
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "original-fs": "fs",
-      "@nexusmods/vortex-api": mock("vortex-api"),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "original-fs": "fs",
+        "@nexusmods/vortex-api": mock("vortex-api"),
+      },
     },
-  },
-  test: {
-    environment: "happy-dom",
-    setupFiles: ["./test-setup.ts"],
-    include: ["src/**/*.test.ts"],
-  },
-});
+    test: {
+      environment: "happy-dom",
+      setupFiles: ["./test-setup.ts"],
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/feedback/vitest.config.ts
+++ b/extensions/feedback/vitest.config.ts
@@ -1,15 +1,20 @@
 import * as path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+      },
     },
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/gamebryo-archive-support/vitest.config.ts
+++ b/extensions/gamebryo-archive-support/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/gamebryo-plugin-management/vitest.config.ts
+++ b/extensions/gamebryo-plugin-management/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/gamebryo-savegame-management/vitest.config.ts
+++ b/extensions/gamebryo-savegame-management/vitest.config.ts
@@ -1,15 +1,20 @@
 import * as path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+      },
     },
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
-  },
-});
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/games/game-baldursgate3/vitest.config.ts
+++ b/extensions/games/game-baldursgate3/vitest.config.ts
@@ -1,11 +1,16 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    // divine.exe invocations can be slow on cold caches.
-    testTimeout: 30000,
-    hookTimeout: 30000,
-  },
-});
+import baseConfig from "../../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      // divine.exe invocations can be slow on cold caches.
+      testTimeout: 30000,
+      hookTimeout: 30000,
+    },
+  }),
+);

--- a/extensions/games/game-stardewvalley/vitest.config.ts
+++ b/extensions/games/game-stardewvalley/vitest.config.ts
@@ -1,15 +1,20 @@
 import * as path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+import baseConfig from "../../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+      },
     },
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/games/game-xrebirth/vitest.config.ts
+++ b/extensions/games/game-xrebirth/vitest.config.ts
@@ -1,6 +1,8 @@
 import { createRequire } from "node:module";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
+
+import baseConfig from "../../../vitest.base.config";
 
 // Resolve through Node's package resolution so the alias survives any future
 // move of the mock package. Regex `find` ensures `vortex-api` is the only
@@ -8,12 +10,15 @@ import { defineConfig } from "vitest/config";
 const require_ = createRequire(import.meta.url);
 const VORTEX_API_MOCK = require_.resolve("@vortex/extension-test-mocks");
 
-export default defineConfig({
-  resolve: {
-    alias: [{ find: /^@nexusmods\/vortex-api$/, replacement: VORTEX_API_MOCK }],
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: [{ find: /^@nexusmods\/vortex-api$/, replacement: VORTEX_API_MOCK }],
+    },
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/extensions/nmm-import-tool/vitest.config.ts
+++ b/extensions/nmm-import-tool/vitest.config.ts
@@ -1,16 +1,21 @@
 import * as path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
-      "modmeta-db": path.resolve(import.meta.dirname, "__mocks__/modmeta-db.ts"),
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@nexusmods/vortex-api": path.resolve(import.meta.dirname, "__mocks__/vortex-api.ts"),
+        "modmeta-db": path.resolve(import.meta.dirname, "__mocks__/modmeta-db.ts"),
+      },
     },
-  },
-  test: {
-    environment: "happy-dom",
-    include: ["src/**/*.test.ts"],
-  },
-});
+    test: {
+      environment: "happy-dom",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/packages/adaptor-api/vitest.config.ts
+++ b/packages/adaptor-api/vitest.config.ts
@@ -1,13 +1,16 @@
 import { doctest } from "vite-plugin-doctest";
-import { defineConfig, type ViteUserConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-const config: ViteUserConfig = defineConfig({
-  plugins: [doctest()],
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    includeSource: ["src/fs/paths.ts", "src/fs/matcher.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
 
-export default config;
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [doctest()],
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      includeSource: ["src/fs/paths.ts", "src/fs/matcher.ts"],
+    },
+  }),
+);

--- a/packages/exe-version/vitest.config.ts
+++ b/packages/exe-version/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/packages/game-extension-test/vitest.config.ts
+++ b/packages/game-extension-test/vitest.config.ts
@@ -1,16 +1,21 @@
 import { createRequire } from "node:module";
 
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.base.config";
 
 const require_ = createRequire(import.meta.url);
 const VORTEX_API_MOCK = require_.resolve("@vortex/extension-test-mocks");
 
-export default defineConfig({
-  resolve: {
-    alias: [{ find: /^@nexusmods\/vortex-api$/, replacement: VORTEX_API_MOCK }],
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: [{ find: /^@nexusmods\/vortex-api$/, replacement: VORTEX_API_MOCK }],
+    },
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/packages/icon-extract/package.json
+++ b/packages/icon-extract/package.json
@@ -32,5 +32,17 @@
       },
       "./package.json": "./package.json"
     }
+  },
+  "nx": {
+    "targets": {
+      "test": {
+        "dependsOn": [
+          {
+            "target": "build:win",
+            "projects": "@tools/dotnetprobe"
+          }
+        ]
+      }
+    }
   }
 }

--- a/packages/icon-extract/src/index.test.ts
+++ b/packages/icon-extract/src/index.test.ts
@@ -11,8 +11,10 @@ const describeOnWindows = process.platform === "win32" ? describe : describe.ski
 const TEST_DATA_DIR = path.resolve(import.meta.dirname, "../test-data");
 const REFERENCE_DIR = path.join(TEST_DATA_DIR, "reference");
 
-// Cross-platform fixture — already committed to the repo
-const DOTNET_PROBE = path.resolve(import.meta.dirname, "../../../assets/dotnetprobe.exe");
+const DOTNET_PROBE = path.resolve(
+  import.meta.dirname,
+  "../../../tools/dotnetprobe/temp/dotnetprobe.exe",
+);
 
 // PNG signature bytes
 const PNG_SIG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
@@ -51,6 +53,8 @@ describe("extractIcon (cross-platform)", () => {
   });
 
   it("handles PE without icons gracefully", async () => {
+    expect(fs.existsSync(DOTNET_PROBE)).toBe(true);
+
     // dotnetprobe.exe is a console app — may not have icons
     const result = await extractIcon(DOTNET_PROBE);
     // Either returns a valid icon or undefined, but must not throw

--- a/packages/icon-extract/src/index.test.ts
+++ b/packages/icon-extract/src/index.test.ts
@@ -161,19 +161,3 @@ describeOnWindows("cross-validation with reference data", () => {
     });
   }
 });
-
-describeOnWindows("benchmark", () => {
-  const notepad = "C:\\Windows\\System32\\notepad.exe";
-  const runs = 500;
-
-  it(`extracts ${runs} icons from notepad.exe`, async () => {
-    await extractIcon(notepad);
-
-    const start = performance.now();
-    for (let i = 0; i < runs; i++) await extractIcon(notepad);
-    const elapsed = performance.now() - start;
-    console.log(
-      `\n  TS PE icon extractor: ${runs} extractions in ${elapsed.toFixed(1)}ms (${(elapsed / runs).toFixed(3)}ms/extraction)`,
-    );
-  });
-});

--- a/packages/icon-extract/vitest.config.ts
+++ b/packages/icon-extract/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/packages/pe-resources/vitest.config.ts
+++ b/packages/pe-resources/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,9 +1,14 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    name: "scripts",
-    environment: "node",
-    include: ["**/*.test.ts"],
-  },
-});
+import baseConfig from "../vitest.base.config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "scripts",
+      environment: "node",
+      include: ["**/*.test.ts"],
+    },
+  }),
+);

--- a/src/main/vitest.config.ts
+++ b/src/main/vitest.config.ts
@@ -1,11 +1,14 @@
-import { defineConfig, type ViteUserConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-const config: ViteUserConfig = defineConfig({
-  test: {
-    name: "@vortex/main",
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
 
-export default config;
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "@vortex/main",
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/src/main/vitest.downloader.config.ts
+++ b/src/main/vitest.downloader.config.ts
@@ -1,12 +1,15 @@
-import { defineConfig, type ViteUserConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-const config: ViteUserConfig = defineConfig({
-  test: {
-    name: "@vortex/main (downloader)",
-    environment: "node",
-    include: ["src/downloading/*.test.integration.ts"],
-    testTimeout: 30_000,
-  },
-});
+import baseConfig from "../../vitest.base.config";
 
-export default config;
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "@vortex/main (downloader)",
+      environment: "node",
+      include: ["src/downloading/*.test.integration.ts"],
+      testTimeout: 30_000,
+    },
+  }),
+);

--- a/src/shared/tsconfig.json
+++ b/src/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig.json",
   "extends": "../../tsconfig.strict.json",
-  "include": ["**/*", "../../typings.custom/promise.d.ts"],
+  "include": ["./src/**/*", "../../typings.custom/promise.d.ts"],
   "compilerOptions": {
     "composite": true,
     "noEmit": true,

--- a/src/shared/vitest.config.ts
+++ b/src/shared/vitest.config.ts
@@ -1,10 +1,13 @@
-import { defineConfig, type ViteUserConfig } from "vitest/config";
+import { mergeConfig, defineConfig } from "vitest/config";
 
-const config: ViteUserConfig = defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});
+import baseConfig from "../../vitest.base.config";
 
-export default config;
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+    },
+  }),
+);

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,6 +8,7 @@
     "./scripts/**/*.ts",
     "./ts-to-zod.config.mjs",
     "./vitest.config.ts",
+    "./vitest.base.config.ts",
     "./rolldown.base.mjs"
   ],
   "compilerOptions": {

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -1,0 +1,22 @@
+import * as path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+const RESULTS_DIR = path.join(import.meta.dirname, "test-results");
+const isGitHubCI = process.env.CI && process.env.GITHUB_ACTIONS;
+
+export default defineConfig({
+  test: {
+    reporters: ["default", "junit", isGitHubCI ? "github-actions" : undefined].filter(
+      Boolean,
+    ) as string[],
+    outputFile: {
+      junit: path.join(RESULTS_DIR, "junit.xml"),
+    },
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "cobertura"],
+      reportsDirectory: RESULTS_DIR,
+    },
+  },
+});

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -1,8 +1,5 @@
-import * as path from "node:path";
-
 import { defineConfig } from "vitest/config";
 
-const RESULTS_DIR = path.join(import.meta.dirname, "test-results");
 const isGitHubCI = process.env.CI && process.env.GITHUB_ACTIONS;
 
 export default defineConfig({
@@ -10,13 +7,5 @@ export default defineConfig({
     reporters: ["default", "junit", isGitHubCI ? "github-actions" : undefined].filter(
       Boolean,
     ) as string[],
-    outputFile: {
-      junit: path.join(RESULTS_DIR, "junit.xml"),
-    },
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "cobertura"],
-      reportsDirectory: RESULTS_DIR,
-    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,8 @@
-import * as path from "node:path";
+import { mergeConfig } from "vitest/config";
 
-import { defineConfig } from "vitest/config";
+import baseConfig from "./vitest.base.config";
 
-const RESULTS_DIR = path.join(import.meta.dirname, "test-results");
-
-const isGitHubCI = process.env.CI && process.env.GITHUB_ACTIONS;
-
-export default defineConfig({
+export default mergeConfig(baseConfig, {
   test: {
     projects: [
       "./src/**/vitest.config.ts",
@@ -15,14 +11,5 @@ export default defineConfig({
       "./extensions/**/vitest.config.ts",
       "./scripts/vitest.config.ts",
     ],
-    reporters: ["default", "junit", isGitHubCI ? "github-actions" : undefined].filter(Boolean),
-    outputFile: {
-      junit: path.join(RESULTS_DIR, "junit.xml"),
-    },
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "cobertura"],
-      reportsDirectory: path.join(RESULTS_DIR),
-    },
   },
 });


### PR DESCRIPTION
Closes LAZ-418.

- Removes the benchmark from icon-extract that was running as a test.
- Use nx for test orchestration with a shared vitest config