### PR TITLE
UI component updates

### DIFF
--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ModRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ModRequirement.tsx
@@ -2,6 +2,8 @@ import { mdiCheck, mdiDiamondStone, mdiDownload, mdiOpenInNew, mdiWeb } from "@m
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
+
 import { Button } from "../../../../ui/components/button/Button";
 import { Icon } from "../../../../ui/components/icon/Icon";
 import { Typography } from "../../../../ui/components/typography/Typography";
@@ -82,13 +84,7 @@ export const ModRequirement = ({
                   buttonType="secondary"
                   filled="strong"
                   leftIconPath={mdiDownload}
-                  rightIcon={
-                    showPremiumBadge ? (
-                      <span className="-m-1 flex size-5 items-center justify-center rounded-sm bg-premium-moderate text-neutral-strong">
-                        <Icon className="size-4" path={mdiDiamondStone} size="none" />
-                      </span>
-                    ) : undefined
-                  }
+                  rightIcon={showPremiumBadge && <PremiumBadge />}
                   size="sm"
                   onClick={() => onShowVortexModal?.()}
                 >

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -17,7 +17,8 @@ import type { IState } from "../../../types/IState";
 import { Button } from "../../../ui/components/button/Button";
 import { Icon } from "../../../ui/components/icon/Icon";
 import { Pictogram } from "../../../ui/components/pictogram/Pictogram";
-import { Typography, TypographyLink } from "../../../ui/components/typography/Typography";
+import { Typography } from "../../../ui/components/typography/Typography";
+import { TypographyLink } from "../../../ui/components/typography/TypographyLink";
 import { opn } from "../../../util/api";
 import { log } from "../../../util/log";
 import { shouldShowPremiumAd } from "../../../util/selectors";
@@ -230,7 +231,6 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
                         modLink: (
                           <TypographyLink
                             appearance="primary"
-                            as="button"
                             typographyType="inherit"
                             variant="secondary"
                             onClick={openRequiringModPage}

--- a/src/renderer/src/ui/components/button/Button.tsx
+++ b/src/renderer/src/ui/components/button/Button.tsx
@@ -7,7 +7,14 @@
  */
 
 import { mdiCircleOutline, mdiLoading } from "@mdi/js";
-import React, { type ButtonHTMLAttributes, forwardRef, type ReactNode } from "react";
+import React, {
+  type ButtonHTMLAttributes,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 
 import { Icon } from "@/ui/components/icon/Icon";
 import { joinClasses } from "@/ui/utils/joinClasses";
@@ -110,8 +117,12 @@ const ButtonIcon = ({
     );
   }
 
-  if (icon) {
-    return <span className="nxm-button-icon flex items-center justify-center">{icon}</span>;
+  if (isValidElement(icon)) {
+    const element = icon as ReactElement<{ className?: string }>;
+
+    return cloneElement(element, {
+      className: joinClasses(["nxm-button-icon", element.props.className]),
+    });
   }
 
   if (path) {

--- a/src/renderer/src/ui/components/icon/Icon.tsx
+++ b/src/renderer/src/ui/components/icon/Icon.tsx
@@ -1,6 +1,6 @@
 import React, { type SVGAttributes } from "react";
 
-import { joinClasses } from "../../utils/joinClasses";
+import { joinClasses } from "@/ui/utils/joinClasses";
 
 export type IconSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "none";
 
@@ -26,12 +26,12 @@ export const Icon = ({
   title?: string;
 }) => (
   <svg
-    className={joinClasses([sizeMap[size], className])}
+    className={joinClasses(["shrink-0", sizeMap[size], className])}
     role={title ? "img" : "presentation"}
     viewBox="0 0 24 24"
     {...props}
   >
-    {title && <title>{title}</title>}
+    {!!title && <title>{title}</title>}
 
     <path d={path} fill="currentColor" />
   </svg>

--- a/src/renderer/src/ui/components/image/Image.tsx
+++ b/src/renderer/src/ui/components/image/Image.tsx
@@ -1,0 +1,70 @@
+import { mdiImageBroken } from "@mdi/js";
+import React, { useState, type ImgHTMLAttributes } from "react";
+
+import { Icon } from "@/ui/components/icon/Icon";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export interface IImageProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "className" | "alt"
+> {
+  alt: string;
+  className?: string;
+  imageClassName?: string;
+  imageType?: "collection" | "mod" | "other";
+  isBlurred?: boolean;
+}
+
+const imageTypeMap: Record<NonNullable<IImageProps["imageType"]>, string> = {
+  collection: "aspect-collection",
+  mod: "aspect-mod",
+  other: "",
+};
+
+export const Image = ({
+  alt,
+  className,
+  imageClassName,
+  imageType = "other",
+  isBlurred,
+  onError,
+  src,
+  ...rest
+}: IImageProps) => {
+  const [lastSrc, setLastSrc] = useState(src);
+  const [errored, setErrored] = useState(false);
+
+  if (src !== lastSrc) {
+    setLastSrc(src);
+    setErrored(false);
+  }
+
+  return (
+    <div
+      className={joinClasses([
+        "group/image relative z-0 flex shrink-0 items-center justify-center overflow-hidden bg-surface-translucent-low",
+        imageTypeMap[imageType],
+        className,
+      ])}
+    >
+      {!errored ? (
+        <img
+          {...rest}
+          alt={alt}
+          className={joinClasses(["absolute z-1 max-h-full rounded-[inherit]", imageClassName], {
+            "blur-xl": isBlurred,
+          })}
+          src={src}
+          onError={(event) => {
+            setErrored(true);
+            onError?.(event);
+          }}
+        />
+      ) : (
+        <Icon className="text-neutral-subdued" path={mdiImageBroken} title={alt} />
+      )}
+
+      <div className="pointer-events-none absolute inset-0 z-2 rounded-[inherit] border border-stroke-weak" />
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/premium_badge/PremiumBadge.tsx
+++ b/src/renderer/src/ui/components/premium_badge/PremiumBadge.tsx
@@ -1,0 +1,16 @@
+import { mdiDiamondStone } from "@mdi/js";
+import React from "react";
+
+import { Icon } from "@/ui/components/icon/Icon";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export const PremiumBadge = ({ className }: { className?: string }) => (
+  <span
+    className={joinClasses([
+      "flex size-5 items-center justify-center rounded-sm bg-premium-moderate text-neutral-strong",
+      className,
+    ])}
+  >
+    <Icon path={mdiDiamondStone} size="sm" />
+  </span>
+);

--- a/src/renderer/src/ui/components/typography/Typography.tsx
+++ b/src/renderer/src/ui/components/typography/Typography.tsx
@@ -5,14 +5,11 @@
  * Provides a consistent typography system with predefined sizes and appearances.
  */
 
-import * as React from "react";
-import type { AllHTMLAttributes, AnchorHTMLAttributes, ReactNode, Ref } from "react";
+import type { AllHTMLAttributes, Ref } from "react";
 import { createElement } from "react";
 
 import { joinClasses } from "../../utils/joinClasses";
-import type { ResponsiveScreenSizes, XOr } from "../../utils/types";
-import type { IconSize } from "../icon/Icon";
-import { Icon } from "../icon/Icon";
+import type { ResponsiveScreenSizes } from "../../utils/types";
 
 export type TypographyTypes =
   | "heading-2xl"
@@ -84,7 +81,7 @@ const toClasses = (type: TypographyTypes, prefix = "") => {
   return classes;
 };
 
-const getTypographyStyles = ({
+export const getTypographyStyles = ({
   as = "span",
   typographyType,
 }: {
@@ -129,138 +126,5 @@ export const Typography = ({
       ...props,
     },
     children,
-  );
-};
-
-//
-type TypographyLinkAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  as?: "a";
-  disabled?: never;
-  isExternal?: boolean;
-  ref?: Ref<HTMLAnchorElement>;
-};
-
-type TypographyLinkButtonProps = AllHTMLAttributes<HTMLAnchorElement | HTMLButtonElement> & {
-  as: "button";
-  disabled?: boolean;
-  href?: never;
-  isExternal?: never;
-  ref?: Ref<HTMLAnchorElement | HTMLButtonElement>;
-};
-
-type TypographyLinkTypes = TypographyTypes | "inherit";
-
-type TypographyLinkTypeObjectDefault = {
-  [key in Extract<ResponsiveScreenSizes, "default">]: TypographyLinkTypes;
-};
-type TypographyLinkTypeObject = TypographyLinkTypeObjectDefault & {
-  [key in Exclude<ResponsiveScreenSizes, "default">]?: TypographyLinkTypes;
-};
-
-export type TypographyLinkProps = (TypographyLinkAnchorProps | TypographyLinkButtonProps) & {
-  /**
-   * The text colour
-   */
-  appearance?: "info" | "premium" | "primary" | "moderate" | "strong" | "subdued" | "none";
-  iconSize?: IconSize;
-  leftIconPath?: string;
-  rightIconPath?: string;
-  typographyType?: TypographyLinkTypes | TypographyLinkTypeObject;
-  variant?: "primary" | "secondary" | "none";
-} & XOr<{ children?: string }, { customContent: ReactNode }>;
-
-const LinkContent = ({
-  iconSize,
-  label,
-  leftIconPath,
-  rightIconPath,
-}: Pick<TypographyLinkProps, "iconSize" | "leftIconPath" | "rightIconPath"> & {
-  label?: string;
-}) => (
-  <>
-    {!!leftIconPath && <Icon className="shrink-0" path={leftIconPath} size={iconSize} />}
-
-    {label}
-
-    {!!rightIconPath && <Icon className="shrink-0" path={rightIconPath} size={iconSize} />}
-  </>
-);
-
-export const TypographyLink = ({
-  appearance = "strong",
-  "aria-disabled": ariaDisabled,
-  as = "a",
-  children,
-  className: additionalClasses = "",
-  customContent,
-  disabled,
-  href,
-  iconSize,
-  isExternal,
-  leftIconPath,
-  ref,
-  rightIconPath,
-  typographyType = "body-md",
-  variant = "primary",
-  ...props
-}: TypographyLinkProps) => {
-  const variantClasses: Record<Exclude<TypographyLinkProps["variant"], undefined>, string> = {
-    none: "",
-    primary: "nxm-link-variant-primary",
-    secondary: "nxm-link-variant-secondary",
-  };
-
-  /* eslint-disable sort-keys */
-  const appearanceClasses: Record<Exclude<TypographyLinkProps["appearance"], undefined>, string> = {
-    none: "",
-    info: "nxm-link-info",
-    premium: "nxm-link-premium",
-    primary: "nxm-link-primary",
-    moderate: "nxm-link-moderate",
-    strong: "nxm-link-strong",
-    subdued: "nxm-link-subdued",
-  };
-  /* eslint-enable sort-keys */
-
-  const className = joinClasses(
-    [
-      "nxm-link",
-      variantClasses[variant],
-      appearanceClasses[appearance],
-      ...(typographyType !== "inherit"
-        ? getTypographyStyles({
-            typographyType: typographyType as TypographyProps["typographyType"],
-          })
-        : []),
-      additionalClasses,
-    ],
-    {
-      "nxm-link-disabled": ariaDisabled === true || ariaDisabled === "true" || disabled,
-    },
-  );
-
-  return createElement(
-    as,
-    {
-      className,
-      ref,
-      ...(as === "a"
-        ? {
-            href,
-            ...(isExternal ? { rel: "noreferrer", target: "_blank" } : {}),
-          }
-        : { disabled }),
-      ...props,
-    },
-    <>
-      {customContent ?? (
-        <LinkContent
-          iconSize={iconSize}
-          label={children}
-          leftIconPath={leftIconPath}
-          rightIconPath={rightIconPath}
-        />
-      )}
-    </>,
   );
 };

--- a/src/renderer/src/ui/components/typography/TypographyLink.tsx
+++ b/src/renderer/src/ui/components/typography/TypographyLink.tsx
@@ -1,0 +1,111 @@
+import React, { type ButtonHTMLAttributes, type ReactNode, type Ref } from "react";
+
+import { joinClasses } from "../../utils/joinClasses";
+import type { ResponsiveScreenSizes, XOr } from "../../utils/types";
+import type { IconSize } from "../icon/Icon";
+import { Icon } from "../icon/Icon";
+import { type TypographyProps, type TypographyTypes, getTypographyStyles } from "./Typography";
+
+type TypographyButtonTypes = TypographyTypes | "inherit";
+
+type TypographyButtonTypeObjectDefault = {
+  [key in Extract<ResponsiveScreenSizes, "default">]: TypographyButtonTypes;
+};
+type TypographyButtonTypeObject = TypographyButtonTypeObjectDefault & {
+  [key in Exclude<ResponsiveScreenSizes, "default">]?: TypographyButtonTypes;
+};
+
+export type TypographyButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /**
+   * The text colour
+   */
+  appearance?: "info" | "premium" | "primary" | "moderate" | "strong" | "subdued" | "none";
+  iconSize?: IconSize;
+  leftIconPath?: string;
+  ref?: Ref<HTMLButtonElement>;
+  rightIconPath?: string;
+  typographyType?: TypographyButtonTypes | TypographyButtonTypeObject;
+  variant?: "primary" | "secondary" | "none";
+} & XOr<{ children?: string }, { customContent: ReactNode }>;
+
+const ButtonContent = ({
+  iconSize,
+  label,
+  leftIconPath,
+  rightIconPath,
+}: Pick<TypographyButtonProps, "iconSize" | "leftIconPath" | "rightIconPath"> & {
+  label?: string;
+}) => (
+  <>
+    {!!leftIconPath && <Icon className="shrink-0" path={leftIconPath} size={iconSize} />}
+
+    {label}
+
+    {!!rightIconPath && <Icon className="shrink-0" path={rightIconPath} size={iconSize} />}
+  </>
+);
+
+export const TypographyLink = ({
+  appearance = "strong",
+  "aria-disabled": ariaDisabled,
+  children,
+  className: additionalClasses = "",
+  customContent,
+  disabled,
+  iconSize,
+  leftIconPath,
+  ref,
+  rightIconPath,
+  typographyType = "body-md",
+  variant = "primary",
+  ...props
+}: TypographyButtonProps) => {
+  const variantClasses: Record<Exclude<TypographyButtonProps["variant"], undefined>, string> = {
+    none: "",
+    primary: "nxm-link-variant-primary",
+    secondary: "nxm-link-variant-secondary",
+  };
+
+  const appearanceClasses: Record<
+    Exclude<TypographyButtonProps["appearance"], undefined>,
+    string
+  > = {
+    none: "",
+    info: "nxm-link-info",
+    premium: "nxm-link-premium",
+    primary: "nxm-link-primary",
+    moderate: "nxm-link-moderate",
+    strong: "nxm-link-strong",
+    subdued: "nxm-link-subdued",
+  };
+
+  const className = joinClasses(
+    [
+      "nxm-link",
+      variantClasses[variant],
+      appearanceClasses[appearance],
+      ...(typographyType !== "inherit"
+        ? getTypographyStyles({
+            typographyType: typographyType as TypographyProps["typographyType"],
+          })
+        : []),
+      additionalClasses,
+    ],
+    {
+      "nxm-link-disabled": ariaDisabled === true || ariaDisabled === "true" || disabled,
+    },
+  );
+
+  return (
+    <button className={className} disabled={disabled} ref={ref} {...props}>
+      {customContent ?? (
+        <ButtonContent
+          iconSize={iconSize}
+          label={children}
+          leftIconPath={leftIconPath}
+          rightIconPath={rightIconPath}
+        />
+      )}
+    </button>
+  );
+};

--- a/src/stylesheets/ui/elements/button.css
+++ b/src/stylesheets/ui/elements/button.css
@@ -2,9 +2,10 @@
     .nxm-button {
         z-index: 1;
         position: relative;
-        border-radius: calc(var(--spacing) * 1);
+        border-radius: var(--radius-sm);
 
         display: flex;
+        flex-shrink: 0;
         align-items: center;
         justify-content: center;
 
@@ -101,17 +102,17 @@
     }
 
     .nxm-button-secondary {
-        color: var(--color-neutral-moderate);
-        border-color: var(--color-stroke-moderate);
+        color: var(--color-translucent-moderate);
+        border-color: var(--color-stroke-weak);
 
         &:is(a, :enabled):not(.nxm-button-disabled) {
             &:before {
-                background-color: var(--color-translucent-200);
+                background-color: var(--color-surface-translucent-mid);
             }
 
             &:hover {
-                color: var(--color-neutral-strong);
-                border-color: var(--color-stroke-strong);
+                color: var(--color-translucent-strong);
+                border-color: var(--color-stroke-moderate);
             }
         }
     }
@@ -150,15 +151,15 @@
     }
 
     .nxm-button-tertiary {
-        color: var(--color-neutral-moderate);
+        color: var(--color-translucent-moderate);
 
         &:is(a, :enabled):not(.nxm-button-disabled) {
             &:before {
-                background-color: var(--color-translucent-200);
+                background-color: var(--color-surface-translucent-mid);
             }
 
             &:hover {
-                color: var(--color-neutral-strong);
+                color: var(--color-translucent-strong);
             }
         }
     }
@@ -204,53 +205,53 @@
             background-color: var(--color-translucent-200);
         }
     }
-}
 
-.nxm-button-xs,
-.nxm-button-sm {
-    min-width: 0;
-    padding-inline: calc(var(--spacing) * 2);
+    .nxm-button-xs,
+    .nxm-button-sm {
+        min-width: 0;
+        padding-inline: calc(var(--spacing) * 2);
 
-    font-size: var(--text-body-sm);
-    line-height: var(--text-body-sm--line-height);
-    letter-spacing: var(--text-body-sm--letter-spacing);
+        font-size: var(--text-body-sm);
+        line-height: var(--text-body-sm--line-height);
+        letter-spacing: var(--text-body-sm--letter-spacing);
 
-    & .nxm-button-icon {
-        width: calc(var(--spacing) * 4);
-        height: calc(var(--spacing) * 4);
+        & .nxm-button-icon {
+            width: calc(var(--spacing) * 4);
+            height: calc(var(--spacing) * 4);
 
-        &:first-child {
-            margin-left: calc(var(--spacing) * -0.5);
+            &:first-child {
+                margin-left: calc(var(--spacing) * -0.5);
+            }
+
+            &:last-child {
+                margin-right: calc(var(--spacing) * -0.5);
+            }
         }
 
-        &:last-child {
-            margin-right: calc(var(--spacing) * -0.5);
+        &:not(.nxm-button-icon-only) .nxm-button-icon {
+            &:first-child {
+                margin-right: calc(var(--spacing) * 1.5);
+            }
+
+            &:last-child {
+                margin-left: calc(var(--spacing) * 1.5);
+            }
         }
     }
 
-    &:not(.nxm-button-icon-only) .nxm-button-icon {
-        &:first-child {
-            margin-right: calc(var(--spacing) * 1.5);
-        }
+    .nxm-button-sm {
+        min-height: calc(var(--spacing) * 7);
 
-        &:last-child {
-            margin-left: calc(var(--spacing) * 1.5);
+        &.nxm-button-icon-only {
+            width: calc(var(--spacing) * 7);
         }
     }
-}
 
-.nxm-button-sm {
-    min-height: calc(var(--spacing) * 7);
+    .nxm-button-xs {
+        min-height: calc(var(--spacing) * 6);
 
-    &.nxm-button-icon-only {
-        width: calc(var(--spacing) * 7);
-    }
-}
-
-.nxm-button-xs {
-    min-height: calc(var(--spacing) * 6);
-
-    &.nxm-button-icon-only {
-        width: calc(var(--spacing) * 6);
+        &.nxm-button-icon-only {
+            width: calc(var(--spacing) * 6);
+        }
     }
 }

--- a/src/stylesheets/ui/elements/dropdown.css
+++ b/src/stylesheets/ui/elements/dropdown.css
@@ -6,7 +6,7 @@
     .nxm-dropdown-button {
         z-index: 1;
         position: relative;
-        border-radius: calc(var(--spacing) * 1);
+        border-radius: var(--radius-sm);
 
         display: flex;
         align-items: center;
@@ -68,7 +68,7 @@
         min-width: calc(var(--spacing) * 52);
         margin-top: calc(var(--spacing) * 1);
         max-height: calc(var(--spacing) * 128);
-        border-radius: calc(var(--spacing) * 1);
+        border-radius: var(--radius-sm);
         border: 1px solid var(--color-stroke-weak);
         background-color: var(--color-surface-mid);
     }
@@ -88,7 +88,7 @@
 
         column-gap: calc(var(--spacing) * 3);
         color: var(--color-neutral-moderate);
-        border-radius: calc(var(--spacing) * 1);
+        border-radius: var(--radius-sm);
         padding-block: calc(var(--spacing) * 1.5);
         padding-inline: calc(var(--spacing) * 3);
 

--- a/src/stylesheets/ui/elements/link.css
+++ b/src/stylesheets/ui/elements/link.css
@@ -4,6 +4,7 @@
         text-align: left;
         column-gap: var(--spacing);
         align-items: center;
+        border-radius: var(--radius-xs);
         transition-property:
             color, background-color, border-color, outline-color, text-decoration-color, fill,
             stroke;
@@ -11,9 +12,7 @@
         transition-timing-function: var(--default-transition-timing-function);
 
         &:focus-visible {
-            outline-style: var(--outline-style);
             outline-width: 1px;
-            outline-color: currentColor;
         }
 
         & svg,

--- a/src/stylesheets/ui/elements/modal.css
+++ b/src/stylesheets/ui/elements/modal.css
@@ -24,7 +24,7 @@
             box-shadow: var(--shadow-xl);
             max-width: var(--container-md);
             padding: calc(var(--spacing) * 4);
-            border-radius: calc(var(--spacing) * 2);
+            border-radius: var(--radius-lg);
             background-color: var(--color-surface-low);
             border: 1px solid var(--color-surface-translucent-low);
         }
@@ -46,7 +46,7 @@
             right: calc(var(--spacing) * 3);
             padding: calc(var(--spacing) * 1);
             color: var(--color-neutral-strong);
-            border-radius: calc(var(--spacing) * 1);
+            border-radius: var(--radius-sm);
 
             display: flex;
             align-items: center;

--- a/src/stylesheets/ui/elements/pagination.css
+++ b/src/stylesheets/ui/elements/pagination.css
@@ -19,7 +19,7 @@
             align-items: center;
             justify-content: center;
             min-height: calc(var(--spacing) * 8);
-            border-radius: calc(var(--spacing) * 0.5);
+            border-radius: var(--radius-xs);
 
             transition-property:
                 color, background-color, border-color, outline-color, fill, stroke, opacity,

--- a/src/stylesheets/ui/elements/tab.css
+++ b/src/stylesheets/ui/elements/tab.css
@@ -1,8 +1,12 @@
 @layer components {
     .nxm-tab-bar {
+        overflow-x: clip;
+        overflow-clip-margin: calc(var(--spacing) * 1);
+
         & .nxm-tab-bar-scroller {
             display: flex;
             overflow-x: auto;
+            /* prevents focus outline being cropped by the overflow */
             margin-inline: calc(var(--spacing) * -1);
             padding-inline: calc(var(--spacing) * 1);
         }
@@ -37,9 +41,10 @@
         position: relative;
 
         &::after {
+            left: 0;
+            right: 0;
             bottom: 0;
             content: "";
-            width: 100%;
             height: 1px;
             position: absolute;
             inset-inline: calc(var(--spacing) * 1);
@@ -63,7 +68,7 @@
                 font-size: var(--text-body-md);
                 line-height: var(--text-body-md--line-height);
                 letter-spacing: var(--text-body-md--letter-spacing);
-                border-radius: calc(var(--spacing) * 0.5);
+                border-radius: var(--radius-xs);
 
                 & .nxm-tab-button-count {
                     display: flex;
@@ -117,7 +122,7 @@
             letter-spacing: var(--text-body-sm--letter-spacing);
 
             min-height: calc(var(--spacing) * 7);
-            border-radius: calc(var(--spacing) * 1);
+            border-radius: var(--radius-sm);
             padding-inline: calc(var(--spacing) * 2);
 
             &.nxm-tab-button-disabled {

--- a/src/stylesheets/ui/form/checkbox.css
+++ b/src/stylesheets/ui/form/checkbox.css
@@ -51,7 +51,7 @@
             position: relative;
             width: calc(var(--spacing) * 4);
             height: calc(var(--spacing) * 4);
-            border-radius: calc(var(--spacing) * 1);
+            border-radius: var(--radius-sm);
 
             display: flex;
             flex-shrink: 0;

--- a/src/stylesheets/ui/form/input.css
+++ b/src/stylesheets/ui/form/input.css
@@ -2,7 +2,7 @@
     .nxm-input {
         width: 100%;
         min-height: calc(var(--spacing) * 9);
-        border-radius: calc(var(--spacing) * 1);
+        border-radius: var(--radius-sm);
         padding-inline: calc(var(--spacing) * 3);
 
         font-size: var(--text-body-lg);

--- a/src/stylesheets/ui/theme/generic.css
+++ b/src/stylesheets/ui/theme/generic.css
@@ -8,6 +8,9 @@
     --z-index-modal: 1050;
     --z-index-toast: 1090;
 
+    --aspect-collection: 4 / 5;
+    --aspect-mod: 16 / 9;
+
     --shadow-sm:
         0px 2px 4px rgb(0 0 0 / 14%), 0px 3px 4px rgb(0 0 0 / 12%), 0px 1px 5px rgb(0 0 0 / 20%);
     --shadow-md:


### PR DESCRIPTION
Refactors shared UI primitives, extracts TypographyLink into its own module, adds Image and PremiumBadge, and replaces hard-coded calc(var(--spacing) * N) radii with the named --radius-* tokens across element/form stylesheets.

### Components
- Button.tsx — when icon is a custom element, clone it with the nxm-button-icon class instead of wrapping in a <span>, so existing classes (sizing, colors) are preserved.
- Icon.tsx — adds shrink-0 by default to stop icons squashing in flex rows; tightens title falsy check.
- Image.tsx — new <Image> component, handles all default styles and aspects out the box.
- PremiumBadge.tsx — new component; replaces the inline diamond-badge markup previously hard-coded in ModRequirement.
- Typography.tsx — slimmed down: TypographyLink and its types removed (moved to TypographyLink.tsx); getTypographyStyles exported so the link module can reuse it. 
- TypographyLink.tsx — new file, hosts the extracted component.
  
### Stylesheets
- button.css — switch to --radius-sm; add flex-shrink: 0; nest size modifiers (xs/sm) inside @layer components; recolor secondary/tertiary variants to the translucent palette.
- dropdown.css, modal.css, pagination.css, checkbox.css, input.css — replace calc(var(--spacing) * N) corner radii with --radius-xs/sm/lg tokens.
- link.css — drop redundant outline declarations on :focus-visible; add a default --radius-xs.
- tab.css — add overflow-x: clip + overflow-clip-margin on .nxm-tab-bar to stop the focus-ring overhang from triggering a page-level horizontal scrollbar.
- theme/generic.css — add --aspect-collection (4/5) and --aspect-mod (16/9) tokens for new image component.
  
### Consumers
- ModRequirement.tsx — adopts the new <PremiumBadge /> in place of the inline diamond markup.
- HealthCheckDetailPage.tsx — imports TypographyLink from its new module and drops the invalid as="button" prop.