### PR TITLE
Changed: Skip CI build/test on non-code file changes

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,22 @@ name: Format
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "locales/**"
+      - ".devcontainer/**"
+      - "docker/**"
+      - "flatpak/**"
+      - "*.nix"
+      - "flake.*"
+      - "default.nix"
+      - "shell.nix"
+      - ".env.example"
+      - ".envrc"
+      - ".editorconfig"
+      - "vortex.bat"
+      - "translation-strings.txt"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,40 @@ name: Main
 on:
   push:
     branches: [master, release/*]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "locales/**"
+      - ".devcontainer/**"
+      - "docker/**"
+      - "flatpak/**"
+      - "*.nix"
+      - "flake.*"
+      - "default.nix"
+      - "shell.nix"
+      - ".env.example"
+      - ".envrc"
+      - ".editorconfig"
+      - "vortex.bat"
+      - "translation-strings.txt"
   pull_request:
     branches: [master, release/*]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "locales/**"
+      - ".devcontainer/**"
+      - "docker/**"
+      - "flatpak/**"
+      - "*.nix"
+      - "flake.*"
+      - "default.nix"
+      - "shell.nix"
+      - ".env.example"
+      - ".envrc"
+      - ".editorconfig"
+      - "vortex.bat"
+      - "translation-strings.txt"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
closes [LAZ-448](https://linear.app/nexus-mods/issue/LAZ-448/exclude-non-code-changes-from-triggering-builds)

- Add `paths-ignore` to `main`.yml `push` and `pull_request` triggers for markdown, docs, locales, devcontainer, docker, flatpak, nix, and other non-code files that are not tested through these workflow.
- Add same `paths-ignore` to `format.yml` `pull_request` trigger