### PR TITLE
Fix main build depends

### DIFF
--- a/src/main/package.json
+++ b/src/main/package.json
@@ -37,7 +37,15 @@
           "copy-assets",
           "copy-extensions",
           "download-duckdb-extensions",
-          "^build"
+          "^build",
+          {
+            "target": "build",
+            "projects": "@vortex/renderer"
+          },
+          {
+            "target": "build",
+            "projects": "@vortex/preload"
+          }
         ],
         "cache": true,
         "outputs": [

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -32,7 +32,8 @@
           "{projectRoot}/api-extractor.json"
         ],
         "outputs": [
-          "{workspaceRoot}/packages/vortex-api/lib/api.d.ts"
+          "{workspaceRoot}/packages/vortex-api/lib/api.d.ts",
+          "{workspaceRoot}/etc/vortex.api.md"
         ]
       }
     }


### PR DESCRIPTION
Makes `@vortex/renderer` and `@vortex/preload` build targets explicit dependencies of `@vortex/main` build target. Otherwise running raw build step as required by E2E tests will produce a broken Vortex build with missing files.