### PR TITLE
fix BodySlide tool detection for Skyrim, SkyrimSE, and Fallout 4

### DIFF
--- a/extensions/games/game-fallout4/package.json
+++ b/extensions/games/game-fallout4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-fallout4",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Support for Fallout 4",
   "scripts": {
     "_assets": "copyfiles -u 1 -f ./assets/* dist",

--- a/extensions/games/game-fallout4/src/index.js
+++ b/extensions/games/game-fallout4/src/index.js
@@ -1,6 +1,6 @@
 const Promise = require("bluebird");
 const path = require("path");
-const { util } = require("vortex-api");
+const { fs, util } = require("vortex-api");
 const winapi = require("winapi-bindings");
 
 /*
@@ -14,6 +14,10 @@ const MS_ID = "BethesdaSoftworks.Fallout4-PC";
 const GOG_ID = "1998527297";
 const EPIC_ID = "61d52ce4d09d41e48800c22784d13ae8";
 const STEAM_ID = "377160";
+
+const BODYSLIDE_DIR = path.join("Data", "Tools", "BodySlide");
+const BODYSLIDE_X64 = path.join(BODYSLIDE_DIR, "BodySlide x64.exe");
+const BODYSLIDE_EXE = path.join(BODYSLIDE_DIR, "BodySlide.exe");
 
 let tools = [
   {
@@ -43,8 +47,18 @@ let tools = [
   {
     id: "bodyslide",
     name: "BodySlide",
-    executable: () => path.join("Data", "Tools", "BodySlide", "BodySlide x64.exe"),
-    requiredFiles: [path.join("Data", "Tools", "BodySlide", "BodySlide x64.exe")],
+    executable: (discoveryPath) => {
+      if (discoveryPath !== undefined) {
+        try {
+          fs.statSync(path.join(discoveryPath, BODYSLIDE_X64));
+          return BODYSLIDE_X64;
+        } catch (err) {
+          return BODYSLIDE_EXE;
+        }
+      }
+      return BODYSLIDE_EXE;
+    },
+    requiredFiles: [BODYSLIDE_EXE],
     relative: true,
     logo: "auto",
   },

--- a/extensions/games/game-skyrim/package.json
+++ b/extensions/games/game-skyrim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-skyrim",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Support for The Elder Scrolls V: Skyrim",
   "scripts": {
     "_assets": "copyfiles -u 1 -f ./assets/* dist",

--- a/extensions/games/game-skyrim/src/index.js
+++ b/extensions/games/game-skyrim/src/index.js
@@ -1,7 +1,11 @@
 const Promise = require("bluebird");
 const path = require("path");
-const { util } = require("vortex-api");
+const { fs, util } = require("vortex-api");
 const winapi = require("winapi-bindings");
+
+const BODYSLIDE_DIR = path.join("Data", "CalienteTools", "BodySlide");
+const BODYSLIDE_X64 = path.join(BODYSLIDE_DIR, "BodySlide x64.exe");
+const BODYSLIDE_EXE = path.join(BODYSLIDE_DIR, "BodySlide.exe");
 
 function findGame() {
   try {
@@ -56,8 +60,18 @@ let tools = [
   {
     id: "bodyslide",
     name: "BodySlide",
-    executable: () => path.join("Data", "CalienteTools", "BodySlide", "BodySlide x64.exe"),
-    requiredFiles: [path.join("Data", "CalienteTools", "BodySlide", "BodySlide x64.exe")],
+    executable: (discoveryPath) => {
+      if (discoveryPath !== undefined) {
+        try {
+          fs.statSync(path.join(discoveryPath, BODYSLIDE_X64));
+          return BODYSLIDE_X64;
+        } catch (err) {
+          return BODYSLIDE_EXE;
+        }
+      }
+      return BODYSLIDE_EXE;
+    },
+    requiredFiles: [BODYSLIDE_EXE],
     relative: true,
     logo: "auto",
   },

--- a/extensions/games/game-skyrimse/package.json
+++ b/extensions/games/game-skyrimse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-skyrimse",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Support for The Elder Scrolls V: Skyrim Special Edition",
   "scripts": {
     "_assets": "copyfiles -u 1 -f ./assets/* dist",

--- a/extensions/games/game-skyrimse/src/index.js
+++ b/extensions/games/game-skyrimse/src/index.js
@@ -8,6 +8,10 @@ const MS_ID = "BethesdaSoftworks.SkyrimSE-PC";
 const EPIC_ID = "ac82db5035584c7f8a2c548d98c86b2c";
 const STEAM_ID = "489830";
 
+const BODYSLIDE_DIR = path.join("Data", "CalienteTools", "BodySlide");
+const BODYSLIDE_X64 = path.join(BODYSLIDE_DIR, "BodySlide x64.exe");
+const BODYSLIDE_EXE = path.join(BODYSLIDE_DIR, "BodySlide.exe");
+
 const tools = [
   {
     id: "SSEEdit",
@@ -46,8 +50,18 @@ const tools = [
   {
     id: "bodyslide",
     name: "BodySlide",
-    executable: () => path.join("Data", "CalienteTools", "BodySlide", "BodySlide x64.exe"),
-    requiredFiles: [path.join("Data", "CalienteTools", "BodySlide", "BodySlide x64.exe")],
+    executable: (discoveryPath) => {
+      if (discoveryPath !== undefined) {
+        try {
+          fs.statSync(path.join(discoveryPath, BODYSLIDE_X64));
+          return BODYSLIDE_X64;
+        } catch (err) {
+          return BODYSLIDE_EXE;
+        }
+      }
+      return BODYSLIDE_EXE;
+    },
+    requiredFiles: [BODYSLIDE_EXE],
     relative: true,
     logo: "auto",
   },


### PR DESCRIPTION
BodySlide 5.8.0 dropped the "BodySlide x64.exe" filename and ships only "BodySlide.exe" (now 64-bit). Detect BodySlide via "BodySlide.exe", then prefer "BodySlide x64.exe" at launch when it exists alongside (older 64-bit installs), otherwise fall back to "BodySlide.exe".

fixes #23372
fixes APP-495