### PR TITLE
feat: add Pill component and missing component with demos, update readme

### DIFF
--- a/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -9,27 +9,27 @@ import numeral from "numeral";
 import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 
-import type { IExtensionApi } from "../../../types/IExtensionContext";
-import type { IState } from "../../../types/IState";
-import { Button } from "../../../ui/components/button/Button";
-import { CollectionTile } from "../../../ui/components/collectiontile/CollectionTile";
-import { CollectionTileSkeleton } from "../../../ui/components/collectiontile/CollectionTileSkeleton";
-import { Input } from "../../../ui/components/form/input/Input";
-import { Listing } from "../../../ui/components/listing/Listing";
-import { NoResults } from "../../../ui/components/no_results/NoResults";
-import { Pagination } from "../../../ui/components/pagination/Pagination";
-import { Picker } from "../../../ui/components/picker/Picker";
-import { TabButton } from "../../../ui/components/tabs/Tab";
-import { TabBar } from "../../../ui/components/tabs/TabBar";
-import { TabPanel } from "../../../ui/components/tabs/TabPanel";
-import { TabProvider } from "../../../ui/components/tabs/tabs.context";
-import { Typography } from "../../../ui/components/typography/Typography";
-import { UserCanceled } from "../../../util/api";
-import { activeGameId } from "../../../util/selectors";
-import MainPage from "../../../views/MainPage";
-import { CollectionsDownloadClickedEvent } from "../../analytics/mixpanel/MixpanelEvents";
-import { getGame } from "../../gamemode_management/util/getGame";
-import { nexusGameId } from "../../nexus_integration/util/convertGameId";
+import { CollectionsDownloadClickedEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
+import { getGame } from "@/extensions/gamemode_management/util/getGame";
+import { nexusGameId } from "@/extensions/nexus_integration/util/convertGameId";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import type { IState } from "@/types/IState";
+import { Button } from "@/ui/components/button/Button";
+import { CollectionTile } from "@/ui/components/collectiontile/CollectionTile";
+import { CollectionTileSkeleton } from "@/ui/components/collectiontile/CollectionTileSkeleton";
+import { Input } from "@/ui/components/form/input/Input";
+import { Listing } from "@/ui/components/listing/Listing";
+import { NoResults } from "@/ui/components/no_results/NoResults";
+import { Pagination } from "@/ui/components/pagination/Pagination";
+import { Picker } from "@/ui/components/picker/Picker";
+import { TabButton } from "@/ui/components/tabs/Tab";
+import { TabBar } from "@/ui/components/tabs/TabBar";
+import { TabPanel } from "@/ui/components/tabs/TabPanel";
+import { TabProvider } from "@/ui/components/tabs/tabs.context";
+import { Typography } from "@/ui/components/typography/Typography";
+import { UserCanceled } from "@/util/api";
+import { activeGameId } from "@/util/selectors";
+import MainPage from "@/views/MainPage";
 
 interface IBrowseNexusPageProps {
   api: IExtensionApi;
@@ -248,7 +248,7 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
           tabListId="browse-nexus-tabs"
           onSetSelectedTab={setSelectedTab}
         >
-          <TabBar className="pl-6">
+          <TabBar className="overflow-clip pl-6">
             <TabButton count={allCollectionsTotal} name={t("collection:browse.tabs.collections")} />
 
             <TabButton name={t("collection:browse.tabs.mods")} />

--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -6,27 +6,33 @@
 
 import React, { useState } from "react";
 
-import type { IExtensionApi } from "../../../types/IExtensionContext";
-import { ButtonDemo } from "../../../ui/components/button/ButtonDemo";
-import { CollectionTileDemo } from "../../../ui/components/collectiontile/CollectionTileDemo";
-import { DropdownDemo } from "../../../ui/components/dropdown/DropdownDemo";
-import { InputDemo } from "../../../ui/components/form/input/InputDemo";
-import { SelectDemo } from "../../../ui/components/form/select/SelectDemo";
-import { IconDemo } from "../../../ui/components/icon/IconDemo";
-import { ListingDemo } from "../../../ui/components/listing/ListingDemo";
-import { PaginationDemo } from "../../../ui/components/pagination/PaginationDemo";
-import { PickerDemo } from "../../../ui/components/picker/PickerDemo";
-import { TabButton } from "../../../ui/components/tabs/Tab";
-import { TabBar } from "../../../ui/components/tabs/TabBar";
-import { TabPanel } from "../../../ui/components/tabs/TabPanel";
-import { TabProvider } from "../../../ui/components/tabs/tabs.context";
-import { TabsDemo } from "../../../ui/components/tabs/TabsDemo";
-import { Typography } from "../../../ui/components/typography/Typography";
-import { TypographyDemo } from "../../../ui/components/typography/TypographyDemo";
-import MainPage from "../../../views/MainPage";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import { ButtonDemo } from "@/ui/components/button/ButtonDemo";
+import { CollectionTileDemo } from "@/ui/components/collectiontile/CollectionTileDemo";
+import { DropdownDemo } from "@/ui/components/dropdown/DropdownDemo";
+import { InputDemo } from "@/ui/components/form/input/InputDemo";
+import { SelectDemo } from "@/ui/components/form/select/SelectDemo";
+import { IconDemo } from "@/ui/components/icon/IconDemo";
+import { ImageDemo } from "@/ui/components/image/ImageDemo";
+import { ListingDemo } from "@/ui/components/listing/ListingDemo";
+import { PaginationDemo } from "@/ui/components/pagination/PaginationDemo";
+import { PickerDemo } from "@/ui/components/picker/PickerDemo";
+import { PillDemo } from "@/ui/components/pill/PillDemo";
+import { PremiumBadgeDemo } from "@/ui/components/premium_badge/PremiumBadgeDemo";
+import { TabButton } from "@/ui/components/tabs/Tab";
+import { TabBar } from "@/ui/components/tabs/TabBar";
+import { TabPanel } from "@/ui/components/tabs/TabPanel";
+import { TabProvider } from "@/ui/components/tabs/tabs.context";
+import { TabsDemo } from "@/ui/components/tabs/TabsDemo";
+import { Typography } from "@/ui/components/typography/Typography";
+import { TypographyDemo } from "@/ui/components/typography/TypographyDemo";
+import { TypographyLinkDemo } from "@/ui/components/typography/TypographyLinkDemo";
+import MainPage from "@/views/MainPage";
 
 export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
   const [selectedTab, setSelectedTab] = useState("button");
+  const [selectedTypographyTab, setSelectedTypographyTab] = useState("typography");
+  const [selectedIconTab, setSelectedIconTab] = useState("icon");
   const [selectedFormTab, setSelectedFormTab] = useState("input");
   const [selectedDropdownTab, setSelectedDropdownTab] = useState("dropdown");
 
@@ -51,6 +57,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
             <TabBar>
               <TabButton name="Button" />
 
+              <TabButton name="Pill" />
+
               <TabButton name="Typography" />
 
               <TabButton name="Form" />
@@ -58,6 +66,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
               <TabButton name="Tabs" />
 
               <TabButton name="Icon" />
+
+              <TabButton name="Image" />
 
               <TabButton name="Dropdown" />
 
@@ -73,8 +83,33 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
                 <ButtonDemo />
               </TabPanel>
 
+              <TabPanel name="Pill">
+                <PillDemo />
+              </TabPanel>
+
               <TabPanel name="Typography">
-                <TypographyDemo />
+                <TabProvider
+                  tab={selectedTypographyTab}
+                  tabListId="typography-demo-tabs"
+                  tabType="secondary"
+                  onSetSelectedTab={setSelectedTypographyTab}
+                >
+                  <TabBar>
+                    <TabButton name="Typography" />
+
+                    <TabButton name="Link" />
+                  </TabBar>
+
+                  <div className="mt-6">
+                    <TabPanel name="Typography">
+                      <TypographyDemo />
+                    </TabPanel>
+
+                    <TabPanel name="Link">
+                      <TypographyLinkDemo />
+                    </TabPanel>
+                  </div>
+                </TabProvider>
               </TabPanel>
 
               <TabPanel name="Form">
@@ -107,7 +142,32 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
               </TabPanel>
 
               <TabPanel name="Icon">
-                <IconDemo />
+                <TabProvider
+                  tab={selectedIconTab}
+                  tabListId="icon-demo-tabs"
+                  tabType="secondary"
+                  onSetSelectedTab={setSelectedIconTab}
+                >
+                  <TabBar>
+                    <TabButton name="Icon" />
+
+                    <TabButton name="Premium Badge" />
+                  </TabBar>
+
+                  <div className="mt-6">
+                    <TabPanel name="Icon">
+                      <IconDemo />
+                    </TabPanel>
+
+                    <TabPanel name="Premium Badge">
+                      <PremiumBadgeDemo />
+                    </TabPanel>
+                  </div>
+                </TabProvider>
+              </TabPanel>
+
+              <TabPanel name="Image">
+                <ImageDemo />
               </TabPanel>
 
               <TabPanel name="Dropdown">

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -15,6 +15,7 @@ ui/
 │   │   ├── input/       - Text input with validation
 │   │   └── select/      - Select dropdown with custom styling
 │   ├── icon/            - Icon rendering (MDI + Nexus custom icons)
+│   ├── image/           - Image wrapper with aspect ratios and fallback
 │   ├── listbox/         - Listbox select (Headless UI Listbox)
 │   ├── listing/         - List display component
 │   ├── modal/           - Modal dialog (Headless UI Dialog)
@@ -23,6 +24,8 @@ ui/
 │   ├── no_results/      - Empty state component
 │   ├── pagination/      - Pagination controls with jump-to-page
 │   ├── picker/          - Picker component
+│   ├── pill/            - Compact rounded label for tags and statuses
+│   ├── premium_badge/   - Premium diamond badge
 │   ├── tabs/            - Tabbed interface with context-based state
 │   └── typography/      - Typography system (heading, title, body)
 ├── lib/
@@ -311,6 +314,57 @@ import { Pictogram } from "../../ui/components/pictogram/Pictogram";
 
 ```tsx
 import { Picker } from "../../ui/components/picker/Picker";
+```
+
+### Pill
+
+Compact, rounded label for tags and statuses. Renders as a non-interactive `div` by default, or as a `button` when given `as="button"`. Accepts an icon via either `iconPath` (an MDI/Nexus path string) or `icon` (a custom node) — not both.
+
+**Defaults:** `pillType="default"`
+
+```tsx
+import { Pill } from "../../ui/components/pill/Pill";
+import { mdiCheckCircleOutline, mdiTag } from "@mdi/js";
+
+// Variants
+<Pill>Default</Pill>
+<Pill pillType="success" iconPath={mdiCheckCircleOutline}>Success</Pill>
+<Pill pillType="none">Unstyled</Pill>
+
+// With an icon (path or custom node)
+<Pill iconPath={mdiTag}>Tagged</Pill>
+<Pill icon={<Icon path={mdiTag} size="none" />}>Custom node</Pill>
+
+// As an interactive button
+<Pill as="button" onClick={handleClick}>Clickable</Pill>
+<Pill as="button" disabled>Disabled</Pill>
+```
+
+**Types:** `default`, `success`, `none` (opts out of styling) — more variants to come
+
+### Image
+
+Image wrapper with predefined aspect ratios, optional blur, and a fallback icon shown when the source fails to load. Resetting `src` clears the previous error state.
+
+**Defaults:** `imageType="other"`
+
+```tsx
+import { Image } from "../../ui/components/image/Image";
+
+<Image alt="Cover" src={url} imageType="collection" />
+<Image alt="Preview" src={url} imageType="mod" isBlurred />
+```
+
+**Image types:** `collection` (4:5 portrait), `mod` (16:9 landscape), `other` (sized by container)
+
+### PremiumBadge
+
+Small diamond badge denoting premium membership.
+
+```tsx
+import { PremiumBadge } from "../../ui/components/premium_badge/PremiumBadge";
+
+<PremiumBadge />;
 ```
 
 ## Adding New Components

--- a/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
@@ -15,15 +15,16 @@ import React, {
   useState,
 } from "react";
 
-import type { IExtensionApi } from "../../../types/IExtensionContext";
-import Debouncer from "../../../util/Debouncer";
-import { isCollectionModPresent } from "../../../util/selectors";
-import { delayed } from "../../../util/util";
-import { nxmFileSize, nxmMod } from "../../icon-paths";
-import { joinClasses } from "../../utils/joinClasses";
-import { Button } from "../button/Button";
-import { Icon } from "../icon/Icon";
-import { Typography } from "../typography/Typography";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import { Button } from "@/ui/components/button/Button";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Image } from "@/ui/components/image/Image";
+import { Typography } from "@/ui/components/typography/Typography";
+import { nxmFileSize, nxmMod } from "@/ui/icon-paths";
+import { joinClasses } from "@/ui/utils/joinClasses";
+import Debouncer from "@/util/Debouncer";
+import { isCollectionModPresent } from "@/util/selectors";
+import { delayed } from "@/util/util";
 
 const debouncer = new Debouncer(
   (func: () => void) => {
@@ -125,27 +126,26 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-x-3.5 p-3">
-        <div className="relative flex aspect-4/5 w-full max-w-35 shrink-0 items-center justify-center overflow-hidden rounded-xs bg-surface-translucent-low">
-          <img
-            alt={collection.name}
-            className="absolute z-1 h-full max-w-none"
-            src={collection.tileImage?.thumbnailUrl}
-          />
-
+        <Image
+          alt={collection.name}
+          className="w-full max-w-35 rounded-xs"
+          fit="cover"
+          imageType="collection"
+          src={collection.tileImage?.thumbnailUrl}
+        >
           {easyInstallBadge && (
-            <div className="absolute inset-x-0 bottom-0 z-2">
-              <Typography
-                appearance="none"
-                className="flex h-7 items-center gap-x-1 bg-info-weak px-1.5 text-info-50"
-                typographyType="title-xs"
-              >
-                <Icon path={mdiStar} size="xs" />
+            <Typography
+              appearance="none"
+              as="div"
+              className="absolute inset-x-0 bottom-0 z-2 flex h-7 items-center gap-x-1 bg-info-weak px-1.5 text-info-50"
+              typographyType="title-xs"
+            >
+              <Icon path={mdiStar} size="xs" />
 
-                <span title={easyInstallBadge.description}>{easyInstallBadge.name}</span>
-              </Typography>
-            </div>
+              <span title={easyInstallBadge.description}>{easyInstallBadge.name}</span>
+            </Typography>
           )}
-        </div>
+        </Image>
 
         <div className="flex min-w-0 grow flex-col gap-y-1.5">
           <div className="flex flex-col gap-y-1">
@@ -159,10 +159,10 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
               typographyType="body-sm"
             >
               <span className="size-4 overflow-hidden rounded-full bg-surface-translucent-low">
-                {collection.user?.avatar && (
+                {!!collection.user?.avatar && (
                   <img
                     alt={collection.user?.name}
-                    className="size-4"
+                    className="size-4 shrink-0"
                     src={collection.user.avatar}
                   />
                 )}
@@ -177,7 +177,7 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
               {collection.category?.name}
             </Typography>
 
-            {revision.adultContent && (
+            {!!revision.adultContent && (
               <>
                 <div className="size-1 rotate-45 bg-neutral-subdued" />
 

--- a/src/renderer/src/ui/components/image/Image.tsx
+++ b/src/renderer/src/ui/components/image/Image.tsx
@@ -10,6 +10,7 @@ export interface IImageProps extends Omit<
 > {
   alt: string;
   className?: string;
+  fit?: "cover" | "contain";
   imageClassName?: string;
   imageType?: "collection" | "mod" | "other";
   isBlurred?: boolean;
@@ -23,7 +24,9 @@ const imageTypeMap: Record<NonNullable<IImageProps["imageType"]>, string> = {
 
 export const Image = ({
   alt,
+  children,
   className,
+  fit = "contain",
   imageClassName,
   imageType = "other",
   isBlurred,
@@ -51,9 +54,16 @@ export const Image = ({
         <img
           {...rest}
           alt={alt}
-          className={joinClasses(["absolute z-1 max-h-full rounded-[inherit]", imageClassName], {
-            "blur-xl": isBlurred,
-          })}
+          className={joinClasses(
+            [
+              "absolute z-1 rounded-[inherit]",
+              fit === "cover" ? "size-full object-cover" : "max-h-full",
+              imageClassName,
+            ],
+            {
+              "blur-xl": isBlurred,
+            },
+          )}
           src={src}
           onError={(event) => {
             setErrored(true);
@@ -64,7 +74,9 @@ export const Image = ({
         <Icon className="text-neutral-subdued" path={mdiImageBroken} title={alt} />
       )}
 
-      <div className="pointer-events-none absolute inset-0 z-2 rounded-[inherit] border border-stroke-weak" />
+      {children}
+
+      <div className="pointer-events-none absolute inset-0 z-5 rounded-[inherit] border border-stroke-weak" />
     </div>
   );
 };

--- a/src/renderer/src/ui/components/image/ImageDemo.tsx
+++ b/src/renderer/src/ui/components/image/ImageDemo.tsx
@@ -1,0 +1,135 @@
+/**
+ * Image Demo Component
+ * Demonstrates the Image component aspect ratios, blur and error fallback
+ */
+
+import React from "react";
+
+import { Typography } from "../typography/Typography";
+import type { IImageProps } from "./Image";
+import { Image } from "./Image";
+
+const imageTypes: {
+  className: string;
+  correctSrc: string;
+  imageType: NonNullable<IImageProps["imageType"]>;
+  incorrectSrc: string;
+  ratio: string;
+}[] = [
+  {
+    imageType: "collection",
+    ratio: "4 / 5 (portrait)",
+    className: "w-40",
+    correctSrc: "https://picsum.photos/seed/collection/400/500",
+    incorrectSrc: "https://picsum.photos/seed/collection/500/280",
+  },
+  {
+    imageType: "mod",
+    ratio: "16 / 9 (landscape)",
+    className: "w-56",
+    correctSrc: "https://picsum.photos/seed/mod/480/270",
+    incorrectSrc: "https://picsum.photos/seed/mod/300/400",
+  },
+  {
+    imageType: "other",
+    ratio: "none (sized by container)",
+    className: "h-40 w-48",
+    correctSrc: "https://picsum.photos/seed/other/360/300",
+    incorrectSrc: "https://picsum.photos/seed/other/200/400",
+  },
+];
+
+export const ImageDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        Image
+      </Typography>
+
+      <Typography appearance="subdued">
+        An image wrapper with predefined aspect ratios, optional blur, and a fallback icon shown
+        when the source fails to load.
+      </Typography>
+    </div>
+
+    <div className="space-y-6">
+      <div>
+        <Typography as="h3" typographyType="heading-xs">
+          Image Types
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          Each type enforces an aspect ratio on the container. A source matching that ratio fills
+          the frame; a mismatched source is centred and letterboxed within it.
+        </Typography>
+      </div>
+
+      {imageTypes.map(({ className, correctSrc, imageType, incorrectSrc, ratio }) => (
+        <div className="space-y-2" key={imageType}>
+          <Typography typographyType="body-sm">
+            <span className="font-semibold">{imageType}</span> — {ratio}
+          </Typography>
+
+          <div className="flex flex-wrap items-end gap-6">
+            <div className="flex flex-col items-center gap-2">
+              <Image
+                alt={`${imageType} with matching aspect`}
+                className={className}
+                imageType={imageType}
+                src={correctSrc}
+              />
+
+              <Typography appearance="subdued" typographyType="body-xs">
+                Matching aspect
+              </Typography>
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+              <Image
+                alt={`${imageType} with mismatched aspect`}
+                className={className}
+                imageType={imageType}
+                src={incorrectSrc}
+              />
+
+              <Typography appearance="subdued" typographyType="body-xs">
+                Mismatched aspect
+              </Typography>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Blurred
+      </Typography>
+
+      <Image
+        isBlurred
+        alt="Blurred example"
+        className="w-48"
+        imageType="collection"
+        src="https://picsum.photos/seed/blurred/300/200"
+      />
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Error Fallback
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        When the source fails to load, a broken-image icon is shown in its place.
+      </Typography>
+
+      <Image
+        alt="Broken image example"
+        className="w-48"
+        imageType="collection"
+        src="https://invalid.example.com/does-not-exist.png"
+      />
+    </div>
+  </div>
+);

--- a/src/renderer/src/ui/components/pill/Pill.tsx
+++ b/src/renderer/src/ui/components/pill/Pill.tsx
@@ -1,0 +1,82 @@
+import React, {
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+import { Icon } from "@/ui/components/icon/Icon";
+import { joinClasses } from "@/ui/utils/joinClasses";
+import type { XOr } from "@/ui/utils/types";
+
+type BasePillProps = {
+  children: string;
+  pillType?: "default" | "none" | "success";
+} & XOr<{ iconPath?: string }, { icon?: ReactNode }>;
+
+type PillDefaultProps = HTMLAttributes<HTMLDivElement> & {
+  as?: never;
+  ref?: Ref<HTMLDivElement>;
+} & BasePillProps;
+
+type ButtonPillProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  as: "button";
+  className?: string;
+  disabled?: boolean;
+  ref?: Ref<HTMLButtonElement>;
+} & BasePillProps;
+
+type PillProps = PillDefaultProps | ButtonPillProps;
+
+const getPillClasses = ({ pillType = "default" }: Pick<BasePillProps, "pillType">) =>
+  joinClasses("nxm-pill", {
+    [`nxm-pill-${pillType}`]: pillType !== "none",
+  });
+
+const Content = ({
+  icon,
+  iconPath,
+  label,
+}: Pick<PillProps, "icon" | "iconPath"> & { label?: string }) => (
+  <>
+    {!!icon && <span className="nxm-pill-icon flex items-center justify-center">{icon}</span>}
+
+    {!!iconPath && <Icon className="nxm-pill-icon" path={iconPath} size="none" />}
+
+    <span className="nxm-pill-label">{label}</span>
+  </>
+);
+
+export const Pill = (allProps: PillProps) => {
+  const { children, className, icon, iconPath, pillType, ref, ...rest } = allProps;
+
+  const content = <Content icon={icon} iconPath={iconPath} label={children} />;
+
+  if (rest.as === "button") {
+    const { as, disabled, ...props } = rest;
+
+    return (
+      <button
+        className={joinClasses([getPillClasses({ pillType }), className])}
+        disabled={disabled}
+        ref={ref as Ref<HTMLButtonElement>}
+        type="button"
+        {...props}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  const { as, ...props } = rest as PillDefaultProps;
+
+  return (
+    <div
+      className={joinClasses([getPillClasses({ pillType }), className])}
+      ref={ref as Ref<HTMLDivElement>}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/pill/PillDemo.tsx
+++ b/src/renderer/src/ui/components/pill/PillDemo.tsx
@@ -1,0 +1,125 @@
+/**
+ * Pill Demo Component
+ * Demonstrates the Pill component variants and features
+ */
+
+import { mdiCheck, mdiCheckCircleOutline, mdiClose, mdiStar, mdiTag } from "@mdi/js";
+import React, { useState, type ComponentProps } from "react";
+
+import { Icon } from "../icon/Icon";
+import { Typography } from "../typography/Typography";
+import { Pill } from "./Pill";
+
+type PillType = NonNullable<ComponentProps<typeof Pill>["pillType"]>;
+
+/**
+ * Styled pill variants showcased in the demo. The `none` variant is intentionally
+ * omitted here (it opts out of styling) and is demonstrated separately above.
+ * Add new variants to this list as they are introduced.
+ */
+const VARIANTS: Array<{ pillType: PillType; label: string; iconPath?: string }> = [
+  { pillType: "default", label: "Default", iconPath: mdiTag },
+  { pillType: "success", label: "Success", iconPath: mdiCheckCircleOutline },
+];
+
+export const PillDemo = () => {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-sm bg-surface-mid p-4">
+        <Typography as="h2" typographyType="heading-sm">
+          Pill
+        </Typography>
+
+        <Typography appearance="subdued">
+          A compact, rounded label used for tags and statuses. Renders as a non-interactive div by
+          default, or as a button when given <code>as="button"</code>.
+        </Typography>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Default Pills
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Pill>Default</Pill>
+
+          <Pill pillType="none">Unstyled (none)</Pill>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Variants
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          Each styled variant is selected with the <code>pillType</code> prop. More variants will be
+          added over time.
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          {VARIANTS.map(({ pillType, label, iconPath }) => (
+            <Pill iconPath={iconPath} key={pillType} pillType={pillType}>
+              {label}
+            </Pill>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Pills with Icons
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Pill iconPath={mdiTag}>Tagged</Pill>
+
+          <Pill iconPath={mdiCheck}>Verified</Pill>
+
+          <Pill icon={<Icon path={mdiStar} size="none" />}>Custom icon node</Pill>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Button Pills
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          {`Clicked ${clicks} ${clicks === 1 ? "time" : "times"}.`}
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Pill as="button" onClick={() => setClicks((count) => count + 1)}>
+            Clickable
+          </Pill>
+
+          <Pill as="button" iconPath={mdiClose} onClick={() => setClicks((count) => count + 1)}>
+            With icon
+          </Pill>
+
+          <Pill as="button" disabled={true}>
+            Disabled
+          </Pill>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Disabled Appearance
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          A non-interactive pill can opt into the disabled styling with the nxm-pill-disabled class.
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Pill className="nxm-pill-disabled">Disabled</Pill>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/premium_badge/PremiumBadgeDemo.tsx
+++ b/src/renderer/src/ui/components/premium_badge/PremiumBadgeDemo.tsx
@@ -1,0 +1,44 @@
+/**
+ * PremiumBadge Demo Component
+ * Demonstrates the PremiumBadge component
+ */
+
+import React from "react";
+
+import { Typography } from "../typography/Typography";
+import { PremiumBadge } from "./PremiumBadge";
+
+export const PremiumBadgeDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        PremiumBadge
+      </Typography>
+
+      <Typography appearance="subdued">
+        An inline badge displaying a diamond icon on a premium background, used to denote premium
+        content.
+      </Typography>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Default
+      </Typography>
+
+      <PremiumBadge />
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Inline with text
+      </Typography>
+
+      <div className="flex items-center gap-2">
+        <PremiumBadge />
+
+        <Typography>Premium feature</Typography>
+      </div>
+    </div>
+  </div>
+);

--- a/src/renderer/src/ui/components/typography/TypographyLinkDemo.tsx
+++ b/src/renderer/src/ui/components/typography/TypographyLinkDemo.tsx
@@ -1,0 +1,105 @@
+/**
+ * TypographyLink Demo Component
+ * Demonstrates the TypographyLink component variants, appearances and icons
+ */
+
+import { mdiArrowRight, mdiOpenInNew } from "@mdi/js";
+import React from "react";
+
+import { Typography } from "./Typography";
+import type { TypographyButtonProps } from "./TypographyLink";
+import { TypographyLink } from "./TypographyLink";
+
+const appearances: NonNullable<TypographyButtonProps["appearance"]>[] = [
+  "info",
+  "premium",
+  "primary",
+  "moderate",
+  "strong",
+  "subdued",
+];
+
+const variants: NonNullable<TypographyButtonProps["variant"]>[] = ["primary", "secondary", "none"];
+
+export const TypographyLinkDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        TypographyLink
+      </Typography>
+
+      <Typography appearance="subdued">
+        A button styled as a link with typography integration. Supports left/right icons, multiple
+        appearances and variants.
+      </Typography>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Variants
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-6">
+        {variants.map((variant) => (
+          <TypographyLink key={variant} variant={variant}>
+            {variant}
+          </TypographyLink>
+        ))}
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Appearances
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-6">
+        {appearances.map((appearance) => (
+          <TypographyLink appearance={appearance} key={appearance}>
+            {appearance}
+          </TypographyLink>
+        ))}
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        With Icons
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-6">
+        <TypographyLink leftIconPath={mdiArrowRight}>Left icon</TypographyLink>
+
+        <TypographyLink rightIconPath={mdiOpenInNew}>Right icon</TypographyLink>
+
+        <TypographyLink leftIconPath={mdiArrowRight} rightIconPath={mdiOpenInNew}>
+          Both icons
+        </TypographyLink>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Typography Types
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-6">
+        <TypographyLink typographyType="body-lg">body-lg</TypographyLink>
+
+        <TypographyLink typographyType="body-md">body-md</TypographyLink>
+
+        <TypographyLink typographyType="body-sm">body-sm</TypographyLink>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Disabled
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-6">
+        <TypographyLink disabled>Disabled link</TypographyLink>
+      </div>
+    </div>
+  </div>
+);

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -4,5 +4,6 @@
 @import "./link.css";
 @import "./modal.css";
 @import "./pagination.css";
+@import "./pill.css";
 @import "./scrollbar.css";
 @import "./tab.css";

--- a/src/stylesheets/ui/elements/pill.css
+++ b/src/stylesheets/ui/elements/pill.css
@@ -1,0 +1,84 @@
+@layer components {
+    .nxm-pill {
+        z-index: 1;
+        position: relative;
+        border: solid 1px transparent;
+        border-radius: calc(infinity * 1px);
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        column-gap: calc(var(--spacing) * 1);
+
+        min-height: calc(var(--spacing) * 5.5);
+        padding-inline: calc(var(--spacing) * 2) calc(var(--spacing) * 2.5);
+
+        transition-property:
+            color, background-color, border-color, outline-color, fill, stroke, opacity,
+            pointer-events;
+        transition-timing-function: var(--default-transition-timing-function);
+        transition-duration: var(--default-transition-duration);
+
+        &:disabled,
+        &.nxm-pill-disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        &:enabled:not(.nxm-pill-disabled) {
+            cursor: pointer;
+
+            &:before {
+                inset: 0;
+                opacity: 0;
+                z-index: -1;
+                content: "";
+                position: absolute;
+                pointer-events: none;
+                border-radius: inherit;
+                transition-property: opacity;
+                transition-timing-function: var(--default-transition-timing-function);
+                transition-duration: var(--default-transition-duration);
+            }
+
+            &:hover,
+            &:focus-visible,
+            &[aria-expanded="true"] {
+                &:before {
+                    opacity: 1;
+                }
+            }
+        }
+
+        & .nxm-pill-label {
+            min-width: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            font-size: var(--text-body-sm);
+            font-weight: var(--font-weight-normal);
+            line-height: var(--text-body-sm--line-height);
+            letter-spacing: var(--text-body-sm--letter-spacing);
+        }
+
+        & .nxm-pill-icon {
+            flex-shrink: 0;
+            width: calc(var(--spacing) * 3.5);
+            height: calc(var(--spacing) * 3.5);
+        }
+    }
+
+    .nxm-pill-default,
+    .nxm-pill-success {
+        color: var(--color-translucent-moderate);
+        border-color: var(--color-stroke-weak);
+
+        &:enabled:not(.nxm-pill-disabled):before {
+            background-color: var(--color-surface-translucent-low);
+        }
+    }
+
+    .nxm-pill-success .nxm-pill-icon {
+        color: var(--color-success-strong);
+    }
+}

--- a/src/stylesheets/ui/elements/tab.css
+++ b/src/stylesheets/ui/elements/tab.css
@@ -1,13 +1,10 @@
 @layer components {
     .nxm-tab-bar {
-        overflow-x: clip;
-        overflow-clip-margin: calc(var(--spacing) * 1);
-
         & .nxm-tab-bar-scroller {
             display: flex;
             overflow-x: auto;
             /* prevents focus outline being cropped by the overflow */
-            margin-inline: calc(var(--spacing) * -1);
+            margin-left: calc(var(--spacing) * -1);
             padding-inline: calc(var(--spacing) * 1);
         }
     }


### PR DESCRIPTION
### Summary
  
Adds several new design-system components with demos and documentation, and tidies up imports on the pages that consume them.

### New component
- Pill — compact rounded label for tags/statuses; renders as a div or button, supports default/success/none variants (built to extend with more) and an icon via iconPath or icon.

### Updated component
- Image — image wrapper with aspect-ratio presets (collection/mod/other), optional blur, error fallback, and a fit prop (cover/contain) controlling object-fit.

### Demos & docs
- Demo components for all components missing demos, wired into the dev-only DesignSystemPage.
- ui/README.md updated for all new components and directory entries.

###  Refactors
- CollectionTile now uses the shared Image component.
- Converted deep relative imports to the @/ alias in BrowseNexusPage, DesignSystemPage, and CollectionTile.