### PR TITLE
UserCancelled Leaking in Error Reporting

### DIFF
--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -3,7 +3,7 @@ import { inspect } from "util";
 
 import { type Span, context, ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api";
 import { isEnvironmentalError, unknownToError } from "@vortex/shared";
-import { isUserCanceled } from "@vortex/shared/errors";
+import { isErrorOfType } from "@vortex/shared/errors";
 import { recordErrorOnSpan } from "@vortex/shared/telemetry";
 import type PromiseBB from "bluebird";
 import type { BrowserWindow } from "electron";
@@ -486,7 +486,7 @@ export function withTrackedActivity<T>(
       const result = await fun(
         (key, value) => span.setAttribute(key, value),
         (error) => {
-          if (isEnvironmentalError(error) || isUserCanceled(error)) {
+          if (isEnvironmentalError(error) || isErrorOfType(error, UserCanceled)) {
             return;
           }
           hasError = true;
@@ -502,7 +502,7 @@ export function withTrackedActivity<T>(
       // Environmental errors (write-protected folders, disk full, etc.) and
       // user cancellations leave the span status UNSET so
       // RingBufferSpanProcessor doesn't flush the trace.
-      if (!isEnvironmentalError(err) && !isUserCanceled(err)) {
+      if (!isEnvironmentalError(err) && !isErrorOfType(err, UserCanceled)) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: err?.message,
@@ -539,7 +539,7 @@ export function recordErrorSpan(
   error: Error,
   attributes?: Record<string, string | number | boolean>,
 ): void {
-  if (isEnvironmentalError(error) || isUserCanceled(error)) {
+  if (isEnvironmentalError(error) || isErrorOfType(error, UserCanceled)) {
     return;
   }
   const activeSpan = trace.getSpan(context.active());

--- a/src/shared/src/types/errors.test.ts
+++ b/src/shared/src/types/errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { rehydrateSerializedError, serializeError } from "../error-serialization";
+import { isErrorOfType, ProcessCanceled, UserCanceled } from "./errors";
+
+// Mirrors what an error looks like after crossing the IPC boundary: the
+// prototype is gone, so it comes back as a plain Error carrying only `name`.
+const acrossWire = (err: unknown): Error => rehydrateSerializedError(serializeError(err));
+
+describe("isErrorOfType", () => {
+  it("UserCanceled reports its class as its name", () => {
+    expect(new UserCanceled().name).toBe("UserCanceled");
+  });
+
+  it("matches a live instance", () => {
+    expect(isErrorOfType(new UserCanceled(), UserCanceled)).toBe(true);
+  });
+
+  it("matches an IPC-rehydrated instance (instanceof is lost, name survives)", () => {
+    const rehydrated = acrossWire(new UserCanceled());
+    expect(rehydrated).not.toBeInstanceOf(UserCanceled);
+    expect(isErrorOfType(rehydrated, UserCanceled)).toBe(true);
+  });
+
+  it("preserves the skipped payload across the wire", () => {
+    const rehydrated = acrossWire(new UserCanceled(true)) as Error & { skipped?: boolean };
+    expect(rehydrated.skipped).toBe(true);
+  });
+
+  it("distinguishes between error types", () => {
+    expect(isErrorOfType(new ProcessCanceled("stop"), UserCanceled)).toBe(false);
+    expect(isErrorOfType(new UserCanceled(), ProcessCanceled)).toBe(false);
+  });
+
+  it("matches an IPC-rehydrated ProcessCanceled", () => {
+    const rehydrated = acrossWire(new ProcessCanceled("stop"));
+    expect(rehydrated).not.toBeInstanceOf(ProcessCanceled);
+    expect(isErrorOfType(rehydrated, ProcessCanceled)).toBe(true);
+  });
+
+  it("rejects unrelated errors and non-errors", () => {
+    expect(isErrorOfType(new Error("nope"), UserCanceled)).toBe(false);
+    expect(isErrorOfType("canceled", UserCanceled)).toBe(false);
+  });
+
+  it("narrows the type for callers (compile-time guard)", () => {
+    const err: unknown = new UserCanceled(true);
+    if (isErrorOfType(err, UserCanceled)) {
+      // `err` is narrowed to UserCanceled here; accessing `skipped` must typecheck.
+      expect(err.skipped).toBe(true);
+    } else {
+      throw new Error("expected match");
+    }
+  });
+});

--- a/src/shared/src/types/errors.ts
+++ b/src/shared/src/types/errors.ts
@@ -51,6 +51,7 @@ export class UserCanceled extends Error {
 
   constructor(skipped?: boolean) {
     super("canceled by user");
+    this.name = this.constructor.name;
     this.skipped = skipped ?? false;
   }
 }
@@ -292,9 +293,16 @@ export class DownloadIsHTML extends Error {
 }
 
 /**
- * Returns true if the error represents a user cancellation (e.g. the user
- * clicked Cancel on a dialog).
+ * Class-identity check that also survives the IPC boundary. An error that
+ * crossed the wire is rebuilt as a plain `Error` (its prototype is lost), so
+ * `instanceof` fails — but `error-serialization` preserves the original type on
+ * `err.name` (falling back to `constructor.name`), so we match on either. Any
+ * custom payload is carried across as own-enumerable properties and reattached,
+ * so callers reading those fields still work on a rehydrated instance.
  */
-export function isUserCanceled(err: unknown): boolean {
-  return err instanceof UserCanceled;
+export function isErrorOfType<T extends Error>(
+  err: unknown,
+  ctor: new (...args: never[]) => T,
+): err is T {
+  return err instanceof ctor || (err instanceof Error && err.name === ctor.name);
 }


### PR DESCRIPTION
We have IPC leaking error we want to ignore, use this as a workaround for now