### PR TITLE
Fixed: Resolve e2e Electron launch paths correctly

### DIFF
--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -18,7 +18,7 @@ import { Timeouts } from "../helpers/timeouts";
 import type { NexusUser } from "../helpers/users";
 
 /** Package root (packages/e2e/) — used for resolving node_modules. */
-const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..", "..");
 
 /** Repo root directory. */
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, "..", "..");


### PR DESCRIPTION
## Summary

Fix `packages/e2e` root resolution so `pnpm e2e` finds the correct package root folder.

To explain. 

`import.meta.dirname == dir of current module file`. 
Here: `packages/e2e/src/fixtures`.

So path math was:
- `import.meta.dirname` → `.../packages/e2e/src/fixtures`
- `path.resolve(import.meta.dirname, "..")` → `.../packages/e2e/src` ❌ (old behaviour)
- `path.resolve(import.meta.dirname, "..", "..")` → `.../packages/e2e` ✅ (new behaviour)
