### PR TITLE
Added an optional discriminator to Fingerprints

### DIFF
--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -192,10 +192,16 @@ const FINGERPRINT_FRAME_LIMIT = 5;
  *   - drops the `:column` from each frame (unstable across builds and call sites),
  *   - keeps only the innermost {@link FINGERPRINT_FRAME_LIMIT} frames (calling
  *     context above the throw site varies per invocation).
+ *
+ * An optional `discriminator` distinguishes error sub-types that share an
+ * identical stack (e.g. several download failure categories thrown from the
+ * same call site). It must be a stable, low-cardinality, non-PII value; when
+ * omitted the fingerprint is unchanged from a pure stack+version hash.
  */
 export const computeErrorFingerprint = (
   stack: string | undefined,
   appVersion: string,
+  discriminator?: string,
 ): string | undefined => {
   if (stack === undefined) return undefined;
   const frames = stack
@@ -206,7 +212,11 @@ export const computeErrorFingerprint = (
     .map((f) => f.replace(STRIP_COLUMN_RE, "$1"))
     .slice(0, FINGERPRINT_FRAME_LIMIT);
   if (frames.length === 0) return undefined;
-  const input = frames.join("\n") + "\n" + appVersion;
+  const input =
+    frames.join("\n") +
+    "\n" +
+    appVersion +
+    (discriminator !== undefined && discriminator !== "" ? "\n" + discriminator : "");
   return fnv1aHash(input);
 };
 

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -194,9 +194,7 @@ const FINGERPRINT_FRAME_LIMIT = 5;
  *     context above the throw site varies per invocation).
  *
  * An optional `discriminator` distinguishes error sub-types that share an
- * identical stack (e.g. several download failure categories thrown from the
- * same call site). It must be a stable, low-cardinality, non-PII value; when
- * omitted the fingerprint is unchanged from a pure stack+version hash.
+ * identical frame.
  */
 export const computeErrorFingerprint = (
   stack: string | undefined,

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -194,7 +194,7 @@ const FINGERPRINT_FRAME_LIMIT = 5;
  *     context above the throw site varies per invocation).
  *
  * An optional `discriminator` distinguishes error sub-types that share an
- * identical frame.
+ * identical stack.
  */
 export const computeErrorFingerprint = (
   stack: string | undefined,

--- a/src/shared/src/telemetry/spans.ts
+++ b/src/shared/src/telemetry/spans.ts
@@ -38,11 +38,28 @@ export const recordErrorOnSpan = (
     }
   }
 
-  const fingerprint = computeErrorFingerprint(sanitizedStack, appVersion);
+  const fingerprint = computeErrorFingerprint(
+    sanitizedStack,
+    appVersion,
+    errorDiscriminator(error),
+  );
   if (fingerprint !== undefined) {
     span.setAttribute("error.fingerprint", fingerprint);
   }
 
   span.recordException(sanitized);
   span.setStatus({ code: SpanStatusCode.ERROR, message: sanitizedMessage });
+};
+
+/**
+ * Stable, low-cardinality tag distinguishing error sub-types that share a
+ * stack — e.g. the download failure categories (`network-timeout`, `fs-error`,
+ * `network-error`, …) that are all thrown as the same class from the same call
+ * site and would otherwise collapse into one fingerprint. Uses the error's
+ * string `code` when present; deliberately excludes the message to keep
+ * cardinality bounded and avoid leaking PII into the fingerprint.
+ */
+const errorDiscriminator = (error: Error): string | undefined => {
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
 };

--- a/src/shared/src/telemetry/spans.ts
+++ b/src/shared/src/telemetry/spans.ts
@@ -52,12 +52,8 @@ export const recordErrorOnSpan = (
 };
 
 /**
- * Stable, low-cardinality tag distinguishing error sub-types that share a
- * stack — e.g. the download failure categories (`network-timeout`, `fs-error`,
- * `network-error`, …) that are all thrown as the same class from the same call
- * site and would otherwise collapse into one fingerprint. Uses the error's
- * string `code` when present; deliberately excludes the message to keep
- * cardinality bounded and avoid leaking PII into the fingerprint.
+ * An error `discriminator` that distinguishes error sub-types that share an
+ * identical stack.
  */
 const errorDiscriminator = (error: Error): string | undefined => {
   const code = (error as { code?: unknown }).code;


### PR DESCRIPTION
Grouping by the first 5 lines of the stacktrace still combines error that should not be combined.
Discriminating by using the optional `error.code` should help  it for now