### PR TITLE
Fix use-codesigning input being ignored for nightly builds

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -85,7 +85,7 @@ runs:
         python-version: "3.11"
 
     - name: Download CodeSignTool
-      if: ${{ inputs.use-codesigning == 'true' || steps.nightly-flag.outputs.is_nightly == 'true' }}
+      if: ${{ inputs.use-codesigning == 'true' }}
       shell: pwsh
       run: .\download-codesigntool.ps1
 
@@ -168,7 +168,7 @@ runs:
       shell: pwsh
       run: |
         $signingAvailable = -not [string]::IsNullOrWhiteSpace($env:ES_USERNAME)
-        $wantSigning = "${{ inputs.use-codesigning }}" -eq "true" -or "${{ steps.nightly-flag.outputs.is_nightly }}" -eq "true"
+        $wantSigning = "${{ inputs.use-codesigning }}" -eq "true"
         if ($wantSigning -and $signingAvailable) {
           pnpm -F @vortex/main run package
         } else {


### PR DESCRIPTION
The `use-codesigning` input in the package action was being OR'd with the nightly flag, meaning `use-codesigning: false` had no effect on nightly builds. Removed the nightly condition so the input is respected as the sole control for codesigning.

Tested with this run https://github.com/Nexus-Mods/Vortex/actions/runs/27339913447 and shows no digital signatures

<img width="461" height="280" alt="image" src="https://github.com/user-attachments/assets/47b32c87-47d7-43a3-854c-edd77c6da08a" />
