### PR TITLE
feat: add Bullet and AdultAwareImage UI components

### DIFF
--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -7,6 +7,7 @@
 import React, { useState } from "react";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { BulletDemo } from "@/ui/components/bullet/BulletDemo";
 import { ButtonDemo } from "@/ui/components/button/ButtonDemo";
 import { CollectionTileDemo } from "@/ui/components/collectiontile/CollectionTileDemo";
 import { DropdownDemo } from "@/ui/components/dropdown/DropdownDemo";
@@ -152,6 +153,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
                     <TabButton name="Icon" />
 
                     <TabButton name="Premium Badge" />
+
+                    <TabButton name="Bullet" />
                   </TabBar>
 
                   <div className="mt-6">
@@ -161,6 +164,10 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
 
                     <TabPanel name="Premium Badge">
                       <PremiumBadgeDemo />
+                    </TabPanel>
+
+                    <TabPanel name="Bullet">
+                      <BulletDemo />
                     </TabPanel>
                   </div>
                 </TabProvider>

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -7,6 +7,7 @@ Components adapted from the web team's "next" project for use in Vortex.
 ```
 ui/
 ├── components/
+│   ├── bullet/          - Small rotated-square dot used as an inline marker/separator
 │   ├── button/          - Button system (primary, secondary, tertiary, success, premium)
 │   ├── collectiontile/  - Collection card with image, metadata, and actions
 │   ├── dropdown/        - Dropdown menu (Headless UI Menu)
@@ -15,7 +16,7 @@ ui/
 │   │   ├── input/       - Text input with validation
 │   │   └── select/      - Select dropdown with custom styling
 │   ├── icon/            - Icon rendering (MDI + Nexus custom icons)
-│   ├── image/           - Image wrapper with aspect ratios and fallback
+│   ├── image/           - Image wrapper with aspect ratios and fallback (+ adult-aware variant)
 │   ├── listbox/         - Listbox select (Headless UI Listbox)
 │   ├── listing/         - List display component
 │   ├── modal/           - Modal dialog (Headless UI Dialog)
@@ -357,6 +358,19 @@ import { Image } from "../../ui/components/image/Image";
 
 **Image types:** `collection` (4:5 portrait), `mod` (16:9 landscape), `other` (sized by container)
 
+#### AdultAwareImage
+
+Wraps `Image` for Nexus content (mods, collections, gallery, …) and blurs adult content according to the logged-in user's `adultBlurImages` preference. When no one is logged in (or the preference is unknown) it blurs by default, so adult content is never shown to a user who hasn't opted into seeing it. The base `Image` stays presentational; this wrapper owns the adult-content policy.
+
+`isAdult` is **required** so the blur decision can never be forgotten at a call site. All other `Image` props (including `imageType`) pass straight through.
+
+```tsx
+import { AdultAwareImage } from "../../ui/components/image/AdultAwareImage";
+
+<AdultAwareImage isAdult={file.adultContent} imageType="mod" alt="Preview" src={url} />
+<AdultAwareImage isAdult={revision.adultContent} imageType="collection" alt="Cover" src={url} />
+```
+
 ### PremiumBadge
 
 Small diamond badge denoting premium membership.
@@ -365,6 +379,20 @@ Small diamond badge denoting premium membership.
 import { PremiumBadge } from "../../ui/components/premium_badge/PremiumBadge";
 
 <PremiumBadge />;
+```
+
+### Bullet
+
+Small rotated-square dot used as an inline marker or separator (e.g. between a label and an "Adult" tag). Defaults (`size-0.75`, 45° rotation, translucent-subdued colour) come from the `.nxm-bullet` class; pass `className` to override any of them — Tailwind utilities sit in a higher layer than `components`, so they win over the defaults.
+
+```tsx
+import { Bullet } from "../../ui/components/bullet/Bullet";
+
+// Default
+<Bullet />
+
+// Override size and colour
+<Bullet className="size-1 bg-neutral-subdued" />
 ```
 
 ## Adding New Components

--- a/src/renderer/src/ui/components/bullet/Bullet.tsx
+++ b/src/renderer/src/ui/components/bullet/Bullet.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export interface IBulletProps {
+  /**
+   * Additional classes. Tailwind utilities override the `.nxm-bullet` defaults
+   * (size, rotation, colour) since the `utilities` layer sits above `components`.
+   */
+  className?: string;
+}
+
+/**
+ * A small rotated-square dot used as an inline marker or separator, e.g. between
+ * a label and an "Adult" tag. Defaults come from the `.nxm-bullet` class; pass
+ * `className` to override any of them (e.g. `bg-neutral-subdued`, `size-1`).
+ */
+export const Bullet = ({ className }: IBulletProps) => (
+  <div className={joinClasses(["nxm-bullet", className])} />
+);

