### PR TITLE
fixed --userData typo in nxm registry argv

### DIFF
--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -101,10 +101,10 @@ export function init() {
       const appPath = path.resolve(process.argv[1]);
       return [
         process.execPath,
-        [appPath, ...(udPath !== undefined ? ["--userData", udPath] : []), "-d"],
+        [appPath, ...(udPath !== undefined ? ["--user-data", udPath] : []), "-d"],
       ];
     } else {
-      return [process.execPath, [...(udPath !== undefined ? ["--userData", udPath] : []), "-d"]];
+      return [process.execPath, [...(udPath !== undefined ? ["--user-data", udPath] : []), "-d"]];
     }
   }
 


### PR DESCRIPTION
selfCL embedded --userData (camelCase) but the CLI parser only accepts --user-data (kebab-case). commander runs with allowUnknownOption(true), so the flag the OS passed back on an nxm:// launch was silently dropped and the launched instance ignored the userdata directory in the registry.

fixes #23299
fixes app-479