### PR TITLE
self-heal LOOT sort when an assigned group no longer exists

### DIFF
--- a/extensions/gamebryo-plugin-management/src/autosort.ts
+++ b/extensions/gamebryo-plugin-management/src/autosort.ts
@@ -14,6 +14,7 @@ import { removeGroupRule, removeRule, setGroup } from "./actions/userlist";
 import { GHOST_EXT, NAMESPACE } from "./statics";
 import { IPluginLoot, IPlugins, IPluginsLoot } from "./types/IPlugins";
 import { gameDataPath, gameSupported, nativePlugins, pluginPath } from "./util/gameSupport";
+import { missingGroupFixes } from "./util/groups";
 import { downloadMasterlist, downloadPrelude } from "./util/masterlist";
 
 const MAX_RESTARTS = 3;
@@ -300,6 +301,22 @@ class LootInterface {
           }
         }
       } else if (err.message.match(/The group "[^"]*" does not exist/)) {
+        // A collection (or the user) assigned plugins to a LOOT group that no longer exists -
+        // typically a masterlist group that was renamed or removed after the collection was
+        // authored. Rather than failing the entire sort, drop every dangling reference (the
+        // master-/userlist groups are in state) so the affected plugins fall back to their
+        // default group, then re-sort. If there's nothing to reset we can't recover this way,
+        // so just notify.
+        const { missing, actions } = missingGroupFixes(store.getState());
+        if (actions.length > 0) {
+          log("info", "resetting plugins assigned to missing loot group(s)", { missing });
+          util.batchDispatch(store, actions);
+          // invalidate the cached userlist mtime so readLists is forced to reload the updated
+          // userlist from disk, and give the persistor a moment to flush it before re-sorting
+          this.mUserlistTime = undefined;
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          return this.doSort(pluginNames, gameMode, loot);
+        }
         this.mExtensionApi.sendNotification({
           id: "loot-failed",
           type: "warning",

--- a/extensions/gamebryo-plugin-management/src/index.ts
+++ b/extensions/gamebryo-plugin-management/src/index.ts
@@ -18,7 +18,7 @@ import {
   setPluginList,
   updatePluginWarnings,
 } from "./actions/plugins";
-import { clearUserlist, removeGroupRule, setGroup } from "./actions/userlist";
+import { clearUserlist, setGroup } from "./actions/userlist";
 import { openGroupEditor, setCreateRule } from "./actions/userlistEdit";
 import LootInterface from "./autosort";
 import { ESPFile } from "./esp/ESPFile";
@@ -51,6 +51,7 @@ import {
   supportsESL,
   supportsMediumMasters,
 } from "./util/gameSupport";
+import { missingGroupFixes } from "./util/groups";
 import { isMasterlistOutdated, masterlistExists, masterlistFilePath } from "./util/masterlist";
 import { markdownToBBCode } from "./util/mdtobb";
 import PluginHistory from "./util/PluginHistory";
@@ -975,29 +976,7 @@ function testMissingGroupsImpl(
     return Promise.resolve(undefined);
   }
 
-  const userlistGroups = state.userlist.groups || [];
-
-  // all known groups
-  const groups = new Set<string>(
-    [].concat(
-      (state.masterlist.groups || []).map((group) => group.name),
-      userlistGroups.map((group) => group.name),
-    ),
-  );
-
-  // all used groups
-  const usedGroups = Array.from(
-    new Set(
-      [].concat(
-        ...userlistGroups.map((group) => group.after || []),
-        (state.userlist.plugins || [])
-          .filter((plugin) => plugin.group !== undefined)
-          .map((plugin) => plugin.group),
-      ),
-    ),
-  );
-
-  const missing = usedGroups.filter((group) => !groups.has(group));
+  const { missing, actions } = missingGroupFixes(state);
 
   // nothing found => everything good
   if (missing.length === 0) {
@@ -1021,19 +1000,7 @@ function testMissingGroupsImpl(
     },
     severity: "error",
     automaticFix: () => {
-      const missingSet = new Set<string>(missing);
-      (state.userlist.plugins || [])
-        .filter((plugin) => plugin.group !== undefined && missingSet.has(plugin.group))
-        .forEach((plugin) => {
-          store.dispatch(setGroup(plugin.name, undefined));
-        });
-      userlistGroups.forEach((group) => {
-        (group.after || [])
-          .filter((after) => missingSet.has(after))
-          .forEach((after) => {
-            store.dispatch(removeGroupRule(group.name, after));
-          });
-      });
+      util.batchDispatch(store, actions);
       return Promise.resolve();
     },
   };

--- a/extensions/gamebryo-plugin-management/src/util/groups.test.ts
+++ b/extensions/gamebryo-plugin-management/src/util/groups.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import { removeGroupRule, setGroup } from "../actions/userlist";
+import { ILOOTList } from "../types/ILOOTList";
+import { IStateWithGamebryo } from "../types/IStateWithGamebryo";
+import { missingGroupFixes } from "./groups";
+
+// missingGroupFixes only reads state.masterlist and state.userlist, so we build a minimal
+// state with just those slices and cast through unknown to the full state type.
+function makeState(
+  masterlist: Partial<ILOOTList> | undefined,
+  userlist: Partial<ILOOTList> | undefined,
+): IStateWithGamebryo {
+  return { masterlist, userlist } as unknown as IStateWithGamebryo;
+}
+
+describe("missingGroupFixes", () => {
+  test("returns nothing when there are no group references at all", () => {
+    const state = makeState({ groups: [] }, { groups: [], plugins: [] });
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+
+  test("ignores a plugin whose group exists in the masterlist", () => {
+    const state = makeState(
+      { groups: [{ name: "Fixes & Resources" }] },
+      { groups: [], plugins: [{ name: "a.esp", group: "Fixes & Resources" }] },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+
+  test("ignores a plugin whose group exists in the userlist", () => {
+    const state = makeState(
+      { groups: [] },
+      {
+        groups: [{ name: "Custom Group" }],
+        plugins: [{ name: "a.esp", group: "Custom Group" }],
+      },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+
+  test("ignores plugins without a group assignment", () => {
+    const state = makeState(
+      { groups: [] },
+      { groups: [], plugins: [{ name: "a.esp" }, { name: "b.esp" }] },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+
+  test("resets a plugin assigned to a group missing from both lists", () => {
+    const state = makeState(
+      { groups: [{ name: "default" }] },
+      { groups: [], plugins: [{ name: "a.esp", group: "Fixes & Resources" }] },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual(["Fixes & Resources"]);
+    expect(result.actions).toEqual([setGroup("a.esp", undefined)]);
+  });
+
+  test("removes a group 'after' rule that references a missing group", () => {
+    const state = makeState(
+      { groups: [] },
+      {
+        groups: [{ name: "Custom Group", after: ["Fixes & Resources"] }],
+        plugins: [],
+      },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual(["Fixes & Resources"]);
+    expect(result.actions).toEqual([removeGroupRule("Custom Group", "Fixes & Resources")]);
+  });
+
+  test("keeps a group 'after' rule that references an existing group", () => {
+    const state = makeState(
+      { groups: [{ name: "Early" }] },
+      {
+        groups: [{ name: "Custom Group", after: ["Early"] }],
+        plugins: [],
+      },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+
+  test("deduplicates the missing group name when several plugins reference it", () => {
+    const state = makeState(
+      { groups: [] },
+      {
+        groups: [],
+        plugins: [
+          { name: "a.esp", group: "Fixes & Resources" },
+          { name: "b.esp", group: "Fixes & Resources" },
+        ],
+      },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual(["Fixes & Resources"]);
+    expect(result.actions).toEqual([setGroup("a.esp", undefined), setGroup("b.esp", undefined)]);
+  });
+
+  test("collects fixes from both plugin assignments and group rules", () => {
+    const state = makeState(
+      { groups: [{ name: "default" }] },
+      {
+        groups: [{ name: "Custom Group", after: ["Gone", "default"] }],
+        plugins: [
+          { name: "a.esp", group: "Missing One" },
+          { name: "b.esp", group: "default" },
+        ],
+      },
+    );
+
+    const result = missingGroupFixes(state);
+
+    expect(result.missing).toEqual(expect.arrayContaining(["Missing One", "Gone"]));
+    expect(result.missing).toHaveLength(2);
+    // plugin assignments are collected before group rules
+    expect(result.actions).toEqual([
+      setGroup("a.esp", undefined),
+      removeGroupRule("Custom Group", "Gone"),
+    ]);
+  });
+
+  test("tolerates missing masterlist / userlist slices", () => {
+    expect(missingGroupFixes(makeState(undefined, undefined))).toEqual({
+      missing: [],
+      actions: [],
+    });
+  });
+});

--- a/extensions/gamebryo-plugin-management/src/util/groups.ts
+++ b/extensions/gamebryo-plugin-management/src/util/groups.ts
@@ -1,0 +1,47 @@
+import * as Redux from "redux";
+
+import { removeGroupRule, setGroup } from "../actions/userlist";
+import { IStateWithGamebryo } from "../types/IStateWithGamebryo";
+
+/**
+ * Find every reference in the userlist to a LOOT group that doesn't exist in either the
+ * masterlist or the userlist. These dangling references happen e.g. when a collection assigns
+ * plugins to a masterlist group that was later renamed or removed - LOOT then refuses to sort
+ * with 'The group "..." does not exist'.
+ *
+ * Returns the names of the missing groups (for reporting) along with the userlist actions needed
+ * to drop the references, resetting the affected plugins back to their default group.
+ */
+export function missingGroupFixes(state: IStateWithGamebryo): {
+  missing: string[];
+  actions: Redux.AnyAction[];
+} {
+  const userlistGroups = state.userlist?.groups ?? [];
+
+  // all groups that actually exist
+  const known = new Set<string>([
+    ...(state.masterlist?.groups ?? []).map((group) => group.name),
+    ...userlistGroups.map((group) => group.name),
+  ]);
+
+  const missing = new Set<string>();
+  const actions: Redux.AnyAction[] = [];
+
+  (state.userlist?.plugins ?? [])
+    .filter((plugin) => plugin.group !== undefined && !known.has(plugin.group))
+    .forEach((plugin) => {
+      missing.add(plugin.group);
+      actions.push(setGroup(plugin.name, undefined));
+    });
+
+  userlistGroups.forEach((group) => {
+    (group.after ?? [])
+      .filter((after) => !known.has(after))
+      .forEach((after) => {
+        missing.add(after);
+        actions.push(removeGroupRule(group.name, after));
+      });
+  });
+
+  return { missing: Array.from(missing), actions };
+}


### PR DESCRIPTION
A collection assigns plugins to a masterlist LOOT group; if the masterlist later drops that group, the userlist still references it and LOOT fails every sort with 'The group "..." does not exist'.

On that error, reset the dangling references so the plugins fall back to their default group, then re-sort. Logic is shared with the existing missing-groups health check via a new missingGroupFixes helper, with tests.

fixes APP-497
closes #23415