--- a/src/renderer/src/ui/components/bullet/BulletDemo.tsx
+++ b/src/renderer/src/ui/components/bullet/BulletDemo.tsx
@@ -1,0 +1,69 @@
+/**
+ * Bullet Demo Component
+ * Demonstrates the Bullet component defaults and className overrides
+ */
+
+import React from "react";
+
+import { Typography } from "../typography/Typography";
+import { Bullet } from "./Bullet";
+
+export const BulletDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        Bullet
+      </Typography>
+
+      <Typography appearance="subdued">
+        A small rotated-square dot used as an inline marker or separator. Defaults come from the
+        `.nxm-bullet` class; pass `className` to override any of them (Tailwind utilities win over
+        the defaults).
+      </Typography>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Default
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        `size-0.75`, rotated 45°, translucent-subdued colour.
+      </Typography>
+
+      <Bullet />
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Overrides
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        Size and colour overridden via `className`.
+      </Typography>
+
+      <div className="flex items-center gap-6">
+        <Bullet className="size-1 bg-neutral-subdued" />
+
+        <Bullet className="size-2 bg-danger-strong" />
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Inline separator
+      </Typography>
+
+      <div className="flex items-center gap-x-2">
+        <Typography appearance="moderate">Mod name</Typography>
+
+        <Bullet />
+
+        <Typography appearance="none" className="text-danger-strong" typographyType="body-sm">
+          Adult
+        </Typography>
+      </div>
+    </div>
+  </div>
+);

--- a/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
@@ -16,6 +16,7 @@ import React, {
 } from "react";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { Bullet } from "@/ui/components/bullet/Bullet";
 import { Button } from "@/ui/components/button/Button";
 import { Icon } from "@/ui/components/icon/Icon";
 import { Image } from "@/ui/components/image/Image";
@@ -179,7 +180,7 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
 
             {!!revision.adultContent && (
               <>
-                <div className="size-1 rotate-45 bg-neutral-subdued" />
+                <Bullet />
 
                 <Typography
                   appearance="none"

--- a/src/renderer/src/ui/components/image/AdultAwareImage.tsx
+++ b/src/renderer/src/ui/components/image/AdultAwareImage.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useSelector } from "react-redux";
+
+import { userInfo as selectUserInfo } from "@/extensions/nexus_integration/selectors";
+
+import { Image, type IImageProps } from "./Image";
+
+export interface IAdultAwareImageProps extends IImageProps {
+  /**
+   * Whether the underlying content is flagged as adult. Required so it can never
+   * be forgotten at a call site — rendering Nexus content imagery always forces
+   * a blur decision.
+   */
+  isAdult: boolean;
+}
+
+/**
+ * An {@link Image} for Nexus content (mods, collections, gallery, ...) that
+ * blurs adult content according to the logged-in user's `adultBlurImages`
+ * preference. When no one is logged in (or the preference is unknown) the image
+ * is blurred by default, so adult content is never shown to a user who has not
+ * opted into seeing it.
+ *
+ * The base `Image` primitive stays presentational; this wrapper owns the
+ * adult-content policy so it lives in exactly one place.
+ */
+export const AdultAwareImage = ({ isAdult, ...props }: IAdultAwareImageProps) => {
+  const blurAdultContent = useSelector(selectUserInfo)?.adultBlurImages ?? true;
+
+  return <Image {...props} isBlurred={isAdult && blurAdultContent} />;
+};

--- a/src/renderer/src/ui/components/image/ImageDemo.tsx
+++ b/src/renderer/src/ui/components/image/ImageDemo.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 
 import { Typography } from "../typography/Typography";
+import { AdultAwareImage } from "./AdultAwareImage";
 import type { IImageProps } from "./Image";
 import { Image } from "./Image";
 
@@ -113,6 +114,50 @@ export const ImageDemo = () => (
         imageType="collection"
         src="https://picsum.photos/seed/blurred/300/200"
       />
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Adult-aware
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        <span className="font-semibold">AdultAwareImage</span> wraps Image for Nexus content. When{" "}
+        <span className="font-semibold">isAdult</span> is set it blurs according to the logged-in
+        user&apos;s <span className="font-semibold">adultBlurImages</span> preference, and blurs by
+        default when no one is logged in or the preference is unknown. Non-adult images are never
+        blurred. (Whether the example below shows blurred depends on your account preference.)
+      </Typography>
+
+      <div className="flex flex-wrap items-end gap-6">
+        <div className="flex flex-col items-center gap-2">
+          <AdultAwareImage
+            isAdult
+            alt="Adult content example"
+            className="w-48"
+            imageType="collection"
+            src="https://picsum.photos/seed/adult/300/375"
+          />
+
+          <Typography appearance="subdued" typographyType="body-xs">
+            isAdult (blur depends on preference)
+          </Typography>
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <AdultAwareImage
+            alt="Non-adult content example"
+            className="w-48"
+            imageType="collection"
+            isAdult={false}
+            src="https://picsum.photos/seed/safe/300/375"
+          />
+
+          <Typography appearance="subdued" typographyType="body-xs">
+            Not adult (never blurred)
+          </Typography>
+        </div>
+      </div>
     </div>
 
     <div className="space-y-4">

--- a/src/stylesheets/ui/elements/bullet.css
+++ b/src/stylesheets/ui/elements/bullet.css
@@ -1,0 +1,9 @@
+@layer components {
+    .nxm-bullet {
+        flex-shrink: 0;
+        width: calc(var(--spacing) * 0.75);
+        height: calc(var(--spacing) * 0.75);
+        rotate: 45deg;
+        background-color: var(--color-translucent-subdued);
+    }
+}

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -1,3 +1,4 @@
+@import "./bullet.css";
 @import "./button.css";
 @import "./dropdown.css";
 @import "./hover-overlay.css";


### PR DESCRIPTION
Adds a reusable Bullet dot and an adult-aware Image wrapper that blurs Nexus content per the user's adultBlurImages preference (blurring by default when logged out). Includes design-system demos and README entries; CollectionTile now uses Bullet.