### PR TITLE
fixed state backup restore potentially wiping state on large profiles

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -34,6 +34,7 @@ import { log, setupLogging, changeLogPath } from "./logging";
 import MainWindow from "./MainWindow";
 import SplashScreen from "./SplashScreen";
 import DuckDBSingleton from "./store/DuckDBSingleton";
+import { flattenState } from "./store/flattenState";
 import LevelPersist, { DatabaseLocked, DatabaseOpenError } from "./store/LevelPersist";
 import {
   initMainPersistence,
@@ -731,9 +732,17 @@ class Application {
       throw new DataInvalid(`The state backup file is invalid: ${getErrorMessageOrDefault(err)}`);
     }
 
+    // Keep DuckDB positional-parameter counts bounded: a bulk set row uses 2
+    // params (key + value) and a bulk remove row uses 1, so 256 rows stays well
+    // under any limit. Matches ReduxPersistorIPC.BULK_CHUNK_SIZE. Restoring a
+    // large profile one key at a time took ~40 minutes and, if it crashed
+    // partway, left state half-cleared (see GH#23355) - bulk ops keep the
+    // destructive window small.
+    const CHUNK_SIZE = 256;
+
     // Wrap all operations in a single transaction so the import is atomic;
     // a partial backup restore on failure would leave state in a confusing
-    // mixed-version condition.
+    // mixed-version (and, with replace, half-cleared) condition.
     await persistor.beginTransaction();
     try {
       for (const [hive, hiveData] of Object.entries(backupData)) {
@@ -741,14 +750,30 @@ class Application {
 
         if (replace) {
           const existingKeys = await sub.getAllKeys();
-          for (const key of existingKeys) {
-            await sub.removeItem(key);
+          if (sub.bulkRemoveItem !== undefined) {
+            for (let i = 0; i < existingKeys.length; i += CHUNK_SIZE) {
+              await sub.bulkRemoveItem(existingKeys.slice(i, i + CHUNK_SIZE));
+            }
+          } else {
+            for (const key of existingKeys) {
+              await sub.removeItem(key);
+            }
           }
         }
 
-        const leaves = this.flattenState(hiveData, []);
-        for (const { key, value } of leaves) {
-          await sub.setItem(key, JSON.stringify(value));
+        const leaves = flattenState(hiveData);
+        if (sub.bulkSetItem !== undefined) {
+          for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
+            await sub.bulkSetItem(
+              leaves
+                .slice(i, i + CHUNK_SIZE)
+                .map((leaf) => ({ key: leaf.key, value: JSON.stringify(leaf.value) })),
+            );
+          }
+        } else {
+          for (const { key, value } of leaves) {
+            await sub.setItem(key, JSON.stringify(value));
+          }
         }
       }
       await persistor.commitTransaction();
@@ -758,22 +783,6 @@ class Application {
     }
 
     log("info", "state backup imported");
-  }
-
-  private flattenState(obj: unknown, prefix: string[]): Array<{ key: string[]; value: unknown }> {
-    if (obj === null || obj === undefined || typeof obj !== "object") {
-      return [{ key: prefix, value: obj }];
-    }
-
-    if (Array.isArray(obj)) {
-      return [{ key: prefix, value: obj }];
-    }
-
-    const result: Array<{ key: string[]; value: unknown }> = [];
-    for (const [key, value] of Object.entries(obj)) {
-      result.push(...this.flattenState(value, [...prefix, key]));
-    }
-    return result;
   }
 
   private createTray(): void {

--- a/src/main/src/store/flattenState.test.ts
+++ b/src/main/src/store/flattenState.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { flattenState } from "./flattenState";
+
+describe("flattenState", () => {
+  it("returns a single leaf for primitives", () => {
+    expect(flattenState(42, ["a"])).toEqual([{ key: ["a"], value: 42 }]);
+    expect(flattenState("x", ["a"])).toEqual([{ key: ["a"], value: "x" }]);
+    expect(flattenState(true, [])).toEqual([{ key: [], value: true }]);
+  });
+
+  it("treats null/undefined and arrays as whole leaf values", () => {
+    expect(flattenState(null, ["a"])).toEqual([{ key: ["a"], value: null }]);
+    expect(flattenState(undefined, ["a"])).toEqual([{ key: ["a"], value: undefined }]);
+    // arrays are stored whole, not recursed into
+    expect(flattenState({ rules: [1, 2, 3] })).toEqual([{ key: ["rules"], value: [1, 2, 3] }]);
+  });
+
+  it("flattens nested objects to one leaf per path", () => {
+    const leaves = flattenState({
+      mods: { skyrimse: { mod1: { installationPath: "p", attributes: { name: "n" } } } },
+    });
+    expect(leaves).toContainEqual({
+      key: ["mods", "skyrimse", "mod1", "installationPath"],
+      value: "p",
+    });
+    expect(leaves).toContainEqual({
+      key: ["mods", "skyrimse", "mod1", "attributes", "name"],
+      value: "n",
+    });
+    expect(leaves).toHaveLength(2);
+  });
+
+  it("does not overflow on a very wide state (GH#23355 regression)", () => {
+    // The previous implementation used `result.push(...flattenState(...))`;
+    // spreading a large array into push throws "Maximum call stack size
+    // exceeded" at ~250k elements. 300k stays safely past that threshold.
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 300000; i++) {
+      wide["k" + i] = i;
+    }
+    const leaves = flattenState({ persistent: { downloads: wide } });
+    expect(leaves).toHaveLength(300000);
+    expect(leaves[0].key.slice(0, 2)).toEqual(["persistent", "downloads"]);
+  });
+});

--- a/src/main/src/store/flattenState.ts
+++ b/src/main/src/store/flattenState.ts
@@ -1,0 +1,37 @@
+export interface StateLeaf {
+  key: string[];
+  value: unknown;
+}
+
+/**
+ * Flatten a nested state object into one leaf entry per primitive/array value,
+ * keyed by its path. Used to write a state backup into the leaf-per-row
+ * persistor (see Application.importBackup).
+ *
+ * Recurses into plain objects only; null, undefined, primitives and arrays are
+ * leaf values (arrays are stored whole). Appends to a shared `result`
+ * accumulator rather than `result.push(...flattenState(...))` - spreading a
+ * large array into push throws "Maximum call stack size exceeded" once it
+ * passes a few hundred thousand elements, which a large profile's persistent
+ * hive easily reaches. See GH#23355.
+ */
+export function flattenState(
+  obj: unknown,
+  prefix: string[] = [],
+  result: StateLeaf[] = [],
+): StateLeaf[] {
+  if (obj === null || obj === undefined || typeof obj !== "object") {
+    result.push({ key: prefix, value: obj });
+    return result;
+  }
+
+  if (Array.isArray(obj)) {
+    result.push({ key: prefix, value: obj });
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(obj)) {
+    flattenState(value, [...prefix, key], result);
+  }
+  return result;
+}


### PR DESCRIPTION
restoring a large profile deleted every key one at a time (~40 min) and flattened the backup with a routine that overflowed the stack via push(...), crashing partway and leaving state half-cleared (#23355).

Use chunked bulk set/remove (256 rows) and a flattenState helper that appends to a shared accumulator instead of spreading into push.

closes app-501
closes #23355