### PR TITLE
Make sure callbacks propagate the error

### DIFF
--- a/src/main/src/downloading/ipc.ts
+++ b/src/main/src/downloading/ipc.ts
@@ -1,9 +1,8 @@
+import { downloadErrorToWire } from "@vortex/shared";
 import type { DownloadState, ResolvedEndpoint, ResolvedResource } from "@vortex/shared/download";
 import { staticChunker } from "@vortex/shared/download";
-import type { DownloadError } from "@vortex/shared/errors";
 import type {
   WireDownloadCheckpoint,
-  WireDownloadError,
   WireEndpoint,
   WireResolvedResource,
 } from "@vortex/shared/ipc";
@@ -12,13 +11,6 @@ import type { WebContents } from "electron";
 import { betterIpcMain } from "../ipc";
 import { log } from "../logging";
 import type { DownloadManager } from "./manager";
-
-function downloadErrorToWire(err: DownloadError): WireDownloadError {
-  const { payload } = err;
-  const wirePayload =
-    "url" in payload ? { ...payload, url: payload.url.toString() } : { ...payload };
-  return { payload: wirePayload, message: err.message };
-}
 
 function wireToResolvedEndpoint(wire: WireEndpoint): ResolvedEndpoint {
   return { url: new URL(wire.url), headers: wire.headers };

--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -1,4 +1,4 @@
-import { deserializeError } from "@vortex/shared";
+import { rehydrateSerializedError } from "@vortex/shared";
 import type {
   RendererChannels,
   MainChannels,
@@ -7,7 +7,7 @@ import type {
   AssertSerializable,
   CallbackChannels,
   MainCallbackChannels,
-  WireError,
+  SerializedError,
 } from "@vortex/shared/ipc";
 import { ipcMain, type WebContents } from "electron";
 
@@ -110,9 +110,11 @@ function mainCallback<C extends keyof CallbackChannels>(
     resolve = undefined;
     reject = undefined;
 
-    const result = args[1] as { ok: true; value: unknown } | { ok: false; error: WireError };
+    const result = args[1] as unknown as
+      | { ok: true; value: unknown }
+      | { ok: false; error: SerializedError };
     if ("error" in result) {
-      rej(deserializeError(result.error));
+      rej(rehydrateSerializedError(result.error));
     } else {
       res(result.value as AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>);
     }

--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -1,3 +1,4 @@
+import { deserializeError } from "@vortex/shared";
 import type {
   RendererChannels,
   MainChannels,
@@ -6,6 +7,7 @@ import type {
   AssertSerializable,
   CallbackChannels,
   MainCallbackChannels,
+  WireError,
 } from "@vortex/shared/ipc";
 import { ipcMain, type WebContents } from "electron";
 
@@ -101,11 +103,18 @@ function mainCallback<C extends keyof CallbackChannels>(
     const receivedCollationId = args[0];
     if (receivedCollationId !== collationId) return;
 
-    const result = args[1];
-    if (resolve) {
-      reject = undefined;
-      resolve(result as AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>);
-      resolve = undefined;
+    // The timer may already have settled this promise; bail if so.
+    if (resolve === undefined || reject === undefined) return;
+    const res = resolve;
+    const rej = reject;
+    resolve = undefined;
+    reject = undefined;
+
+    const result = args[1] as { ok: true; value: unknown } | { ok: false; error: WireError };
+    if ("error" in result) {
+      rej(deserializeError(result.error));
+    } else {
+      res(result.value as AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>);
     }
   });
 

--- a/src/main/src/node-adaptor-host/transport.ts
+++ b/src/main/src/node-adaptor-host/transport.ts
@@ -1,5 +1,12 @@
 import type { IMethodMessage } from "@nexusmods/adaptor-api";
-import { getErrorMessage } from "@vortex/shared";
+import {
+  getErrorMessage,
+  extractErrorFields,
+  serializeCause,
+  rehydrateSerializedError,
+  MAX_CAUSE_DEPTH,
+} from "@vortex/shared";
+import type { SerializedError } from "@vortex/shared/ipc";
 
 // --- Wire protocol types ---
 
@@ -15,26 +22,6 @@ interface ResultMessage {
   value: unknown;
 }
 
-/**
- * Structured error envelope. The transport itself is agnostic to the error
- * classes it carries: the sender serialises `name`, `code`, and any extra
- * own enumerable properties (e.g. `FileSystemError.isTransient`); the
- * receiver rehydrates a generic `Error` with those fields copied back, so
- * contract-specific clients (like `@nexusmods/adaptor-api/fs`'s client polyfill) can
- * branch on `err.name` and reconstruct their concrete error type.
- *
- * `cause` chains are serialised recursively up to {@link MAX_CAUSE_DEPTH}
- * levels. Deeper chains (and non-Error causes) are truncated silently to
- * avoid runaway recursion on circular references.
- */
-interface SerializedError {
-  message: string;
-  name?: string;
-  code?: string;
-  data?: Record<string, unknown>;
-  cause?: SerializedError;
-}
-
 interface ErrorMessage {
   type: "error";
   correlationId: string;
@@ -46,39 +33,6 @@ interface ErrorMessage {
 }
 
 type RpcMessage = CallMessage | ResultMessage | ErrorMessage;
-
-/** Own-property keys that are part of the standard Error surface. */
-const STANDARD_ERROR_KEYS = new Set<string>(["name", "message", "stack", "cause", "code"]);
-
-/** How many levels of `cause` chain to carry across the wire. */
-const MAX_CAUSE_DEPTH = 3;
-
-function extractErrorFields(err: Error): Omit<SerializedError, "cause"> {
-  const result: Omit<SerializedError, "cause"> = { message: err.message };
-  if (err.name && err.name !== "Error") result.name = err.name;
-
-  const errWithCode = err as Error & { code?: unknown };
-  if (typeof errWithCode.code === "string") result.code = errWithCode.code;
-
-  const extras: Record<string, unknown> = {};
-  for (const key of Object.getOwnPropertyNames(err)) {
-    if (STANDARD_ERROR_KEYS.has(key)) continue;
-    const value = (err as unknown as Record<string, unknown>)[key];
-    if (typeof value === "function") continue;
-    extras[key] = value;
-  }
-  if (Object.keys(extras).length > 0) result.data = extras;
-
-  return result;
-}
-
-function serializeCause(value: unknown, depth: number): SerializedError | undefined {
-  if (depth <= 0) return undefined;
-  if (!(value instanceof Error)) return undefined;
-  const fields = extractErrorFields(value);
-  const nested = serializeCause((value as Error & { cause?: unknown }).cause, depth - 1);
-  return nested === undefined ? fields : { ...fields, cause: nested };
-}
 
 function serialiseError(correlationId: string, err: unknown): ErrorMessage {
   const message = getErrorMessage(err);
@@ -94,20 +48,6 @@ function serialiseError(correlationId: string, err: unknown): ErrorMessage {
   if (cause !== undefined) base.cause = cause;
 
   return base;
-}
-
-function rehydrateSerializedError(serialized: SerializedError): Error {
-  const err = new Error(serialized.message, {
-    cause: serialized.cause !== undefined ? rehydrateSerializedError(serialized.cause) : undefined,
-  });
-  if (serialized.name !== undefined) err.name = serialized.name;
-  if (serialized.code !== undefined) {
-    (err as Error & { code?: string }).code = serialized.code;
-  }
-  if (serialized.data !== undefined) {
-    Object.assign(err, serialized.data);
-  }
-  return err;
 }
 
 function deserialiseError(envelope: Record<string, unknown>): Error {

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -1,8 +1,10 @@
+import { serializeError } from "@vortex/shared";
 import type {
   AppInitMetadata,
   RendererChannels,
   InvokeChannels,
   MainChannels,
+  CallbackChannels,
   SerializableArgs,
   AssertSerializable,
   Serializable,
@@ -20,6 +22,7 @@ const betterIpcRenderer = {
   send: rendererSend,
   on: rendererOn,
   off: rendererOff,
+  callback: rendererCallback,
 };
 
 try {
@@ -225,24 +228,11 @@ try {
       cancel: (downloadId) => betterIpcRenderer.invoke("download:cancel", downloadId),
       getState: (downloadId) => betterIpcRenderer.invoke("download:getState", downloadId),
       getStates: (downloadIds) => betterIpcRenderer.invoke("download:getStates", downloadIds),
-      onResolve: (handler) => {
-        const listener = (_event: Electron.IpcRendererEvent, collationId: number) => {
-          handler(collationId)
-            .then((result) => {
-              betterIpcRenderer.send("callback:download:resolve", collationId, result);
-            })
-            .catch((err: unknown) => {
-              // The callback wire carries success only; rejections can't be
-              // sent back. Cancellation is driven explicitly elsewhere, so
-              // these are routine on every canceled batch; debug log keeps
-              // vortex.log clean.
-              const message = err instanceof Error ? err.message : String(err);
-              betterIpcRenderer.send("logging:log", "debug", "download resolver rejected", message);
-            });
-        };
-        ipcRenderer.on("download:resolve", listener);
-        return () => ipcRenderer.removeListener("download:resolve", listener);
-      },
+      // A rejection here propagates back to main so download:start rejects
+      // immediately with the real reason instead of waiting out the callback
+      // timeout. Cancellation rejects too, but the install manager drops
+      // aborted downloads, so it won't be reported as a failure.
+      onResolve: (handler) => betterIpcRenderer.callback("download:resolve", handler),
     },
 
     diag: {
@@ -303,4 +293,37 @@ function rendererOff<C extends keyof MainChannels>(
   ) => void,
 ): void {
   ipcRenderer.off(channel, listener);
+}
+
+// Registers a handler for a callback channel. Main sends a request on `channel`
+// with a collation id; the handler produces (or rejects with) a value, which is
+// sent back on `callback:${channel}` wrapped in a WireCallbackResult. Rejections
+// are serialized so main can rehydrate the real error instead of waiting out the
+// callback timeout. Returns an unsubscribe function. This is the renderer-side
+// counterpart to betterIpcMain.callback.
+function rendererCallback<C extends keyof CallbackChannels>(
+  channel: C,
+  handler: (
+    collationId: number,
+    ...args: SerializableArgs<Parameters<CallbackChannels[C]>>
+  ) => Promise<Awaited<ReturnType<CallbackChannels[C]>>>,
+): () => void {
+  const listener = (
+    _event: Electron.IpcRendererEvent,
+    collationId: number,
+    ...args: SerializableArgs<Parameters<CallbackChannels[C]>>
+  ) => {
+    handler(collationId, ...args)
+      .then((value) => {
+        ipcRenderer.send(`callback:${channel}`, collationId, { ok: true, value });
+      })
+      .catch((err: unknown) => {
+        ipcRenderer.send(`callback:${channel}`, collationId, {
+          ok: false,
+          error: serializeError(err),
+        });
+      });
+  };
+  ipcRenderer.on(channel, listener);
+  return () => ipcRenderer.removeListener(channel, listener);
 }

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -4,14 +4,8 @@ import { access, mkdir, rename, rm } from "node:fs/promises";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
 
-import { unknownToError } from "@vortex/shared";
-import {
-  AlreadyDownloaded,
-  DownloadIsHTML,
-  HTTPError,
-  UserCanceled,
-  DownloadError,
-} from "@vortex/shared/errors";
+import { unknownToError, wireToDownloadError } from "@vortex/shared";
+import { AlreadyDownloaded, UserCanceled } from "@vortex/shared/errors";
 import type { WireDownloadState, WireResolvedResource } from "@vortex/shared/ipc";
 import { z } from "zod";
 
@@ -51,18 +45,7 @@ import { batchDispatch, flatten } from "./util/util";
 function rehydrateDownloadError(state: WireDownloadState): Error | null {
   if (state.status === "canceled") return new UserCanceled();
   if (state.status !== "failed" || state.error === null) return null;
-  const { payload, message } = state.error;
-  switch (payload.code) {
-    case "is-html":
-      return new DownloadIsHTML(payload.url);
-    case "network-bad-status":
-      return new HTTPError(payload.statusCode, message, payload.url);
-    default:
-      return new DownloadError(
-        "url" in payload ? { ...payload, url: new URL(payload.url) } : { ...payload },
-        message,
-      );
-  }
+  return wireToDownloadError(state.error);
 }
 
 type ProtocolHandler = (

--- a/src/shared/src/download-errors.ts
+++ b/src/shared/src/download-errors.ts
@@ -1,0 +1,31 @@
+// Single source of truth for mapping a DownloadError to and from its wire form.
+// Used by the download-state path (main serializes, renderer rehydrates) and by
+// the generic error codec on the callback path, so a given payload always
+// rebuilds into the same concrete error class regardless of which channel it
+// travelled on. The payload's `URL` is not part of the IPC Serializable
+// contract, so it crosses as a string and is rebuilt on arrival.
+
+import { DownloadError, DownloadIsHTML, HTTPError } from "./types/errors";
+import type { WireDownloadError } from "./types/ipc";
+
+export function downloadErrorToWire(err: DownloadError): WireDownloadError {
+  const { payload } = err;
+  const wirePayload =
+    "url" in payload ? { ...payload, url: payload.url.toString() } : { ...payload };
+  return { payload: wirePayload, message: err.message };
+}
+
+export function wireToDownloadError(wire: WireDownloadError): Error {
+  const { payload, message } = wire;
+  switch (payload.code) {
+    case "is-html":
+      return new DownloadIsHTML(payload.url);
+    case "network-bad-status":
+      return new HTTPError(payload.statusCode, message, payload.url);
+    default:
+      return new DownloadError(
+        "url" in payload ? { ...payload, url: new URL(payload.url) } : { ...payload },
+        message,
+      );
+  }
+}

--- a/src/shared/src/error-serialization.test.ts
+++ b/src/shared/src/error-serialization.test.ts
@@ -1,80 +1,61 @@
 import { describe, it, expect } from "vitest";
 
-import { serializeError, deserializeError } from "./error-serialization";
-import { DownloadError, HTTPError } from "./types/errors";
+import { serializeError, rehydrateSerializedError } from "./error-serialization";
+import { DownloadError } from "./types/errors";
 
 // A round-trip mirrors what crosses the IPC boundary: serialize on one side,
-// hand the plain object to the other, deserialize there.
-const roundTrip = (err: unknown): Error => deserializeError(serializeError(err));
+// hand the plain object to the other, rehydrate there.
+const roundTrip = (err: unknown): Error => rehydrateSerializedError(serializeError(err));
 
-describe("serializeError / deserializeError", () => {
-  describe("generic errors", () => {
-    it("preserves name and message", () => {
-      const out = roundTrip(new Error("boom"));
-      expect(out).toBeInstanceOf(Error);
-      expect(out.name).toBe("Error");
-      expect(out.message).toBe("boom");
-    });
-
-    it("rehydrates built-in error subclasses by name", () => {
-      const out = roundTrip(new TypeError("nope"));
-      expect(out).toBeInstanceOf(TypeError);
-      expect(out.message).toBe("nope");
-    });
-
-    it("preserves own-enumerable properties", () => {
-      const err = Object.assign(new Error("fail"), { code: "EACCES", retries: 3 });
-      const out = roundTrip(err) as Error & { code: string; retries: number };
-      expect(out.code).toBe("EACCES");
-      expect(out.retries).toBe(3);
-    });
-
-    it("preserves the stack", () => {
-      const err = new Error("with stack");
-      const out = roundTrip(err);
-      expect(out.stack).toBe(err.stack);
-    });
-
-    it("preserves a nested cause chain", () => {
-      const root = new Error("root");
-      const out = roundTrip(new Error("outer", { cause: root }));
-      expect((out.cause as Error).message).toBe("root");
-    });
-
-    it("coerces non-Error throwables", () => {
-      expect(roundTrip("just a string").message).toBe("just a string");
-      expect(roundTrip(42).message).toBe("42");
-    });
+describe("serializeError / rehydrateSerializedError", () => {
+  it("preserves name and message", () => {
+    const out = roundTrip(new Error("boom"));
+    expect(out).toBeInstanceOf(Error);
+    expect(out.message).toBe("boom");
   });
 
-  describe("registered Vortex classes", () => {
-    it("round-trips HTTPError with its getter-backed fields", () => {
-      const out = roundTrip(new HTTPError(404, "Not Found", "https://example.com"));
-      expect(out).toBeInstanceOf(HTTPError);
-      const http = out as HTTPError;
-      expect(http.statusCode).toBe(404);
-      expect(http.statusMessage).toBe("Not Found");
-      expect(http.url).toBe("https://example.com");
-    });
+  it("preserves a named error's name", () => {
+    const out = roundTrip(new TypeError("nope"));
+    expect(out.name).toBe("TypeError");
+    expect(out.message).toBe("nope");
+  });
 
-    it("round-trips DownloadError including its payload and URL", () => {
-      const err = new DownloadError(
+  it("preserves the code field", () => {
+    const out = roundTrip(Object.assign(new Error("denied"), { code: "EACCES" }));
+    expect((out as Error & { code?: string }).code).toBe("EACCES");
+  });
+
+  it("preserves extra own-enumerable properties via data", () => {
+    const out = roundTrip(Object.assign(new Error("fail"), { retries: 3, where: "disk" }));
+    const e = out as Error & { retries?: number; where?: string };
+    expect(e.retries).toBe(3);
+    expect(e.where).toBe("disk");
+  });
+
+  it("skips function-valued properties", () => {
+    const out = roundTrip(Object.assign(new Error("fn"), { handler: () => 1 }));
+    expect((out as Error & { handler?: unknown }).handler).toBeUndefined();
+  });
+
+  it("preserves a nested cause chain", () => {
+    const out = roundTrip(new Error("outer", { cause: new Error("root") }));
+    expect((out.cause as Error).message).toBe("root");
+  });
+
+  it("coerces non-Error throwables", () => {
+    expect(roundTrip("just a string").message).toBe("just a string");
+  });
+
+  it("round-trips a DownloadError generically (name + payload, no concrete prototype)", () => {
+    const out = roundTrip(
+      new DownloadError(
         { code: "network-bad-status", url: new URL("https://cdn.example/file"), statusCode: 503 },
-        "server unavailable",
-      );
-      const out = roundTrip(err);
-      expect(out).toBeInstanceOf(DownloadError);
-      const dl = out as DownloadError;
-      expect(dl.code).toBe("network-bad-status");
-      expect(dl.payload).toMatchObject({ statusCode: 503 });
-      expect((dl.payload as { url: URL }).url).toBeInstanceOf(URL);
-      expect((dl.payload as { url: URL }).url.toString()).toBe("https://cdn.example/file");
-    });
-
-    it("round-trips a payload variant without a URL", () => {
-      const out = roundTrip(new DownloadError({ code: "cancellation" }, "canceled"));
-      expect(out).toBeInstanceOf(DownloadError);
-      expect((out as DownloadError).code).toBe("cancellation");
-    });
+        "Server returned 503",
+      ),
+    );
+    expect(out).not.toBeInstanceOf(DownloadError);
+    expect(out.name).toBe("DownloadError");
+    expect((out as Error & { code?: string }).code).toBe("network-bad-status");
+    expect((out as Error & { payload?: { statusCode: number } }).payload?.statusCode).toBe(503);
   });
 });

--- a/src/shared/src/error-serialization.test.ts
+++ b/src/shared/src/error-serialization.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+
+import { serializeError, deserializeError } from "./error-serialization";
+import { DownloadError, HTTPError } from "./types/errors";
+
+// A round-trip mirrors what crosses the IPC boundary: serialize on one side,
+// hand the plain object to the other, deserialize there.
+const roundTrip = (err: unknown): Error => deserializeError(serializeError(err));
+
+describe("serializeError / deserializeError", () => {
+  describe("generic errors", () => {
+    it("preserves name and message", () => {
+      const out = roundTrip(new Error("boom"));
+      expect(out).toBeInstanceOf(Error);
+      expect(out.name).toBe("Error");
+      expect(out.message).toBe("boom");
+    });
+
+    it("rehydrates built-in error subclasses by name", () => {
+      const out = roundTrip(new TypeError("nope"));
+      expect(out).toBeInstanceOf(TypeError);
+      expect(out.message).toBe("nope");
+    });
+
+    it("preserves own-enumerable properties", () => {
+      const err = Object.assign(new Error("fail"), { code: "EACCES", retries: 3 });
+      const out = roundTrip(err) as Error & { code: string; retries: number };
+      expect(out.code).toBe("EACCES");
+      expect(out.retries).toBe(3);
+    });
+
+    it("preserves the stack", () => {
+      const err = new Error("with stack");
+      const out = roundTrip(err);
+      expect(out.stack).toBe(err.stack);
+    });
+
+    it("preserves a nested cause chain", () => {
+      const root = new Error("root");
+      const out = roundTrip(new Error("outer", { cause: root }));
+      expect((out.cause as Error).message).toBe("root");
+    });
+
+    it("coerces non-Error throwables", () => {
+      expect(roundTrip("just a string").message).toBe("just a string");
+      expect(roundTrip(42).message).toBe("42");
+    });
+  });
+
+  describe("registered Vortex classes", () => {
+    it("round-trips HTTPError with its getter-backed fields", () => {
+      const out = roundTrip(new HTTPError(404, "Not Found", "https://example.com"));
+      expect(out).toBeInstanceOf(HTTPError);
+      const http = out as HTTPError;
+      expect(http.statusCode).toBe(404);
+      expect(http.statusMessage).toBe("Not Found");
+      expect(http.url).toBe("https://example.com");
+    });
+
+    it("round-trips DownloadError including its payload and URL", () => {
+      const err = new DownloadError(
+        { code: "network-bad-status", url: new URL("https://cdn.example/file"), statusCode: 503 },
+        "server unavailable",
+      );
+      const out = roundTrip(err);
+      expect(out).toBeInstanceOf(DownloadError);
+      const dl = out as DownloadError;
+      expect(dl.code).toBe("network-bad-status");
+      expect(dl.payload).toMatchObject({ statusCode: 503 });
+      expect((dl.payload as { url: URL }).url).toBeInstanceOf(URL);
+      expect((dl.payload as { url: URL }).url.toString()).toBe("https://cdn.example/file");
+    });
+
+    it("round-trips a payload variant without a URL", () => {
+      const out = roundTrip(new DownloadError({ code: "cancellation" }, "canceled"));
+      expect(out).toBeInstanceOf(DownloadError);
+      expect((out as DownloadError).code).toBe("cancellation");
+    });
+  });
+});

--- a/src/shared/src/error-serialization.ts
+++ b/src/shared/src/error-serialization.ts
@@ -1,173 +1,70 @@
-// Symmetric Error <-> wire codec for moving errors across the IPC boundary.
-// Electron's structured-clone serializer already carries an Error's
-// name/message/stack/cause, but it drops own-enumerable properties and the
-// concrete prototype. This pair closes both gaps:
-//   - the generic path preserves the standard fields, the `cause` chain, and any
-//     own properties, rehydrating as a base Error;
-//   - registered error classes round-trip through an explicit codec so they keep
-//     their real prototype and any fields exposed only through getters.
-// Keep this the single place that knows how to (de)serialize errors; both ends
-// of the boundary import from here.
+// Generic Error <-> wire serializer shared across the IPC boundaries (the
+// adaptor RPC transport and the renderer<->main callback channels). The
+// serializer is agnostic to the error classes it carries: the sender serializes
+// `name`, `code`, and any extra own enumerable properties; the receiver
+// rehydrates a generic `Error` with those fields copied back, so callers can
+// branch on `err.name` and reconstruct their concrete error type.
+//
+// `cause` chains are serialized recursively up to MAX_CAUSE_DEPTH levels.
+// Deeper chains (and non-Error causes) are truncated silently to avoid runaway
+// recursion on circular references.
 
-import { DownloadError, HTTPError } from "./types/errors";
-import type { DownloadErrorPayload } from "./types/errors";
-import type { Serializable, WireError } from "./types/ipc";
+import { getErrorMessage } from "./errors";
+import type { SerializedError } from "./types/ipc";
 
-/** Standard fields handled explicitly; never copied as generic properties. */
-const RESERVED_KEYS = new Set(["name", "message", "stack", "cause"]);
+/** Own-property keys that are part of the standard Error surface. */
+const STANDARD_ERROR_KEYS = new Set<string>(["name", "message", "stack", "cause", "code"]);
 
-/** Guard against pathological or cyclic `cause` chains. */
-const MAX_CAUSE_DEPTH = 8;
+/** How many levels of `cause` chain to carry across the wire. */
+export const MAX_CAUSE_DEPTH = 3;
 
-/** Built-in error constructors we can rehydrate into by name. */
-const BUILTIN_ERRORS: { [name: string]: new (message?: string) => Error } = {
-  Error,
-  EvalError,
-  RangeError,
-  ReferenceError,
-  SyntaxError,
-  TypeError,
-  URIError,
-};
+export function extractErrorFields(err: Error): Omit<SerializedError, "cause"> {
+  const result: Omit<SerializedError, "cause"> = { message: err.message };
+  if (err.name && err.name !== "Error") result.name = err.name;
 
-/**
- * Per-class codec for an error whose public shape can't be reconstructed by
- * copying own-enumerable properties — typically because the data lives behind
- * getters over private fields, or needs constructor arguments.
- */
-type ErrorCodec<E extends Error> = {
-  /** Concrete class, used to match instances when serializing. */
-  type: abstract new (...args: never[]) => E;
-  /** Structured data to carry beyond name/message/stack. */
-  toWire: (err: E) => { [key: string]: Serializable };
-  /** Rebuild the concrete error from the wire payload (stack/cause are
-   *  re-applied by {@link deserializeError} afterwards). */
-  fromWire: (wire: WireError) => E;
-};
+  const errWithCode = err as Error & { code?: unknown };
+  if (typeof errWithCode.code === "string") result.code = errWithCode.code;
 
-const CODECS = new Map<string, ErrorCodec<Error>>();
+  const extras: Record<string, unknown> = {};
+  for (const key of Object.getOwnPropertyNames(err)) {
+    if (STANDARD_ERROR_KEYS.has(key)) continue;
+    const value = (err as unknown as Record<string, unknown>)[key];
+    if (typeof value === "function") continue;
+    extras[key] = value;
+  }
+  if (Object.keys(extras).length > 0) result.data = extras;
 
-function defineCodec<E extends Error>(name: string, codec: ErrorCodec<E>): void {
-  CODECS.set(name, codec as unknown as ErrorCodec<Error>);
+  return result;
 }
 
-// --- Registered Vortex error classes ----------------------------------------
-
-defineCodec<HTTPError>("HTTPError", {
-  type: HTTPError,
-  toWire: (err) => ({
-    statusCode: err.statusCode,
-    statusMessage: err.statusMessage,
-    url: err.url,
-  }),
-  fromWire: (wire) => {
-    const props = wire.properties ?? {};
-    const statusCode = typeof props.statusCode === "number" ? props.statusCode : 0;
-    const statusMessage = typeof props.statusMessage === "string" ? props.statusMessage : "";
-    const url = typeof props.url === "string" ? props.url : "";
-    return new HTTPError(statusCode, statusMessage, url);
-  },
-});
-
-defineCodec<DownloadError>("DownloadError", {
-  type: DownloadError,
-  toWire: (err) => ({ payload: wirifyDownloadPayload(err.payload) }),
-  fromWire: (wire) =>
-    new DownloadError(dewirifyDownloadPayload(wire.properties?.payload), wire.message),
-});
-
-// The payload carries a `URL`, which is not part of the IPC `Serializable`
-// contract, so it travels as a string and is rebuilt on arrival.
-function wirifyDownloadPayload(payload: DownloadErrorPayload): Serializable {
-  if ("url" in payload) {
-    return { ...payload, url: payload.url.toString() };
-  }
-  return { ...payload };
+export function serializeCause(value: unknown, depth: number): SerializedError | undefined {
+  if (depth <= 0) return undefined;
+  if (!(value instanceof Error)) return undefined;
+  const fields = extractErrorFields(value);
+  const nested = serializeCause((value as Error & { cause?: unknown }).cause, depth - 1);
+  return nested === undefined ? fields : { ...fields, cause: nested };
 }
 
-function dewirifyDownloadPayload(raw: Serializable | undefined): DownloadErrorPayload {
-  const obj = (raw ?? { code: "resolver-error" }) as Record<string, unknown>;
-  if (typeof obj.url === "string") {
-    return { ...obj, url: new URL(obj.url) } as DownloadErrorPayload;
+/** Serialize any thrown value into its wire representation. */
+export function serializeError(err: unknown): SerializedError {
+  if (!(err instanceof Error)) {
+    return { message: getErrorMessage(err) ?? "" };
   }
-  return obj as DownloadErrorPayload;
+  const fields = extractErrorFields(err);
+  const cause = serializeCause((err as Error & { cause?: unknown }).cause, MAX_CAUSE_DEPTH);
+  return cause === undefined ? fields : { ...fields, cause };
 }
 
-// --- Public API --------------------------------------------------------------
-
-/**
- * Convert any thrown value into its wire representation. Non-Error throwables
- * are coerced to a minimal `{ name, message }`.
- */
-export function serializeError(value: unknown, depth = 0): WireError {
-  if (!(value instanceof Error)) {
-    return { name: "Error", message: typeof value === "string" ? value : safeString(value) };
+export function rehydrateSerializedError(serialized: SerializedError): Error {
+  const err = new Error(serialized.message, {
+    cause: serialized.cause !== undefined ? rehydrateSerializedError(serialized.cause) : undefined,
+  });
+  if (serialized.name !== undefined) err.name = serialized.name;
+  if (serialized.code !== undefined) {
+    (err as Error & { code?: string }).code = serialized.code;
   }
-
-  const codec = findCodec(value);
-  const properties = codec ? codec.toWire(value) : collectOwnProperties(value);
-
-  const wire: WireError = { name: value.name, message: value.message };
-  if (value.stack !== undefined) wire.stack = value.stack;
-  if (Object.keys(properties).length > 0) wire.properties = properties;
-
-  const cause = (value as { cause?: unknown }).cause;
-  if (cause !== undefined && depth < MAX_CAUSE_DEPTH) {
-    wire.cause = serializeError(cause, depth + 1);
+  if (serialized.data !== undefined) {
+    Object.assign(err, serialized.data);
   }
-
-  return wire;
-}
-
-/**
- * Rebuild an Error from its wire representation. Registered Vortex classes
- * regain their real prototype; built-in errors are matched by name; everything
- * else becomes a base Error carrying the same properties.
- */
-export function deserializeError(wire: WireError): Error {
-  const codec = CODECS.get(wire.name);
-
-  let err: Error;
-  if (codec) {
-    err = codec.fromWire(wire);
-  } else {
-    const Ctor = BUILTIN_ERRORS[wire.name] ?? Error;
-    err = new Ctor(wire.message);
-    err.name = wire.name;
-    if (wire.properties) Object.assign(err, wire.properties);
-  }
-
-  if (wire.stack !== undefined) err.stack = wire.stack;
-  if (wire.cause !== undefined) {
-    (err as { cause?: unknown }).cause = deserializeError(wire.cause);
-  }
-
   return err;
-}
-
-// --- Internals ---------------------------------------------------------------
-
-function findCodec(err: Error): ErrorCodec<Error> | undefined {
-  for (const codec of CODECS.values()) {
-    if (err instanceof codec.type) return codec;
-  }
-  return undefined;
-}
-
-function collectOwnProperties(err: Error): { [key: string]: Serializable } {
-  const out: { [key: string]: Serializable } = {};
-  const record = err as unknown as Record<string, unknown>;
-  for (const key of Object.keys(err)) {
-    if (RESERVED_KEYS.has(key)) continue;
-    out[key] = record[key] as Serializable;
-  }
-  return out;
-}
-
-function safeString(value: unknown): string {
-  try {
-    return String(value);
-  } catch {
-    return "unknown error";
-  }
 }

--- a/src/shared/src/error-serialization.ts
+++ b/src/shared/src/error-serialization.ts
@@ -1,0 +1,173 @@
+// Symmetric Error <-> wire codec for moving errors across the IPC boundary.
+// Electron's structured-clone serializer already carries an Error's
+// name/message/stack/cause, but it drops own-enumerable properties and the
+// concrete prototype. This pair closes both gaps:
+//   - the generic path preserves the standard fields, the `cause` chain, and any
+//     own properties, rehydrating as a base Error;
+//   - registered error classes round-trip through an explicit codec so they keep
+//     their real prototype and any fields exposed only through getters.
+// Keep this the single place that knows how to (de)serialize errors; both ends
+// of the boundary import from here.
+
+import { DownloadError, HTTPError } from "./types/errors";
+import type { DownloadErrorPayload } from "./types/errors";
+import type { Serializable, WireError } from "./types/ipc";
+
+/** Standard fields handled explicitly; never copied as generic properties. */
+const RESERVED_KEYS = new Set(["name", "message", "stack", "cause"]);
+
+/** Guard against pathological or cyclic `cause` chains. */
+const MAX_CAUSE_DEPTH = 8;
+
+/** Built-in error constructors we can rehydrate into by name. */
+const BUILTIN_ERRORS: { [name: string]: new (message?: string) => Error } = {
+  Error,
+  EvalError,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+  URIError,
+};
+
+/**
+ * Per-class codec for an error whose public shape can't be reconstructed by
+ * copying own-enumerable properties — typically because the data lives behind
+ * getters over private fields, or needs constructor arguments.
+ */
+type ErrorCodec<E extends Error> = {
+  /** Concrete class, used to match instances when serializing. */
+  type: abstract new (...args: never[]) => E;
+  /** Structured data to carry beyond name/message/stack. */
+  toWire: (err: E) => { [key: string]: Serializable };
+  /** Rebuild the concrete error from the wire payload (stack/cause are
+   *  re-applied by {@link deserializeError} afterwards). */
+  fromWire: (wire: WireError) => E;
+};
+
+const CODECS = new Map<string, ErrorCodec<Error>>();
+
+function defineCodec<E extends Error>(name: string, codec: ErrorCodec<E>): void {
+  CODECS.set(name, codec as unknown as ErrorCodec<Error>);
+}
+
+// --- Registered Vortex error classes ----------------------------------------
+
+defineCodec<HTTPError>("HTTPError", {
+  type: HTTPError,
+  toWire: (err) => ({
+    statusCode: err.statusCode,
+    statusMessage: err.statusMessage,
+    url: err.url,
+  }),
+  fromWire: (wire) => {
+    const props = wire.properties ?? {};
+    const statusCode = typeof props.statusCode === "number" ? props.statusCode : 0;
+    const statusMessage = typeof props.statusMessage === "string" ? props.statusMessage : "";
+    const url = typeof props.url === "string" ? props.url : "";
+    return new HTTPError(statusCode, statusMessage, url);
+  },
+});
+
+defineCodec<DownloadError>("DownloadError", {
+  type: DownloadError,
+  toWire: (err) => ({ payload: wirifyDownloadPayload(err.payload) }),
+  fromWire: (wire) =>
+    new DownloadError(dewirifyDownloadPayload(wire.properties?.payload), wire.message),
+});
+
+// The payload carries a `URL`, which is not part of the IPC `Serializable`
+// contract, so it travels as a string and is rebuilt on arrival.
+function wirifyDownloadPayload(payload: DownloadErrorPayload): Serializable {
+  if ("url" in payload) {
+    return { ...payload, url: payload.url.toString() };
+  }
+  return { ...payload };
+}
+
+function dewirifyDownloadPayload(raw: Serializable | undefined): DownloadErrorPayload {
+  const obj = (raw ?? { code: "resolver-error" }) as Record<string, unknown>;
+  if (typeof obj.url === "string") {
+    return { ...obj, url: new URL(obj.url) } as DownloadErrorPayload;
+  }
+  return obj as DownloadErrorPayload;
+}
+
+// --- Public API --------------------------------------------------------------
+
+/**
+ * Convert any thrown value into its wire representation. Non-Error throwables
+ * are coerced to a minimal `{ name, message }`.
+ */
+export function serializeError(value: unknown, depth = 0): WireError {
+  if (!(value instanceof Error)) {
+    return { name: "Error", message: typeof value === "string" ? value : safeString(value) };
+  }
+
+  const codec = findCodec(value);
+  const properties = codec ? codec.toWire(value) : collectOwnProperties(value);
+
+  const wire: WireError = { name: value.name, message: value.message };
+  if (value.stack !== undefined) wire.stack = value.stack;
+  if (Object.keys(properties).length > 0) wire.properties = properties;
+
+  const cause = (value as { cause?: unknown }).cause;
+  if (cause !== undefined && depth < MAX_CAUSE_DEPTH) {
+    wire.cause = serializeError(cause, depth + 1);
+  }
+
+  return wire;
+}
+
+/**
+ * Rebuild an Error from its wire representation. Registered Vortex classes
+ * regain their real prototype; built-in errors are matched by name; everything
+ * else becomes a base Error carrying the same properties.
+ */
+export function deserializeError(wire: WireError): Error {
+  const codec = CODECS.get(wire.name);
+
+  let err: Error;
+  if (codec) {
+    err = codec.fromWire(wire);
+  } else {
+    const Ctor = BUILTIN_ERRORS[wire.name] ?? Error;
+    err = new Ctor(wire.message);
+    err.name = wire.name;
+    if (wire.properties) Object.assign(err, wire.properties);
+  }
+
+  if (wire.stack !== undefined) err.stack = wire.stack;
+  if (wire.cause !== undefined) {
+    (err as { cause?: unknown }).cause = deserializeError(wire.cause);
+  }
+
+  return err;
+}
+
+// --- Internals ---------------------------------------------------------------
+
+function findCodec(err: Error): ErrorCodec<Error> | undefined {
+  for (const codec of CODECS.values()) {
+    if (err instanceof codec.type) return codec;
+  }
+  return undefined;
+}
+
+function collectOwnProperties(err: Error): { [key: string]: Serializable } {
+  const out: { [key: string]: Serializable } = {};
+  const record = err as unknown as Record<string, unknown>;
+  for (const key of Object.keys(err)) {
+    if (RESERVED_KEYS.has(key)) continue;
+    out[key] = record[key] as Serializable;
+  }
+  return out;
+}
+
+function safeString(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    return "unknown error";
+  }
+}

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
 export * from "./Debouncer";
 export * from "./errors";
+export * from "./error-serialization";
 export * from "./types/logging";

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -2,4 +2,5 @@ export * from "./constants";
 export * from "./Debouncer";
 export * from "./errors";
 export * from "./error-serialization";
+export * from "./download-errors";
 export * from "./types/logging";

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -113,25 +113,28 @@ export type WireDownloadState = DownloadProgress & {
 export type WireDownloadCheckpoint = DownloadCheckpoint<string>;
 
 /**
- * Wire representation of an Error, produced by `serializeError` and consumed by
- * `deserializeError` (both exported from `@vortex/shared`).
- *
- * Carries the standard Error fields, the recursive `cause` chain, and any
- * own-enumerable properties across the IPC boundary. Registered error classes
- * are rebuilt with their real prototype via the codec registry; all others
- * rehydrate as a base `Error` carrying the same properties.
+ * Structured error envelope shared across the IPC boundaries. The serializer is
+ * agnostic to the error classes it carries: it serializes `name`, `code`, and
+ * any extra own enumerable properties (in `data`), with `cause` chains
+ * serialized recursively. The receiver rehydrates a generic `Error` with those
+ * fields copied back, so callers can branch on `err.name` and reconstruct their
+ * concrete error type.
  */
-export type WireError = {
-  name: string;
+export interface SerializedError {
   message: string;
-  stack?: string;
-  cause?: WireError;
-  /** Own-enumerable data properties carried verbatim across the boundary. */
-  properties?: { [key: string]: Serializable };
-};
+  name?: string;
+  code?: string;
+  data?: Record<string, unknown>;
+  cause?: SerializedError;
+}
 
-/** A callback reply is either a successful value or a serialized error. */
-export type WireCallbackResult<T> = { ok: true; value: T } | { ok: false; error: WireError };
+/**
+ * A callback reply is either a successful value or a serialized error. The
+ * error rides as an opaque {@link Serializable} (a {@link SerializedError}
+ * shape at runtime) so it satisfies the IPC serialization contract; the
+ * receiver casts and rehydrates it via `rehydrateSerializedError`.
+ */
+export type WireCallbackResult<T> = { ok: true; value: T } | { ok: false; error: Serializable };
 
 export interface CallbackChannels {
   "example:ping": (ping: string) => Promise<{ pong: string }>;

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -112,6 +112,27 @@ export type WireDownloadState = DownloadProgress & {
 
 export type WireDownloadCheckpoint = DownloadCheckpoint<string>;
 
+/**
+ * Wire representation of an Error, produced by `serializeError` and consumed by
+ * `deserializeError` (both exported from `@vortex/shared`).
+ *
+ * Carries the standard Error fields, the recursive `cause` chain, and any
+ * own-enumerable properties across the IPC boundary. Registered error classes
+ * are rebuilt with their real prototype via the codec registry; all others
+ * rehydrate as a base `Error` carrying the same properties.
+ */
+export type WireError = {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: WireError;
+  /** Own-enumerable data properties carried verbatim across the boundary. */
+  properties?: { [key: string]: Serializable };
+};
+
+/** A callback reply is either a successful value or a serialized error. */
+export type WireCallbackResult<T> = { ok: true; value: T } | { ok: false; error: WireError };
+
 export interface CallbackChannels {
   "example:ping": (ping: string) => Promise<{ pong: string }>;
 
@@ -130,7 +151,7 @@ export type RendererCallbackChannels = {
   [C in keyof CallbackChannels as `callback:${C}`]: CallbackChannels[C] extends (
     ...args: infer _Args
   ) => Promise<infer Return>
-    ? (collationId: number, result: Return) => void
+    ? (collationId: number, result: WireCallbackResult<Return>) => void
     : never;
 };
 


### PR DESCRIPTION
No new functionality but better logging to hopefully gather more info without need user logs regarding potential download issue.
The callbacks didn't propagate the error before, it was just logged. I want to make sure it's propagated, so here will be not a generic error message, but the actual one