### PR TITLE
E2E test improvements and fixes

### DIFF
--- a/packages/e2e/fixtures/vortex-app.ts
+++ b/packages/e2e/fixtures/vortex-app.ts
@@ -184,7 +184,7 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
 
       const app = await electron.launch({
         executablePath: electronBinary,
-        args: [mainDir, "--disable-gpu", "--disable-software-rasterizer"],
+        args: [mainDir],
         env: buildElectronEnv(sharedUserDataDir),
         cwd: mainDir,
         // CI runners are slower — allow up to 2 minutes for cold start
@@ -217,6 +217,11 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
           }),
       );
 
+      // Block unwanted connections that slow down tests:
+      await mainWindow.route(/youtube(-nocookie)?\.com|youtu\.be/, (route) =>
+        route.fulfill({ status: 204, body: "" }),
+      );
+
       await mainWindow.waitForLoadState("domcontentloaded");
       await showWindowPromise;
 
@@ -245,7 +250,7 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
       await sharedVortexWindow
         .screenshot({ timeout: 5_000, animations: "disabled", type: "png" })
         .then((buf) => testInfo.attach("screenshot", { body: buf, contentType: "image/png" }))
-        .catch(() => {});
+        .catch((e) => console.error(`Failed to capture screenshot: ${e}`));
     }
   },
 });

--- a/packages/e2e/fixtures/vortex-app.ts
+++ b/packages/e2e/fixtures/vortex-app.ts
@@ -243,7 +243,7 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
       const logPath = path.join(sharedUserDataDir, "userData", "vortex.log");
       await testInfo.attach("vortex.log", { path: logPath }).catch(() => {});
       await sharedVortexWindow
-        .screenshot()
+        .screenshot({ timeout: 5_000, animations: "disabled", type: "png" })
         .then((buf) => testInfo.attach("screenshot", { body: buf, contentType: "image/png" }))
         .catch(() => {});
     }

--- a/packages/e2e/fixtures/vortex-app.ts
+++ b/packages/e2e/fixtures/vortex-app.ts
@@ -242,14 +242,39 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
     await use(sharedVortexApp);
   },
 
-  vortexWindow: async ({ sharedVortexWindow, sharedUserDataDir }, use, testInfo) => {
+  vortexWindow: async (
+    { sharedVortexApp, sharedVortexWindow, sharedUserDataDir },
+    use,
+    testInfo,
+  ) => {
     await use(sharedVortexWindow);
     if (testInfo.status !== testInfo.expectedStatus) {
       const logPath = path.join(sharedUserDataDir, "userData", "vortex.log");
       await testInfo.attach("vortex.log", { path: logPath }).catch(() => {});
-      await sharedVortexWindow
-        .screenshot({ timeout: 5_000, animations: "disabled", type: "png" })
-        .then((buf) => testInfo.attach("screenshot", { body: buf, contentType: "image/png" }))
+
+      // Use Electron's webContents.capturePage() instead of page.screenshot().
+      // The e2e build runs with VORTEX_E2E_HEADLESS=1, which prevents the
+      // BrowserWindow from being shown — hidden windows don't produce
+      // compositor frames, so page.screenshot() hangs waiting for one.
+      // capturePage() reads directly from the renderer and works while hidden.
+      await sharedVortexApp
+        .evaluate(async ({ BrowserWindow }) => {
+          const win = BrowserWindow.getAllWindows().find((w) =>
+            w.webContents.getURL().includes("index.html"),
+          );
+          if (!win) return null;
+          const image = await win.webContents.capturePage();
+          return image.toPNG().toBase64();
+        })
+        .then((base64) => {
+          if (!base64) {
+            return Promise.resolve();
+          }
+          return testInfo.attach("screenshot", {
+            body: Buffer.from(base64, "base64"),
+            contentType: "image/png",
+          });
+        })
         .catch((e) => console.error(`Failed to capture screenshot: ${e}`));
     }
   },

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   use: {
     actionTimeout: 5_000,
     navigationTimeout: 5_000,
-    screenshot: "only-on-failure",
+    screenshot: "off",
     trace: "on-first-retry",
     video: "on-first-retry",
   },

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -11,6 +11,7 @@ if (existsSync(envFilePath)) {
 
 export default defineConfig({
   testDir: "./tests",
+  globalTimeout: 1000 * 60 * 45,
   timeout: 60_000,
   expect: {
     timeout: 5_000,

--- a/packages/e2e/selectors/settings.ts
+++ b/packages/e2e/selectors/settings.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from "@playwright/test";
 export class SettingsPage {
   readonly page: Page;
   readonly languageLabel: Locator;
-  readonly englishOption: Locator;
+  readonly languageSelect: Locator;
   readonly checkboxes: Locator;
   readonly darkThemeLabel: Locator;
 
@@ -18,7 +18,7 @@ export class SettingsPage {
   constructor(page: Page) {
     this.page = page;
     this.languageLabel = page.getByText("Language").first();
-    this.englishOption = page.getByText("English").first();
+    this.languageSelect = page.getByRole("combobox", { name: "Language" });
     this.checkboxes = page.getByRole("checkbox");
     this.darkThemeLabel = page.getByText("Dark theme").first();
 

--- a/packages/e2e/tests/settings.spec.ts
+++ b/packages/e2e/tests/settings.spec.ts
@@ -23,7 +23,7 @@ test.describe("Settings - Interface Tab", () => {
 
     await test.step("Verify English is selected", async () => {
       if (await settings.languageLabel.isVisible()) {
-        await expect(settings.englishOption).toBeVisible();
+        await expect(settings.languageSelect).toHaveValue("en");
       }
     });
   });


### PR DESCRIPTION
- Use global timeout to prevent sudden exists in CI
- Fixes language options selector for settings test
- Fixes screenshots by using electron `capturePage` which is much faster

Instead of needing 45 minutes to run tests, tests now finish in under a minute without the login tests and under 3 minutes with the login tests (which still fail locally).