### PR TITLE
Changed: Improve E2E auth setup and scripts

### DIFF
--- a/docs/error-reporting/fingerprint-resolution.md
+++ b/docs/error-reporting/fingerprint-resolution.md
@@ -105,7 +105,7 @@ dist/index.js         bundled by @vercel/ncc, committed for runtime
 ```bash
 cd .github/actions/fingerprints
 pnpm install
-pnpm test
+pnpm run test
 pnpm run build
 ```
 

--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -15,7 +15,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @msgpack/msgpack | 2.8.0 |
 | @nexusmods/adaptor-api | link:../../packages/adaptor-api |
 | @nexusmods/fomod-installer-ipc | 0.13.1 |
-| @nexusmods/fomod-installer-native | 0.13.1 |
+| @nexusmods/fomod-installer-native | 0.13.2 |
 | @nexusmods/nexus-api | 1.6.2 |
 | @opentelemetry/api | 1.9.1 |
 | @opentelemetry/context-async-hooks | 2.6.1 |

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,10 @@
             # Electron (wrapped with GTK dependencies)
             electron_42-bin
 
+            # Playwright on NixOS uses Nix-provided Chromium instead of
+            # downloaded browser binaries, which are not patched for NixOS.
+            chromium
+
             # GTK dependencies for Electron runtime
             gtk3
             gtk4
@@ -67,6 +71,13 @@
 
             # Point to Nix-provided Electron
             ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_42-bin.dist}";
+
+            # Point E2E auth-browser launches at Nix-provided Chromium.
+            # Do not use `playwright install --with-deps` on NixOS; it tries apt-get.
+            E2E_PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = "${pkgs.chromium}/bin/chromium";
+
+            # Avoid Playwright host dependency checks. Nix supplies runtime deps.
+            PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 
             # Make the dotnet runtime available
             DOTNET_ROOT = "${pkgs.dotnetCorePackages.runtime_9_0}/share/dotnet";

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "format": "pnpm oxfmt",
     "format:check": "pnpm oxfmt --check",
     "format:staged": "git diff --name-only --cached | xargs --no-run-if-empty pnpm oxfmt",
-    "e2e": "pnpm nx run @vortex/e2e:test",
-    "e2e:headed": "pnpm nx run @vortex/e2e:test:headed",
-    "e2e:debug": "pnpm nx run @vortex/e2e:test:debug",
+    "e2e": "pnpm -F @vortex/e2e e2e",
+    "e2e:headed": "pnpm -F @vortex/e2e e2e:headed",
+    "e2e:debug": "pnpm -F @vortex/e2e e2e:debug",
     "generate:query-types": "pnpm tsx scripts/generate-query-types.ts"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "format": "pnpm oxfmt",
     "format:check": "pnpm oxfmt --check",
     "format:staged": "git diff --name-only --cached | xargs --no-run-if-empty pnpm oxfmt",
-    "e2e": "pnpm nx run @vortex/e2e:test",
-    "e2e:headed": "pnpm nx run @vortex/e2e:test:headed",
-    "e2e:debug": "pnpm nx run @vortex/e2e:test:debug",
+    "e2e": "pnpm nx run @vortex/e2e:e2e",
+    "e2e:headed": "pnpm nx run @vortex/e2e:e2e:headed",
+    "e2e:debug": "pnpm nx run @vortex/e2e:e2e:debug",
+    "e2e:report": "pnpm nx run @vortex/e2e:e2e:report",
     "generate:query-types": "pnpm tsx scripts/generate-query-types.ts"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "format": "pnpm oxfmt",
     "format:check": "pnpm oxfmt --check",
     "format:staged": "git diff --name-only --cached | xargs --no-run-if-empty pnpm oxfmt",
