### PR TITLE
E2E tracing and stubbed asset loading

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -16,7 +16,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @nexusmods/adaptor-api | link:../../packages/adaptor-api |
 | @nexusmods/fomod-installer-ipc | 0.13.1 |
 | @nexusmods/fomod-installer-native | 0.13.2 |
-| @nexusmods/nexus-api | 1.6.2 |
+| @nexusmods/nexus-api | 1.7.0 |
 | @opentelemetry/api | 1.9.1 |
 | @opentelemetry/context-async-hooks | 2.6.1 |
 | @opentelemetry/context-zone | 2.7.1 |

--- a/packages/e2e/E2E-BEST-PRACTICES.md
+++ b/packages/e2e/E2E-BEST-PRACTICES.md
@@ -350,22 +350,6 @@ Current `Timeouts` / `GlobalTimeouts` values are starting points, not measured. 
 
 ---
 
-## Diagnostics
-
-Don't sprinkle `vortexWindow.screenshot(...)` calls in tests. Playwright config already captures:
-
-- **Screenshots** on failure
-- **Traces** on first retry
-- **Video** on first retry
-
-View results:
-
-```bash
-pnpm e2e:report
-```
-
----
-
 ## Pre-Commit Checklist
 
 Do not add code comments unless ABSOLUTELY needed for explaining vague code. If you want to add a comment, try to rewrite the code to be understandable without one.
@@ -390,3 +374,14 @@ pnpm -F @vortex/e2e exec playwright test <your-spec> --workers=1
 If `format:check` reports any file, run `pnpm exec oxfmt <that-file>` and amend the commit. Don't push and rely on CI to tell you — it's a slow feedback loop.
 
 The repo formats with **oxfmt**, not prettier. There is no `.prettierrc`. oxfmt's default is double-quoted strings; some older files in this package still have single quotes from before the formatter switch — when you edit one of those files, oxfmt will convert it. Don't fight it.
