### PR TITLE
fixed v2.1 beta.4 download path regression

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -39,7 +39,9 @@ import {
   setDownloadSpeed,
 } from "./extensions/download_management/actions/state";
 import { downloadPathForGame } from "./extensions/download_management/selectors";
+import { knownGames } from "./extensions/gamemode_management/selectors";
 import { nexusIdsFromDownloadId } from "./extensions/nexus_integration/selectors";
+import { convertGameIdReverse } from "./extensions/nexus_integration/util/convertGameId";
 import { makeModAndFileUIDs } from "./extensions/nexus_integration/util/UIDs";
 import { activeGameId } from "./extensions/profile_management/selectors";
 import { log } from "./logging";
@@ -79,6 +81,19 @@ type EncodedUrl = {
 function parseEncodedUrl(raw: string): EncodedUrl {
   const [rawUrl, referer] = raw.split("<");
   return { url: new URL(rawUrl), referer };
+}
+
+/**
+ * Callers can supply a game id as either a Nexus domain (e.g. "skyrimspecialedition")
+ * or an internal id (e.g. "skyrimse"). The on-disk download layout and `download.game`
+ * records are keyed on the internal id (the install handler also converts before
+ * stat'ing), so the IPC adapter normalizes here. Returns the original id when no
+ * mapping is found, including for the SITE pseudo-domain.
+ */
+function toInternalGameId(api: IExtensionApi, gameId: string | undefined): string | undefined {
+  if (gameId === undefined) return undefined;
+  const state = api.getState();
+  return convertGameIdReverse(knownGames(state), gameId) || gameId;
 }
 
 type StoredDownloadInfo = {
@@ -371,7 +386,7 @@ export class IPCDownloadAdapter {
     const download = reduxState.persistent.downloads.files?.[downloadId];
 
     if (download?.localPath !== undefined) {
-      const gameId = download.game?.[0] ?? activeGameId(reduxState);
+      const gameId = toInternalGameId(this.#api, download.game?.[0] ?? activeGameId(reduxState));
       const dlPath = downloadPathForGame(reduxState, gameId);
       const tempPath = path.join(dlPath, download.localPath);
 
@@ -445,7 +460,8 @@ export class IPCDownloadAdapter {
     const encodedUrl = parseEncodedUrl(rawUrl.toString());
 
     const state = this.#api.getState();
-    const dlPath = downloadPathForGame(state, modInfo.game ?? activeGameId(state));
+    const gameId = toInternalGameId(this.#api, modInfo.game ?? activeGameId(state));
+    const dlPath = downloadPathForGame(state, gameId);
 
     // The per-game subfolder may not exist yet - ensureDownloadsDirectory only
     // creates the active game's folder, but downloads can target any game
@@ -531,7 +547,6 @@ export class IPCDownloadAdapter {
       });
       log("debug", "download queued", { downloadId, collationId });
 
-      const gameId = modInfo.game ?? activeGameId(state);
       // Create the Redux record. nexus_integration's onChangeDownloads watches
       // downloads.files and triggers metadata enrichment when nexus.ids is present.
       this.#api.store.dispatch(initDownload(downloadId, rawUrls, modInfo, [gameId]));
@@ -574,7 +589,7 @@ export class IPCDownloadAdapter {
         const state = this.#api.getState();
         const download = state.persistent.downloads.files?.[downloadId];
         if (download?.localPath) {
-          const gameId = download.game?.[0] ?? activeGameId(state);
+          const gameId = toInternalGameId(this.#api, download.game?.[0] ?? activeGameId(state));
           const dlPath = downloadPathForGame(state, gameId);
           await rm(path.join(dlPath, download.localPath), { force: true });
         }

--- a/src/renderer/src/extensions/health_check/util.ts
+++ b/src/renderer/src/extensions/health_check/util.ts
@@ -1,7 +1,8 @@
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IGame } from "../../types/IGame";
 import { getGame, toPromise } from "../../util/api";
-import { nexusGameId } from "../nexus_integration/util/convertGameId";
+import { knownGames } from "../gamemode_management/selectors";
+import { convertGameIdReverse, nexusGameId } from "../nexus_integration/util/convertGameId";
 import { setModFiles, setModFilesLoading } from "./actions/session";
 import { getModFiles as getModFilesSelector } from "./selectors";
 import type { IModFileInfo, IModRequirementExt } from "./types";
@@ -133,12 +134,16 @@ export async function onDownloadRequirement(
   const game: IGame = getGame(gameId);
   const nexusDomainName = nexusGameId(game, gameId);
   const nxmUrl = `nxm://${nexusDomainName}/mods/${modId}/files/${targetFile.fileId}`;
+  // mod.gameId is the Nexus domain (e.g. "skyrimspecialedition"); the downloader and
+  // download.game records key on the internal id ("skyrimse"). Convert before emitting
+  // so the file lands in the same folder the install handler later looks in.
+  const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
 
   const dlId = await toPromise<string>((cb) =>
     api.events.emit(
       "start-download",
       [nxmUrl],
-      { game: gameId, name: targetFile.name, fileId: targetFile.fileId, modId },
+      { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
       undefined,
       cb,
       undefined,

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -813,12 +813,16 @@ async function load(extensions: ExtensionManager): Promise<void> {
 
   // Run version-gated migrations now that bundled extensions have registered
   // their games (so knownGames is populated for domain → internal id lookups).
-  try {
-    await migrate(store, priorAppVersion);
-  } catch (err) {
-    log("warn", "migration sequence failed", {
-      err: getErrorMessageOrDefault(err),
-    });
+  // Skipped in dev: package.json is pinned at 1.0.0, so without this guard a
+  // fresh profile's empty appVersion would trip every version-gated migration.
+  if (process.env.NODE_ENV !== "development") {
+    try {
+      await migrate(store, priorAppVersion);
+    } catch (err) {
+      log("warn", "migration sequence failed", {
+        err: getErrorMessageOrDefault(err),
+      });
+    }
   }
 
   log("info", "activating language", {

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -142,6 +142,7 @@ import { setTFunction } from "./util/fs";
 import GlobalNotifications from "./util/GlobalNotifications";
 import getI18n, { changeLanguage, fallbackTFunc, type TFunction } from "./util/i18n";
 import { showError } from "./util/message";
+import migrate from "./util/migrate";
 import { readStartupSettings } from "./util/startupSettings";
 import { getSafe } from "./util/storeHelper";
 import { bytesToString, getAllPropertyNames } from "./util/util";
@@ -193,6 +194,10 @@ function sanityCheckCB(err: StateError) {
 }
 
 let store: ThunkStore<IState>;
+// Captured between hydration and `applyAppMetadata` (which overwrites
+// state.app.appVersion with the running version). migrate() reads it to
+// gate version-keyed migrations during an upgrade.
+let priorAppVersion: string = "";
 
 const terminateFromError = (error: any, allowReport?: boolean) => {
   log("warn", "about to report an error", { stack: new Error().stack });
@@ -568,6 +573,12 @@ async function init(): Promise<ExtensionManager | null> {
     });
   }
 
+  // Capture the previously-persisted appVersion before applyAppMetadata
+  // overwrites it with the currently-running version. migrate() reads this
+  // value to decide which version-gated migrations need to run for an
+  // upgrade; once setApplicationVersion fires, the signal is gone.
+  priorAppVersion = store.getState().app?.appVersion ?? "";
+
   // Apply app init metadata (commandLine, version, etc.) before extensions
   // interact with the store — extensions depend on commandLine state
   if (appInitMetadata !== null) {
@@ -799,6 +810,16 @@ async function load(extensions: ExtensionManager): Promise<void> {
 
   extensions.setTranslation(i18n);
   await Promise.resolve(extensions.doOnce());
+
+  // Run version-gated migrations now that bundled extensions have registered
+  // their games (so knownGames is populated for domain → internal id lookups).
+  try {
+    await migrate(store, priorAppVersion);
+  } catch (err) {
+    log("warn", "migration sequence failed", {
+      err: getErrorMessageOrDefault(err),
+    });
+  }
 
   log("info", "activating language", {
     lang: store.getState().settings.interface.language,

--- a/src/renderer/src/util/migrate.test.ts
+++ b/src/renderer/src/util/migrate.test.ts
@@ -1,0 +1,361 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type * as Redux from "redux";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { IDownload } from "../extensions/download_management/types/IDownload";
+import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
+import type { IState } from "../types/IState";
+
+// `getDownloadPath` reads getVortexPath("userData") lazily and caches it the
+// first time it's called. We never consult the cached value when state has
+// an absolute downloads pattern, but the cache still needs *something* to
+// initialize against; without this stub the test crashes on first use.
+vi.mock("./getVortexPath", () => ({
+  default: () => "/test-userdata",
+}));
+
+// Silence the deprecated migration logger so test output stays clean.
+vi.mock("../logging", () => ({
+  log: vi.fn(),
+}));
+
+// Imports must come after vi.mock() so the mocks are applied to the module
+// graph that pulls them in.
+// eslint-disable-next-line import/first
+import migrate from "./migrate";
+
+let tempRoot: string;
+let testCounter = 0;
+
+beforeAll(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vortex-migrate-"));
+});
+
+afterAll(async () => {
+  // CI volumes occasionally hold Windows file handles a beat longer than the
+  // test runner expects (AV, indexing); swallow rm errors so the cleanup
+  // doesn't leak into the suite exit code.
+  try {
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  } catch {
+    // ignored
+  }
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function buildScenario(opts: {
+  downloads?: Record<string, Partial<IDownload>>;
+  knownGames?: Partial<IGameStored>[];
+  migrations?: string[];
+  activeGameId?: string;
+}): Promise<{
+  downloadsRoot: string;
+  store: Redux.Store<IState>;
+  dispatch: ReturnType<typeof vi.fn>;
+}> {
+  const downloadsRoot = path.join(tempRoot, `case-${++testCounter}`, "downloads");
+  await fs.mkdir(downloadsRoot, { recursive: true });
+
+  const profileId = opts.activeGameId !== undefined ? "test-profile" : undefined;
+  const profiles =
+    opts.activeGameId !== undefined && profileId !== undefined
+      ? { [profileId]: { id: profileId, gameId: opts.activeGameId } }
+      : {};
+
+  const state = {
+    app: {
+      appVersion: "2.0.0",
+      migrations: opts.migrations ?? [],
+    },
+    persistent: {
+      downloads: { files: opts.downloads ?? {} },
+      profiles,
+    },
+    session: {
+      gameMode: { known: opts.knownGames ?? [] },
+    },
+    settings: {
+      downloads: { path: downloadsRoot },
+      profiles: { activeProfileId: profileId },
+    },
+  } as unknown as IState;
+
+  const dispatch = vi.fn();
+  const store = {
+    getState: () => state,
+    dispatch,
+    subscribe: vi.fn(),
+    replaceReducer: vi.fn(),
+    [Symbol.observable]: vi.fn(),
+  } as unknown as Redux.Store<IState>;
+
+  return { downloadsRoot, store, dispatch };
+}
+
+// `batchDispatch` wraps actions in a redux-act batch action; unwrap that
+// so individual setCompatibleGames/completeMigration actions are inspectable.
+function unwrapDispatched(dispatch: ReturnType<typeof vi.fn>): Redux.AnyAction[] {
+  return dispatch.mock.calls.flatMap((call): Redux.AnyAction[] => {
+    const action = call[0] as Redux.AnyAction;
+    if (action && Array.isArray(action.payload) && typeof action.type === "string") {
+      return action.payload as Redux.AnyAction[];
+    }
+    return [action];
+  });
+}
+
+const skyrimseGame: Partial<IGameStored> = {
+  id: "skyrimse",
+  name: "Skyrim Special Edition",
+  details: { nexusPageId: "skyrimspecialedition" },
+};
+
+const skyrimvrGame: Partial<IGameStored> = {
+  id: "skyrimvr",
+  name: "Skyrim VR",
+  details: { nexusPageId: "skyrimspecialedition" },
+};
+
+describe("moveDomainFolders_2_1 migration", () => {
+  it("moves a file from downloads/<domain>/ to downloads/<internal>/", async () => {
+    const { downloadsRoot, store } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    const toDir = path.join(downloadsRoot, "skyrimse");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    let fromStillThere = true;
+    try {
+      await fs.stat(path.join(fromDir, "MyMod.7z"));
+    } catch {
+      fromStillThere = false;
+    }
+    expect(fromStillThere).toBe(false);
+    expect((await fs.stat(path.join(toDir, "MyMod.7z"))).isFile()).toBe(true);
+  });
+
+  it("rewrites download.game[0] to the internal id and keeps the domain as a compat alias", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    const actions = unwrapDispatched(dispatch);
+    const setCompat = actions.find(
+      (a) => a?.type === "SET_COMPATIBLE_GAMES" && a.payload?.id === "dl1",
+    );
+    expect(setCompat).toBeDefined();
+    expect(setCompat?.payload.games).toEqual(["skyrimse", "skyrimspecialedition"]);
+  });
+
+  it("disambiguates skyrimspecialedition to skyrimvr when VR is the only loaded Skyrim", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimvrGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    const toDir = path.join(downloadsRoot, "skyrimvr");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.stat(path.join(toDir, "MyMod.7z"))).isFile()).toBe(true);
+
+    const actions = unwrapDispatched(dispatch);
+    const setCompat = actions.find(
+      (a) => a?.type === "SET_COMPATIBLE_GAMES" && a.payload?.id === "dl1",
+    );
+    expect(setCompat?.payload.games[0]).toBe("skyrimvr");
+  });
+
+  it("prefers activeGameId when both skyrimse and skyrimvr share the nexusPageId", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      // Order intentionally puts VR first: without the activeGameId
+      // preference, convertGameIdReverse would pick skyrimvr.
+      knownGames: [skyrimvrGame, skyrimseGame],
+      activeGameId: "skyrimse",
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    const toDir = path.join(downloadsRoot, "skyrimse");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.stat(path.join(toDir, "MyMod.7z"))).isFile()).toBe(true);
+
+    const actions = unwrapDispatched(dispatch);
+    const setCompat = actions.find(
+      (a) => a?.type === "SET_COMPATIBLE_GAMES" && a.payload?.id === "dl1",
+    );
+    expect(setCompat?.payload.games[0]).toBe("skyrimse");
+  });
+
+  it("records all loaded candidate games so the install handler can pick the right one regardless of active game", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame, skyrimvrGame],
+      activeGameId: "skyrimse",
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    const actions = unwrapDispatched(dispatch);
+    const setCompat = actions.find(
+      (a) => a?.type === "SET_COMPATIBLE_GAMES" && a.payload?.id === "dl1",
+    );
+    expect(setCompat?.payload.games).toEqual(["skyrimse", "skyrimvr", "skyrimspecialedition"]);
+  });
+
+  it("produces a unique game array even when the input already contains duplicates", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: {
+        dl1: {
+          localPath: "MyMod.7z",
+          game: ["skyrimspecialedition", "skyrimspecialedition", "skyrimse"],
+        },
+      },
+      knownGames: [skyrimseGame, skyrimvrGame],
+      activeGameId: "skyrimse",
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    const actions = unwrapDispatched(dispatch);
+    const setCompat = actions.find(
+      (a) => a?.type === "SET_COMPATIBLE_GAMES" && a.payload?.id === "dl1",
+    );
+    expect(setCompat?.payload.games).toEqual(["skyrimse", "skyrimvr", "skyrimspecialedition"]);
+  });
+
+  it("no-ops when game[0] is already an internal id", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimse"] } },
+      knownGames: [skyrimseGame],
+    });
+    const sameDir = path.join(downloadsRoot, "skyrimse");
+    await fs.mkdir(sameDir, { recursive: true });
+    await fs.writeFile(path.join(sameDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.stat(path.join(sameDir, "MyMod.7z"))).isFile()).toBe(true);
+
+    const actions = unwrapDispatched(dispatch);
+    expect(actions.find((a) => a?.type === "SET_COMPATIBLE_GAMES")).toBeUndefined();
+  });
+
+  it("leaves both files in place when the destination already has a file with the same name", async () => {
+    const { downloadsRoot, store } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    const toDir = path.join(downloadsRoot, "skyrimse");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.mkdir(toDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "older");
+    await fs.writeFile(path.join(toDir, "MyMod.7z"), "newer");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.readFile(path.join(fromDir, "MyMod.7z"))).toString()).toBe("older");
+    expect((await fs.readFile(path.join(toDir, "MyMod.7z"))).toString()).toBe("newer");
+  });
+
+  it("sweeps orphan files in the domain folder once a state record establishes the mapping", async () => {
+    const { downloadsRoot, store } = await buildScenario({
+      downloads: { dl1: { localPath: "InState.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    const toDir = path.join(downloadsRoot, "skyrimse");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "InState.7z"), "state");
+    await fs.writeFile(path.join(fromDir, "Orphan.7z"), "orphan");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.stat(path.join(toDir, "InState.7z"))).isFile()).toBe(true);
+    expect((await fs.stat(path.join(toDir, "Orphan.7z"))).isFile()).toBe(true);
+
+    // The rmdir at the end of the sweep is best-effort; on CI it can lose to
+    // a lingering handle, in which case the folder is allowed to remain. We
+    // only assert that nothing got left INSIDE the folder.
+    try {
+      const remaining = await fs.readdir(fromDir);
+      expect(remaining).toEqual([]);
+    } catch {
+      // ENOENT is fine too: the folder was removed.
+    }
+  });
+
+  it("records the migration on the state.app.migrations log", async () => {
+    const { store, dispatch } = await buildScenario({ knownGames: [skyrimseGame] });
+
+    await migrate(store, "2.0.0");
+
+    const actions = unwrapDispatched(dispatch);
+    const completed = actions.find(
+      (a) => a?.type === "COMPLETE_MIGRATION" && a.payload === "moveDomainFolders_2_1",
+    );
+    expect(completed).toBeDefined();
+  });
+
+  it("does not run when state.app.migrations already contains its id", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+      migrations: ["moveDomainFolders_2_1"],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.0.0");
+
+    expect((await fs.stat(path.join(fromDir, "MyMod.7z"))).isFile()).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not run when oldVersion is already >= the migration minVersion", async () => {
+    const { downloadsRoot, store, dispatch } = await buildScenario({
+      downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
+      knownGames: [skyrimseGame],
+    });
+    const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
+    await fs.mkdir(fromDir, { recursive: true });
+    await fs.writeFile(path.join(fromDir, "MyMod.7z"), "content");
+
+    await migrate(store, "2.1.0");
+
+    expect((await fs.stat(path.join(fromDir, "MyMod.7z"))).isFile()).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/util/migrate.ts
+++ b/src/renderer/src/util/migrate.ts
@@ -1,9 +1,8 @@
+import { mkdir, readdir, rename, rmdir, stat } from "node:fs/promises";
 import * as path from "path";
 
 import { getErrorCode } from "@vortex/shared";
 import PromiseBB from "bluebird";
-import type { BrowserWindow } from "electron";
-import { dialog } from "electron";
 import type * as Redux from "redux";
 import * as semver from "semver";
 import format from "string-template";
@@ -19,12 +18,18 @@ import {
   setUserAPIKey,
   setUserInfo,
 } from "../actions";
+import { setCompatibleGames } from "../extensions/download_management/actions/state";
+import { downloadPathForGame } from "../extensions/download_management/selectors";
 import getDownloadPath from "../extensions/download_management/util/getDownloadPath";
+import { knownGames } from "../extensions/gamemode_management/selectors";
+import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import resolvePath, { pathDefaults } from "../extensions/mod_management/util/resolvePath";
+import { convertGameIdReverse } from "../extensions/nexus_integration/util/convertGameId";
+import { activeGameId } from "../extensions/profile_management/selectors";
+import { log } from "../logging";
 import type { IState } from "../types/IState";
 import { UserCanceled } from "./CustomErrors";
 import * as fs from "./fs";
-import { log } from "./log";
 import makeCI from "./makeCaseInsensitive";
 import { batchDispatch } from "./util";
 
@@ -34,18 +39,15 @@ interface IMigration {
   maySkip: boolean;
   doQuery: boolean;
   description: string;
-  apply: (window: BrowserWindow | null, store: Redux.Store<IState>) => PromiseBB<void>;
+  apply: (store: Redux.Store<IState>) => PromiseBB<void> | Promise<void>;
 }
 
-function selectDirectory(
-  window: BrowserWindow | null,
-  defaultPathPattern: string,
-): PromiseBB<string> {
+function selectDirectory(defaultPathPattern: string): PromiseBB<string> {
   const defaultPath = getDownloadPath(defaultPathPattern, undefined);
   return fs
     .ensureDirWritableAsync(defaultPath, () => PromiseBB.resolve())
     .then(() =>
-      dialog.showOpenDialog(window, {
+      window.api.dialog.showOpen({
         title: "Select empty directory to store downloads",
         properties: ["openDirectory", "createDirectory", "promptToCreate"],
         defaultPath,
@@ -66,8 +68,11 @@ function selectDirectory(
         })
         .then((files) => {
           if (files.length > 0) {
-            dialog.showErrorBox("Invalid path selected", "The directory needs to be empty");
-            return selectDirectory(window, defaultPathPattern);
+            void window.api.dialog.showErrorBox(
+              "Invalid path selected",
+              "The directory needs to be empty",
+            );
+            return selectDirectory(defaultPathPattern);
           } else {
             return PromiseBB.resolve(filePaths[0]);
           }
@@ -100,14 +105,13 @@ function transferPath(from: string, to: string): PromiseBB<void> {
 }
 
 function dialogProm(
-  window: BrowserWindow | null,
   type: string,
   title: string,
   message: string,
   options: string[],
 ): PromiseBB<string> {
   return PromiseBB.resolve(
-    dialog.showMessageBox(window, {
+    window.api.dialog.showMessageBox({
       type: type as "none" | "info" | "error" | "question" | "warning",
       buttons: options,
       title,
@@ -117,10 +121,7 @@ function dialogProm(
   ).then((result) => options[result.response]);
 }
 
-function forceLogoutForOauth_1_9(
-  window: BrowserWindow,
-  store: Redux.Store<IState>,
-): PromiseBB<void> {
+function forceLogoutForOauth_1_9(store: Redux.Store<IState>): PromiseBB<void> {
   const state = store.getState();
 
   const apiKey = state.confidential.account?.["nexus"]?.["APIKey"];
@@ -151,18 +152,17 @@ function forceLogoutForOauth_1_9(
   return PromiseBB.resolve();
 }
 
-function moveDownloads_0_16(window: BrowserWindow, store: Redux.Store<IState>): PromiseBB<void> {
+function moveDownloads_0_16(store: Redux.Store<IState>): PromiseBB<void> {
   const state = store.getState();
   log("info", "importing downloads from pre-0.16.0 version");
   return dialogProm(
-    window,
     "info",
     "Moving Downloads",
     "On the next screen, please select an empty directory where all your " +
       "downloads from vortex (for all games) will be placed",
     ["Next"],
   )
-    .then(() => selectDirectory(window, state.settings.downloads.path))
+    .then(() => selectDirectory(state.settings.downloads.path))
     .then((downloadPath) => {
       store.dispatch(setDownloadPath(downloadPath));
       return PromiseBB.map(Object.keys(state.settings.gameMode.discovered), (gameId) => {
@@ -179,10 +179,7 @@ function moveDownloads_0_16(window: BrowserWindow, store: Redux.Store<IState>): 
     });
 }
 
-function updateInstallPath_0_16(
-  window: BrowserWindow,
-  store: Redux.Store<IState>,
-): PromiseBB<void> {
+function updateInstallPath_0_16(store: Redux.Store<IState>): PromiseBB<void> {
   const state = store.getState();
   const { paths } = state.settings.mods as any;
   return PromiseBB.map(Object.keys(paths || {}), (gameId) => {
@@ -209,12 +206,160 @@ function updateInstallPath_0_16(
   }).then(() => {});
 }
 
-function enableModernLayout_2_0(
-  _window: BrowserWindow,
-  store: Redux.Store<IState>,
-): PromiseBB<void> {
+function enableModernLayout_2_0(store: Redux.Store<IState>): PromiseBB<void> {
   batchDispatch(store, [setUseModernLayout(true), setProfilesVisible(true)]);
   return PromiseBB.resolve();
+}
+
+async function moveDomainFile(src: string, dest: string): Promise<boolean> {
+  try {
+    await stat(dest);
+    // Destination already exists; leave both in place rather than overwrite.
+    return false;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+  try {
+    await stat(src);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+  await mkdir(path.dirname(dest), { recursive: true });
+  await rename(src, dest);
+  return true;
+}
+
+// Ordered list of loaded game ids that share the same nexusPageId as `domain`.
+// First entry is the preferred internal: active game wins when multiple
+// candidates qualify, otherwise convertGameIdReverse's hardcoded fallback.
+// Empty array means "leave the download alone" (unknown domain).
+function resolveDomainCandidates(
+  games: IGameStored[],
+  activeId: string | undefined,
+  domain: string,
+): string[] {
+  const matches = games.filter(
+    (g) => g.id === domain.toLowerCase() || (g.details && g.details.nexusPageId === domain),
+  );
+  if (matches.length === 0) {
+    const fallback = convertGameIdReverse(games, domain) || domain;
+    return fallback === domain ? [] : [fallback];
+  }
+  let preferred: string | undefined;
+  if (activeId !== undefined) {
+    preferred = matches.find((g) => g.id === activeId)?.id;
+  }
+  if (preferred === undefined) {
+    const fallback = convertGameIdReverse(games, domain);
+    preferred = matches.find((g) => g.id === fallback)?.id ?? matches[0].id;
+  }
+  return Array.from(new Set([preferred, ...matches.map((g) => g.id)]));
+}
+
+// Fixes the v2.1 regression where some callers passed Nexus domains as
+// `modInfo.game`, causing downloads to land in `downloads/<domain>/` while
+// install lookups key on the internal id. Rewrites `download.game` so the
+// preferred internal comes first, moves the file to the matching folder, and
+// sweeps any orphans left behind in domain-named directories.
+async function moveDomainFolders_2_1(store: Redux.Store<IState>): Promise<void> {
+  const state = store.getState();
+  const downloads = state.persistent.downloads?.files ?? {};
+  const games = knownGames(state);
+  const activeId = activeGameId(state);
+
+  const candidatesByDomain = new Map<string, string[]>();
+  const stateActions: Redux.AnyAction[] = [];
+
+  for (const dlId of Object.keys(downloads)) {
+    const dl = downloads[dlId];
+    const first = Array.isArray(dl.game) ? dl.game[0] : undefined;
+    if (!first) continue;
+
+    if (!candidatesByDomain.has(first)) {
+      candidatesByDomain.set(first, resolveDomainCandidates(games, activeId, first));
+    }
+    const candidates = candidatesByDomain.get(first) ?? [];
+    const internal = candidates[0];
+    if (internal === undefined || internal === first) continue;
+
+    if (dl.localPath) {
+      const src = path.join(downloadPathForGame(state, first), dl.localPath);
+      const dest = path.join(downloadPathForGame(state, internal), dl.localPath);
+      try {
+        const moved = await moveDomainFile(src, dest);
+        if (moved) {
+          log("info", "migration: moved download archive", { dlId, src, dest });
+        }
+      } catch (err) {
+        // Keep going: state still gets rewritten so the install handler
+        // points at the right folder once the user re-downloads.
+        log("warn", "migration: failed to move download archive", {
+          dlId,
+          src,
+          dest,
+          err: (err as Error).message,
+        });
+      }
+    }
+
+    // All loaded candidates land in download.game so the install handler can
+    // pick the right one regardless of which game the user is on at install
+    // time. `Set` collapses any overlap with dl.game while preserving order.
+    stateActions.push(setCompatibleGames(dlId, Array.from(new Set([...candidates, ...dl.game]))));
+  }
+
+  // Sweep orphan files left in domain folders (downloads dropped from state
+  // earlier but still present on disk). Only run for domains we actually
+  // remapped above.
+  let folderPairs = 0;
+  for (const [domain, candidates] of candidatesByDomain) {
+    const internal = candidates[0];
+    if (internal === undefined || domain === internal) continue;
+    folderPairs += 1;
+
+    const fromPath = downloadPathForGame(state, domain);
+    const toPath = downloadPathForGame(state, internal);
+    let leftover: string[];
+    try {
+      leftover = await readdir(fromPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      log("warn", "migration: failed to scan domain folder", {
+        fromPath,
+        err: (err as Error).message,
+      });
+      continue;
+    }
+    for (const name of leftover) {
+      try {
+        await moveDomainFile(path.join(fromPath, name), path.join(toPath, name));
+      } catch (err) {
+        log("warn", "migration: failed to move orphan file", {
+          src: path.join(fromPath, name),
+          err: (err as Error).message,
+        });
+      }
+    }
+    // Best-effort: folder stays if anything got skipped (collision, perms).
+    try {
+      await rmdir(fromPath);
+    } catch {
+      // ignored
+    }
+  }
+
+  if (stateActions.length > 0) {
+    batchDispatch(store, stateActions);
+  }
+  log("info", "migration: domain folders normalized", {
+    rewroteDownloads: stateActions.length,
+    folderPairs,
+  });
 }
 
 const migrations: IMigration[] = [
@@ -252,16 +397,26 @@ const migrations: IMigration[] = [
     description: "Switch to Modern UI layout for 2.0",
     apply: enableModernLayout_2_0,
   },
+  {
+    id: "moveDomainFolders_2_1",
+    minVersion: "2.1.0",
+    maySkip: false,
+    doQuery: false,
+    description:
+      "Move downloads saved under Nexus domain folders (e.g. skyrimspecialedition) " +
+      "to the internal-id folder (skyrimse) used by the rest of Vortex.",
+    apply: moveDomainFolders_2_1,
+  },
 ];
 
-function queryMigration(window: BrowserWindow | null, migration: IMigration): PromiseBB<boolean> {
+function queryMigration(migration: IMigration): PromiseBB<boolean> {
   if (!migration.doQuery) {
     return PromiseBB.resolve(true);
   }
   return new PromiseBB((resolve, reject) => {
     const buttons = migration.maySkip ? ["Cancel", "Skip", "Continue"] : ["Cancel", "Continue"];
-    dialog
-      .showMessageBox(window, {
+    void window.api.dialog
+      .showMessageBox({
         type: "info",
         buttons,
         title: "Migration necessary",
@@ -277,9 +432,8 @@ function queryMigration(window: BrowserWindow | null, migration: IMigration): Pr
   });
 }
 
-function queryContinue(window: BrowserWindow | null, err: Error): PromiseBB<void> {
+function queryContinue(err: Error): PromiseBB<void> {
   return dialogProm(
-    window,
     "error",
     "Migration failed",
     "A migration step failed. You should quit now and resolve the cause of the issue.\n" +
@@ -288,15 +442,21 @@ function queryContinue(window: BrowserWindow | null, err: Error): PromiseBB<void
   ).then((selection) => (selection === "Ignore" ? PromiseBB.resolve() : PromiseBB.reject(err)));
 }
 
-function migrate(store: Redux.Store<IState>, window: BrowserWindow | null): PromiseBB<void> {
+function migrate(store: Redux.Store<IState>, oldVersion?: string): PromiseBB<void> {
   const state = store.getState();
-  const oldVersion = state.app.appVersion || "0.0.0";
+  // Callers should pass the *prior* persisted appVersion: in v2.x renderer
+  // startup, `state.app.appVersion` is overwritten with the current version
+  // by `applyAppMetadata` before any migration code gets to run, which would
+  // make the semver filter below trivially false.
+  const effectiveOldVersion = oldVersion ?? state.app.appVersion ?? "0.0.0";
+  const alreadyApplied = state.app.migrations ?? [];
+
   const neccessaryMigrations = migrations
-    .filter((mig) => semver.lt(oldVersion, mig.minVersion))
-    .filter((mig) => state.app.migrations.indexOf(mig.id) === -1);
+    .filter((mig) => semver.lt(effectiveOldVersion, mig.minVersion))
+    .filter((mig) => alreadyApplied.indexOf(mig.id) === -1);
   return PromiseBB.each(neccessaryMigrations, (migration) =>
-    queryMigration(window, migration)
-      .then((proceed: boolean) => (proceed ? migration.apply(window, store) : PromiseBB.resolve()))
+    queryMigration(migration)
+      .then((proceed: boolean) => (proceed ? migration.apply(store) : PromiseBB.resolve()))
       .then(() => {
         store.dispatch(completeMigration(migration.id));
         return PromiseBB.resolve();
@@ -305,7 +465,7 @@ function migrate(store: Redux.Store<IState>, window: BrowserWindow | null): Prom
         if (err instanceof UserCanceled) {
           throw err;
         }
-        return queryContinue(window, err);
+        return queryContinue(err);
       }),
   ).then(() => {});
 }


### PR DESCRIPTION
IPCDownloadAdapter was trusting modInfo.game verbatim. When the requirements-check auto-download path passed the Nexus domain (e.g. "skyrimspecialedition") instead of the internal id ("skyrimse"), files landed in downloads/<domain>/ while install lookups went through convertGameIdReverse and looked under downloads/<internal>/, producing ENOENT on auto-install.

* Source fix: onDownloadRequirement now converts mod.gameId to the internal id before emitting start-download.
* Defensive fix: IPCDownloadAdapter normalizes modInfo.game through convertGameIdReverse at every read site.
* Migration: re-wired the dormant util/migrate.ts framework (call from renderer.tsx after doOnce, dialog APIs routed through window.api, explicit oldVersion parameter) and added moveDomainFolders_2_1, which moves affected files to the right folder and rewrites download.game, bundling all loaded candidate games so install works regardless of which Skyrim the user is on.

closes https://linear.app/nexus-mods/issue/APP-487 closes https://linear.app/nexus-mods/issue/APP-488