-    "e2e": "pnpm -F @vortex/e2e e2e",
-    "e2e:headed": "pnpm -F @vortex/e2e e2e:headed",
-    "e2e:debug": "pnpm -F @vortex/e2e e2e:debug",
+    "e2e": "pnpm nx run @vortex/e2e:test",
+    "e2e:headed": "pnpm nx run @vortex/e2e:test:headed",
+    "e2e:debug": "pnpm nx run @vortex/e2e:test:debug",
     "generate:query-types": "pnpm tsx scripts/generate-query-types.ts"
   },
   "lint-staged": {

--- a/packages/e2e/E2E-BEST-PRACTICES.md
+++ b/packages/e2e/E2E-BEST-PRACTICES.md
@@ -334,7 +334,7 @@ Don't sprinkle `vortexWindow.screenshot(...)` calls in tests. Playwright config 
 View results:
 
 ```bash
-pnpm -F @vortex/e2e run test:report
+pnpm e2e:report
 ```
 
 ---

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -134,7 +134,7 @@ No inline `page.screenshot()` in tests. Diagnostics are handled by the Playwrigh
 View reports after a run:
 
 ```bash
-pnpm -F @vortex/e2e run test:report
+pnpm e2e:report
 ```
 
 ### Fake Game Installations

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -10,6 +10,21 @@ Automated E2E tests for Vortex using [Playwright for Electron](https://playwrigh
 pnpm -F @vortex/e2e exec playwright install chromium
 ```
 
+## Setup Environment
+
+E2E tests load env from `packages/e2e/.env` automatically. File is gitignored.
+Get Nexus creds from password manager, then add:
+
+```env
+E2E_NEXUS_FREE_USER_USERNAME=NXMMember
+E2E_NEXUS_FREE_USER_PASSWORD=...
+E2E_NEXUS_PREMIUM_USER_USERNAME=NXMPremium
+E2E_NEXUS_PREMIUM_USER_PASSWORD=...
+```
+
+Free-user creds cover login, upgrade, and some smoke tests. Premium-user creds
+are needed for specs that assert premium-only behaviour.
+
 ## Running Tests
 
 ```bash
@@ -31,6 +46,8 @@ pnpm -F @vortex/e2e exec playwright test --grep @smoke
 # Run tests matching a name pattern
 pnpm -F @vortex/e2e exec playwright test -g "Settings"
 ```
+
+Examples above assume `.env` has needed creds.
 
 ## Project Structure
 

--- a/packages/e2e/helpers/login.ts
+++ b/packages/e2e/helpers/login.ts
@@ -88,15 +88,20 @@ export async function loginToNexus(
       // remains valid. Real Chrome + AutomationControlled disabled +
       // navigator.webdriver spoof matches what was cleared during warmup.
       const headless = options.headless ?? !process.env.PWDEBUG;
+      const executablePath = process.env.E2E_PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
       const launchArgs = ["--disable-blink-features=AutomationControlled"];
       try {
         authBrowser = await chromium.launch({
           headless,
-          channel: "chrome",
+          ...(executablePath !== undefined ? { executablePath } : { channel: "chrome" }),
           args: launchArgs,
         });
       } catch {
-        authBrowser = await chromium.launch({ headless, args: launchArgs });
+        authBrowser = await chromium.launch({
+          headless,
+          ...(executablePath !== undefined ? { executablePath } : {}),
+          args: launchArgs,
+        });
       }
       const authContext = await authBrowser.newContext(
         options.storageStatePath !== undefined

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -8,14 +8,11 @@
     "e2e": "pnpm playwright test",
     "e2e:headed": "pnpm playwright test --headed",
     "e2e:debug": "pnpm playwright test --debug",
-    "test": "pnpm playwright test",
-    "test:headed": "pnpm playwright test --headed",
-    "test:debug": "pnpm playwright test --debug",
-    "test:report": "pnpm playwright show-report"
+    "e2e:report": "pnpm playwright show-report"
   },
   "nx": {
     "targets": {
-      "test": {
+      "e2e": {
         "cache": false,
         "continuous": true,
         "dependsOn": [

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "e2e": "pnpm playwright test",
+    "e2e:headed": "pnpm playwright test --headed",
+    "e2e:debug": "pnpm playwright test --debug",
     "test": "pnpm playwright test",
     "test:headed": "pnpm playwright test --headed",
     "test:debug": "pnpm playwright test --debug",


### PR DESCRIPTION
## Summary
- Use Nix-provided Chromium for Playwright auth on NixOS
- Add root and package-level E2E script aliases
- Document local Nexus credential env vars for E2E runs

closes [LAZ-475](<https://linear.app/nexus-mods/issue/LAZ-475/document-required-e2e-environment-variables-in-readme-files>)