+
+---
+
+## Reports and Traces
+
+CI uploads reports with traces enabled as encrypted artifacts.
+
+- Show reports: `pnpm exec playwright show-report`
+- Show traces: `pnpm exec playwright show-trace <path to zip file>`
+
+Note that "regular" playwright traces don't work with our electron setup. We manually enable tracing and manually create trace outputs. Those outputs will be attached to the playwright test as `page-trace.zip` files. Use those to view the trace snapshots. Screenshots are only included if `VORTEX_E2E_HEADED=1`.

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,13 +5,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "e2e": "pnpm playwright test",
-    "e2e:headed": "pnpm playwright test --headed",
-    "e2e:debug": "pnpm playwright test --debug",
-    "e2e:report": "pnpm playwright show-report",
-    "typecheck": "pnpm tsc",
-    "lint": "pnpm eslint --quiet --concurrency auto .",
-    "lint:verbose": "pnpm eslint --concurrency auto ."
+    "e2e": "pnpm exec playwright test",
+    "e2e:headed": "pnpm exec cross-env VORTEX_E2E_HEADED=1 pnpm exec playwright test",
+    "e2e:ui": "pnpm exec cross-env VORTEX_E2E_HEADED=1 pnpm exec playwright test --ui",
+    "e2e:report": "pnpm exec playwright show-report",
+    "typecheck": "pnpm exec tsc",
+    "lint": "pnpm exec eslint --quiet --concurrency auto .",
+    "lint:verbose": "pnpm exec eslint --concurrency auto ."
   },
   "nx": {
     "targets": {

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -33,9 +33,6 @@ export default defineConfig({
     navigationTimeout: GlobalTimeouts.NAVIGATION,
     screenshot: "off",
     video: "off",
-    trace: {
-      mode: "retain-on-failure",
-      snapshots: true,
-    },
+    trace: "off",
   },
 });

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -32,7 +32,10 @@ export default defineConfig({
     actionTimeout: GlobalTimeouts.ACTION,
     navigationTimeout: GlobalTimeouts.NAVIGATION,
     screenshot: "off",
-    trace: "on-first-retry",
-    video: "on-first-retry",
+    video: "off",
+    trace: {
+      mode: "retain-on-failure",
+      snapshots: true,
+    },
   },
 });

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -80,7 +80,7 @@ function buildElectronEnv(userDataDir: string): Record<string, string> {
   // Always set — disables single-instance lock so parallel workers can run
   env.VORTEX_E2E = "1";
   // Hide windows unless debugging with PWDEBUG
-  if (!process.env.PWDEBUG) {
+  if (!process.env.PWDEBUG && !process.env.VORTEX_E2E_HEADED) {
     env.VORTEX_E2E_HEADLESS = "1";
   }
   return env;
@@ -402,7 +402,18 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
   vortexWindow: async ({ vortexApp, vortexUserDataDir }, use, testInfo) => {
     const mainWindow = await setupMainWindow(vortexApp, Timeouts.LIFECYCLE);
 
+    await mainWindow
+      .context()
+      .tracing.start({
+        snapshots: true,
+        screenshots: !!process.env.VORTEX_E2E_HEADED,
+        sources: true,
+      });
     await use(mainWindow);
+
+    const tracePath = testInfo.outputPath("page-trace.zip");
+    await mainWindow.context().tracing.stop({ path: tracePath });
+    await testInfo.attach("page-trace.zip", { path: tracePath, contentType: "application/zip" });
 
     if (testInfo.status !== testInfo.expectedStatus) {
       const logPath = path.join(vortexUserDataDir, "userData", "vortex.log");

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -13,6 +13,7 @@ import {
 
 import { cleanupFakeGame } from "../fixtures/game-setup/fake-game";
 import { manageGame, type ManagedGame } from "../helpers/games";
+import { stubRemoteImages } from "../helpers/imageStub";
 import { loginToNexus } from "../helpers/login";
 import { Timeouts } from "../helpers/timeouts";
 import type { NexusUser } from "../helpers/users";
@@ -186,6 +187,10 @@ async function setupMainWindow(app: ElectronApplication, timeoutMs: number): Pro
   await mainWindow.route(/youtube(-nocookie)?\.com|youtu\.be/, (route) =>
     route.fulfill({ status: 204, body: "" }),
   );
+
+  // Serve a single cached empty image instead of fetching mod thumbnails and
+  // other remote images from the server (e.g. staticdelivery.nexusmods.com).
+  await stubRemoteImages(mainWindow);
 
   await mainWindow.waitForLoadState("domcontentloaded");
   await showWindowPromise;
@@ -402,13 +407,11 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
   vortexWindow: async ({ vortexApp, vortexUserDataDir }, use, testInfo) => {
     const mainWindow = await setupMainWindow(vortexApp, Timeouts.LIFECYCLE);
 
-    await mainWindow
-      .context()
-      .tracing.start({
-        snapshots: true,
-        screenshots: !!process.env.VORTEX_E2E_HEADED,
-        sources: true,
-      });
+    await mainWindow.context().tracing.start({
+      snapshots: true,
+      screenshots: !!process.env.VORTEX_E2E_HEADED,
+      sources: true,
+    });
     await use(mainWindow);
 
     const tracePath = testInfo.outputPath("page-trace.zip");

--- a/packages/e2e/src/helpers/imageStub.ts
+++ b/packages/e2e/src/helpers/imageStub.ts
@@ -1,0 +1,43 @@
+import type { BrowserContext, Page, Route } from "@playwright/test";
+
+/**
+ * A single 1x1 transparent PNG, decoded once and reused for every intercepted
+ * image request. Avoids hitting the network for mod thumbnails and similar
+ * assets (e.g. https://staticdelivery.nexusmods.com/mods/.../images/...) which
+ * are irrelevant to the tests, slow, and a source of flakiness.
+ */
+const EMPTY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+/** Hosts whose images should be stubbed with the cached empty PNG. */
+const IMAGE_HOST_PATTERN = /staticdelivery\.nexusmods\.com|\.nexusmods\.com\/.*\/images\//;
+
+function fulfillEmptyImage(route: Route): Promise<void> {
+  return route.fulfill({
+    status: 200,
+    contentType: "image/png",
+    body: EMPTY_PNG,
+  });
+}
+
+/**
+ * Intercept remote image requests on a page or browser context and serve a
+ * single cached empty PNG instead of fetching from the server. Matches both
+ * by image resource type and by known Nexus static-delivery hosts so direct
+ * <img src> loads are covered too.
+ */
+export async function stubRemoteImages(target: Page | BrowserContext): Promise<void> {
+  await target.route(
+    (url) => IMAGE_HOST_PATTERN.test(url.href),
+    (route) => fulfillEmptyImage(route),
+  );
+
+  await target.route("**/*", (route) => {
+    if (route.request().resourceType() === "image") {
+      return fulfillEmptyImage(route);
+    }
+    return route.fallback();
+  });
+}

--- a/packages/e2e/src/helpers/imageStub.ts
+++ b/packages/e2e/src/helpers/imageStub.ts
@@ -18,6 +18,14 @@ function fulfillEmptyImage(route: Route): Promise<void> {
   return route.fulfill({
     status: 200,
     contentType: "image/png",
+    // Strong, immutable cache headers so Chromium serves repeat loads of the
+    // same URL from its HTTP cache. After the first fulfill the route handler
+    // is no longer invoked for that URL, so 1000 <img> of the same src cost a
+    // single interception instead of 1000 round trips through Playwright.
+    headers: {
+      "Cache-Control": "public, max-age=31536000, immutable",
+      ETag: '"vortex-e2e-empty-image"',
+    },
     body: EMPTY_PNG,
   });
 }

--- a/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
@@ -120,7 +120,12 @@ class GameRow extends ComponentEx<IProps, {}> {
         <Media>
           <Media.Left>
             <div className="game-thumbnail-container-list">
-              <img className="game-thumbnail-img-list" src={imgurl} />
+              <img
+                className="game-thumbnail-img-list"
+                src={imgurl}
+                loading="lazy"
+                decoding="async"
+              />
             </div>
           </Media.Left>
 

--- a/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -109,7 +109,7 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
     return (
       <Panel className={classes.join(" ")} bsStyle={active ? "primary" : "default"}>
         <Panel.Body className="game-thumbnail-body">
-          <img className={"thumbnail-img"} src={imgurl} />
+          <img className={"thumbnail-img"} src={imgurl} loading="lazy" decoding="async" />
           <div className="bottom">
             <div className="name">{game.name}</div>
             {modCount !== undefined ? (


### PR DESCRIPTION
- Explicit electron page tracing, playwright tracing doesn't work with our setup
- Lazy load and decode async game thumbnails to reduce network calls
- Stub image network calls to prevent 1000 outgoing connections per test
