### PR TITLE
Increase the default IPC callback timeout to 45 seconds

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ catalogs:
       specifier: ^0.13.2
       version: 0.13.2
     '@nexusmods/nexus-api':
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
-      version: 1.6.2
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
+      version: 1.7.0
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.1
@@ -512,8 +512,8 @@ catalogs:
       specifier: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
       version: 0.9.3
     nexus-api:
-      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
-      version: 1.6.2
+      specifier: git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
+      version: 1.7.0
     node:
       specifier: runtime:24.15.0
       version: 24.15.0
@@ -972,7 +972,7 @@ importers:
         version: 0.30.6
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -2284,7 +2284,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
@@ -2609,7 +2609,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3554,7 +3554,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/3298c42e69e3220dc39694bc2f610c077c3e213a
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@types/bluebird':
         specifier: 'catalog:'
         version: 3.5.20
@@ -3581,7 +3581,7 @@ importers:
         version: 4.17.23
       nexus-api:
         specifier: 'catalog:'
-        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835'
+        version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe'
       react:
         specifier: 'catalog:'
         version: 16.14.0
@@ -3893,7 +3893,7 @@ importers:
     devDependencies:
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@types/react':
         specifier: '16'
         version: 16.14.69
@@ -3959,7 +3959,7 @@ importers:
         version: 0.13.2
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -4456,7 +4456,7 @@ importers:
         version: 0.13.2
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
-        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+        version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -5856,9 +5856,9 @@ packages:
     resolution: {integrity: sha512-5yRkKEQ8vtbmHYk4z5Mk3H3zoEc5SfZw79r4VFvlaSm73U9f5xYmnyoP0Locn7GXkYjuYa2FNyPmMUtXebZVjA==}
     engines: {node: '>=22'}
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835':
-    resolution: {gitHosted: true, integrity: sha512-Q/2lKCGUM4QSf4uSQU06sIUS8VW+E98wZjucZTg0AXRG0bbMMx8SHHuYHg6TDJCrE/wxwfzL/QJJ1Owk+r+IqQ==, tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835}
-    version: 1.6.2
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe':
+    resolution: {gitHosted: true, integrity: sha512-djt94OCZU1gokDeuTEiHGN6P9c3REexI8y+IA4d2t54TXgpxo6VBuy5mF6R6AZ5YZXTOQH8939isJ84QP1u+mA==, tarball: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe}
+    version: 1.7.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -14002,7 +14002,7 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
-  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/6eb0c3a8c826a881b3c0f001339e8f2a71fc7835':
+  '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe':
     dependencies:
       form-data: 4.0.5
       jsonwebtoken: 9.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalog:
   "@msgpack/msgpack": ^2.7.0
   "@nexusmods/fomod-installer-ipc": ^0.13.1
   "@nexusmods/fomod-installer-native": ^0.13.2
-  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+  "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
   "@opentelemetry/api": ^1.9.0
   "@opentelemetry/context-async-hooks": ^2.5.1
   "@opentelemetry/context-zone": ^2.5.1
@@ -201,7 +201,7 @@ catalog:
   minimist: ^1.2.8
   mixpanel-browser: ^2.71.0
   modmeta-db: git+https://github.com/Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
-  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#6eb0c3a8c826a881b3c0f001339e8f2a71fc7835
+  nexus-api: git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
   node: runtime:24.15.0
   node-7z: git+https://github.com/Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
   normalize-url: ^6.0.1

--- a/src/main/src/downloading/ipc.ts
+++ b/src/main/src/downloading/ipc.ts
@@ -34,7 +34,9 @@ function resourceToUrl(resource: ResolvedResource): string {
 }
 
 export function init(manager: DownloadManager): void {
-  const timeout = 30_000;
+  // Our network timeouts are 30 seconds, which means that we will fail
+  // with the callback before the network could. Give it a bit of extra time to avoid spurious failures.
+  const timeout = 45_000;
 
   const webContentsByDownloadId = new Map<string, WebContents>();
 


### PR DESCRIPTION
Should make sure that underlying callbacks will finish before us
Also updated node-nexus-api
Part of LAZ-516