### PR TITLE
persist skip/ignored decisions as part of the new tracking mechanism

### DIFF
--- a/src/renderer/src/extensions/collections/actions/installTracking.ts
+++ b/src/renderer/src/extensions/collections/actions/installTracking.ts
@@ -7,7 +7,7 @@ export const startInstallSession = createAction(
   (
     sessionInfo: Omit<
       types.ICollectionInstallSession,
-      "downloadedCount" | "installedCount" | "failedCount" | "skippedCount"
+      "downloadedCount" | "installedCount" | "failedCount" | "ignoredCount"
     >,
   ) => sessionInfo,
 );

--- a/src/renderer/src/extensions/collections/installSession/selectors.ts
+++ b/src/renderer/src/extensions/collections/installSession/selectors.ts
@@ -274,7 +274,7 @@ export const getCollectionInstallProgress = createSelector(
     downloadedCount: number;
     installedCount: number;
     failedCount: number;
-    skippedCount: number;
+    ignoredCount: number;
     downloadProgress: number; // Percentage (0-100)
     installProgress: number; // Percentage (0-100)
     isComplete: boolean;
@@ -290,7 +290,7 @@ export const getCollectionInstallProgress = createSelector(
 
     // Compute isComplete and installProgress from individual mod entries
     // filtered by type, because the aggregate counters (installedCount,
-    // failedCount, skippedCount) include BOTH required and optional mods,
+    // failedCount, ignoredCount) include BOTH required and optional mods,
     // but totalRequired only counts 'requires' mods.  When optional mods
     // install before the last required mods the aggregate totals exceed
     // totalRequired, causing a premature isComplete.
@@ -301,7 +301,7 @@ export const getCollectionInstallProgress = createSelector(
       : [];
     const installedRequired = requiredMods.filter((mod) => mod.status === "installed").length;
     const completedRequired = requiredMods.filter(
-      (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "skipped",
+      (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "ignored",
     ).length;
 
     const installProgress =
@@ -315,7 +315,7 @@ export const getCollectionInstallProgress = createSelector(
       downloadedCount: session.downloadedCount,
       installedCount: session.installedCount,
       failedCount: session.failedCount,
-      skippedCount: session.skippedCount,
+      ignoredCount: session.ignoredCount,
       downloadProgress,
       installProgress,
       isComplete,
@@ -437,7 +437,7 @@ export const getCollectionPendingMods = (state: IState): ICollectionModInstallIn
 export const getCollectionCompletedMods = (state: IState): ICollectionModInstallInfo[] => {
   const mods = getCollectionActiveSessionMods(state);
   return Object.values(mods).filter(
-    (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "skipped",
+    (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "ignored",
   );
 };
 
@@ -455,7 +455,7 @@ export const isCollectionPhaseComplete = (state: IState, phase: number): boolean
   }
 
   return requiredPhaseMods.every(
-    (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "skipped",
+    (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "ignored",
   );
 };
 
@@ -513,7 +513,7 @@ export const getCollectionPhaseProgress = createSelector(
       const optional = phaseMods.filter((m) => m.type === "recommends");
       const installed = required.filter((m) => m.status === "installed").length;
       const failed = required.filter((m) => m.status === "failed").length;
-      const skipped = required.filter((m) => m.status === "skipped" || m.rule.ignored).length;
+      const skipped = required.filter((m) => m.status === "ignored" || m.rule.ignored).length;
       const pending = required.filter(
         (m) =>
           m.status === "pending" ||

--- a/src/renderer/src/extensions/collections/installSession/types.ts
+++ b/src/renderer/src/extensions/collections/installSession/types.ts
@@ -10,7 +10,7 @@ export type CollectionModStatus =
   | "installing" // Currently being installed
   | "installed" // Successfully installed
   | "failed" // Installation failed
-  | "skipped" // Skipped by user choice
+  | "ignored" // Excluded by user choice (skipped during install or manually ignored)
   | "optional"; // Optional mod not selected
 
 /**
@@ -54,7 +54,7 @@ export interface ICollectionInstallSession {
   /** Number of mods that failed to install */
   failedCount: number;
   /** Number of optional mods skipped */
-  skippedCount: number;
+  ignoredCount: number;
 }
 
 export interface ICollectionInstallState {

--- a/src/renderer/src/extensions/collections/installSession/util.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/util.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { IModRule } from "../../mod_management/types/IMod";
+import { reconstructModStatus } from "./util";
+
+function makeRule(overrides: Partial<IModRule> = {}): IModRule {
+  return {
+    type: "requires",
+    reference: { tag: "abc" },
+    ...overrides,
+  };
+}
+
+describe("reconstructModStatus", () => {
+  it('rehydrates an ignored rule as the terminal "ignored" status so a skip survives a restart', () => {
+    // The durable `ignored` flag is the only record of a skip once the session is
+    // gone; without this, a skipped required mod would come back as "pending" and
+    // the collection could never reach completion.
+    expect(reconstructModStatus(makeRule({ ignored: true }), false, false)).toBe("ignored");
+  });
+
+  it('"ignored" takes precedence over "installed"', () => {
+    expect(reconstructModStatus(makeRule({ ignored: true }), true, true)).toBe("ignored");
+  });
+
+  it('rehydrates an installed (non-ignored) rule as "installed"', () => {
+    expect(reconstructModStatus(makeRule(), true, false)).toBe("installed");
+  });
+
+  it('rehydrates a downloaded-but-not-installed rule as "downloaded"', () => {
+    expect(reconstructModStatus(makeRule(), false, true)).toBe("downloaded");
+  });
+
+  it('rehydrates an untouched rule as "pending"', () => {
+    expect(reconstructModStatus(makeRule(), false, false)).toBe("pending");
+  });
+
+  it("treats ignored === false the same as absent (not ignored)", () => {
+    expect(reconstructModStatus(makeRule({ ignored: false }), true, false)).toBe("installed");
+  });
+});

--- a/src/renderer/src/extensions/collections/installSession/util.ts
+++ b/src/renderer/src/extensions/collections/installSession/util.ts
@@ -1,4 +1,5 @@
 import type { IModRule } from "../../mod_management/types/IMod";
+import type { CollectionModStatus } from "./types";
 
 export function generateCollectionSessionId(collectionId: string, profileId: string): string {
   if (!profileId || !collectionId) {
@@ -18,4 +19,34 @@ export function modRuleId(input: IModRule): string {
       input.reference.fileExpression ||
       input.reference.description)
   );
+}
+
+/**
+ * Determine the status of a required collection rule when the install session is
+ * (re)built. The session lives in state.session and is NOT persisted, so on a
+ * mid-install restart it is reconstructed from inputs that DO survive: the set of
+ * installed mods, present downloads, and the rule's durable `ignored` flag. The
+ * `ignored` flag is written whenever the user skips a mod (see
+ * InstallDriver.markRuleIgnored), so a skipped required mod rehydrates as the
+ * terminal "ignored" status rather than reverting to "pending" (which would leave
+ * the collection permanently incomplete after a restart).
+ *
+ * `ignored` takes precedence over `installed` to preserve the prior behaviour: a
+ * mod the user chose to skip stays skipped even if a copy happens to be installed.
+ */
+export function reconstructModStatus(
+  rule: IModRule,
+  isInstalled: boolean,
+  isDownloaded: boolean,
+): CollectionModStatus {
+  if (rule.ignored === true) {
+    return "ignored";
+  }
+  if (isInstalled) {
+    return "installed";
+  }
+  if (isDownloaded) {
+    return "downloaded";
+  }
+  return "pending";
 }

--- a/src/renderer/src/extensions/collections/reducers/installTracking.test.ts
+++ b/src/renderer/src/extensions/collections/reducers/installTracking.test.ts
@@ -30,7 +30,7 @@ function makeSession(overrides: Partial<any> = {}): any {
     downloadedCount: 0,
     installedCount: 0,
     failedCount: 0,
-    skippedCount: 0,
+    ignoredCount: 0,
     mods: {},
     ...overrides,
   };
@@ -149,7 +149,7 @@ describe("installTracking reducer", () => {
       expect(result.activeSession.downloadedCount).toBe(0);
     });
 
-    it("increments skippedCount when transitioning to skipped", () => {
+    it("increments ignoredCount when transitioning to ignored", () => {
       const session = makeSession({
         mods: {
           rule1: { status: "pending", type: "recommends", rule: {} },
@@ -160,11 +160,11 @@ describe("installTracking reducer", () => {
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
         ruleId: "rule1",
-        status: "skipped",
+        status: "ignored",
       });
 
-      expect(result.activeSession.skippedCount).toBe(1);
-      // pending → skipped: skipped IS a downloaded status
+      expect(result.activeSession.ignoredCount).toBe(1);
+      // pending → ignored: ignored IS a downloaded status
       expect(result.activeSession.downloadedCount).toBe(1);
     });
 

--- a/src/renderer/src/extensions/collections/reducers/installTracking.ts
+++ b/src/renderer/src/extensions/collections/reducers/installTracking.ts
@@ -1,6 +1,7 @@
 import type * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import { merge, setSafe } from "../../../util/storeHelper";
 import * as actions from "../actions/installTracking";
+import { generateCollectionSessionId } from "../installSession/util";
 
 // Initial state
 const initialState: types.ICollectionInstallState = {
@@ -56,7 +57,7 @@ function adjustCounters(
 const collectionInstallReducer = {
   reducers: {
     [actions.startInstallSession as any]: (state: types.ICollectionInstallState, payload: any) => {
-      const sessionId = util.generateCollectionSessionId(payload.collectionId, payload.profileId);
+      const sessionId = generateCollectionSessionId(payload.collectionId, payload.profileId);
       const mods = payload.mods as { [ruleId: string]: any };
       // Full iteration is fine here — this runs once per session start
       const downloadedCount = Object.values(mods).filter((mod) =>
@@ -72,7 +73,7 @@ const collectionInstallReducer = {
         ignoredCount: 0,
       };
 
-      return util.setSafe(state, ["activeSession"], session);
+      return setSafe(state, ["activeSession"], session);
     },
 
     [actions.updateModStatus as any]: (state: types.ICollectionInstallState, payload: any) => {
@@ -82,11 +83,11 @@ const collectionInstallReducer = {
 
       const oldStatus = state.activeSession.mods?.[payload.ruleId]?.status;
       const modPath = ["activeSession", "mods", payload.ruleId];
-      let newState = util.setSafe(state, [...modPath, "status"], payload.status);
+      let newState = setSafe(state, [...modPath, "status"], payload.status);
 
       // Incremental counter update — O(1) instead of iterating all mods
       const counters = adjustCounters(state.activeSession, oldStatus, payload.status);
-      newState = util.merge(newState, ["activeSession"], counters);
+      newState = merge(newState, ["activeSession"], counters);
 
       return newState;
     },
@@ -98,17 +99,17 @@ const collectionInstallReducer = {
 
       const oldStatus = state.activeSession.mods?.[payload.ruleId]?.status;
 
-      let newState = util.setSafe(
+      let newState = setSafe(
         state,
         ["activeSession", "mods", payload.ruleId, "modId"],
         payload.modId,
       );
-      newState = util.setSafe(
+      newState = setSafe(
         newState,
         ["activeSession", "mods", payload.ruleId, "status"],
         "installed",
       );
-      newState = util.setSafe(
+      newState = setSafe(
         newState,
         ["activeSession", "mods", payload.ruleId, "endTime"],
         Date.now(),
@@ -116,16 +117,8 @@ const collectionInstallReducer = {
 
       // Incremental counter update
       const counters = adjustCounters(state.activeSession, oldStatus, "installed");
-      newState = util.setSafe(
-        newState,
-        ["activeSession", "downloadedCount"],
-        counters.downloadedCount,
-      );
-      newState = util.setSafe(
-        newState,
-        ["activeSession", "installedCount"],
-        counters.installedCount,
-      );
+      newState = setSafe(newState, ["activeSession", "downloadedCount"], counters.downloadedCount);
+      newState = setSafe(newState, ["activeSession", "installedCount"], counters.installedCount);
 
       return newState;
     },
@@ -135,13 +128,9 @@ const collectionInstallReducer = {
         return state;
       }
 
-      let newState = util.setSafe(
-        state,
-        ["sessionHistory", payload.sessionId],
-        state.activeSession,
-      );
-      newState = util.setSafe(newState, ["lastActiveSessionId"], payload.sessionId);
-      newState = util.setSafe(newState, ["activeSession"], undefined);
+      let newState = setSafe(state, ["sessionHistory", payload.sessionId], state.activeSession);
+      newState = setSafe(newState, ["lastActiveSessionId"], payload.sessionId);
+      newState = setSafe(newState, ["activeSession"], undefined);
 
       return newState;
     },

--- a/src/renderer/src/extensions/collections/reducers/installTracking.ts
+++ b/src/renderer/src/extensions/collections/reducers/installTracking.ts
@@ -15,7 +15,7 @@ const DOWNLOADED_STATUSES = new Set([
   "downloading",
   "installed",
   "installing",
-  "skipped",
+  "ignored",
 ]);
 
 /**
@@ -30,9 +30,9 @@ function adjustCounters(
   downloadedCount: number;
   installedCount: number;
   failedCount: number;
-  skippedCount: number;
+  ignoredCount: number;
 } {
-  let { downloadedCount, installedCount, failedCount, skippedCount } = session;
+  let { downloadedCount, installedCount, failedCount, ignoredCount } = session;
 
   // downloadedCount tracks mods in any "active" (non-pending, non-failed) state
   if (!DOWNLOADED_STATUSES.has(oldStatus) && DOWNLOADED_STATUSES.has(newStatus)) downloadedCount++;
@@ -46,11 +46,11 @@ function adjustCounters(
   if (oldStatus !== "failed" && newStatus === "failed") failedCount++;
   if (oldStatus === "failed" && newStatus !== "failed") failedCount--;
 
-  // skippedCount
-  if (oldStatus !== "skipped" && newStatus === "skipped") skippedCount++;
-  if (oldStatus === "skipped" && newStatus !== "skipped") skippedCount--;
+  // ignoredCount
+  if (oldStatus !== "ignored" && newStatus === "ignored") ignoredCount++;
+  if (oldStatus === "ignored" && newStatus !== "ignored") ignoredCount--;
 
-  return { downloadedCount, installedCount, failedCount, skippedCount };
+  return { downloadedCount, installedCount, failedCount, ignoredCount };
 }
 
 const collectionInstallReducer = {
@@ -69,7 +69,7 @@ const collectionInstallReducer = {
         downloadedCount,
         installedCount,
         failedCount: 0,
-        skippedCount: 0,
+        ignoredCount: 0,
       };
 
       return util.setSafe(state, ["activeSession"], session);

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -14,6 +14,7 @@ import * as selectors from "../../../util/selectors";
 import * as installActions from "../actions/installTracking";
 import { setPendingVote } from "../actions/persistent";
 import { INSTALLING_NOTIFICATION_ID, MOD_TYPE } from "../constants";
+import { reconstructModStatus } from "../installSession/util";
 import { postprocessCollection } from "../postprocessCollection";
 import { ICollection } from "../types/ICollection";
 import { IRevisionEx } from "../types/IRevisionEx";
@@ -113,7 +114,7 @@ class InstallDriver {
     const currentStatus = currentSession?.mods?.[ruleId]?.status;
 
     // Don't downgrade from terminal states (installed, skipped, failed)
-    const terminalStates: types.CollectionModStatus[] = ["installed", "skipped", "failed"];
+    const terminalStates: types.CollectionModStatus[] = ["installed", "ignored", "failed"];
     if (currentStatus && terminalStates.includes(currentStatus)) {
       return;
     }
@@ -130,6 +131,25 @@ class InstallDriver {
     const ruleId = util.modRuleId(rule);
     this.mStateUpdates.push(installActions.markModInstalled(this.mCurrentSessionId, ruleId, modId));
     this.mModStatusDebouncer.schedule();
+  }
+
+  /**
+   * Mark a collection rule as ignored. Updates the transient install session and
+   * persists the decision durably via the rule's `ignored` flag. The session lives
+   * in state.session (not persisted), so without the durable flag a mid-install
+   * restart would rehydrate an ignored required mod as "pending" and the collection
+   * could never reach completion. startImpl()'s reconstruction reads `ignored` to
+   * restore the "ignored" status; the unfulfilled-rules and dependency-completion
+   * checks already treat ignored rules as resolved.
+   */
+  private markRuleIgnored(rule: types.IModRule) {
+    this.updateModTracking(rule, "ignored");
+
+    if (this.mGameId !== undefined && this.mCollection !== undefined) {
+      this.mApi.store.dispatch(
+        actions.addModRule(this.mGameId, this.mCollection.id, { ...rule, ignored: true }),
+      );
+    }
   }
 
   private completeInstallationTracking(success: boolean) {
@@ -308,7 +328,7 @@ class InstallDriver {
           return util.testRefByIdentifiers({ ...identifiers, condition } as any, r.reference);
         });
         if (rule) {
-          this.updateModTracking(rule, "skipped");
+          this.markRuleIgnored(rule);
         } else {
           log("error", "could not find rule for skipped free user download", {
             identifiers,
@@ -380,13 +400,7 @@ class InstallDriver {
         return false;
       });
       if (matchingRule) {
-        this.updateModTracking(matchingRule, "skipped");
-
-        // Also set the ignored flag on the rule so it's persisted
-        // api.store.dispatch(actions.addModRule(this.mGameId, this.mCollection.id, {
-        //   ...matchingRule,
-        //   ignored: true,
-        // } as any));
+        this.markRuleIgnored(matchingRule);
       }
     });
 
@@ -1056,16 +1070,9 @@ class InstallDriver {
           const download = util.findDownloadByRef(rule.reference, downloads);
           const isBundled = rule.extra?.localPath != null;
           const isInstalled = installedRuleIds.has(ruleId);
-          const isIgnored = rule["ignored"] === true;
           const isDownloaded = download != null || isBundled;
 
-          const status: types.CollectionModStatus = isIgnored
-            ? "skipped"
-            : isInstalled
-              ? "installed"
-              : isDownloaded
-                ? "downloaded"
-                : "pending";
+          const status = reconstructModStatus(rule, isInstalled, isDownloaded);
 
           return [
             ruleId,

--- a/src/renderer/src/extensions/collections/util/postProcessRule.ts
+++ b/src/renderer/src/extensions/collections/util/postProcessRule.ts
@@ -1,4 +1,4 @@
-import * as util from "../../../util/api";
+import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
 import type { ICollectionModRule } from "../types/ICollection";
 
 /**
@@ -15,10 +15,10 @@ export function postProcessRule(rule: ICollectionModRule): ICollectionModRule {
   // because with an md5 hash it's generally the case it will only match one version whereas
   // fileExpression supports matching multiple versions, it's simply that we have no automated
   // way of generating glob patterns that ignore the version and date field in the file names
-  if (util.isFuzzyVersion(result.reference.versionMatch) && !!result.reference.logicalFileName) {
+  if (isFuzzyVersion(result.reference.versionMatch) && !!result.reference.logicalFileName) {
     delete result.reference.fileExpression;
   }
-  if (util.isFuzzyVersion(result.source.versionMatch) && !!result.source.logicalFileName) {
+  if (isFuzzyVersion(result.source.versionMatch) && !!result.source.logicalFileName) {
     delete result.source.fileExpression;
   }
   return result;

--- a/src/renderer/src/extensions/collections/util/selectors.test.ts
+++ b/src/renderer/src/extensions/collections/util/selectors.test.ts
@@ -37,7 +37,7 @@ function makeSession(overrides: Partial<any> = {}): any {
     downloadedCount: 0,
     installedCount: 0,
     failedCount: 0,
-    skippedCount: 0,
+    ignoredCount: 0,
     mods: {},
     ...overrides,
   };
@@ -154,7 +154,7 @@ describe("getOptionalModsProgress", () => {
       mods: {
         r1: { type: "requires", status: "installed", rule: {} },
         o1: { type: "recommends", status: "installed", rule: {} },
-        o2: { type: "recommends", status: "skipped", rule: {} },
+        o2: { type: "recommends", status: "ignored", rule: {} },
       },
     });
     const result = getOptionalModsProgress(makeState(session), "col1");
@@ -162,7 +162,7 @@ describe("getOptionalModsProgress", () => {
     expect(result).toEqual({
       installed: 1,
       total: 2,
-      skipped: 1,
+      ignored: 1,
     });
   });
 });

--- a/src/renderer/src/extensions/collections/util/selectors.ts
+++ b/src/renderer/src/extensions/collections/util/selectors.ts
@@ -3,7 +3,7 @@ import { createSelector } from "reselect";
 import type * as types from "../../../types/api";
 
 const getCollectionInstallState = (state: types.IState): types.ICollectionInstallState =>
-  (state as any).session?.collections || {
+  state.session?.collections || {
     activeSession: undefined,
     lastActiveSessionId: undefined,
     sessionHistory: {},
@@ -54,7 +54,7 @@ export const getRequiredModsProgress = createSelector(
 
 export const getOptionalModsProgress = createSelector(
   [getActiveInstallSession, (_state: types.IState, collectionId: string) => collectionId],
-  (activeSession, collectionId): { installed: number; total: number; skipped: number } | null => {
+  (activeSession, collectionId): { installed: number; total: number; ignored: number } | null => {
     if (!activeSession || activeSession.collectionId !== collectionId) {
       return null;
     }
@@ -63,12 +63,12 @@ export const getOptionalModsProgress = createSelector(
       (mod) => mod.type === "recommends",
     );
     const installed = optionalMods.filter((mod) => mod.status === "installed").length;
-    const skipped = optionalMods.filter((mod) => mod.status === "skipped").length;
+    const ignored = optionalMods.filter((mod) => mod.status === "ignored").length;
 
     return {
       installed,
       total: activeSession.totalOptional,
-      skipped,
+      ignored,
     };
   },
 );

--- a/src/renderer/src/extensions/collections/util/transformCollection.ts
+++ b/src/renderer/src/extensions/collections/util/transformCollection.ts
@@ -5,7 +5,12 @@ import { generate as shortid } from "shortid";
 
 import { log } from "../../../logging";
 import type * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import { coerceToSemver } from "../../mod_management/util/coerceToSemver";
+import { findModByRef } from "../../mod_management/util/findModByRef";
+import renderModName from "../../mod_management/util/modName";
+import { makeModReference } from "../../mod_management/util/modReference";
+import testModReference from "../../mod_management/util/testModReference";
+import { convertGameIdReverse } from "../../nexus_integration/util/convertGameId";
 import { MAX_COLLECTION_NAME_LENGTH, MIN_COLLECTION_NAME_LENGTH, MOD_TYPE } from "../constants";
 import type {
   ICollection,
@@ -60,7 +65,7 @@ export function deduceSource(
 
   if (res.type === "nexus") {
     if (mod.attributes?.source !== "nexus") {
-      throw new Error(`"${util.renderModName(mod)}" doesn't have Nexus as its source`);
+      throw new Error(`"${renderModName(mod)}" doesn't have Nexus as its source`);
     }
     const modId = mod.type === MOD_TYPE ? mod.attributes?.collectionId : mod.attributes?.modId;
     const fileId = mod.type === MOD_TYPE ? mod.attributes?.revisionId : mod.attributes?.fileId;
@@ -152,7 +157,7 @@ export function makeTransferrable(
   rule: types.IModRule,
 ): types.IModRule {
   let newRef: types.IModReference = { ...rule.reference };
-  const mod = util.findModByRef(rule.reference, mods);
+  const mod = findModByRef(rule.reference, mods);
 
   if (
     rule.reference.fileMD5 === undefined &&
@@ -173,13 +178,13 @@ export function makeTransferrable(
       return undefined;
     }
 
-    newRef = util.makeModReference(mod);
+    newRef = makeModReference(mod);
   }
 
   // ok, this gets a bit complex now. If the referenced mod gets updated, also make sure
   // the rules referencing it apply to newer versions
   if (mod !== undefined) {
-    const mpRule = collection.rules.find((iter) => util.testModReference(mod, iter.reference));
+    const mpRule = collection.rules.find((iter) => testModReference(mod, iter.reference));
     if (
       mpRule !== undefined &&
       (mpRule.reference.versionMatch === undefined ||
@@ -213,18 +218,18 @@ export function collectionModToRule(
       }
     : undefined;
 
-  const coerced = util.coerceToSemver(mod.version);
+  const coerced = coerceToSemver(mod.version);
 
   const { updatePolicy } = mod.source;
 
   let versionMatch: string;
   if (updatePolicy === "prefer") {
-    versionMatch = coerced ? `>=${coerced ?? "0.0.0"}+prefer` : util.coerceToSemver(mod.version);
+    versionMatch = coerced ? `>=${coerced ?? "0.0.0"}+prefer` : coerceToSemver(mod.version);
   } else if (updatePolicy === "latest") {
     versionMatch = "*";
   } else {
     // Default to 'exact' for undefined or explicit 'exact' updatePolicy
-    versionMatch = coerced ? coerced : util.coerceToSemver(mod.version);
+    versionMatch = coerced ? coerced : coerceToSemver(mod.version);
   }
 
   // we can't use the md5 hash for a bundled file because they are recompressed
@@ -239,7 +244,7 @@ export function collectionModToRule(
   const reference: types.IModReference = {
     description: mod.name,
     fileMD5: refMD5,
-    gameId: util.convertGameIdReverse(knownGames, mod.domainName),
+    gameId: convertGameIdReverse(knownGames, mod.domainName),
     fileSize: mod.source.fileSize,
     versionMatch,
     logicalFileName: mod.source.logicalFilename,

--- a/src/renderer/src/extensions/mod_management/InstallManager.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.test.ts
@@ -184,7 +184,7 @@ describe("Phased Installer", () => {
       for (const phase of Array.from(allPhases).sort((a, b) => a - b)) {
         const required = allMods.filter((m) => (m.phase ?? 0) === phase && m.type === "requires");
         const completed = required.filter((m) =>
-          ["installed", "failed", "skipped"].includes(m.status),
+          ["installed", "failed", "ignored"].includes(m.status),
         );
         if (completed.length >= required.length && required.length > 0) {
           highest = phase;

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -3024,7 +3024,7 @@ class InstallManager {
     }
 
     return Object.values(session.mods).filter((mod: any) =>
-      ["installed", "failed", "skipped"].includes(mod.status),
+      ["installed", "failed", "ignored"].includes(mod.status),
     ).length;
   }
 


### PR DESCRIPTION
Skips were written only to the non-persisted install session, so a mid-install restart rehydrated a skipped required mod as "pending". Both skip events now go through markRuleIgnored(), which sets the session status and the durable rule "ignored" flag.

Also rename the session status "skipped" -> "ignored" (and skippedCount -> ignoredCount) to match the rule flag, and extract a tested reconstructModStatus().