### PR TITLE
chore: route Mixpanel events through Nexus Mods API proxy

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
@@ -40,7 +40,7 @@ class MixpanelAnalytics {
       debug: false, // Disable internal Mixpanel logging (we use our own analyticsServiceLog)
       track_pageview: false, // We're not a web page
       persistence: "localStorage",
-      api_host: "https://api-eu.mixpanel.com",
+      api_host: "https://api.nexusmods.com/events",
       // IP and geolocation are automatically tracked by mixpanel-browser
     });
 


### PR DESCRIPTION
## Summary
- Changes the Mixpanel `api_host` from `https://api-eu.mixpanel.com` to `https://api.nexusmods.com/events`, routing analytics events through the Nexus Mods API proxy.

## Test plan
- [ ] Verify analytics events are received at the new endpoint in a dev environment
- [ ] Confirm no regressions in event tracking behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)