### PR TITLE
Rework test timeouts

### DIFF
--- a/packages/e2e/E2E-BEST-PRACTICES.md
+++ b/packages/e2e/E2E-BEST-PRACTICES.md
@@ -292,23 +292,34 @@ The smoke spec watches the renderer console for unexpected errors at startup. Wh
 
 ## Timeouts
 
-Use the `X_000` format for readability:
+All explicit timeouts live in `helpers/timeouts.ts`. Do not hardcode `X_000` literals in tests, helpers, or fixtures.
+
+Rules:
+
+- **Default UI waits use the config defaults** (5s `actionTimeout` / `expect.timeout` / `navigationTimeout`, sourced from `GlobalTimeouts` in `helpers/timeouts.ts` and applied via `playwright.config.ts`). Do not pass an explicit timeout for pure UI assertions/actions. If a UI wait "needs" longer, the test is racing something it should `await` explicitly.
+- **Network-backed waits** (page navigation, API fetch, mod list populating, Cloudflare clear, OAuth flow) use `Timeouts.NETWORK`.
+- **Fixture / launch timeouts** use `Timeouts.LIFECYCLE`.
+- **No per-test `test.setTimeout(...)` overrides.** `GlobalTimeouts.TEST` is sized to cover the slowest test. If a test exceeds it, the test is broken, not the timeout.
+- **Probes** (best-effort "is this element here right now") use `await locator.isVisible().catch(() => false)` with no timeout. Never use 1s/3s "fast probe" timeouts.
 
 ```typescript
-// GOOD
-test.setTimeout(120_000);
-await expect(element).toBeVisible({ timeout: 30_000 });
+// GOOD - UI assertion, relies on the config default
+await expect(saveButton).toBeVisible();
 
-// BAD
-test.setTimeout(120000);
-await expect(element).toBeVisible({ timeout: 30000 });
+// GOOD - network-backed assertion
+await expect(modRow).toBeVisible({ timeout: Timeouts.NETWORK });
+
+// BAD - hardcoded literal, no semantic context
+await expect(modRow).toBeVisible({ timeout: 30_000 });
+
+// BAD - explicit timeout on a pure UI element; bump GlobalTimeouts.EXPECT if the default isn't enough
+await expect(navbar.gamesLink).toBeVisible({ timeout: 10_000 });
+
+// BAD - per-test override; bump GlobalTimeouts.TEST in helpers/timeouts.ts instead
+test.setTimeout(120_000);
 ```
 
-Defaults that match the fixture's expectations:
-
-- Worker-scoped fixtures: 180s (Electron cold start can take ~2 min on slow CI).
-- Renderer-render assertion (`mainWindow.locator('body')` non-empty): 60s.
-- Per-test default: keep under 60s; if you need more, set `test.setTimeout(...)` explicitly.
+Current `Timeouts` / `GlobalTimeouts` values are starting points, not measured. Calibration follow-up is tracked in LAZ-443.
 
 ---
 

--- a/packages/e2e/fixtures/vortex-app.ts
+++ b/packages/e2e/fixtures/vortex-app.ts
@@ -11,6 +11,8 @@ import {
   type Page,
 } from "@playwright/test";
 
+import { Timeouts } from "../helpers/timeouts";
+
 /** Package root (packages/e2e/) — used for resolving node_modules. */
 const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
 
@@ -120,7 +122,6 @@ async function waitForMainWindow(vortexApp: ElectronApplication): Promise<Page> 
       }
     }, 500);
 
-    // CI runners can be slow — allow up to 2 minutes for the main window
     setTimeout(() => {
       cleanup();
       const windows = vortexApp.windows();
@@ -130,7 +131,7 @@ async function waitForMainWindow(vortexApp: ElectronApplication): Promise<Page> 
       } else {
         reject(new Error("Timed out waiting for the Vortex main window to appear."));
       }
-    }, 120_000);
+    }, Timeouts.LIFECYCLE);
   });
 }
 
@@ -187,14 +188,13 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
         args: [mainDir],
         env: buildElectronEnv(sharedUserDataDir),
         cwd: mainDir,
