### PR TITLE
Fingerprint Improvement

### DIFF
--- a/src/shared/src/error-serialization.test.ts
+++ b/src/shared/src/error-serialization.test.ts
@@ -20,6 +20,22 @@ describe("serializeError / rehydrateSerializedError", () => {
     expect(out.message).toBe("nope");
   });
 
+  it("recovers the type from constructor.name when the class never sets this.name", () => {
+    class NamelessError extends Error {}
+    const original = new NamelessError("boom");
+    // The live error reports "Error" as its name (no `this.name` assignment), so
+    // the only type signal is the runtime class name.
+    expect(original.name).toBe("Error");
+    expect(roundTrip(original).name).toBe("NamelessError");
+  });
+
+  it("prefers an explicit this.name over constructor.name", () => {
+    class FancyError extends Error {
+      override name = "fancy-error";
+    }
+    expect(roundTrip(new FancyError("boom")).name).toBe("fancy-error");
+  });
+
   it("preserves the code field", () => {
     const out = roundTrip(Object.assign(new Error("denied"), { code: "EACCES" }));
     expect((out as Error & { code?: string }).code).toBe("EACCES");

--- a/src/shared/src/error-serialization.ts
+++ b/src/shared/src/error-serialization.ts
@@ -20,7 +20,20 @@ export const MAX_CAUSE_DEPTH = 3;
 
 export function extractErrorFields(err: Error): Omit<SerializedError, "cause"> {
   const result: Omit<SerializedError, "cause"> = { message: err.message };
-  if (err.name && err.name !== "Error") result.name = err.name;
+  // Type identity only exists on the live error and is lost the moment it crosses
+  // the wire (the receiver always mints a plain `Error`). Prefer the explicit
+  // `name` when the author set one; otherwise fall back to the runtime class name
+  // (`constructor.name`) so subclasses that never assign `this.name` — and would
+  // otherwise serialize as a nameless "Error" — keep their type for downstream
+  // consumers (e.g. error fingerprinting that branches on `name`).
+  if (err.name && err.name !== "Error") {
+    result.name = err.name;
+  } else {
+    const ctorName = err.constructor?.name;
+    if (ctorName !== undefined && ctorName !== "" && ctorName !== "Error") {
+      result.name = ctorName;
+    }
+  }
 
   const errWithCode = err as Error & { code?: unknown };
   if (typeof errWithCode.code === "string") result.code = errWithCode.code;

--- a/src/shared/src/telemetry/spans.test.ts
+++ b/src/shared/src/telemetry/spans.test.ts
@@ -1,0 +1,73 @@
+import type { Span } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
+
+import { computeErrorFingerprint } from "../errors";
+import { recordErrorOnSpan } from "./spans";
+
+const VERSION = "1.0.0";
+
+/** Minimal fake span that records the attributes set on it. */
+const fakeSpan = () => {
+  const attributes: Record<string, string | number | boolean> = {};
+  const span = {
+    setAttribute: (key: string, value: string | number | boolean) => {
+      attributes[key] = value;
+      return span;
+    },
+    setStatus: () => span,
+    recordException: () => undefined,
+  } as unknown as Span;
+  return { span, attributes };
+};
+
+/** Build an error with a fixed stack so the fingerprint only varies by discriminator. */
+const errorWithStack = (err: Error): Error => {
+  err.stack = ["Error: boom", "    at f (src/foo.ts:1:2)", "    at g (src/bar.ts:3:4)"].join("\n");
+  return err;
+};
+
+class HttpError extends Error {}
+
+describe("recordErrorOnSpan fingerprint discriminator", () => {
+  it("distinguishes errors with the same stack but different constructors", () => {
+    const a = fakeSpan();
+    const b = fakeSpan();
+    recordErrorOnSpan(a.span, errorWithStack(new Error("boom")), VERSION);
+    recordErrorOnSpan(b.span, errorWithStack(new TypeError("boom")), VERSION);
+    expect(a.attributes["error.fingerprint"]).not.toBe(b.attributes["error.fingerprint"]);
+  });
+
+  it("includes the custom error class name in the discriminator", () => {
+    const { span, attributes } = fakeSpan();
+    recordErrorOnSpan(span, errorWithStack(new HttpError("boom")), VERSION);
+    const expected = computeErrorFingerprint(
+      ["    at f (src/foo.ts:1:2)", "    at g (src/bar.ts:3:4)"].join("\n"),
+      VERSION,
+      "HttpError",
+    );
+    expect(attributes["error.fingerprint"]).toBe(expected);
+  });
+
+  it("keeps the generic Error class out of the discriminator (plain errors stay stable)", () => {
+    const { span, attributes } = fakeSpan();
+    recordErrorOnSpan(span, errorWithStack(new Error("boom")), VERSION);
+    const expected = computeErrorFingerprint(
+      ["    at f (src/foo.ts:1:2)", "    at g (src/bar.ts:3:4)"].join("\n"),
+      VERSION,
+    );
+    expect(attributes["error.fingerprint"]).toBe(expected);
+  });
+
+  it("combines constructor name with the error code", () => {
+    const { span, attributes } = fakeSpan();
+    const err = errorWithStack(new TypeError("boom")) as TypeError & { code: string };
+    err.code = "ENOENT";
+    recordErrorOnSpan(span, err, VERSION);
+    const expected = computeErrorFingerprint(
+      ["    at f (src/foo.ts:1:2)", "    at g (src/bar.ts:3:4)"].join("\n"),
+      VERSION,
+      "TypeError:ENOENT",
+    );
+    expect(attributes["error.fingerprint"]).toBe(expected);
+  });
+});

--- a/src/shared/src/telemetry/spans.test.ts
+++ b/src/shared/src/telemetry/spans.test.ts
@@ -58,6 +58,21 @@ describe("recordErrorOnSpan fingerprint discriminator", () => {
     expect(attributes["error.fingerprint"]).toBe(expected);
   });
 
+  it("falls back to error.name when constructor.name is the generic Error (IPC-rehydrated)", () => {
+    // Mirrors an error rebuilt by rehydrateSerializedError: a plain Error whose
+    // only type signal is `name` (constructor.name is "Error").
+    const { span, attributes } = fakeSpan();
+    const rehydrated = errorWithStack(new Error("boom"));
+    rehydrated.name = "FileSystemError";
+    recordErrorOnSpan(span, rehydrated, VERSION);
+    const expected = computeErrorFingerprint(
+      ["    at f (src/foo.ts:1:2)", "    at g (src/bar.ts:3:4)"].join("\n"),
+      VERSION,
+      "FileSystemError",
+    );
+    expect(attributes["error.fingerprint"]).toBe(expected);
+  });
+
   it("combines constructor name with the error code", () => {
     const { span, attributes } = fakeSpan();
     const err = errorWithStack(new TypeError("boom")) as TypeError & { code: string };

--- a/src/shared/src/telemetry/spans.ts
+++ b/src/shared/src/telemetry/spans.ts
@@ -61,7 +61,14 @@ export const recordErrorOnSpan = (
  */
 const errorDiscriminator = (error: Error): string | undefined => {
   const code = (error as { code?: unknown }).code;
-  const parts = [error.constructor?.name, typeof code === "string" ? code : undefined].filter(
+  // `constructor.name` is accurate for live errors but degrades to "Error" for
+  // any error rebuilt from the IPC wire (see error-serialization.ts, which always
+  // mints a plain Error). `error.name` is the serialization-durable type signal,
+  // so fall back to it once `constructor.name` is the generic "Error".
+  const ctorName = error.constructor?.name;
+  const typeName =
+    ctorName !== undefined && ctorName !== "" && ctorName !== "Error" ? ctorName : error.name;
+  const parts = [typeName, typeof code === "string" ? code : undefined].filter(
     (part): part is string => part !== undefined && part !== "" && part !== "Error",
   );
   return parts.length > 0 ? parts.join(":") : undefined;

--- a/src/shared/src/telemetry/spans.ts
+++ b/src/shared/src/telemetry/spans.ts
@@ -53,9 +53,16 @@ export const recordErrorOnSpan = (
 
 /**
  * An error `discriminator` that distinguishes error sub-types that share an
- * identical stack.
+ * identical stack. Combines the runtime class name (`error.constructor.name`,
+ * e.g. `TypeError`, `HttpError`) with the `code` property when present, so
+ * different error types thrown from the same call site don't collapse into one
+ * fingerprint. The generic `Error` class name is omitted to keep plain errors'
+ * fingerprints stable.
  */
 const errorDiscriminator = (error: Error): string | undefined => {
   const code = (error as { code?: unknown }).code;
-  return typeof code === "string" ? code : undefined;
+  const parts = [error.constructor?.name, typeof code === "string" ? code : undefined].filter(
+    (part): part is string => part !== undefined && part !== "" && part !== "Error",
+  );
+  return parts.length > 0 ? parts.join(":") : undefined;
 };


### PR DESCRIPTION
Same stacktrace (the first 5 frames or when flattened) still causes different error to be merged.
Lets use `error.constructor?.name` and `error.name` when `error.constructor?.name = "Error"` as an additional discriminator for errors

Closes LAZ-524