### PR TITLE
fix: wrap text in changelog popup and filter dropdown (LAZ-383)

### DIFF
--- a/src/renderer/src/extensions/mod_management/views/VersionChangelogButton.tsx
+++ b/src/renderer/src/extensions/mod_management/views/VersionChangelogButton.tsx
@@ -58,20 +58,18 @@ class VersionChangelogButton extends ComponentEx<IProps, {}> {
 
     const popoverBottom = (
       <Popover id="popover-changelog" title={t("Changelogs")}>
-        <div style={{ maxHeight: 500, overflowY: "auto" }}>
-          <FormGroup>
-            <ControlLabel>{t("Current Version")}</ControlLabel>
-            <div key="dialog-form-changelog" className="mod-changelog">
-              {this.renderChangelog(changelog)}
-            </div>
-          </FormGroup>
-          <FormGroup>
-            <ControlLabel>{t("Newest Version")}</ControlLabel>
-            <div key="dialog-form-newestChangelog" className="mod-changelog">
-              {this.renderChangelog(newestChangelog)}
-            </div>
-          </FormGroup>
-        </div>
+        <FormGroup>
+          <ControlLabel>{t("Current Version")}</ControlLabel>
+          <div key="dialog-form-changelog" className="mod-changelog">
+            {this.renderChangelog(changelog)}
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <ControlLabel>{t("Newest Version")}</ControlLabel>
+          <div key="dialog-form-newestChangelog" className="mod-changelog">
+            {this.renderChangelog(newestChangelog)}
+          </div>
+        </FormGroup>
       </Popover>
     );
 

--- a/src/stylesheets/react-select.scss
+++ b/src/stylesheets/react-select.scss
@@ -39,7 +39,12 @@
     .Select-value {
         margin: 1px 0;
         padding: 0px;
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+    .Select-menu-outer .Select-option {
+        white-space: normal;
+        overflow-wrap: anywhere;
     }
     .Select-value-icon {
         padding: 0px 7px;

--- a/src/stylesheets/vortex/page-mod.scss
+++ b/src/stylesheets/vortex/page-mod.scss
@@ -113,6 +113,7 @@
 
 #popover-changelog {
     .mod-changelog {
-        white-space: pre;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
     }
 }


### PR DESCRIPTION
 ## Summary

Fix [LAZ-383](https://linear.app/nexus-mods/issue/LAZ-383/mod-changelog-popup-and-filter-dropdown-do-not-wrap-text) — long content now wraps in the mod **changelog popover** and in **table column filter dropdowns** instead of forcing horizontal scroll.

## Changes

- **`src/stylesheets/vortex/page-mod.scss`** — `.mod-changelog`: `white-space: pre` → `pre-wrap` (preserves author line breaks but allows wrapping). Added `overflow-wrap: anywhere` so very long unbroken tokens (URLs, hashes) also break. 
- **`src/stylesheets/react-select.scss`** — `.select-compact`: Removed `white-space: nowrap` from `.Select-value` so multi-select chips / single-select value wrap.
 - Added `white-space: normal; overflow-wrap: anywhere;` on `.Select-menu-outer .Select-option` so long option labels wrap inside the open menu.
- **`VersionChangelogButton.tsx`** — removed the inner `<div style={{ maxHeight: 500, overflowY: 'auto' }}>` wrapper. `.popover-content` already has `max-height: 50vh; overflow-y: auto` from the bootstrap override, so the inner wrapper produced a second nested vertical scrollbar once content actually wrapped. With it gone the popover has a single scrollbar.