-        // CI runners are slower — allow up to 2 minutes for cold start
-        timeout: 120_000,
+        timeout: Timeouts.LIFECYCLE,
       });
 
       await use(app);
       await app.close().catch(() => {});
     },
-    { scope: "worker", timeout: 180_000 },
+    { scope: "worker", timeout: Timeouts.LIFECYCLE },
   ],
 
   sharedVortexWindow: [
@@ -204,17 +204,18 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
       // Register before domcontentloaded — show-window fires after React mounts
       // LoadingScreen, which is after dcl, so this listener is always set up first.
       const showWindowPromise = sharedVortexApp.evaluate(
-        ({ ipcMain }) =>
+        ({ ipcMain }, timeoutMs) =>
           new Promise<void>((resolve, reject) => {
             const timer = setTimeout(
               () => reject(new Error("Timed out waiting for show-window")),
-              120_000,
+              timeoutMs,
             );
             ipcMain.once("show-window", () => {
               clearTimeout(timer);
               resolve();
             });
           }),
+        Timeouts.LIFECYCLE,
       );
 
       // Block unwanted connections that slow down tests:
@@ -234,7 +235,7 @@ export const test = base.extend<VortexTestFixtures, VortexWorkerFixtures>({
 
       await use(mainWindow);
     },
-    { scope: "worker", timeout: 180_000 },
+    { scope: "worker", timeout: Timeouts.LIFECYCLE },
   ],
 
   // Test-scoped aliases that reference the shared worker fixtures

--- a/packages/e2e/helpers/consent.ts
+++ b/packages/e2e/helpers/consent.ts
@@ -14,12 +14,12 @@ export async function acceptConsent(page: Page): Promise<void> {
     if (
       await locator
         .first()
-        .isVisible({ timeout: 1_000 })
+        .isVisible()
         .catch(() => false)
     ) {
       await locator
         .first()
-        .click({ timeout: 5_000 })
+        .click()
         .catch(() => undefined);
       return;
     }
@@ -27,8 +27,8 @@ export async function acceptConsent(page: Page): Promise<void> {
   // Quantcast can render inside an iframe.
   for (const frame of page.frames()) {
     const acceptInFrame = frame.locator("button#accept-btn, button:has-text('Allow all')").first();
-    if (await acceptInFrame.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await acceptInFrame.click({ timeout: 5_000 }).catch(() => undefined);
+    if (await acceptInFrame.isVisible().catch(() => false)) {
+      await acceptInFrame.click().catch(() => undefined);
       return;
     }
   }

--- a/packages/e2e/helpers/games.ts
+++ b/packages/e2e/helpers/games.ts
@@ -4,6 +4,7 @@ import { setupFakeGame, GAME_CONFIGS } from "../fixtures/game-setup/fake-game";
 import { test } from "../fixtures/vortex-app";
 import { GamesPage } from "../selectors/games";
 import { NavBar } from "../selectors/navbar";
+import { Timeouts } from "./timeouts";
 
 // Only auto-discoverable games are supported today. Skyrim SE goes through
 // Vortex's manual-discovery dialog flow which our fake-game install isn't
@@ -24,7 +25,7 @@ export async function manageGame(vortexWindow: Page, gameId: ManagedGameId): Pro
     const navbar = new NavBar(vortexWindow);
     const gamesPage = new GamesPage(vortexWindow);
 
-    await expect(navbar.gamesLink).toBeVisible({ timeout: 10_000 });
+    await expect(navbar.gamesLink).toBeVisible();
     await navbar.gamesLink.click();
 
     await vortexWindow.evaluate((path) => {
@@ -39,12 +40,15 @@ export async function manageGame(vortexWindow: Page, gameId: ManagedGameId): Pro
     }, fakeGame.gamePath);
 
     const row = gamesPage.gameRow(gameName);
-    await expect(row).toBeVisible({ timeout: 30_000 });
+    await expect(row).toBeVisible({ timeout: Timeouts.NETWORK });
     await row.scrollIntoViewIfNeeded();
     await row.hover();
-    await gamesPage.manageButton(gameName).click({ timeout: 15_000, force: true });
 
-    await expect(navbar.modsLink).toBeVisible({ timeout: 60_000 });
+    const manageButton = gamesPage.manageButton(gameName);
+    await expect(manageButton).toBeVisible();
+    await manageButton.click();
+
+    await expect(navbar.modsLink).toBeVisible({ timeout: Timeouts.NETWORK });
   });
 
   return fakeGame;

--- a/packages/e2e/helpers/login.ts
+++ b/packages/e2e/helpers/login.ts
@@ -8,6 +8,7 @@ import {
 
 import { test } from "../fixtures/vortex-app";
 import { LoginPage } from "../selectors/loginPage";
+import { Timeouts } from "./timeouts";
 import { freeUser, type NexusUser } from "./users";
 
 export interface LoginToNexusOptions {
@@ -109,7 +110,7 @@ export async function loginToNexus(
 
       await authPage.goto(oauthUrl, {
         waitUntil: "domcontentloaded",
-        timeout: 60000,
+        timeout: Timeouts.NETWORK,
       });
       await expect(authPage).toHaveURL(/nexusmods|users\./i);
     });
@@ -119,8 +120,9 @@ export async function loginToNexus(
     const skipCredentials =
       options.storageStatePath !== undefined &&
       authPage !== null &&
-      (await new LoginPage(authPage).oauthPermissionTitle
-        .isVisible({ timeout: 10_000 })
+      (await expect(new LoginPage(authPage).oauthPermissionTitle)
+        .toBeVisible()
+        .then(() => true)
         .catch(() => false));
 
     if (!skipCredentials) {

--- a/packages/e2e/helpers/navigation.ts
+++ b/packages/e2e/helpers/navigation.ts
@@ -19,5 +19,4 @@ export async function navigateToGames(page: Page): Promise<void> {
   } else if (await navbar.homeLink.isVisible().catch(() => false)) {
     await navbar.homeLink.click();
   }
-  await page.waitForTimeout(1000);
 }

--- a/packages/e2e/helpers/timeouts.ts
+++ b/packages/e2e/helpers/timeouts.ts
@@ -1,0 +1,33 @@
+const isCI = !!process.env.CI;
+
+const scalingFactor = isCI ? 2 : 1;
+
+/** Global defaults applied via playwright.config.ts. */
+export const GlobalTimeouts = {
+  /** Upper bound on the entire `playwright test` run. */
+  GLOBAL: isCI ? min(45) : min(10),
+  /** Per-test budget. */
+  TEST: sec(30) * scalingFactor,
+  /** Default poll budget for web-first assertions (`expect(locator).toBe...`). */
+  EXPECT: sec(5),
+  /** Default budget for locator actions (`click`, `fill`, `hover`, ...). */
+  ACTION: sec(5),
+  /** Default budget for navigation (`goto`, `reload`, `waitForLoadState`, ...). */
+  NAVIGATION: sec(5),
+} as const;
+
+/** Constant values for custom timeouts */
+export const Timeouts = {
+  /** For assertions or actions that depend on a network round-trip. */
+  NETWORK: sec(30) * scalingFactor,
+  /** Cold-start and worker fixture setup. */
+  LIFECYCLE: min(1) * scalingFactor,
+} as const;
+
+function min(x: number): number {
+  return x * 1000 * 60;
+}
+
+function sec(x: number): number {
+  return x * 1000;
+}

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { defineConfig } from "@playwright/test";
 
+import { GlobalTimeouts } from "./helpers/timeouts";
+
 const envFilePath = path.resolve(import.meta.dirname, ".env");
 
 if (existsSync(envFilePath)) {
@@ -11,10 +13,10 @@ if (existsSync(envFilePath)) {
 
 export default defineConfig({
   testDir: "./tests",
-  globalTimeout: 1000 * 60 * 45,
-  timeout: 60_000,
+  globalTimeout: GlobalTimeouts.GLOBAL,
+  timeout: GlobalTimeouts.TEST,
   expect: {
-    timeout: 5_000,
+    timeout: GlobalTimeouts.EXPECT,
   },
   retries: 1,
   reporter: [
@@ -27,8 +29,8 @@ export default defineConfig({
     ...(process.env.CI ? [["github"] as const] : []),
   ],
   use: {
-    actionTimeout: 5_000,
-    navigationTimeout: 5_000,
+    actionTimeout: GlobalTimeouts.ACTION,
+    navigationTimeout: GlobalTimeouts.NAVIGATION,
     screenshot: "off",
     trace: "on-first-retry",
     video: "on-first-retry",

--- a/packages/e2e/tests/account.spec.ts
+++ b/packages/e2e/tests/account.spec.ts
@@ -5,6 +5,7 @@
  */
 import { test, expect } from "../fixtures/vortex-app";
 import { loginToNexus } from "../helpers/login";
+import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser, type NexusUser } from "../helpers/users";
 import { Header } from "../selectors/header";
 
@@ -37,16 +38,14 @@ test.describe("Account - Header Premium badge", () => {
       vortexApp,
       vortexWindow,
     }) => {
-      test.setTimeout(120_000);
-
       await loginToNexus(vortexApp, vortexWindow, user);
 
       const header = new Header(vortexWindow);
       if (expectBadge) {
-        await expect(header.premiumIndicator).toBeVisible({ timeout: 15_000 });
+        await expect(header.premiumIndicator).toBeVisible({ timeout: Timeouts.NETWORK });
         await expect(header.premiumIndicator).toHaveText(/premium/i);
       } else {
-        await expect(header.premiumIndicator).toBeHidden({ timeout: 15_000 });
+        await expect(header.premiumIndicator).toBeHidden({ timeout: Timeouts.NETWORK });
       }
     });
   }

--- a/packages/e2e/tests/mods-manual.spec.ts
+++ b/packages/e2e/tests/mods-manual.spec.ts
@@ -14,6 +14,7 @@ import { test, expect } from "../fixtures/vortex-app";
 import { acceptConsent } from "../helpers/consent";
 import { manageGame, type ManagedGame } from "../helpers/games";
 import { loginToNexus } from "../helpers/login";
+import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { ModsPage } from "../selectors/modsPage";
 import { NavBar } from "../selectors/navbar";
@@ -34,8 +35,6 @@ test.describe("Mods - Manual Downloads", () => {
       vortexApp,
       vortexWindow,
     }) => {
-      test.setTimeout(180_000);
-
       let managed: ManagedGame | null = null;
       let authBrowser: Browser | null = null;
 
@@ -56,13 +55,13 @@ test.describe("Mods - Manual Downloads", () => {
         await test.step("Open the SMAPI mod page", async () => {
           await auth.page.goto(SDV_MOD_URL, {
             waitUntil: "domcontentloaded",
-            timeout: 60_000,
+            timeout: Timeouts.NETWORK,
           });
           await expect(auth.page).toHaveURL(/stardewvalley\/mods\/2400/);
 
           if (await nexusModPage.cloudflareHeading.isVisible().catch(() => false)) {
             await expect(nexusModPage.cloudflareHeading).toBeHidden({
-              timeout: 30_000,
+              timeout: Timeouts.NETWORK,
             });
           }
 
@@ -75,20 +74,22 @@ test.describe("Mods - Manual Downloads", () => {
           // Premium skips the slow-download interstitial — set up the listener
           // first so both paths funnel through the same waitForEvent.
           const downloadPromise = auth.page.waitForEvent("download", {
-            timeout: 120_000,
+            timeout: Timeouts.NETWORK,
           });
 
           await expect(nexusModPage.manualDownloadLink).toBeVisible({
-            timeout: 30_000,
+            timeout: Timeouts.NETWORK,
           });
-          await nexusModPage.manualDownloadLink.click({ timeout: 15_000 });
-          await auth.page.waitForLoadState("load", { timeout: 30_000 }).catch(() => undefined);
+          await nexusModPage.manualDownloadLink.click({ timeout: Timeouts.NETWORK });
+          await auth.page
+            .waitForLoadState("load", { timeout: Timeouts.NETWORK })
+            .catch(() => undefined);
           await acceptConsent(auth.page);
 
-          if (
-            await nexusModPage.slowDownloadButton.isVisible({ timeout: 5_000 }).catch(() => false)
-          ) {
-            await nexusModPage.slowDownloadButton.click({ timeout: 15_000 }).catch(() => undefined);
+          if (await nexusModPage.slowDownloadButton.isVisible().catch(() => false)) {
+            await nexusModPage.slowDownloadButton
+              .click({ timeout: Timeouts.NETWORK })
+              .catch(() => undefined);
           }
 
           const download = await downloadPromise;
@@ -115,15 +116,15 @@ test.describe("Mods - Manual Downloads", () => {
 
           const modsPage = new ModsPage(vortexWindow);
           await expect(modsPage.installFromFileButton).toBeVisible({
-            timeout: 30_000,
+            timeout: Timeouts.NETWORK,
           });
-          await modsPage.installFromFileButton.click({ timeout: 15_000 });
+          await modsPage.installFromFileButton.click({ timeout: Timeouts.NETWORK });
         });
 
         await test.step("Verify SMAPI is installed in Vortex", async () => {
           const modsPage = new ModsPage(vortexWindow);
           await expect(modsPage.modRow(/SMAPI/i)).toBeVisible({
-            timeout: 90_000,
+            timeout: Timeouts.NETWORK,
           });
         });
       } finally {

--- a/packages/e2e/tests/mods.spec.ts
+++ b/packages/e2e/tests/mods.spec.ts
@@ -11,6 +11,7 @@ import { acceptConsent } from "../helpers/consent";
 import { manageGame, type ManagedGame } from "../helpers/games";
 import { loginToNexus } from "../helpers/login";
 import { installNxmCapture, waitForNxmUrl } from "../helpers/nxmCapture";
+import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { NavBar } from "../selectors/navbar";
 
@@ -30,8 +31,6 @@ test.describe("Mods - Downloads", () => {
       vortexApp,
       vortexWindow,
     }) => {
-      test.setTimeout(180_000);
-
       let managed: ManagedGame | null = null;
       let authBrowser: Browser | null = null;
 
@@ -52,7 +51,7 @@ test.describe("Mods - Downloads", () => {
         await test.step("Open the SMAPI mod page", async () => {
           await auth.page.goto(SDV_MOD_URL, {
             waitUntil: "domcontentloaded",
-            timeout: 60_000,
+            timeout: Timeouts.NETWORK,
           });
           await expect(auth.page).toHaveURL(/stardewvalley\/mods\/2400/);
 
@@ -60,7 +59,7 @@ test.describe("Mods - Downloads", () => {
             name: /Performing security verification/i,
           });
           if (await cloudflareHeading.isVisible().catch(() => false)) {
-            await expect(cloudflareHeading).toBeHidden({ timeout: 30_000 });
+            await expect(cloudflareHeading).toBeHidden({ timeout: Timeouts.NETWORK });
           }
 
           await acceptConsent(auth.page);
@@ -72,14 +71,14 @@ test.describe("Mods - Downloads", () => {
           const modManagerLink = auth.page
             .getByRole("link", { name: /mod manager download|vortex/i })
             .first();
-          await expect(modManagerLink).toBeVisible({ timeout: 30_000 });
-          await modManagerLink.click({ timeout: 15_000 });
+          await expect(modManagerLink).toBeVisible({ timeout: Timeouts.NETWORK });
+          await modManagerLink.click({ timeout: Timeouts.NETWORK });
 
           const modal = auth.page
             .locator('.popup, .modal, [role="dialog"], #popup-content')
             .first();
           const modalAppeared = await modal
-            .waitFor({ state: "visible", timeout: 5_000 })
+            .waitFor({ state: "visible" })
             .then(() => true)
             .catch(() => false);
 
@@ -87,14 +86,16 @@ test.describe("Mods - Downloads", () => {
             // Premium users (and dep-free mods) skip this confirmation —
             // the nxm:// URL fires directly without an inner Download link.
             const modalDownloadButton = modal.getByRole("link", { name: /^download$/i }).first();
-            if (await modalDownloadButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-              await modalDownloadButton.click({ timeout: 15_000 });
+            if (await modalDownloadButton.isVisible().catch(() => false)) {
+              await modalDownloadButton.click({ timeout: Timeouts.NETWORK });
             }
           }
         });
 
         await test.step("Capture the nxm:// URL", async () => {
-          await auth.page.waitForLoadState("load", { timeout: 30_000 }).catch(() => undefined);
+          await auth.page
+            .waitForLoadState("load", { timeout: Timeouts.NETWORK })
+            .catch(() => undefined);
           await acceptConsent(auth.page);
           await installNxmCapture(auth.page);
 
@@ -105,16 +106,16 @@ test.describe("Mods - Downloads", () => {
           if (
             await slowDownloadButton
               .first()
-              .isVisible({ timeout: 5_000 })
+              .isVisible()
               .catch(() => false)
           ) {
             await slowDownloadButton
               .first()
-              .click({ timeout: 15_000 })
+              .click({ timeout: Timeouts.NETWORK })
               .catch(() => undefined);
           }
 
-          nxmUrl = await waitForNxmUrl(auth.page, 60_000);
+          nxmUrl = await waitForNxmUrl(auth.page, Timeouts.NETWORK);
           if (nxmUrl === null) {
             throw new Error("No nxm:// URL appeared in the page after the download click");
           }
@@ -140,7 +141,7 @@ test.describe("Mods - Downloads", () => {
           await navbar.modsLink.click();
 
           const modRow = vortexWindow.getByText(/SMAPI/i).first();
-          await expect(modRow).toBeVisible({ timeout: 60_000 });
+          await expect(modRow).toBeVisible({ timeout: Timeouts.NETWORK });
         });
       } finally {
         if (authBrowser !== null) {

--- a/packages/e2e/tests/profile.spec.ts
+++ b/packages/e2e/tests/profile.spec.ts
@@ -4,6 +4,7 @@ import { cleanupFakeGame, GAME_CONFIGS } from "../fixtures/game-setup/fake-game"
  */
 import { test, expect } from "../fixtures/vortex-app";
 import { manageGame, type ManagedGame } from "../helpers/games";
+import { Timeouts } from "../helpers/timeouts";
 import { NavBar } from "../selectors/navbar";
 import { SettingsPage } from "../selectors/settings";
 import { Spine } from "../selectors/spine";
@@ -13,8 +14,6 @@ test.describe("Profiles - Add", () => {
     vortexApp,
     vortexWindow,
   }) => {
-    test.setTimeout(120_000);
-
     const profileName = `QA-113 ${Date.now()}`;
     let managed: ManagedGame | null = null;
 
@@ -28,7 +27,7 @@ test.describe("Profiles - Add", () => {
         await spine.homeButton.click();
 
         const navbar = new NavBar(vortexWindow);
-        await expect(navbar.settingsLink).toBeVisible({ timeout: 10_000 });
+        await expect(navbar.settingsLink).toBeVisible();
         await navbar.settingsLink.click();
 
         const settings = new SettingsPage(vortexWindow);
@@ -37,10 +36,10 @@ test.describe("Profiles - Add", () => {
         const toggleRow = vortexWindow.locator(".toggle-container", {
           hasText: "Enable Profile Management",
         });
-        await expect(toggleRow).toBeVisible({ timeout: 10_000 });
+        await expect(toggleRow).toBeVisible();
 
         const offToggle = toggleRow.locator(".toggle.toggle-off");
-        if (await offToggle.isVisible({ timeout: 1_000 }).catch(() => false)) {
+        if (await offToggle.isVisible().catch(() => false)) {
           await offToggle.click();
         }
       });
@@ -50,17 +49,17 @@ test.describe("Profiles - Add", () => {
         await spine.gameButton(gameName).click();
 
         const navbar = new NavBar(vortexWindow);
-        await expect(navbar.profilesLink).toBeVisible({ timeout: 10_000 });
+        await expect(navbar.profilesLink).toBeVisible();
         await navbar.profilesLink.click();
       });
 
       await test.step("Click Add Profile and enter a name", async () => {
         const addBtn = vortexWindow.getByRole("button", { name: /Add ".+" Profile/i }).first();
-        await expect(addBtn).toBeVisible({ timeout: 10_000 });
+        await expect(addBtn).toBeVisible();
         await addBtn.click();
 
         const nameInput = vortexWindow.locator(".profile-edit-panel input[type=text]");
-        await expect(nameInput).toBeVisible({ timeout: 10_000 });
+        await expect(nameInput).toBeVisible();
         await nameInput.fill(profileName);
 
         const saveBtn = vortexWindow.locator("#__accept");
@@ -70,7 +69,7 @@ test.describe("Profiles - Add", () => {
 
       await test.step("Verify the new profile appears in the list", async () => {
         const newProfile = vortexWindow.getByText(profileName).first();
-        await expect(newProfile).toBeVisible({ timeout: 15_000 });
+        await expect(newProfile).toBeVisible({ timeout: Timeouts.NETWORK });
       });
     } finally {
       if (managed !== null) {

--- a/packages/e2e/tests/settings.spec.ts
+++ b/packages/e2e/tests/settings.spec.ts
@@ -64,7 +64,6 @@ test.describe("Settings - Tab Navigation", () => {
       await test.step(`Click ${tabName} tab`, async () => {
         if (await tab.isVisible()) {
           await tab.click();
-          await vortexWindow.waitForTimeout(500);
         }
       });
 
@@ -82,7 +81,6 @@ test.describe("Settings - Theme Tab", () => {
     const settings = new SettingsPage(vortexWindow);
     if (await settings.themeTab.isVisible()) {
       await settings.themeTab.click();
-      await vortexWindow.waitForTimeout(500);
     }
   });
 

--- a/packages/e2e/tests/upgrade-to-premium.spec.ts
+++ b/packages/e2e/tests/upgrade-to-premium.spec.ts
@@ -4,6 +4,7 @@
  */
 import { test, expect } from "../fixtures/vortex-app";
 import { loginToNexus } from "../helpers/login";
+import { Timeouts } from "../helpers/timeouts";
 import { freeUser } from "../helpers/users";
 import { NavBar } from "../selectors/navbar";
 
@@ -12,14 +13,12 @@ test.describe("Account - Upgrade to Premium", () => {
     vortexApp,
     vortexWindow,
   }) => {
-    test.setTimeout(120_000);
-
     await loginToNexus(vortexApp, vortexWindow, freeUser);
 
     await test.step("Wait for userInfo and force Dashboard re-render", async () => {
       await vortexWindow.keyboard.press("Escape").catch(() => undefined);
       const headerGoPremium = vortexWindow.getByRole("button", { name: /Go premium/i }).first();
-      await expect(headerGoPremium).toBeVisible({ timeout: 60_000 });
+      await expect(headerGoPremium).toBeVisible({ timeout: Timeouts.NETWORK });
 
       const navbar = new NavBar(vortexWindow);
       await navbar.gamesLink.click();
@@ -39,7 +38,7 @@ test.describe("Account - Upgrade to Premium", () => {
 
     await test.step("Click the Go Premium dashlet button", async () => {
       const goPremiumBtn = vortexWindow.locator(".dashlet-premium-button");
-      await expect(goPremiumBtn).toBeVisible({ timeout: 30_000 });
+      await expect(goPremiumBtn).toBeVisible({ timeout: Timeouts.NETWORK });
       await goPremiumBtn.click();
     });
 


### PR DESCRIPTION
Closes LAZ-443.

Removes all hardcoded timeouts from tests using global config as fallback or pre-defined values for certain scenarios.