### PR TITLE
fixed collection installation cancellation through free user dl dialog

### DIFF
--- a/extensions/collections/src/index.ts
+++ b/extensions/collections/src/index.ts
@@ -1567,6 +1567,16 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
     driver.start(profile, mod);
   });
 
+  // Keeps the full cleanup path (driver, notification, queued downloads,
+  // InstallManager cancel) owned by this extension instead of forcing
+  // external callers to chain the pieces.
+  api.events.on("pause-collection", (gameId: string, modId: string) => {
+    log("info", "pause collection", { gameId, modId });
+    pauseCollection(api, gameId, modId, true).catch((err) => {
+      log("error", "failed to pause collection", { gameId, modId, error: err.message });
+    });
+  });
+
   api.onStateChange(["persistent", "collections", "collections"], (prev, cur) => {
     // tslint:disable-next-line:no-shadowed-variable
     const state = api.getState();

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -231,7 +231,14 @@ try {
             .then((result) => {
               betterIpcRenderer.send("callback:download:resolve", collationId, result);
             })
-            .catch((err) => console.error(err));
+            .catch((err: unknown) => {
+              // The callback wire carries success only; rejections can't be
+              // sent back. Cancellation is driven explicitly elsewhere, so
+              // these are routine on every canceled batch; debug log keeps
+              // vortex.log clean.
+              const message = err instanceof Error ? err.message : String(err);
+              betterIpcRenderer.send("logging:log", "debug", "download resolver rejected", message);
+            });
         };
         ipcRenderer.on("download:resolve", listener);
         return () => ipcRenderer.removeListener("download:resolve", listener);

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -452,13 +452,37 @@ async function mapWithConcurrency<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R> | R,
   concurrency: number,
+  signal?: AbortSignal,
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let nextIdx = 0;
   async function worker() {
+    let abortPromise: Promise<never> | undefined;
+    if (signal !== undefined) {
+      abortPromise = new Promise<never>((_, reject) => {
+        if (signal.aborted) {
+          reject(new UserCanceled());
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new UserCanceled()), { once: true });
+      });
+      // silences the unhandled-rejection warning
+      // that fires when Promise.race picks the fn result and the loser later
+      // rejects on a late abort
+      abortPromise.catch(() => undefined);
+    }
     while (nextIdx < items.length) {
+      if (signal?.aborted) return;
       const idx = nextIdx++;
-      results[idx] = await fn(items[idx], idx);
+      try {
+        results[idx] =
+          abortPromise === undefined
+            ? await fn(items[idx], idx)
+            : await Promise.race([Promise.resolve(fn(items[idx], idx)), abortPromise]);
+      } catch (err) {
+        if (signal?.aborted) return;
+        throw err;
+      }
     }
   }
   await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
@@ -2466,8 +2490,15 @@ class InstallManager {
           const err = unknownToError(unknownError);
           this.mActiveInstalls.delete(installKey);
           const currentRetryCount = this.mDependencyRetryCount.get(installKey) || 0;
+          // A missing mDependencyInstalls entry means the install was torn down
+          // externally (cancel-dependency-install / clearQueued). Treat the
+          // late error as cancellation so it doesn't surface as a notification
+          // or trigger a retry for a download the user already canceled.
+          const installCanceled = !this.mDependencyInstalls[sourceModId];
           const isCanceled =
-            unknownError instanceof UserCanceled || unknownError instanceof ProcessCanceled;
+            installCanceled ||
+            unknownError instanceof UserCanceled ||
+            unknownError instanceof ProcessCanceled;
           const hasRetriesLeft = currentRetryCount < InstallManager.MAX_DEPENDENCY_RETRIES;
           if (!isCanceled && hasRetriesLeft) {
             this.mPendingInstalls.set(installKey, dep); // Re-queue for potential retry
@@ -5445,6 +5476,12 @@ class InstallManager {
             const updatedDependency = { ...dep, mod: mods[modId] };
             return updatedDependency;
           } catch (innerErr: unknown) {
+            // After abort, doDownload's promise can still settle later (e.g.
+            // when a pending download:resolve IPC times out). Drop those so
+            // canceled downloads don't get reported as install failures.
+            if (abort.signal.aborted) {
+              return undefined;
+            }
             if (dep.extra?.onlyIfFulfillable) {
               this.dropUnfulfilled(api, dep, gameId, sourceModId, recommended);
               return undefined;
@@ -5595,6 +5632,7 @@ class InstallManager {
           }
         },
         10,
+        abort.signal,
       );
     } catch (outerErr: unknown) {
       if (outerErr instanceof ProcessCanceled) {

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -29,6 +29,7 @@ import { showDialog } from "../../actions/notifications";
 import FlexLayout from "../../controls/FlexLayout";
 import Image from "../../controls/Image";
 import LazyComponent from "../../controls/LazyComponent";
+import { log } from "../../logging";
 import type { IComponentContext } from "../../types/IComponentContext";
 import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionContext";
 import type { IModLookupResult } from "../../types/IModLookupResult";
@@ -45,7 +46,6 @@ import Debouncer from "../../util/Debouncer";
 import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
 import type { LogLevel } from "../../util/log";
-import { log } from "../../util/log";
 import { showError } from "../../util/message";
 import opn from "../../util/opn";
 import { activeGameId, downloadPathForGame, gameById, knownGames } from "../../util/selectors";
@@ -61,6 +61,7 @@ import {
 } from "../../util/util";
 import { MainContext } from "../../views/MainWindow";
 import type { ICategoryDictionary } from "../category_management/types/ICategoryDictionary";
+import { getCollectionActiveSession } from "../collections_integration/selectors";
 import type { IDownload } from "../download_management/types/IDownload";
 import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
 import { SITE_ID } from "../gamemode_management/constants";
@@ -1705,9 +1706,17 @@ function makeNXMProtocol(api: IExtensionApi, onAwaitLink: AwaitLinkCB) {
           }
         })
         .catch((err) => {
+          const message = getErrorMessageOrDefault(err);
+          // Cancellation must propagate; otherwise sibling deps whose in-flight
+          // mod-info queries get aborted re-enter freeUserDownload, repopulate
+          // the queue, and the dialog re-opens behind the one the user just
+          // dismissed.
+          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
+            return PromiseBB.reject(err);
+          }
           // If we can't query mod info, fall back to free user flow
           log("warn", "failed to query mod info for direct download check", {
-            error: err.message,
+            error: message,
           });
           return freeUserDownload(input, url);
         });
@@ -1808,6 +1817,14 @@ function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
     copy.forEach((item) => {
       item.rej(new UserCanceled(false));
     });
+    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
+    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
+    // routes through the collections plugin for the full cleanup: stop queuing,
+    // reset the driver, dismiss the install notification.
+    const session = getCollectionActiveSession(api.getState());
+    if (session?.collectionId && session.gameId) {
+      api.events.emit("pause-collection", session.gameId, session.collectionId);
+    }
     return true;
   } else {
     api.store.dispatch(removeFreeUserDLItem(inputUrl));


### PR DESCRIPTION
- nexus_integration: emit pause-collection so the install pipeline, driver state and notification are torn down on Cancel
- collections: register pause-collection handler routing to pauseCollection
- nexus_integration: propagate UserCanceled/ProcessCanceled in resolveFunc catch so aborted sibling queries don't repopulate the dialog
- InstallManager: mapWithConcurrency is abort-aware (workers exit between items, in-flight calls race against the signal)
- InstallManager: drop late per-dep errors when the install was already aborted so canceled downloads don't appear as failures
- preload: fixed swallowed error

closes https://linear.app/nexus-mods/issue/APP-465