### PR TITLE
fixed licenses in about page not being displayed

### DIFF
--- a/src/main/package.json
+++ b/src/main/package.json
@@ -64,6 +64,22 @@
           "script": "package:nosign"
         }
       },
+      "dependency-report": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "node ./scripts/dependency-report.mjs",
+          "cwd": "{workspaceRoot}"
+        },
+        "cache": true,
+        "inputs": [
+          "{workspaceRoot}/scripts/dependency-report.mjs",
+          "{workspaceRoot}/pnpm-lock.yaml",
+          "{projectRoot}/package.json"
+        ],
+        "outputs": [
+          "{workspaceRoot}/assets/modules.json"
+        ]
+      },
       "copy-assets": {
         "executor": "nx:run-commands",
         "options": {
@@ -74,13 +90,17 @@
           {
             "target": "build",
             "projects": "@vortex/stylesheets"
-          }
+          },
+          "dependency-report"
         ],
         "cache": true,
         "inputs": [
           "default",
           {
             "dependentTasksOutputFiles": "**/dist/**"
+          },
+          {
+            "dependentTasksOutputFiles": "**/assets/modules.json"
           },
           "{projectRoot}/copy-assets.mjs",
           "{workspaceRoot}/src/stylesheets/**/*.scss",

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -72,9 +72,8 @@
         },
         "cache": true,
         "inputs": [
-          "{workspaceRoot}/scripts/dependency-report.mjs",
-          "{workspaceRoot}/pnpm-lock.yaml",
-          "{projectRoot}/package.json"
+          "default",
+          "{workspaceRoot}/scripts/dependency-report.mjs"
         ],
         "outputs": [
           "{workspaceRoot}/assets/modules.json"


### PR DESCRIPTION
Wire dependency-report into nx as a copy-assets dependency so assets/modules.json is generated before the asset copy. It was missing from packaged builds, leaving the third-party license list empty.

Note: v2.1 has now diverged from master, which uses pnpm sbom / bom.json instead. This fix is specific to v2.1's modules.json mechanism.

closes app-499