### PR TITLE
[QA-106] assert signed-out state for game-management test

### DIFF
--- a/packages/e2e/src/tests/game-management.spec.ts
+++ b/packages/e2e/src/tests/game-management.spec.ts
@@ -6,6 +6,7 @@ import { setupFakeGame, cleanupFakeGame, GAME_CONFIGS } from "../fixtures/game-s
  */
 import { test, expect } from "../fixtures/vortex-app";
 import { navigateToGames } from "../helpers/navigation";
+import { LoginPage } from "../selectors/loginPage";
 import { NavBar } from "../selectors/navbar";
 
 test.describe("Game Management", () => {
@@ -39,11 +40,18 @@ test.describe("Game Management", () => {
     });
   });
 
-  test("can add Stardew Valley to managed games via manageGame helper", async ({
+  test("[QA-106] can manage a game while not logged in", async ({
     vortexWindow,
     managedGame: _g,
   }) => {
-    const navbar = new NavBar(vortexWindow);
-    await expect(navbar.modsLink).toBeVisible();
+    await test.step("App is signed out", async () => {
+      const loginPage = new LoginPage(vortexWindow);
+      await expect(loginPage.vortexLoginButton).toBeVisible();
+    });
+
+    await test.step("Mods page is reachable for the managed game", async () => {
+      const navbar = new NavBar(vortexWindow);
+      await expect(navbar.modsLink).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## What

Tags the existing game-management test with **QA-106** and adds an explicit
assertion that the app is signed out, so the "manage a game while not logged
in" precondition is verified rather than implied.

## Why

The scenario for QA-106 — a not-logged-in user can manage a game — was already
exercised on master by the `game-management.spec.ts` test that manages Stardew
Valley via the `managedGame` fixture (the "Game Management" describe has no
`test.use({ nexusUser })`, so it runs unauthenticated). But that test:

- wasn't tagged with the ticket, and
- never asserted the signed-out precondition — the unauthenticated state was
  implicit (just the absence of a login fixture), not verified.

Rather than add a second spec (which would duplicate the existing test), this
strengthens the existing one in place.

## Change

- Renamed/tagged the test `[QA-106] can manage a game while not logged in`.
- Added a `test.step` asserting the **Log in** button is visible (signed-out
  state) alongside the existing Mods-link assertion.
- Kept the `managedGame` fixture (auto setup/cleanup) per the e2e best-practices.
