### PR TITLE
fixed mods losing metadata/splitting from archive on close/relaunch

### DIFF
--- a/src/main/src/store/persistenceIPC.ts
+++ b/src/main/src/store/persistenceIPC.ts
@@ -10,8 +10,9 @@
  * 3. Main process applies operations to LevelDB via ReduxPersistorIPC
  */
 
+import type { DiffOperation } from "@vortex/shared/ipc";
 import type { PersistedHive, PersistedState } from "@vortex/shared/state";
-import type { WebContents } from "electron";
+import { ipcMain, type WebContents } from "electron";
 
 import { betterIpcMain } from "../ipc";
 import { log } from "../logging";
@@ -32,6 +33,22 @@ export function setupPersistenceIPC(persistor: ReduxPersistorIPC): void {
     });
     persistor.applyDiffOperations(hive, operations);
   });
+
+  // Synchronous flush used by the renderer on quit (beforeunload). Queues the
+  // ops and returns immediately; the actual write is drained by finalizeWrite
+  // during shutdown. Blocking here guarantees the final batch is queued before
+  // the renderer process tears down, so it isn't lost (GH#23363). Raw ipcMain
+  // because betterIpcMain has no synchronous channel.
+  ipcMain.on(
+    "persist:diff-sync",
+    (event: Electron.IpcMainEvent, hive: PersistedHive, operations: DiffOperation[]) => {
+      try {
+        persistor.applyDiffOperations(hive, operations);
+      } finally {
+        event.returnValue = true;
+      }
+    },
+  );
 
   // Handle hydration request from renderer at startup
   // Auto-discovers all hives in the database and registers them

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -50,6 +50,13 @@ try {
     persist: {
       sendDiff: (hive, operations) => betterIpcRenderer.send("persist:diff", hive, operations),
 
+      // Synchronous variant used only on quit (beforeunload): blocks until main
+      // has queued the ops so the final batch is persisted before teardown.
+      // Raw ipcRenderer because betterIpcRenderer has no sendSync helper.
+      sendDiffSync: (hive, operations) => {
+        ipcRenderer.sendSync("persist:diff-sync", hive, operations);
+      },
+
       getHydration: () => betterIpcRenderer.invoke("persist:get-hydration"),
 
       onHydrate: (callback: (hive: PersistedHive, data: Serializable) => void) =>

--- a/src/renderer/src/extensions/mod_management/reducers/mods.test.ts
+++ b/src/renderer/src/extensions/mod_management/reducers/mods.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 
+import { verify } from "../../../reducers/verify";
 import { modsReducer } from "./mods";
+
+const noEmit = (): void => undefined;
 
 describe("removeMod", () => {
   it("removes the mod", () => {
@@ -346,5 +349,74 @@ describe("addMod", () => {
       gameId1: { modId1: mod },
       gameId2: { modId1: oldMod },
     });
+  });
+});
+
+describe("verifiers: installationPath self-heal (GH#23363/#23355)", () => {
+  it("recovers installationPath from the modId instead of dropping the mod", () => {
+    // a mod that lost its installationPath (and id) leaf to a partial write,
+    // keeping only archiveId + attributes - the #23363 corruption shape.
+    const state = {
+      skyrimse: {
+        "Fences of Skyrim-123-1-0-17000": {
+          archiveId: "arch1",
+          attributes: { endorsed: "Undecided", allowRating: true, version: "1.0" },
+        },
+      },
+    };
+
+    const result = verify(
+      "persistent.mods",
+      modsReducer.verifiers,
+      state,
+      modsReducer.defaults,
+      noEmit,
+    );
+
+    const mod = result?.skyrimse?.["Fences of Skyrim-123-1-0-17000"];
+    // record preserved (not culled) and installationPath healed to the modId
+    expect(mod).toBeDefined();
+    expect(mod.installationPath).toBe("Fences of Skyrim-123-1-0-17000");
+    expect(mod.archiveId).toBe("arch1");
+    expect(mod.attributes).toEqual({ endorsed: "Undecided", allowRating: true, version: "1.0" });
+  });
+
+  it("leaves a valid mod untouched", () => {
+    const state = {
+      skyrimse: {
+        modA: {
+          id: "modA",
+          type: "",
+          installationPath: "modA",
+          state: "installed",
+          attributes: { name: "Mod A" },
+        },
+      },
+    };
+
+    const result = verify(
+      "persistent.mods",
+      modsReducer.verifiers,
+      state,
+      modsReducer.defaults,
+      noEmit,
+    );
+
+    expect(result.skyrimse.modA.installationPath).toBe("modA");
+  });
+
+  it("still drops a mod entry that isn't an object", () => {
+    const state = { skyrimse: { good: { installationPath: "good" }, bad: "not an object" } };
+
+    const result = verify(
+      "persistent.mods",
+      modsReducer.verifiers,
+      state,
+      modsReducer.defaults,
+      noEmit,
+    );
+
+    expect(result.skyrimse.good.installationPath).toBe("good");
+    expect(result.skyrimse).not.toHaveProperty("bad");
   });
 });

--- a/src/renderer/src/extensions/mod_management/reducers/mods.ts
+++ b/src/renderer/src/extensions/mod_management/reducers/mods.ts
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import type { IRule } from "modmeta-db";
 
 import type { IReducerSpec } from "../../../types/IExtensionContext";
+import { VerifierDropParent } from "../../../types/IExtensionContext";
 import { log } from "../../../util/log";
 import { removeValue } from "../../../util/storeHelper";
 import {
@@ -212,12 +213,27 @@ export const modsReducer: IReducerSpec = {
           elements: {
             installationPath: {
               type: "string",
-              description: () => "Mod with invalid attribute will be reset.",
+              description: () =>
+                "Mod with invalid installationPath will be self-healed from its id.",
               noUndefined: true,
               noNull: true,
               noEmpty: true,
               required: true,
-              deleteBroken: "parent",
+              // Self-heal instead of discarding the whole mod (GH#23363/#23355).
+              // installationPath is the staging-folder name, which by convention
+              // equals the modId - and the modId is this record's map key, still
+              // present even when the installationPath leaf was lost to a partial
+              // write. Recovering it preserves the mod's archiveId, attributes and
+              // rules instead of orphaning the staging folder and splitting the
+              // mod from its download. Only drop the record if the modId itself is
+              // unusable.
+              repair: (_input, _def, context) => {
+                const modId = context?.parentKey;
+                if (typeof modId === "string" && modId.length > 0) {
+                  return modId;
+                }
+                throw new VerifierDropParent();
+              },
             },
             attributes: {
               type: "object",

--- a/src/renderer/src/reducers/verify.test.ts
+++ b/src/renderer/src/reducers/verify.test.ts
@@ -276,6 +276,73 @@ describe("verify", () => {
     expect(result).not.toHaveProperty("dl2");
   });
 
+  it("passes key/parentKey/parent to the repair context", () => {
+    const seen: Array<unknown> = [];
+    const verifiers: Record<string, IStateVerifier> = {
+      _: {
+        description: desc("x"),
+        elements: {
+          val: {
+            description: desc("bad"),
+            type: "number",
+            repair: (_input, _def, ctx) => {
+              seen.push(ctx);
+              return 0;
+            },
+          },
+        },
+      },
+    };
+
+    verify("test", verifiers, { item1: { val: "bad" } }, {}, emitSpy());
+
+    // parentKey is the containing object's map key (here "item1")
+    expect(seen[0]).toEqual({ parentKey: "item1", parent: { val: "bad" }, key: "val" });
+  });
+
+  it("self-heals a value from its map key via the repair context (mods installationPath)", () => {
+    // mirrors mods.ts: a mod that lost its installationPath leaf (and its id
+    // leaf) recovers installationPath from the modId map key instead of being
+    // dropped, preserving the rest of the record.
+    const input = {
+      "Mod-A": { attributes: { endorsed: "Undecided" } }, // installationPath lost
+      "Mod-B": { installationPath: "Mod-B", attributes: {} }, // intact
+      "": { attributes: {} }, // unusable key -> must drop
+    };
+    const verifiers: Record<string, IStateVerifier> = {
+      _: {
+        description: desc("bad mod"),
+        elements: {
+          installationPath: {
+            description: desc("installationPath required"),
+            type: "string",
+            required: true,
+            noEmpty: true,
+            repair: (_val, _def, ctx) => {
+              const modId = ctx?.parentKey;
+              if (typeof modId === "string" && modId.length > 0) {
+                return modId;
+              }
+              throw new VerifierDropParent();
+            },
+          },
+        },
+      },
+    };
+
+    const result = verify("test", verifiers, input, {}, emitSpy());
+
+    // Mod-A: installationPath recovered from its map key, record preserved
+    expect(result["Mod-A"]).toEqual({
+      installationPath: "Mod-A",
+      attributes: { endorsed: "Undecided" },
+    });
+    // Mod-B: untouched
+    expect(result["Mod-B"].installationPath).toBe("Mod-B");
+    // empty-key record: unrecoverable -> dropped
+    expect(Object.keys(result)).not.toContain("");
+  });
+
   it("emits descriptions for each broken field", () => {
     const input = { a: "wrong", b: "also wrong" };
     const verifiers: Record<string, IStateVerifier> = {

--- a/src/renderer/src/reducers/verify.ts
+++ b/src/renderer/src/reducers/verify.ts
@@ -48,6 +48,11 @@ export function verify(
   defaults: { [key: string]: any },
   emitDescription: (description: string) => void,
   log: LogFn = noop,
+  // key under which `input` lives in its parent (e.g. a modId for a mod
+  // record). Threaded through the recursion so a `repair` can recover a value
+  // from the record's own identity - see the installationPath self-heal in
+  // mod_management/reducers/mods.ts (GH#23363/#23355).
+  containerKey?: string,
 ): any {
   if (input === undefined || verifiers === undefined) {
     return input;
@@ -55,7 +60,15 @@ export function verify(
   let res = input;
 
   const recurse = (key: string, mapKey: string) => {
-    const sane = verify(statePath, verifiers[key].elements, res[mapKey], {}, emitDescription, log);
+    const sane = verify(
+      statePath,
+      verifiers[key].elements,
+      res[mapKey],
+      {},
+      emitDescription,
+      log,
+      mapKey,
+    );
     if (sane !== res[mapKey]) {
       res = sane === undefined ? deleteKey(res, mapKey) : update(res, { [mapKey]: { $set: sane } });
     }
@@ -77,7 +90,11 @@ export function verify(
         res = verifiers[key].deleteBroken === "parent" ? undefined : deleteKey(res, realKey);
       } else if (verifiers[key].repair !== undefined) {
         try {
-          const fixed = verifiers[key].repair(input[realKey], defaults[realKey]);
+          const fixed = verifiers[key].repair(input[realKey], defaults[realKey], {
+            parentKey: containerKey,
+            parent: input,
+            key: realKey,
+          });
           res = update(res, { [realKey]: { $set: fixed } });
         } catch (err) {
           if (err instanceof VerifierDrop) {

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -124,7 +124,7 @@ import { log } from "./logging";
 import { initApplicationMenu } from "./menu";
 import reducer, { buildReducerTree, Decision, sanitizeHydrationState } from "./reducers/index";
 import { fetchHydrationState } from "./store/hydration";
-import { persistDiffMiddleware } from "./store/persistDiffMiddleware";
+import { flushPendingDiffsSync, persistDiffMiddleware } from "./store/persistDiffMiddleware";
 import { reduxLogger } from "./store/reduxLogger";
 import { reduxSanity, type StateError } from "./store/reduxSanity";
 import { computeStateDiff } from "./store/stateDiff";
@@ -183,6 +183,14 @@ const middleware = [
   persistDiffMiddleware,
   reduxLogger(),
 ];
+
+// On quit, persistDiffMiddleware may still hold up to DEBOUNCE_MS of un-sent
+// state diffs. window-all-closed fires in main after the renderer is already
+// gone, so flush synchronously here while we're still alive - otherwise the
+// final writes are lost and affected mods reload missing fields (GH#23363).
+window.addEventListener("beforeunload", () => {
+  flushPendingDiffsSync();
+});
 
 function sanityCheckCB(err: StateError) {
   err["attachLogOnReport"] = true;

--- a/src/renderer/src/store/persistDiffMiddleware.test.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.test.ts
@@ -1,0 +1,69 @@
+import { applyMiddleware, createStore, type Reducer } from "redux";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createPersistDiffMiddleware, flushPendingDiffsSync } from "./persistDiffMiddleware";
+
+type S = Record<string, unknown>;
+const initial: S = { app: {}, settings: {}, persistent: {}, confidential: {}, user: {} };
+const reducer: Reducer<S> = (state = initial, action: { type: string; payload?: unknown }) =>
+  action.type === "SET_PERSISTENT" ? { ...state, persistent: action.payload } : state;
+
+afterEach(() => vi.useRealTimers());
+
+describe("flushPendingDiffsSync (GH#23363 quit flush)", () => {
+  it("flushes pending diffs synchronously via sendDiffSync before the debounce fires", () => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn();
+    const sendDiffSync = vi.fn();
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff, sendDiffSync }));
+    const store = createStore(reducer, applyMiddleware(mw));
+
+    store.dispatch({ type: "INIT" }); // initializes previousState
+    store.dispatch({
+      type: "SET_PERSISTENT",
+      payload: { mods: { skyrimse: { m1: { installationPath: "m1" } } } },
+    });
+
+    // the 100ms debounce has not elapsed, so nothing has been sent yet
+    expect(sendDiff).not.toHaveBeenCalled();
+
+    flushPendingDiffsSync();
+
+    expect(sendDiffSync).toHaveBeenCalledTimes(1);
+    const [hive, ops] = sendDiffSync.mock.calls[0] as [string, Array<{ path: string[] }>];
+    expect(hive).toBe("persistent");
+    expect(ops.map((o) => o.path.join("."))).toContain("mods.skyrimse.m1.installationPath");
+
+    // the async debounced path must not also fire (writes already flushed + cleared)
+    vi.runAllTimers();
+    expect(sendDiff).not.toHaveBeenCalled();
+  });
+
+  it("falls back to sendDiff when sendDiffSync is unavailable", () => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn();
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff }));
+    const store = createStore(reducer, applyMiddleware(mw));
+
+    store.dispatch({ type: "INIT" });
+    store.dispatch({
+      type: "SET_PERSISTENT",
+      payload: { mods: { g: { m2: { installationPath: "m2" } } } },
+    });
+
+    flushPendingDiffsSync();
+
+    expect(sendDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when there are no pending diffs", () => {
+    const sendDiff = vi.fn();
+    const sendDiffSync = vi.fn();
+    createPersistDiffMiddleware(() => ({ sendDiff, sendDiffSync }));
+
+    flushPendingDiffsSync();
+
+    expect(sendDiffSync).not.toHaveBeenCalled();
+    expect(sendDiff).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/store/persistDiffMiddleware.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.ts
@@ -95,7 +95,17 @@ function serializeOperation(op: DiffOperation): DiffOperation {
 
 type PersistApi = {
   sendDiff: (hive: PersistedHive, operations: DiffOperation[]) => void;
+  // Synchronous send used only on quit (beforeunload). It blocks until main has
+  // queued the ops, so the final debounced batch is persisted before the window
+  // tears down. Optional so test overrides can omit it (they fall back to
+  // sendDiff). See GH#23363.
+  sendDiffSync?: (hive: PersistedHive, operations: DiffOperation[]) => void;
 };
+
+// The middleware instance registers its synchronous flush here so the renderer
+// entry can call flushPendingDiffsSync() from a beforeunload handler. The app
+// creates exactly one instance; tests create their own (the most recent wins).
+let activeSyncFlush: (() => void) | undefined;
 
 /**
  * Get the persist API lazily - it may not be available at module load time
@@ -150,6 +160,41 @@ export function createPersistDiffMiddleware(
     pendingDiffs = {};
     flushTimeout = null;
   };
+
+  /**
+   * Flush pending diffs synchronously. Used on quit (beforeunload): an async
+   * send would not complete before the renderer process is torn down, so the
+   * final debounced batch would be lost (the mods-changed-on-disk / split seen
+   * in GH#23363). Uses the synchronous IPC when available; otherwise best-effort
+   * async.
+   */
+  const flushDiffsSync = () => {
+    const persistApi = getApi();
+    if (persistApi == null) {
+      return;
+    }
+    if (flushTimeout != null) {
+      clearTimeout(flushTimeout);
+      flushTimeout = null;
+    }
+    for (const [hive, operations] of Object.entries(pendingDiffs) as [
+      PersistedHive,
+      DiffOperation[],
+    ][]) {
+      if (operations.length > 0) {
+        const serializedOps = operations.map(serializeOperation);
+        if (persistApi.sendDiffSync != null) {
+          persistApi.sendDiffSync(hive, serializedOps);
+        } else {
+          persistApi.sendDiff(hive, serializedOps);
+        }
+      }
+    }
+    pendingDiffs = {};
+  };
+
+  // Expose this instance's synchronous flush for the quit-time beforeunload hook.
+  activeSyncFlush = flushDiffsSync;
 
   /**
    * Schedule a flush of pending diffs
@@ -237,3 +282,14 @@ export function createPersistDiffMiddleware(
  * available when this module was first loaded.
  */
 export const persistDiffMiddleware = createPersistDiffMiddleware();
+
+/**
+ * Synchronously flush any pending (debounced) diffs for the default middleware
+ * instance. Call this from a `beforeunload` handler so the last batch of state
+ * changes is persisted before the renderer process is torn down on quit -
+ * otherwise those writes are lost and the affected mods reload missing fields
+ * (GH#23363). No-op if the middleware/persist API isn't ready.
+ */
+export function flushPendingDiffsSync(): void {
+  activeSyncFlush?.();
+}

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -839,6 +839,18 @@ export interface IExtensionApi {
   NAMESPACE: string;
 }
 
+// Context passed to a verifier's `repair` function, letting it recover a value
+// from the surrounding record's identity rather than only from the broken value.
+export interface IVerifierRepairContext {
+  // key under which the verified object lives in its parent (e.g. a modId for a
+  // mod record), even when the record's own id leaf was lost
+  parentKey?: string;
+  // the object that contains the element being repaired
+  parent?: unknown;
+  // the key of the element being repaired
+  key: string;
+}
+
 export interface IStateVerifier {
   // Human readable description of the problem, emitted if this verifier detects a problem
   description: (input: any) => string;
@@ -857,8 +869,11 @@ export interface IStateVerifier {
   // if set, delete this element or an ancestor element if this one doesn't
   // match the verifier.
   deleteBroken?: boolean | "parent";
-  // if set, this function is called to generate the "repaired" value
-  repair?: (input: any, def: any) => any;
+  // if set, this function is called to generate the "repaired" value. The
+  // optional `context` carries the surrounding record's key/parent so a repair
+  // can recover from identity (e.g. a mod recovering installationPath from its
+  // modId) - see mod_management/reducers/mods.ts.
+  repair?: (input: any, def: any, context?: IVerifierRepairContext) => any;
 }
 
 /**

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -355,6 +355,13 @@ export interface PersistApi {
   sendDiff(hive: PersistedHive, operations: DiffOperation[]): void;
 
   /**
+   * Synchronously send diff operations to main, blocking until they are queued.
+   * Used only on quit (from a beforeunload handler) so the final debounced batch
+   * is persisted before the renderer process is torn down (GH#23363).
+   */
+  sendDiffSync(hive: PersistedHive, operations: DiffOperation[]): void;
+
+  /**
    * Get all hydration data from main process at startup.
    * Returns persisted state for all hives.
    */


### PR DESCRIPTION
Two faults combined: state diffs still in the renderer's 100ms debounce at quit were never written (window-all-closed tears down persistence after the renderer is gone), and on relaunch a mod missing installationPath was discarded whole, re-appearing as a metadata-less duplicate.

Flush pending diffs synchronously from a beforeunload handler over a new persist:diff-sync channel so the final batch lands before teardown, and self-heal installationPath from the modId instead of culling the record.

closes app-500
closes #23363
part of #23355