### PR TITLE
Fix game and store detection

### DIFF
--- a/packages/e2e/src/fixtures/game-setup/fake-game.ts
+++ b/packages/e2e/src/fixtures/game-setup/fake-game.ts
@@ -16,7 +16,7 @@ export interface GameConfig {
   modFolderPath?: string;
 }
 
-export const GAME_CONFIGS: Record<string, GameConfig> = {
+export const GAME_CONFIGS = {
   stardewvalley: {
     gameId: "stardewvalley",
     gameName: "Stardew Valley",
@@ -34,7 +34,7 @@ export const GAME_CONFIGS: Record<string, GameConfig> = {
       { path: "Content/XACT/FarmerSounds.xwb", content: "FAKE_AUDIO_FILE" },
     ],
     modFolderPath: "Mods",
-  },
+  } satisfies GameConfig,
   skyrimse: {
     gameId: "skyrimse",
     gameName: "Skyrim Special Edition",
@@ -46,8 +46,8 @@ export const GAME_CONFIGS: Record<string, GameConfig> = {
       { path: "Data/Skyrim.esm", content: "TES4\x00\x00\x00\x00" },
     ],
     modFolderPath: "Data",
-  },
-};
+  } satisfies GameConfig,
+} as const;
 
 /** Creates a minimal fake PE executable header that passes file type checks. */
 function createFakeExecutable(): Buffer {
@@ -89,7 +89,10 @@ export function createFakeGameInstallation(gameConfig: GameConfig, basePath: str
 }
 
 /** Creates a temp directory with a fake game installation. Returns both paths for cleanup. */
-export function setupFakeGame(configKey: string): { basePath: string; gamePath: string } {
+export function setupFakeGame(configKey: keyof typeof GAME_CONFIGS): {
+  basePath: string;
+  gamePath: string;
+} {
   const config = GAME_CONFIGS[configKey];
   if (!config) throw new Error(`Unknown game config: ${configKey}`);
 

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -422,10 +422,10 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
   },
 
   managedGame: async (
-    { vortexWindow }: { vortexWindow: Page },
+    { vortexWindow, vortexApp }: { vortexWindow: Page; vortexApp: ElectronApplication },
     use: (game: ManagedGame) => Promise<void>,
   ) => {
-    const game = await manageGame(vortexWindow, "stardewvalley");
+    const game = await manageGame(vortexWindow, vortexApp, "stardewvalley");
     await use(game);
     cleanupFakeGame(game.basePath);
   },

--- a/packages/e2e/src/helpers/games.ts
+++ b/packages/e2e/src/helpers/games.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type ElectronApplication, type Page } from "@playwright/test";
 
 import { setupFakeGame, GAME_CONFIGS } from "../fixtures/game-setup/fake-game";
 import { test } from "../fixtures/vortex-app";
@@ -6,10 +6,8 @@ import { GamesPage } from "../selectors/games";
 import { NavBar } from "../selectors/navbar";
 import { Timeouts } from "./timeouts";
 
-// Only auto-discoverable games are supported today. Skyrim SE goes through
-// Vortex's manual-discovery dialog flow which our fake-game install isn't
-// rich enough to satisfy yet (TODO: add when fake-game produces a real PE
-// header with version info, or expose a stronger Vortex test hook).
+// VORTEX_E2E=1 disables automatic discovery, so all games go through the
+// "Game not discovered" dialog and have their path set via a dialog.showOpenDialog stub.
 export type ManagedGameId = "stardewvalley";
 
 export interface ManagedGame {
@@ -17,9 +15,13 @@ export interface ManagedGame {
   gamePath: string;
 }
 
-export async function manageGame(vortexWindow: Page, gameId: ManagedGameId): Promise<ManagedGame> {
+export async function manageGame(
+  vortexWindow: Page,
+  electronApp: ElectronApplication,
+  gameId: ManagedGameId,
+): Promise<ManagedGame> {
   const fakeGame = setupFakeGame(gameId);
-  const gameName = GAME_CONFIGS[gameId]!.gameName;
+  const gameName = GAME_CONFIGS[gameId].gameName;
 
   await test.step(`Manage game: ${gameId}`, async () => {
     const navbar = new NavBar(vortexWindow);
@@ -28,15 +30,8 @@ export async function manageGame(vortexWindow: Page, gameId: ManagedGameId): Pro
     await expect(navbar.gamesLink).toBeVisible();
     await navbar.gamesLink.click();
 
-    await vortexWindow.evaluate((path) => {
-      const slot = globalThis as {
-        __VORTEX_TEST_GAME_PATH__?: string;
-        global?: { __VORTEX_TEST_GAME_PATH__?: string };
-      };
-      slot.__VORTEX_TEST_GAME_PATH__ = path;
-      if (slot.global !== undefined) {
-        slot.global.__VORTEX_TEST_GAME_PATH__ = path;
-      }
+    await electronApp.evaluate(({ dialog }, gamePath) => {
+      dialog.showOpenDialog = () => Promise.resolve({ canceled: false, filePaths: [gamePath] });
     }, fakeGame.gamePath);
 
     const row = gamesPage.gameRow(gameName);
@@ -47,6 +42,10 @@ export async function manageGame(vortexWindow: Page, gameId: ManagedGameId): Pro
     const manageButton = gamesPage.manageButton(gameName);
     await expect(manageButton).toBeVisible();
     await manageButton.click();
+
+    const continueButton = vortexWindow.getByRole("button", { name: "Continue" });
+    await expect(continueButton).toBeVisible();
+    await continueButton.click();
 
     await expect(navbar.modsLink).toBeVisible({ timeout: Timeouts.NETWORK });
   });

--- a/packages/e2e/src/tests/game-management.spec.ts
+++ b/packages/e2e/src/tests/game-management.spec.ts
@@ -23,7 +23,7 @@ test.describe("Game Management", () => {
   test("fake game installation helper works", async () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
-    const config = GAME_CONFIGS.stardewvalley!;
+    const config = GAME_CONFIGS.stardewvalley;
 
     await test.step("Create fake game installation", () => {
       const { basePath, gamePath } = setupFakeGame("stardewvalley");

--- a/packages/e2e/src/tests/profile.spec.ts
+++ b/packages/e2e/src/tests/profile.spec.ts
@@ -14,7 +14,7 @@ test.describe("Profiles - Add", () => {
     managedGame: _g,
   }) => {
     const profileName = `QA-113 ${Date.now()}`;
-    const gameName = GAME_CONFIGS.stardewvalley!.gameName;
+    const gameName = GAME_CONFIGS.stardewvalley.gameName;
 
     await test.step("Enable Profile Management via global Settings", async () => {
       // Settings only appears in the home spine context, not per-game.

--- a/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
+++ b/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
@@ -69,7 +69,7 @@ class GameModeManager {
     this.mStore = null;
     this.mKnownGames = extensionGames;
     this.mGameStubs = gameStubs;
-    this.mKnownGameStores = [Steam, EpicGamesLauncher, ...gameStoreExtensions];
+    this.mKnownGameStores = [Steam, EpicGamesLauncher, ...gameStoreExtensions].filter(Boolean);
     this.mActiveSearch = null;
     this.mOnGameModeActivated = onGameModeActivated;
   }

--- a/src/renderer/src/extensions/gamemode_management/index.ts
+++ b/src/renderer/src/extensions/gamemode_management/index.ts
@@ -302,21 +302,7 @@ function browseGameLocation(api: IExtensionApi, gameId: string): PromiseBB<void>
   return new PromiseBB<void>((resolve) => {
     const defaultPath = discovery?.path;
 
-    // Check for test path stored in global (for automated testing)
-    const testPath = (global as any).__VORTEX_TEST_GAME_PATH__;
-
-    // If test path is set, use it; otherwise open the dialog
-    const pathPromise =
-      testPath !== undefined
-        ? PromiseBB.resolve(testPath)
-        : api.selectDir(defaultPath !== undefined ? { defaultPath } : {});
-
-    // Clear the global after using it
-    if (testPath !== undefined) {
-      delete (global as any).__VORTEX_TEST_GAME_PATH__;
-    }
-
-    pathPromise.then((result) => {
+    api.selectDir(defaultPath !== undefined ? { defaultPath } : {}).then((result) => {
       if (result !== undefined) {
         findGamePath(game, result, 0, searchDepth(game.requiredFiles || []))
           .then((corrected: string) => manualGameStoreSelection(api, corrected))
@@ -385,7 +371,8 @@ function browseGameLocation(api: IExtensionApi, gameId: string): PromiseBB<void>
             }
             resolve();
           })
-          .catch(() => {
+          .catch((err: unknown) => {
+            log("warn", "browseGameLocation: failed to locate game", { gameId, err: err });
             api.store.dispatch(
               showDialog(
                 "error",
@@ -956,19 +943,34 @@ function init(context: IExtensionContext): boolean {
       const discoveredGames = new Set(
         Object.keys(discovered).filter((gameId) => discovered[gameId].path !== undefined),
       );
-      $.gameModeManager.startQuickDiscovery().then(() =>
-        removeDisappearedGames(
-          context.api,
-          discoveredGames,
-          $.extensionStubs.reduce((prev, stub) => {
-            prev[stub.game.id] = stub.ext;
-            return prev;
-          }, {}),
-        ),
-      );
+      if (process.env.VORTEX_E2E === "1") {
+        log(
+          "debug",
+          "startup quick discovery disabled: VORTEX_E2E=1, tests manage game paths explicitly to ensure deterministic behaviour across machines",
+        );
+      } else {
+        $.gameModeManager.startQuickDiscovery().then(() =>
+          removeDisappearedGames(
+            context.api,
+            discoveredGames,
+            $.extensionStubs.reduce((prev, stub) => {
+              prev[stub.game.id] = stub.ext;
+              return prev;
+            }, {}),
+          ),
+        );
+      }
     }
 
     context.api.onAsync("discover-game", (gameId: string) => {
+      if (process.env.VORTEX_E2E === "1") {
+        log(
+          "debug",
+          "discover-game suppressed: VORTEX_E2E=1, tests manage game paths explicitly to ensure deterministic behaviour across machines",
+          { gameId },
+        );
+        return PromiseBB.resolve();
+      }
       const game = getGame(gameId);
       if (game !== undefined) {
         return $.gameModeManager.startQuickDiscovery([game]);

--- a/src/renderer/src/extensions/gamemode_management/index.ts
+++ b/src/renderer/src/extensions/gamemode_management/index.ts
@@ -305,7 +305,17 @@ function browseGameLocation(api: IExtensionApi, gameId: string): PromiseBB<void>
     api.selectDir(defaultPath !== undefined ? { defaultPath } : {}).then((result) => {
       if (result !== undefined) {
         findGamePath(game, result, 0, searchDepth(game.requiredFiles || []))
-          .then((corrected: string) => manualGameStoreSelection(api, corrected))
+          .then((corrected: string) => {
+            if (process.env.VORTEX_E2E === "1") {
+              log(
+                "debug",
+                "browseGameLocation: skipping store selection (VORTEX_E2E), store detection is irrelevant in test environments",
+                { gameId },
+              );
+              return PromiseBB.resolve({ corrected, store: undefined as string });
+            }
+            return manualGameStoreSelection(api, corrected);
+          })
           .then(({ corrected, store }) => {
             let executable = game.executable(corrected);
             if (executable === game.executable()) {


### PR DESCRIPTION
- Prevent automatic game discovery from messing with tests
- Fix broken game stores on Linux (not test exclusive, this has always been broken on Linux)

Closes LAZ-561.

All game management tests should now run successfully on CI with this PR.