### PR TITLE
separate mod identity matching from install-spec matching (483 WIP)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -575,7 +575,7 @@ const collapseGroup: reduxAct.ComplexActionCreator3<string, string, boolean, {
 }, {}>;
 
 // @public
-type CollectionModStatus = "pending" | "downloading" | "downloaded" | "installing" | "installed" | "failed" | "skipped" | "optional";
+type CollectionModStatus = "pending" | "downloading" | "downloaded" | "installing" | "installed" | "failed" | "ignored" | "optional";
 
 // Warning: (ae-forgotten-export) The symbol "MixpanelEvent" needs to be exported by the entry point api.d.ts
 //
@@ -1022,7 +1022,7 @@ function findModByRef(reference: IModReference, mods: {
 }, source?: {
     gameId: string;
     modId: string;
-}): IMod;
+}, installSpec?: IModInstallSpec): IMod;
 
 // @public
 const finishDownload: ComplexActionCreator3<string, "finished" | "failed" | "redirect", any, {
@@ -1271,7 +1271,7 @@ const getCollectionInstallProgress: ((state: IState) => {
     downloadedCount: number;
     installedCount: number;
     failedCount: number;
-    skippedCount: number;
+    ignoredCount: number;
     downloadProgress: number;
     installProgress: number;
     isComplete: boolean;
@@ -1281,7 +1281,7 @@ totalOptional: number;
 downloadedCount: number;
 installedCount: number;
 failedCount: number;
-skippedCount: number;
+ignoredCount: number;
 downloadProgress: number;
 installProgress: number;
 isComplete: boolean;
@@ -1743,19 +1743,25 @@ interface ICheckbox extends IControlBase {
     value: boolean;
 }
 
+// @public (undocumented)
+type IChoiceType = {
+    type: string;
+    options: IChoices;
+};
+
 // @public
 interface ICollectionInstallSession {
     collectionId: string;
     downloadedCount: number;
     failedCount: number;
     gameId: string;
+    ignoredCount: number;
     installedCount: number;
     mods: {
         [ruleId: string]: ICollectionModInstallInfo;
     };
     profileId: string;
     sessionId: string;
-    skippedCount: number;
     totalOptional: number;
     totalRequired: number;
 }
@@ -2403,6 +2409,16 @@ interface IFileFilter {
     name: string;
 }
 
+// @public
+interface IFileListItem {
+    // (undocumented)
+    md5?: string;
+    // (undocumented)
+    path: string;
+    // (undocumented)
+    xxh64?: string;
+}
+
 // @public (undocumented)
 interface IFilterProps {
     // (undocumented)
@@ -3001,6 +3017,16 @@ interface IModifiers {
 }
 
 // @public (undocumented)
+interface IModInstallSpec {
+    // (undocumented)
+    fileList?: IFileListItem[];
+    // (undocumented)
+    installerChoices?: IChoiceType;
+    // (undocumented)
+    patches?: IModPatches;
+}
+
+// @public (undocumented)
 interface IModLookupInfo {
     // (undocumented)
     additionalLogicalFileNames?: string[];
@@ -3008,8 +3034,6 @@ interface IModLookupInfo {
     customFileName?: string;
     // (undocumented)
     fileId?: string;
-    // Warning: (ae-forgotten-export) The symbol "IFileListItem" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     fileList?: IFileListItem[];
     // (undocumented)
@@ -3023,7 +3047,7 @@ interface IModLookupInfo {
     // (undocumented)
     id?: string;
     // (undocumented)
-    installerChoices?: any;
+    installerChoices?: IChoiceType;
     // (undocumented)
     logicalFileName?: string;
     // (undocumented)
@@ -3031,13 +3055,19 @@ interface IModLookupInfo {
     // (undocumented)
     name?: string;
     // (undocumented)
-    patches?: any;
+    patches?: IModPatches;
     // (undocumented)
     referenceTag?: string;
     // (undocumented)
     source?: string;
     // (undocumented)
     version: string;
+}
+
+// @public
+interface IModPatches {
+    // (undocumented)
+    [filePath: string]: string;
 }
 
 // @public (undocumented)
@@ -3047,19 +3077,13 @@ interface IModReference extends IReference {
     // (undocumented)
     description?: string;
     // (undocumented)
-    fileList?: IFileListItem[];
-    // (undocumented)
     id?: string;
     // (undocumented)
     idHint?: string;
     // (undocumented)
-    installerChoices?: any;
-    // (undocumented)
     instructions?: string;
     // (undocumented)
     md5Hint?: string;
-    // (undocumented)
-    patches?: any;
     // (undocumented)
     repo?: {
         repository: string;
@@ -3094,7 +3118,9 @@ interface IModRule extends IRule {
     // (undocumented)
     ignored?: boolean;
     // (undocumented)
-    installerChoices?: any;
+    installerChoices?: IChoiceType;
+    // (undocumented)
+    patches?: IModPatches;
     // (undocumented)
     reference: IModReference;
 }
@@ -3206,7 +3232,7 @@ type InstallerMatchMode = "any" | "all";
 type InstallerSpecInstallFunc = (files: string[], destinationPath: string) => Promise<IInstallResult>;
 
 // @public (undocumented)
-type InstallFunc = (files: string[], destinationPath: string, gameId: string, progressDelegate: ProgressDelegate, choices?: any, unattended?: boolean, archivePath?: string, options?: IInstallationDetails) => PromiseLike<IInstallResult>;
+type InstallFunc = (files: string[], destinationPath: string, gameId: string, progressDelegate: ProgressDelegate, choices?: IChoiceType, unattended?: boolean, archivePath?: string, options?: IInstallationDetails) => PromiseLike<IInstallResult>;
 
 // @public
 const installIconSet: (set: string, setPath: string) => Promise<Set<string>>;
@@ -5013,6 +5039,9 @@ type Revertability = "yes" | "never" | "invalid";
 // @public (undocumented)
 function rmdirAsync(dirPath: string): Promise_2<void>;
 
+// @public
+function ruleInstallSpec(rule: IModRule): IModInstallSpec;
+
 // Warning: (ae-forgotten-export) The symbol "IElevatedIpc" needs to be exported by the entry point api.d.ts
 //
 // @public
@@ -6060,7 +6089,11 @@ declare namespace types {
         IGameStored,
         IDeploymentManifest,
         IModLookupInfo,
+        IModInstallSpec,
+        IChoiceType,
+        IFileListItem,
         IMod,
+        IModPatches,
         IModReference,
         IModRepoId,
         IModRule,
@@ -6407,6 +6440,7 @@ declare namespace util {
         renderModReference,
         resolveCategoryName,
         resolveCategoryPath,
+        ruleInstallSpec,
         runElevated,
         runThreaded,
         sanitizeCSSId,
@@ -6575,6 +6609,7 @@ export class ZoomableImage extends React_2.Component<IZoomableImageProps, {
 
 // Warnings were encountered during analysis:
 //
+// lib/extensions/installer_fomod_shared/types/interface.d.ts:76:5 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
 // lib/extensions/mod_management/selectors.d.ts:59:5 - (ae-forgotten-export) The symbol "INeedToDeployMap" needs to be exported by the entry point api.d.ts
 // lib/types/IDialog.d.ts:84:9 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
 // lib/types/IState.d.ts:161:9 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts

--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -12,11 +12,31 @@ import type * as Redux from "redux";
 import { generate as shortid } from "shortid";
 
 import * as actions from "../../actions";
-import { OptionsFilter } from "../../controls/api";
+import { installIconSet } from "../../controls/Icon";
+import OptionsFilter from "../../controls/table/OptionsFilter";
 import { log } from "../../logging";
-import type * as types from "../../types/api";
-import * as util from "../../util/api";
+import type { IDialogResult } from "../../types/IDialog";
+import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionContext";
+import type { INotification } from "../../types/INotification";
+import type { IState } from "../../types/IState";
+import type { ITableAttribute } from "../../types/ITableAttribute";
+import { ProcessCanceled, UserCanceled } from "../../util/CustomErrors";
+import Debouncer from "../../util/Debouncer";
+import getVortexPath from "../../util/getVortexPath";
+import type { TFunction } from "../../util/i18n";
+import makeReactive from "../../util/makeReactive";
 import * as selectors from "../../util/selectors";
+import { getSafe } from "../../util/storeHelper";
+import { batchDispatch, setdefault, toPromise } from "../../util/util";
+import type { IDownload } from "../download_management/types/IDownload";
+import { getGame } from "../gamemode_management/util/getGame";
+import type { IMod, IModRule } from "../mod_management/types/IMod";
+import { findDownloadByRef } from "../mod_management/util/dependencies";
+import { findModByRef } from "../mod_management/util/findModByRef";
+import renderModName from "../mod_management/util/modName";
+import testModReference from "../mod_management/util/testModReference";
+import { convertGameIdReverse } from "../nexus_integration/util/convertGameId";
+import type { IProfile } from "../profile_management/types/IProfile";
 /* eslint-disable */
 import { clearPendingVote, updateSuccessRate } from "./actions/persistent";
 import {
@@ -70,23 +90,23 @@ import {
 export const nxmCollection =
   "M11.7229 15.369L6.21146 11.084L5 12.0262L11.7304 17.261L18.4607 12.0262L17.2418 11.0765L11.7229 15.369ZM11.7229 19.1079L6.21146 14.823L5 15.7652L11.7304 20.9999L18.4607 15.7652L17.2418 14.8155L11.7229 19.1079ZM11.7304 13.4694L17.2343 9.18445L18.4607 8.23472L11.7304 3L5 8.23472L6.21894 9.18445L11.7304 13.4694Z";
 
-function isEditableCollection(state: types.IState, modIds: string[]): boolean {
+function isEditableCollection(state: IState, modIds: string[]): boolean {
   const gameMode = selectors.activeGameId(state);
   const mod = state.persistent.mods[gameMode][modIds[0]];
   if (mod === undefined) {
     return false;
   }
-  return util.getSafe(mod.attributes, ["editable"], false);
+  return getSafe(mod.attributes, ["editable"], false);
 }
 
-function profileCollectionExists(api: types.IExtensionApi, profileId: string) {
+function profileCollectionExists(api: IExtensionApi, profileId: string) {
   const state = api.store.getState();
   const gameMode = selectors.activeGameId(state);
   const mods = state.persistent.mods[gameMode];
   return mods[makeCollectionId(profileId)] !== undefined;
 }
 
-function onlyLocalRules(rule: types.IModRule) {
+function onlyLocalRules(rule: IModRule) {
   return (
     ["requires", "recommends"].includes(rule.type) &&
     rule.reference.fileExpression === undefined &&
@@ -102,7 +122,7 @@ function makeModKey(gameId: string, modId: string): string {
   return `${gameId}_${modId}`;
 }
 
-function makeWillRemoveMods(api: types.IExtensionApi) {
+function makeWillRemoveMods(api: IExtensionApi) {
   return (gameId: string, modIds: string[]) => {
     const state = api.getState();
     const mods = state.persistent.mods[gameId];
@@ -120,11 +140,11 @@ function makeDidRemoveMods() {
   };
 }
 
-function makeOnUnfulfilledRules(api: types.IExtensionApi) {
+function makeOnUnfulfilledRules(api: IExtensionApi) {
   const reported = new Set<string>();
 
-  return (profileId: string, modId: string, rules: types.IModRule[]): Bluebird<boolean> => {
-    const state: types.IState = api.store.getState();
+  return (profileId: string, modId: string, rules: IModRule[]): Bluebird<boolean> => {
+    const state: IState = api.store.getState();
 
     const profile = selectors.profileById(state, profileId);
     const gameId = profile.gameId;
@@ -136,7 +156,7 @@ function makeOnUnfulfilledRules(api: types.IExtensionApi) {
       return Bluebird.resolve(false);
     }
 
-    const collection: types.IMod = util.getSafe(state.persistent.mods, [gameId, modId], undefined);
+    const collection: IMod = getSafe(state.persistent.mods, [gameId, modId], undefined);
 
     if (
       collection !== undefined &&
@@ -190,7 +210,7 @@ function makeOnUnfulfilledRules(api: types.IExtensionApi) {
         id: getUnfulfilledNotificationId(collection.id),
         type: "info",
         title: "Collection incomplete",
-        message: util.renderModName(collection),
+        message: renderModName(collection),
         actions: notiActions,
       });
       return Bluebird.resolve(true);
@@ -202,15 +222,12 @@ function makeOnUnfulfilledRules(api: types.IExtensionApi) {
 
 let driver: InstallDriver;
 
-async function cloneInstalledCollection(
-  api: types.IExtensionApi,
-  collectionId: string,
-): Promise<string> {
+async function cloneInstalledCollection(api: IExtensionApi, collectionId: string): Promise<string> {
   const state = api.getState();
   const gameMode = selectors.activeGameId(state);
   const mods = state.persistent.mods[gameMode];
 
-  const result: types.IDialogResult = await api.showDialog(
+  const result: IDialogResult = await api.showDialog(
     "question",
     'Clone collection "{{collectionName}}"?',
     {
@@ -221,7 +238,7 @@ async function cloneInstalledCollection(
         "collection, otherwise you will create a new collection associated with your own " +
         "account.",
       parameters: {
-        collectionName: util.renderModName(mods[collectionId]),
+        collectionName: renderModName(mods[collectionId]),
       },
     },
     [{ label: "Cancel" }, { label: "Clone" }],
@@ -236,11 +253,7 @@ async function cloneInstalledCollection(
   }
 }
 
-async function createNewCollection(
-  api: types.IExtensionApi,
-  profile: types.IProfile,
-  name: string,
-) {
+async function createNewCollection(api: IExtensionApi, profile: IProfile, name: string) {
   const id = makeCollectionId(shortid());
   await createCollection(api, profile.gameId, id, name, []);
 
@@ -275,7 +288,7 @@ async function createNewCollection(
   });
 }
 
-async function installCollection(api: types.IExtensionApi, revision: IRevision) {
+async function installCollection(api: IExtensionApi, revision: IRevision) {
   return api
     .showDialog(
       "question",
@@ -316,7 +329,7 @@ async function installCollection(api: types.IExtensionApi, revision: IRevision) 
           },
           undefined,
           (err) => {
-            if (err !== null && !(err instanceof util.UserCanceled)) {
+            if (err !== null && !(err instanceof UserCanceled)) {
               api.showErrorNotification("Failed to download collection", unknownToError(err));
             }
           },
@@ -328,7 +341,7 @@ async function installCollection(api: types.IExtensionApi, revision: IRevision) 
 }
 
 async function pauseCollection(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   modId: string,
   silent?: boolean,
@@ -343,14 +356,7 @@ async function pauseCollection(
   }
 
   (collection?.rules ?? []).forEach((rule) => {
-    // findDownloadByRef has been modified to omit these fields as well, BUT, the vortex-api
-    //  types don't reflect that change currently. The API submodule needs a complete cleanup
-    //  before we can update the dependency and given the massive changes we've been making
-    //  to the codebase recently + the imminent 1.16 stable release - updating the API submodule
-    //  is not worth the risk at this moment, so will just omit the fields here as well.
-    // TODO: update the vortex-api types and remove the omit when we update the dependency.
-    const cleanReference = _.omit(rule.reference, ["installerChoices", "fileList", "patches"]);
-    const dlId = util.findDownloadByRef(cleanReference, downloads);
+    const dlId = findDownloadByRef(rule.reference, downloads);
     if (dlId !== undefined) {
       api.events.emit("pause-download", dlId);
     }
@@ -372,7 +378,7 @@ async function pauseCollection(
 }
 
 async function removeCollection(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   modId: string,
   cancel: boolean,
@@ -390,7 +396,7 @@ async function removeCollection(
   const filter = (rule) =>
     rule.type === "requires" &&
     rule["ignored"] !== true &&
-    util.findModByRef(rule.reference, mods) === undefined;
+    findModByRef(rule.reference, mods) === undefined;
 
   const incomplete = (collection.rules ?? []).find(filter);
 
@@ -413,7 +419,7 @@ async function removeCollection(
         "\nPlease note, some mods may be required by multiple collections.\n" +
         '\nAre you sure you want to remove "{{collectionName}}" from your collections?',
       parameters: {
-        collectionName: util.renderModName(collection),
+        collectionName: renderModName(collection),
       },
       checkboxes: [
         { id: "delete_mods", text: t("Remove mods"), value: false },
@@ -437,7 +443,7 @@ async function removeCollection(
 
   let progress = 0;
   const notiId = shortid();
-  const modName = util.renderModName(collection);
+  const modName = renderModName(collection);
   const doProgress = (step: string, value: number) => {
     if (value <= progress) {
       return;
@@ -463,12 +469,12 @@ async function removeCollection(
     let completed = 0;
     await Promise.all(
       (collection.rules ?? []).map(async (rule) => {
-        const dlId = util.findDownloadByRef(rule.reference, downloads);
+        const dlId = findDownloadByRef(rule.reference, downloads);
 
         if (dlId !== undefined) {
           const download = state.persistent.downloads.files[dlId];
           if (download !== undefined && (deleteArchives || download.state !== "finished")) {
-            await util.toPromise((cb) =>
+            await toPromise((cb) =>
               api.events.emit("remove-download", dlId, cb, {
                 silent: true,
                 confirmed: true,
@@ -485,11 +491,11 @@ async function removeCollection(
     // if selected, remove mods
     if (deleteMods) {
       const removeMods: string[] = (collection.rules ?? [])
-        .map((rule) => util.findModByRef(rule.reference, mods))
+        .map((rule) => findModByRef(rule.reference, mods))
         .filter((mod) => mod !== undefined)
         .map((mod) => mod.id);
 
-      await util.toPromise((cb) =>
+      await toPromise((cb) =>
         api.events.emit("remove-mods", gameId, removeMods, cb, {
           silent: true,
           progressCB: (idx: number, length: number, name: string) => {
@@ -505,14 +511,14 @@ async function removeCollection(
       doProgress("Removing collection", 0.99);
       const download = state.persistent.downloads.files[collection.archiveId];
       if (download !== undefined) {
-        await util.toPromise((cb) =>
+        await toPromise((cb) =>
           api.events.emit("remove-download", collection.archiveId, cb, {
             silent: true,
             confirmed: true,
           }),
         );
       }
-      await util.toPromise((cb) =>
+      await toPromise((cb) =>
         api.events.emit("remove-mod", gameId, modId, cb, {
           silent: true,
           incomplete: true,
@@ -520,13 +526,13 @@ async function removeCollection(
       );
     }
   } catch (err) {
-    if (!(err instanceof util.UserCanceled)) {
+    if (!(err instanceof UserCanceled)) {
       // possible reason for ProcessCanceled is that (un-)deployment may
       // not be possible atm, we definitively should report that
       api.showErrorNotification("Failed to remove mods", unknownToError(err), {
         message: modName,
-        allowReport: !(err instanceof util.ProcessCanceled),
-        warning: err instanceof util.ProcessCanceled,
+        allowReport: !(err instanceof ProcessCanceled),
+        warning: err instanceof ProcessCanceled,
       } as any);
     }
   } finally {
@@ -535,7 +541,7 @@ async function removeCollection(
   }
 }
 
-function genAttributeExtractor(api: types.IExtensionApi) {
+function genAttributeExtractor(api: IExtensionApi) {
   // tslint:disable-next-line:no-shadowed-variable
   return (modInfo: any, modPath: string): Bluebird<{ [key: string]: any }> => {
     const collectionId = modInfo.download?.modInfo?.nexus?.ids?.collectionId;
@@ -556,21 +562,21 @@ function genAttributeExtractor(api: types.IExtensionApi) {
   };
 }
 
-function generateCollectionMap(mods: { [modId: string]: types.IMod }): {
-  [modId: string]: types.IMod[];
+function generateCollectionMap(mods: { [modId: string]: IMod }): {
+  [modId: string]: IMod[];
 } {
   const collections = Object.values(mods).filter((mod) => mod.type === MOD_TYPE);
 
-  const result: { [modId: string]: types.IMod[] } = {};
+  const result: { [modId: string]: IMod[] } = {};
 
   collections.forEach((coll) =>
     (coll.rules ?? []).forEach((rule) => {
       if (rule.reference.id !== undefined) {
-        util.setdefault(result, rule.reference.id, []).push(coll);
+        setdefault(result, rule.reference.id, []).push(coll);
       } else {
-        const installed = util.findModByRef(rule.reference, mods);
+        const installed = findModByRef(rule.reference, mods);
         if (installed !== undefined) {
-          util.setdefault(result, installed.id, []).push(coll);
+          setdefault(result, installed.id, []).push(coll);
         }
       }
     }),
@@ -580,7 +586,7 @@ function generateCollectionMap(mods: { [modId: string]: types.IMod }): {
 }
 
 interface IModTable {
-  [modId: string]: types.IMod;
+  [modId: string]: IMod;
 }
 
 function collectionListEqual(lArgs: IModTable[], rArgs: IModTable[]): boolean {
@@ -605,14 +611,14 @@ function collectionListEqual(lArgs: IModTable[], rArgs: IModTable[]): boolean {
 }
 
 function generateCollectionOptions(mods: {
-  [modId: string]: types.IMod;
+  [modId: string]: IMod;
 }): Array<{ label: string; value: string }> {
   return Object.values(mods)
     .filter((mod) => mod.type === MOD_TYPE)
-    .map((mod) => ({ label: util.renderModName(mod), value: mod.id }));
+    .map((mod) => ({ label: renderModName(mod), value: mod.id }));
 }
 
-async function updateMeta(api: types.IExtensionApi, collectionId?: string) {
+async function updateMeta(api: IExtensionApi, collectionId?: string) {
   const state = api.getState();
   const gameMode = selectors.activeGameId(state);
   const mods = state.persistent.mods[gameMode] ?? {};
@@ -640,7 +646,7 @@ async function updateMeta(api: types.IExtensionApi, collectionId?: string) {
     const { revisionId, collectionSlug, revisionNumber } = mods[modId].attributes ?? {};
     try {
       if (revisionId !== undefined || collectionSlug !== undefined) {
-        progress(util.renderModName(mods[modId]), i);
+        progress(renderModName(mods[modId]), i);
 
         const info: nexusApi.IRevision = await driver.infoCache.getRevisionInfo(
           revisionId,
@@ -688,7 +694,7 @@ interface ICallbackMap {
 
 let collectionChangedCB: () => void;
 
-function onAddSelectionImpl(api: types.IExtensionApi, collectionId: string, modIds: string[]) {
+function onAddSelectionImpl(api: IExtensionApi, collectionId: string, modIds: string[]) {
   const state = api.getState();
   const gameId = selectors.activeGameId(state);
   const collection = state.persistent.mods[gameId][collectionId];
@@ -715,13 +721,13 @@ function onAddSelectionImpl(api: types.IExtensionApi, collectionId: string, modI
   }
 }
 
-const localState = util.makeReactive<{
+const localState = makeReactive<{
   ownCollections: IRevision[];
 }>({
   ownCollections: [],
 });
 
-function register(context: types.IExtensionContext, collectionsCB: ICallbackMap) {
+function register(context: IExtensionContext, collectionsCB: ICallbackMap) {
   context.registerReducer(["session", "collections"], sessionReducer);
   context.registerReducer(["session", "collections"], trackingReducer);
   context.registerReducer(["settings", "collections"], settingsReducer);
@@ -760,7 +766,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
   }));
 
   const onClone = (collectionId: string) => cloneInstalledCollection(context.api, collectionId);
-  const onCreateCollection = (profile: types.IProfile, name: string) =>
+  const onCreateCollection = (profile: IProfile, name: string) =>
     createNewCollection(context.api, profile, name);
   const onRemoveCollection = (gameId: string, modId: string, cancel: boolean) =>
     removeCollection(context.api, gameId, modId, cancel);
@@ -826,7 +832,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
     } as any,
   );
 
-  const stateFunc: () => types.IState = () => context.api.store.getState();
+  const stateFunc: () => IState = () => context.api.store.getState();
 
   const emptyArray = [];
   const emptyObj = {};
@@ -839,18 +845,18 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
     );
   const collectionOptions = memoize(generateCollectionOptions);
 
-  const collectionChanged = new util.Debouncer(() => {
+  const collectionChanged = new Debouncer(() => {
     collectionChangedCB?.();
     return null;
   }, 500);
 
-  const collectionAttribute: types.ITableAttribute<types.IMod> = {
+  const collectionAttribute: ITableAttribute<IMod> = {
     id: "collection",
     name: "Collection",
     description: "Collection(s) this mod was installed from (if any)",
     icon: "collection",
     placement: "both",
-    customRenderer: (mod: types.IMod, detailCell: boolean) => {
+    customRenderer: (mod: IMod, detailCell: boolean) => {
       const collections = collectionsMap()[mod.id] || emptyArray;
       return React.createElement(
         CollectionAttributeRenderer,
@@ -858,7 +864,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
         [],
       );
     },
-    calc: (mod: types.IMod) => {
+    calc: (mod: IMod) => {
       const collections = collectionsMap()[mod.id];
       return collections === undefined ? "" : collections.map((iter) => iter.id);
     },
@@ -883,7 +889,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
     ),
     isGroupable: true,
     groupName: (modId: string) =>
-      util.renderModName(stateFunc().persistent.mods[selectors.activeGameId(stateFunc())]?.[modId]),
+      renderModName(stateFunc().persistent.mods[selectors.activeGameId(stateFunc())]?.[modId]),
     isDefaultVisible: false,
   };
   context.registerTableAttribute("mods", collectionAttribute);
@@ -929,7 +935,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
                 "Failed to apply collection rules",
                 unknownToError(err),
                 {
-                  message: util.renderModName(mod),
+                  message: renderModName(mod),
                 },
               );
             }
@@ -939,7 +945,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
               "Failed to read collection info",
               unknownToError(err),
               {
-                message: util.renderModName(mod),
+                message: renderModName(mod),
               },
             );
           });
@@ -955,7 +961,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
   /*
   context.registerAction('mods-action-icons', 75, 'start-install', {}, 'Install Optional Mods...',
     (modIds: string[]) => {
-      const profile: types.IProfile = selectors.activeProfile(stateFunc());
+      const profile: IProfile = selectors.activeProfile(stateFunc());
       context.api.events.emit('install-recommendations', profile.id, profile.gameId, modIds);
     }, (modIds: string[]) => {
       const gameMode = selectors.activeGameId(stateFunc());
@@ -1096,14 +1102,9 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
     id: string,
     generate: (gameId: string, includedMods: string[]) => Promise<any>,
     parse: (gameId: string, collection: ICollection) => Promise<void>,
-    clone: (
-      gameId: string,
-      collection: ICollection,
-      from: types.IMod,
-      to: types.IMod,
-    ) => Promise<void>,
-    title: (t: types.TFunction) => string,
-    condition?: (state: types.IState, gameId: string) => boolean,
+    clone: (gameId: string, collection: ICollection, from: IMod, to: IMod) => Promise<void>,
+    title: (t: TFunction) => string,
+    condition?: (state: IState, gameId: string) => boolean,
     editComponent?: React.ComponentType<IExtendedInterfaceProps>,
   ) => {
     addExtension({
@@ -1117,11 +1118,11 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
     });
   };
 
-  context.registerActionCheck("ADD_NOTIFICATION", (state: types.IState, action: Redux.Action) => {
-    const notification: types.INotification = action["payload"];
+  context.registerActionCheck("ADD_NOTIFICATION", (state: IState, action: Redux.Action) => {
+    const notification: INotification = action["payload"];
     const ruleMatches = (rule) => rule.reference.tag === notification.replace?.tag;
 
-    let collection: types.IMod;
+    let collection: IMod;
     if (driver?.collection !== undefined && notification.id.startsWith("multiple-plugins-")) {
       // reference tags may be updated during installation, so we need to get the
       // updated collection if necessary
@@ -1141,7 +1142,7 @@ function register(context: types.IExtensionContext, collectionsCB: ICallbackMap)
 }
 
 async function triggerVoteNotification(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   revisionId: number,
   collectionSlug: string,
   revisionNumber: number,
@@ -1209,7 +1210,7 @@ async function triggerVoteNotification(
   });
 }
 
-async function checkVoteRequest(api: types.IExtensionApi): Promise<number> {
+async function checkVoteRequest(api: IExtensionApi): Promise<number> {
   let elapsed = 0;
   const state = api.getState();
   const pendingVotes = state.persistent["collections"].pendingVotes ?? {};
@@ -1237,20 +1238,20 @@ async function checkVoteRequest(api: types.IExtensionApi): Promise<number> {
   return TIME_BEFORE_VOTE - elapsed;
 }
 
-function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
+function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
   const { store } = api;
 
-  const applyCollectionModDefaults = new util.Debouncer(() => {
+  const applyCollectionModDefaults = new Debouncer(() => {
     const gameMode = selectors.activeGameId(state());
-    const mods = util.getSafe(state(), ["persistent", "mods", gameMode], {});
+    const mods = getSafe(state(), ["persistent", "mods", gameMode], {});
     const collectionIds = Object.keys(mods).filter((id) => mods[id]?.type === MOD_TYPE);
     const redActions: Redux.Action[] = collectionIds.reduce((accum, id) => {
-      const collection: types.IMod = mods[id];
+      const collection: IMod = mods[id];
       if (collection === undefined || collection.attributes["editable"] !== true) {
         return accum;
       }
       const collMods = (collection.rules ?? [])
-        .map((rule) => util.findModByRef(rule.reference, mods))
+        .map((rule) => findModByRef(rule.reference, mods))
         .filter((rule) => rule !== undefined);
       const action = genDefaultsAction(api, id, collMods, gameMode);
       if (action !== undefined) {
@@ -1260,7 +1261,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
     }, []);
 
     if (redActions.length > 0) {
-      util.batchDispatch(api.store, redActions);
+      batchDispatch(api.store, redActions);
     }
     return null;
   }, 1000);
@@ -1325,10 +1326,10 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
   // (src/stylesheets/collections.scss, registered in StyleManager) now that
   // collections is an in-repo extension, so there is no setStylesheet call here.
 
-  const state: () => types.IState = () => store.getState();
+  const state: () => IState = () => store.getState();
 
   interface IModsDict {
-    [gameId: string]: { [modId: string]: types.IMod };
+    [gameId: string]: { [modId: string]: IMod };
   }
 
   api.onStateChange(["persistent", "mods"], (prev: IModsDict, cur: IModsDict) => {
@@ -1409,7 +1410,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
             [{ label: "Take me to instructions" }, { label: "Close" }],
             OVERLAY_ID,
           )
-          .then((result: types.IDialogResult) => {
+          .then((result: IDialogResult) => {
             if (result.input["dont_show_again"]) {
               api.store.dispatch(actions.suppressNotification(OVERLAY_ID, true));
             }
@@ -1441,7 +1442,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
     if (profile === undefined) {
       return;
     }
-    const mod = util.getSafe(state().persistent.mods, [gameId, modId], undefined);
+    const mod = getSafe(state().persistent.mods, [gameId, modId], undefined);
     if (mod === undefined) {
       // how ?
       return;
@@ -1465,7 +1466,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
         if (!validType) {
           return false;
         }
-        const matchedRule = util.testModReference(mod, rule.reference);
+        const matchedRule = testModReference(mod, rule.reference);
         return matchedRule;
       });
       const isDependency = dependency !== undefined;
@@ -1476,10 +1477,10 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
           collection,
           gameId,
         );
-        util.batchDispatch(
+        batchDispatch(
           api.store,
           (modRules ?? []).reduce((prev, rule) => {
-            if (util.testModReference(mod, rule.source)) {
+            if (testModReference(mod, rule.source)) {
               prev.push(
                 actions.addModRule(gameId, modId, {
                   type: rule.type,
@@ -1505,7 +1506,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
 
   api.events.on("did-finish-download", (dlId: string, outcome: string) => {
     if (outcome === "finished") {
-      const download: types.IDownload = state().persistent.downloads.files[dlId];
+      const download: IDownload = state().persistent.downloads.files[dlId];
       if (download === undefined) {
         return;
       }
@@ -1514,11 +1515,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
 
   api.events.on("did-download-collection", async (dlId: string) => {
     try {
-      const dlInfo: types.IDownload = util.getSafe(
-        state().persistent.downloads.files,
-        [dlId],
-        undefined,
-      );
+      const dlInfo: IDownload = getSafe(state().persistent.downloads.files, [dlId], undefined);
       const profile = selectors.activeProfile(state());
       if (profile === undefined || dlInfo === undefined) {
         return;
@@ -1528,8 +1525,8 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
           gameMode: profile.gameId,
           game: dlInfo.game,
         });
-        const expectedGame = util.getGame(dlInfo.game[0]);
-        const actualGame = util.getGame(profile.gameId);
+        const expectedGame = getGame(dlInfo.game[0]);
+        const actualGame = getGame(profile.gameId);
         api.sendNotification({
           message:
             '"{{collectionName}}" - This collection is intended for {{expectedGame}} ' +
@@ -1547,7 +1544,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
       } else {
         // once this is complete it will automatically trigger did-install-mod
         // which will then start the ui for the installation process
-        await util.toPromise<string>((cb) =>
+        await toPromise<string>((cb) =>
           api.events.emit(
             "start-install-download",
             dlId,
@@ -1559,9 +1556,9 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
         );
       }
     } catch (err) {
-      if (!(err instanceof util.UserCanceled)) {
+      if (!(err instanceof UserCanceled)) {
         api.showErrorNotification("Failed to add collection", unknownToError(err), {
-          allowReport: !(err instanceof util.ProcessCanceled),
+          allowReport: !(err instanceof ProcessCanceled),
         });
       }
     }
@@ -1624,7 +1621,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
 
     changedIds.forEach((collId) => {
       const coll: nexusApi.ICollection = cur[collId].info;
-      const gameId = util.convertGameIdReverse(knownGames, coll.game.domainName);
+      const gameId = convertGameIdReverse(knownGames, coll.game.domainName);
       const collModId = Object.keys(mods[gameId] ?? {}).find(
         (modId) => mods[gameId][modId].attributes["collectionId"] === coll.id,
       );
@@ -1642,16 +1639,14 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
     });
   });
 
-  util
-    .installIconSet(
-      "collections",
-      path.join(util.getVortexPath("assets"), "fonts", "collections.svg"),
-    )
-    .catch((err: unknown) =>
-      api.showErrorNotification("failed to install icon set", unknownToError(err)),
-    );
+  installIconSet(
+    "collections",
+    path.join(getVortexPath("assets"), "fonts", "collections.svg"),
+  ).catch((err: unknown) =>
+    api.showErrorNotification("failed to install icon set", unknownToError(err)),
+  );
 
-  const iconPath = path.join(util.getVortexPath("assets"), "images", "collectionicon.svg");
+  const iconPath = path.join(getVortexPath("assets"), "images", "collectionicon.svg");
   document
     .getElementById("content")
     .style.setProperty("--collection-icon", `url(${pathToFileURL(iconPath).href})`);
@@ -1679,7 +1674,7 @@ function once(api: types.IExtensionApi, collectionsCB: () => ICallbackMap) {
     }
   });
 
-  const restartDebouncer = new util.Debouncer(
+  const restartDebouncer = new Debouncer(
     async () => {
       if (driver?.collection !== undefined) {
         // user info changed, so we need to update the collection info
@@ -1701,7 +1696,7 @@ const pathTool: IPathTools = {
   relative: path.relative,
 };
 
-function init(context: types.IExtensionContext): boolean {
+function init(context: IExtensionContext): boolean {
   const collectionsCB: ICallbackMap = {};
 
   register(context, collectionsCB);

--- a/src/renderer/src/extensions/collections/types/ICollection.ts
+++ b/src/renderer/src/extensions/collections/types/ICollection.ts
@@ -1,4 +1,9 @@
-import type * as types from "../../../types/api";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IModPatches,
+  IModReference,
+} from "../../mod_management/types/IMod";
 import type { ICollectionGamebryo } from "../util/gameSupport/gamebryo";
 import type { ICollectionConfig } from "./ICollectionConfig";
 
@@ -48,11 +53,10 @@ export interface ICollectionMod {
   optional: boolean;
   domainName: string;
   source: ICollectionSourceInfo;
-  // hashes?: types.IFileListItem[];
-  hashes?: any;
+  hashes?: IFileListItem[];
   // installer-specific data to replicate the choices the author made
-  choices?: any;
-  patches?: { [filePath: string]: string };
+  choices?: IChoiceType;
+  patches?: IModPatches;
   instructions?: string;
   author?: string;
   details?: ICollectionModDetails;
@@ -63,9 +67,9 @@ export interface ICollectionMod {
 export type RuleType = "before" | "after" | "requires" | "conflicts" | "recommends" | "provides";
 
 export interface ICollectionModRule {
-  source: types.IModReference;
+  source: IModReference;
   type: RuleType;
-  reference: types.IModReference;
+  reference: IModReference;
 }
 
 export interface ICollectionTool {

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -8,13 +8,38 @@ import * as _ from "lodash";
 
 import * as actions from "../../../actions";
 import { log } from "../../../logging";
-import * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+import Debouncer from "../../../util/Debouncer";
 import * as selectors from "../../../util/selectors";
+import { getSafe, setSafe } from "../../../util/storeHelper";
+import { batchDispatch } from "../../../util/util";
+import {
+  CollectionsInstallationCompletedEvent,
+  CollectionsInstallationFailedEvent,
+  CollectionsInstallationStartedEvent,
+} from "../../analytics/mixpanel/MixpanelEvents";
+import type { IDownload } from "../../download_management/types/IDownload";
+import { getGame } from "../../gamemode_management/util/getGame";
+import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
+import { findDownloadByRef, lookupFromDownload } from "../../mod_management/util/dependencies";
+import { findModByRef } from "../../mod_management/util/findModByRef";
+import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
+import renderModName from "../../mod_management/util/modName";
+import testModReference, {
+  ruleInstallSpec,
+  testRefByIdentifiers,
+} from "../../mod_management/util/testModReference";
+import type { IProfile } from "../../profile_management/types/IProfile";
 import * as installActions from "../actions/installTracking";
 import { setPendingVote } from "../actions/persistent";
 import { INSTALLING_NOTIFICATION_ID, MOD_TYPE } from "../constants";
-import { reconstructModStatus } from "../installSession/util";
+import type { CollectionModStatus, ICollectionModInstallInfo } from "../installSession/types";
+import {
+  generateCollectionSessionId,
+  modRuleId,
+  reconstructModStatus,
+} from "../installSession/util";
 import { postprocessCollection } from "../postprocessCollection";
 import { ICollection } from "../types/ICollection";
 import { IRevisionEx } from "../types/IRevisionEx";
@@ -36,15 +61,15 @@ export type Step =
 export type UpdateCB = () => void;
 
 class InstallDriver {
-  private mApi: types.IExtensionApi;
-  private mProfile: types.IProfile;
+  private mApi: IExtensionApi;
+  private mProfile: IProfile;
   private mGameId: string;
-  private mCollection: types.IMod;
-  private mLastCollection: types.IMod;
+  private mCollection: IMod;
+  private mLastCollection: IMod;
   private mStep: Step = "prepare";
   private mUpdateHandlers: UpdateCB[] = [];
-  private mInstalledMods: types.IMod[] = [];
-  private mDependentMods: types.IModRule[] = [];
+  private mInstalledMods: IMod[] = [];
+  private mDependentMods: IModRule[] = [];
   private mInstallingMod: string;
   private mInstallDone: boolean = false;
   private mCollectionInfo: nexusApi.ICollection;
@@ -57,11 +82,11 @@ class InstallDriver {
   private mPostprocessing: boolean = false;
 
   private mStateUpdates: any[] = [];
-  private mModStatusDebouncer: util.Debouncer = new util.Debouncer(
+  private mModStatusDebouncer: Debouncer = new Debouncer(
     () => {
       const actions = this.mStateUpdates.slice();
       this.mStateUpdates = [];
-      util.batchDispatch(this.mApi.store, actions);
+      batchDispatch(this.mApi.store, actions);
       return Bluebird.resolve();
     },
     100,
@@ -73,7 +98,7 @@ class InstallDriver {
   // single mod event.  Tracking dispatches (mModStatusDebouncer) are unaffected.
   // reset=false keeps it from starving, triggerImmediately=true shows instant
   // feedback on the first event.
-  private mProgressDebouncer: util.Debouncer = new util.Debouncer(
+  private mProgressDebouncer: Debouncer = new Debouncer(
     () => {
       if (this.mProfile && this.mGameId && this.mCollection) {
         this.updateProgress(this.mProfile, this.mGameId, this.mCollection);
@@ -95,7 +120,7 @@ class InstallDriver {
     return this.mDependentMods.filter((m) => m.type === "recommends");
   }
 
-  public updateModTracking(rule: types.IModRule, status: types.CollectionModStatus) {
+  public updateModTracking(rule: IModRule, status: CollectionModStatus) {
     if (!this.mTrackingEnabled || !this.mCurrentSessionId) {
       return;
     }
@@ -106,7 +131,7 @@ class InstallDriver {
       return;
     }
 
-    const ruleId = util.modRuleId(rule);
+    const ruleId = modRuleId(rule);
 
     // Check current status to prevent downgrades from terminal states
     const state = this.mApi.getState();
@@ -114,7 +139,7 @@ class InstallDriver {
     const currentStatus = currentSession?.mods?.[ruleId]?.status;
 
     // Don't downgrade from terminal states (installed, skipped, failed)
-    const terminalStates: types.CollectionModStatus[] = ["installed", "ignored", "failed"];
+    const terminalStates: CollectionModStatus[] = ["installed", "ignored", "failed"];
     if (currentStatus && terminalStates.includes(currentStatus)) {
       return;
     }
@@ -123,12 +148,12 @@ class InstallDriver {
     this.mModStatusDebouncer.schedule();
   }
 
-  public markModInstalledInTracking(rule: types.IModRule, modId: string) {
+  public markModInstalledInTracking(rule: IModRule, modId: string) {
     if (!this.mTrackingEnabled || !this.mCurrentSessionId) {
       return;
     }
 
-    const ruleId = util.modRuleId(rule);
+    const ruleId = modRuleId(rule);
     this.mStateUpdates.push(installActions.markModInstalled(this.mCurrentSessionId, ruleId, modId));
     this.mModStatusDebouncer.schedule();
   }
@@ -142,7 +167,7 @@ class InstallDriver {
    * restore the "ignored" status; the unfulfilled-rules and dependency-completion
    * checks already treat ignored rules as resolved.
    */
-  private markRuleIgnored(rule: types.IModRule) {
+  private markRuleIgnored(rule: IModRule) {
     this.updateModTracking(rule, "ignored");
 
     if (this.mGameId !== undefined && this.mCollection !== undefined) {
@@ -162,7 +187,7 @@ class InstallDriver {
     this.mCurrentSessionId = undefined;
   }
 
-  private mDebounce: util.Debouncer = new util.Debouncer(
+  private mDebounce: Debouncer = new Debouncer(
     (collectionSlug: string, revisionNumber: number, error: Error | undefined) => {
       // this.mApi.events.emit('analytics-track-event-with-payload', 'Collection Installation Failed', {
       //   collection_slug: collectionSlug,
@@ -176,7 +201,7 @@ class InstallDriver {
 
       this.mApi.events.emit(
         "analytics-track-mixpanel-event",
-        new util.CollectionsInstallationFailedEvent(
+        new CollectionsInstallationFailedEvent(
           nexusIds.collectionId,
           nexusIds.revisionId,
           nexusIds.numericGameId,
@@ -193,13 +218,13 @@ class InstallDriver {
     1000,
   );
 
-  constructor(api: types.IExtensionApi) {
+  constructor(api: IExtensionApi) {
     this.mApi = api;
 
     this.mInfoCache = new InfoCache(api);
 
     api.onAsync("will-install-mod", (gameId: string, archiveId: string, modId: string) => {
-      const state: types.IState = api.store.getState();
+      const state: IState = api.store.getState();
       const download = state.persistent.downloads.files[archiveId];
       if (download !== undefined) {
         this.mInstallingMod = download.localPath;
@@ -208,8 +233,8 @@ class InstallDriver {
     });
 
     api.events.on("did-install-mod", (gameId: string, archiveId: string, modId: string) => {
-      const state: types.IState = api.store.getState();
-      const mod = util.getSafe(state.persistent.mods, [gameId, modId], undefined);
+      const state: IState = api.store.getState();
+      const mod = getSafe(state.persistent.mods, [gameId, modId], undefined);
       const downloads = state.persistent.downloads.files;
       // verify the mod installed is actually one required by this collection
       const dependent = this.mDependentMods.find((iter) => {
@@ -225,8 +250,7 @@ class InstallDriver {
           fileNames: Array.from(nameSet).filter((n) => n !== undefined) as string[],
         };
         return (
-          util.testModReference(mod, iter.reference) ||
-          util.testRefByIdentifiers(identifiers, iter.reference)
+          testModReference(mod, iter.reference) || testRefByIdentifiers(identifiers, iter.reference)
         );
       });
 
@@ -251,20 +275,25 @@ class InstallDriver {
           if (dependent.type === "requires") {
             this.mProgressDebouncer.schedule();
           }
+          const installSpec = ruleInstallSpec(dependent);
           applyPatches(
             api,
             this.mCollection,
             gameId,
             dependent.reference.description,
             modId,
-            dependent.extra?.patches,
+            installSpec.patches,
           );
-          const choices = dependent.installerChoices ?? dependent.extra?.installerChoices;
-          util.batchDispatch(api.store, [
+          batchDispatch(api.store, [
             actions.setFileOverride(gameId, modId, dependent.extra?.fileOverrides),
-            actions.setModAttribute(gameId, modId, "installerChoices", choices),
-            actions.setModAttribute(gameId, modId, "patches", dependent.extra?.patches),
-            actions.setModAttribute(gameId, modId, "fileList", dependent.fileList),
+            actions.setModAttribute(
+              gameId,
+              modId,
+              "installerChoices",
+              installSpec.installerChoices,
+            ),
+            actions.setModAttribute(gameId, modId, "patches", installSpec.patches),
+            actions.setModAttribute(gameId, modId, "fileList", installSpec.fileList),
           ]);
         }
       }
@@ -281,10 +310,9 @@ class InstallDriver {
         const state = api.getState();
         const download = state.persistent.downloads.files[downloadId];
         if (download) {
-          const lookup = util.lookupFromDownload(download);
+          const lookup = lookupFromDownload(download);
           const matchingRule = this.mDependentMods.find((rule) => {
-            const { patches, fileList, installerChoices, ...refWithoutExtras } = rule.reference;
-            return util.testModReference(lookup, refWithoutExtras);
+            return testModReference(lookup, rule.reference);
           });
           if (matchingRule) {
             this.updateModTracking(matchingRule, "downloaded");
@@ -307,7 +335,7 @@ class InstallDriver {
           const condition = () => {
             // So this is shit, but we need to account for the fact that the fileId may never match
             //  due to incorrect update chains.
-            if (r.reference.versionMatch != null && util.isFuzzyVersion(r.reference.versionMatch)) {
+            if (r.reference.versionMatch != null && isFuzzyVersion(r.reference.versionMatch)) {
               if (
                 identifiers.modId == null ||
                 r.reference.repo?.modId !== identifiers.modId.toString()
@@ -325,7 +353,7 @@ class InstallDriver {
               return true;
             }
           };
-          return util.testRefByIdentifiers({ ...identifiers, condition } as any, r.reference);
+          return testRefByIdentifiers({ ...identifiers, condition } as any, r.reference);
         });
         if (rule) {
           this.markRuleIgnored(rule);
@@ -339,7 +367,7 @@ class InstallDriver {
 
     api.onStateChange(
       ["persistent", "downloads", "files"],
-      (prev: { [id: string]: types.IDownload }, current: { [id: string]: types.IDownload }) => {
+      (prev: { [id: string]: IDownload }, current: { [id: string]: IDownload }) => {
         if (this.mDependentMods.length === 0) return;
 
         const newIds = Object.keys(current).filter((id) => prev?.[id] === undefined);
@@ -347,10 +375,9 @@ class InstallDriver {
           const download = current[dlId];
           if (!download) continue;
 
-          const lookup = util.lookupFromDownload(download);
+          const lookup = lookupFromDownload(download);
           const matchingRule = this.mDependentMods.find((rule) => {
-            const { patches, fileList, installerChoices, ...refWithoutExtras } = rule.reference;
-            return util.testModReference(lookup, refWithoutExtras);
+            return testModReference(lookup, rule.reference);
           });
 
           const isBundled = matchingRule?.extra?.localPath != null;
@@ -369,10 +396,9 @@ class InstallDriver {
       dlIds.forEach((dlId) => {
         const download = downloads[dlId];
         if (download) {
-          const lookup = util.lookupFromDownload(download);
+          const lookup = lookupFromDownload(download);
           const matchingRule = this.mDependentMods.find((rule) => {
-            const { patches, fileList, installerChoices, ...refWithoutExtras } = rule.reference;
-            return util.testModReference(lookup, refWithoutExtras);
+            return testModReference(lookup, rule.reference);
           });
           if (matchingRule) {
             this.updateModTracking(matchingRule, "downloaded");
@@ -381,7 +407,7 @@ class InstallDriver {
       });
     });
 
-    api.events.on("collection-mod-skipped", (reference: types.IModReference) => {
+    api.events.on("collection-mod-skipped", (reference: IModReference) => {
       // Update tracking when a mod download is skipped (for both free and premium users)
       const matchingRule = this.mDependentMods.find((rule) => {
         // Match by tag (most reliable) or other identifiers
@@ -430,17 +456,13 @@ class InstallDriver {
           const required = (collection?.rules ?? []).filter((rule) =>
             ["requires", "recommends"].includes(rule.type),
           );
-          this.mDependentMods = required.filter((rule) => {
-            const modRef: any = {
-              ...rule.reference,
-              patches: rule?.extra?.patches ? { ...rule.extra.patches } : undefined,
-              fileList: rule?.fileList,
-            };
-            return util.findModByRef(modRef, mods) === undefined;
-          });
+          this.mDependentMods = required.filter(
+            (rule) =>
+              findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule)) === undefined,
+          );
         }
 
-        const isCollectionMod = (rule) => util.findModByRef(rule.reference, mods)?.id === modId;
+        const isCollectionMod = (rule) => findModByRef(rule.reference, mods)?.id === modId;
 
         if (
           this.mCollection !== undefined &&
@@ -464,7 +486,7 @@ class InstallDriver {
     this.mPrepare = this.mPrepare.then(func);
   }
 
-  public async query(profile: types.IProfile, collection: types.IMod) {
+  public async query(profile: IProfile, collection: IMod) {
     await this.mPrepare;
     this.mPrepare = Bluebird.resolve();
 
@@ -487,7 +509,7 @@ class InstallDriver {
     this.triggerUpdate();
   }
 
-  public async start(profile: types.IProfile, collection: types.IMod) {
+  public async start(profile: IProfile, collection: IMod) {
     await this.mPrepare;
     this.mPrepare = Bluebird.resolve();
 
@@ -525,7 +547,7 @@ class InstallDriver {
     return this.mProfile;
   }
 
-  public set profile(val: types.IProfile) {
+  public set profile(val: IProfile) {
     this.mProfile = val;
     if (val !== undefined) {
       this.mGameId = val?.gameId;
@@ -544,7 +566,7 @@ class InstallDriver {
     return this.mPostprocessing;
   }
 
-  public get installedMods(): types.IMod[] {
+  public get installedMods(): IMod[] {
     return this.mInstalledMods;
   }
 
@@ -556,7 +578,7 @@ class InstallDriver {
     return this.mInstallingMod;
   }
 
-  public get collection(): types.IMod {
+  public get collection(): IMod {
     return this.mCollection;
   }
 
@@ -565,12 +587,12 @@ class InstallDriver {
    * does not get reset after the installation completes but please be aware that there is
    * no guarantee this collection is still installed
    */
-  public get lastCollection(): types.IMod {
+  public get lastCollection(): IMod {
     return this.mLastCollection;
   }
 
   public get collectionId(): string {
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const modInfo =
       this.mCollection !== undefined
         ? state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo
@@ -581,7 +603,7 @@ class InstallDriver {
   }
 
   public get collectionSlug(): string {
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const modInfo =
       this.mCollection !== undefined
         ? state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo
@@ -592,7 +614,7 @@ class InstallDriver {
   }
 
   public get revisionNumber(): number {
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const modInfo =
       this.mCollection !== undefined
         ? state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo
@@ -603,7 +625,7 @@ class InstallDriver {
   }
 
   public get revisionId(): number {
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const modInfo =
       this.mCollection !== undefined
         ? state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo
@@ -700,7 +722,7 @@ class InstallDriver {
       return;
     }
     const slug = this.collectionSlug;
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const modInfo = state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo;
     const nexusInfo = modInfo?.nexus;
     this.mCollectionInfo =
@@ -729,7 +751,7 @@ class InstallDriver {
       if (this.mCollection !== undefined) {
         if (!recommendations) {
           const isInstalled = (rule: any) => {
-            const mod = util.findModByRef(rule.reference, mods);
+            const mod = findModByRef(rule.reference, mods);
             return mod != null && mod?.state === "installed";
           };
           const filter = (rule) =>
@@ -751,7 +773,7 @@ class InstallDriver {
           const filter = (rule) =>
             ["requires", "recommends"].includes(rule.type) &&
             rule["ignored"] !== true &&
-            util.findModByRef(rule.reference, mods) === undefined;
+            findModByRef(rule.reference, mods) === undefined;
 
           const incomplete = (this.mCollection.rules ?? []).find(filter);
 
@@ -804,7 +826,7 @@ class InstallDriver {
 
         this.mApi.events.emit(
           "analytics-track-mixpanel-event",
-          new util.CollectionsInstallationCompletedEvent(
+          new CollectionsInstallationCompletedEvent(
             nexusIds.collectionId,
             nexusIds.revisionId,
             nexusIds.numericGameId,
@@ -861,10 +883,10 @@ class InstallDriver {
   }
 
   private getModsEx(
-    profile: types.IProfile,
+    profile: IProfile,
     gameId: string,
-    collection: types.IMod,
-  ): { [id: string]: types.IMod & { collectionRule: types.IModRule } } {
+    collection: IMod,
+  ): { [id: string]: IMod & { collectionRule: IModRule } } {
     if (profile === undefined) {
       profile = this.mProfile;
     }
@@ -884,8 +906,8 @@ class InstallDriver {
         return prev;
       }
 
-      const mod = util.findModByRef(rule.reference, mods);
-      prev[util.modRuleId(rule)] = { ...mod, collectionRule: rule };
+      const mod = findModByRef(rule.reference, mods);
+      prev[modRuleId(rule)] = { ...mod, collectionRule: rule };
 
       return prev;
     }, {});
@@ -922,7 +944,7 @@ class InstallDriver {
     const profile = this.mProfile;
     const gameId = this.mGameId;
 
-    const state: types.IState = this.mApi.store.getState();
+    const state: IState = this.mApi.store.getState();
     const mods = state.persistent.mods[gameId] ?? {};
     const modInfo = state.persistent.downloads.files[collection.archiveId]?.modInfo;
     const nexusInfo = modInfo?.nexus;
@@ -952,7 +974,7 @@ class InstallDriver {
     }
 
     const gameMode = gameId;
-    const currentgame = util.getGame(gameMode);
+    const currentgame = getGame(gameMode);
     const discovery = selectors.discoveryByGame(state, gameMode);
     const gameVersion = await currentgame.getInstalledVersion(discovery);
     const gvMatch = (gv) => gv.reference === gameVersion;
@@ -1002,19 +1024,8 @@ class InstallDriver {
     const required = (collection?.rules ?? []).filter((rule) =>
       ["requires", "recommends"].includes(rule.type),
     );
-    const dependencies: types.IModRule[] = required.reduce((accum, rule) => {
-      // Mods with binary patches are always reinstalled as variants so the
-      // correct diffs are applied to clean files.
-      if (rule.extra?.patches != null) {
-        accum.push(rule);
-        return accum;
-      }
-      const modRef: any = {
-        ...rule.reference,
-        patches: undefined,
-        fileList: rule?.fileList,
-      };
-      const mod = util.findModByRef(modRef, mods);
+    const dependencies: IModRule[] = required.reduce((accum, rule) => {
+      const mod = findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule));
       if (mod === undefined) {
         accum.push(rule);
       } else {
@@ -1038,7 +1049,7 @@ class InstallDriver {
     if (nexusIds?.collectionId != null) {
       this.mApi.events.emit(
         "analytics-track-mixpanel-event",
-        new util.CollectionsInstallationStartedEvent(
+        new CollectionsInstallationStartedEvent(
           nexusIds.collectionId,
           nexusIds.revisionId,
           nexusIds.numericGameId,
@@ -1058,16 +1069,16 @@ class InstallDriver {
       const totalRequired = required.length - optional.length;
 
       // Generate unique session ID
-      this.mCurrentSessionId = util.generateCollectionSessionId(collectionId, profile.id);
+      this.mCurrentSessionId = generateCollectionSessionId(collectionId, profile.id);
 
       const downloads = state.persistent.downloads.files;
-      const installedRuleIds = new Set(installed.map((r) => util.modRuleId(r)));
+      const installedRuleIds = new Set(installed.map((r) => modRuleId(r)));
 
       // Create mod info map
-      const mods: { [ruleId: string]: types.ICollectionModInstallInfo } = Object.fromEntries(
+      const mods: { [ruleId: string]: ICollectionModInstallInfo } = Object.fromEntries(
         required.map((rule) => {
-          const ruleId = util.modRuleId(rule);
-          const download = util.findDownloadByRef(rule.reference, downloads);
+          const ruleId = modRuleId(rule);
+          const download = findDownloadByRef(rule.reference, downloads);
           const isBundled = rule.extra?.localPath != null;
           const isInstalled = installedRuleIds.has(ruleId);
           const isDownloaded = download != null || isBundled;
@@ -1106,7 +1117,7 @@ class InstallDriver {
     });
   };
 
-  private matchRepo(rule: types.IModRule, ref: nexusApi.IModFile) {
+  private matchRepo(rule: IModRule, ref: nexusApi.IModFile) {
     if (ref === null) {
       return false;
     }
@@ -1121,8 +1132,8 @@ class InstallDriver {
     return modId.toString() === ref.modId.toString() && fileId.toString() === ref.fileId.toString();
   }
 
-  private augmentRules(gameId: string, collection: types.IMod) {
-    util.batchDispatch(
+  private augmentRules(gameId: string, collection: IMod) {
+    batchDispatch(
       this.mApi.store,
       (collection.rules ?? [])
         .map((rule) => {
@@ -1143,7 +1154,7 @@ class InstallDriver {
           }
           const revMod = modFiles.find((iter) => this.matchRepo(rule, iter.file));
           if (revMod?.file !== undefined) {
-            const newRule = util.setSafe(rule, ["extra", "fileName"], revMod.file.uri);
+            const newRule = setSafe(rule, ["extra", "fileName"], revMod.file.uri);
             return actions.addModRule(gameId, collection.id, newRule);
           }
         })
@@ -1195,7 +1206,7 @@ class InstallDriver {
     });
   }
 
-  private installProgress(profile: types.IProfile, gameId: string, collection: types.IMod): number {
+  private installProgress(profile: IProfile, gameId: string, collection: IMod): number {
     const mods = this.getModsEx(profile, gameId, collection);
 
     const downloads = this.mApi.getState().persistent.downloads.files;
@@ -1226,7 +1237,7 @@ class InstallDriver {
     return (dlPerc + instPerc) * 50.0;
   }
 
-  private updateProgress(profile: types.IProfile, gameId: string, collection: types.IMod) {
+  private updateProgress(profile: IProfile, gameId: string, collection: IMod) {
     if (collection === undefined) {
       return;
     }
@@ -1239,7 +1250,7 @@ class InstallDriver {
       id: INSTALLING_NOTIFICATION_ID + collection.id,
       type: "activity",
       title: "Installing Collection",
-      message: util.renderModName(collection),
+      message: renderModName(collection),
       progress: this.installProgress(profile, gameId, collection),
       actions: [
         {

--- a/src/renderer/src/extensions/collections/util/cloneCollection.ts
+++ b/src/renderer/src/extensions/collections/util/cloneCollection.ts
@@ -2,10 +2,14 @@ import * as path from "path";
 
 import { unknownToError } from "@vortex/shared";
 
-import type * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import type { IDialogResult } from "../../../types/IDialog";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
 import * as fs from "../../../util/fs";
 import * as selectors from "../../../util/selectors";
+import type { IMod, IModRule } from "../../mod_management/types/IMod";
+import { findModByRef } from "../../mod_management/util/findModByRef";
+import renderModName from "../../mod_management/util/modName";
+import { ruleInstallSpec } from "../../mod_management/util/testModReference";
 import { MOD_TYPE } from "../constants";
 import type { ICollection, ICollectionAttributes } from "../types/ICollection";
 import type { IExtensionFeature } from "./extension";
@@ -13,9 +17,9 @@ import { findExtensions } from "./extension";
 import { hasEditPermissions } from "./util";
 
 function deduceCollectionAttributes(
-  collectionMod: types.IMod,
+  collectionMod: IMod,
   collection: ICollection,
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
 ): ICollectionAttributes {
   const existingInstallMode: { [modId: string]: string } =
     collectionMod.attributes?.collection?.installMode ?? {};
@@ -30,7 +34,7 @@ function deduceCollectionAttributes(
   };
 
   (collectionMod.rules ?? []).forEach((rule) => {
-    const mod = util.findModByRef(rule.reference, mods);
+    const mod = findModByRef(rule.reference, mods);
     if (mod === undefined) {
       // allowing mods to be missing, prior to r32 this would throw an exception
       return;
@@ -51,7 +55,7 @@ function deduceCollectionAttributes(
       url: rule.downloadHint?.url,
       instructions: rule.downloadHint?.instructions,
     };
-    res.saveEdits[mod.id] = rule.extra?.patches !== undefined;
+    res.saveEdits[mod.id] = ruleInstallSpec(rule).patches !== undefined;
   });
 
   return res;
@@ -63,7 +67,7 @@ function deduceCollectionAttributes(
  *          in that case an error notification has already been reported
  */
 export async function cloneCollection(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   id: string,
   sourceId: string,
@@ -73,7 +77,7 @@ export async function cloneCollection(
 
   const { userInfo } = state.persistent["nexus"] ?? {};
   const mods = state.persistent.mods[gameId] ?? {};
-  const existingCollection: types.IMod = mods[sourceId];
+  const existingCollection: IMod = mods[sourceId];
 
   const stagingPath = selectors.installPathForGame(state, gameId);
 
@@ -90,20 +94,20 @@ export async function cloneCollection(
     return undefined;
   }
 
-  const ruleFilter = (rule: types.IModRule) => {
+  const ruleFilter = (rule: IModRule) => {
     if (rule.ignored) {
       return false;
     }
 
-    if (util.findModByRef(rule.reference, mods) === undefined) {
+    if (findModByRef(rule.reference, mods) === undefined) {
       return false;
     }
 
     return true;
   };
 
-  const ruleSimplify = (rule: types.IModRule): types.IModRule => {
-    const referencedMod = util.findModByRef(rule.reference, mods);
+  const ruleSimplify = (rule: IModRule): IModRule => {
+    const referencedMod = findModByRef(rule.reference, mods);
     return {
       ...rule,
       reference: {
@@ -123,7 +127,7 @@ export async function cloneCollection(
   let ownCollection: boolean =
     userInfo?.userId != null && existingCollection.attributes?.uploaderId === userInfo.userId;
   if (editPermissions && !ownCollection) {
-    const result: types.IDialogResult = await api.showDialog(
+    const result: IDialogResult = await api.showDialog(
       "question",
       "Clone Collection",
       {
@@ -131,7 +135,7 @@ export async function cloneCollection(
           'You have edit permissions for the collection "{{name}}", but you are not the owner.[br][/br]' +
           "Would you like to clone it as your own collection, or contribute to the existing one?[br][/br][br][/br]",
         parameters: {
-          name: util.renderModName(existingCollection),
+          name: renderModName(existingCollection),
         },
       },
       [{ label: "Contribute" }, { label: "Clone", default: true }],
@@ -163,7 +167,7 @@ export async function cloneCollection(
       }
     : {};
 
-  const mod: types.IMod = {
+  const mod: IMod = {
     id,
     type: MOD_TYPE,
     state: "installed",

--- a/src/renderer/src/extensions/collections/util/modToCollection.ts
+++ b/src/renderer/src/extensions/collections/util/modToCollection.ts
@@ -5,10 +5,25 @@ import { generate as shortid } from "shortid";
 import type { IEntry } from "turbowalk";
 import turbowalk from "turbowalk";
 
-import type * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IGame } from "../../../types/IGame";
 import * as fs from "../../../util/fs";
 import * as selectors from "../../../util/selectors";
+import { sanitizeFilename } from "../../../util/util";
+import { resolveCategoryName } from "../../category_management/util/retrieveCategoryPath";
+import { getGame } from "../../gamemode_management/util/getGame";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IMod,
+  IModReference,
+  IModRule,
+} from "../../mod_management/types/IMod";
+import { findModByRef } from "../../mod_management/util/findModByRef";
+import renderModName from "../../mod_management/util/modName";
+import { makeModReference } from "../../mod_management/util/modReference";
+import testModReference from "../../mod_management/util/testModReference";
+import { nexusGameId } from "../../nexus_integration/util/convertGameId";
 import { BUNDLED_PATH, MOD_TYPE, PATCHES_PATH } from "../constants";
 import type {
   ICollection,
@@ -31,20 +46,20 @@ import { ruleId } from "./util";
 import { fileMD5Async } from "./walk";
 
 interface IResolvedRule {
-  mod: types.IMod;
-  rule: types.IModRule;
+  mod: IMod;
+  rule: IModRule;
 }
 
 /**
  * converts the rules in a mod into mod entries for a collection, ready for export
  */
 async function rulesToCollectionMods(
-  api: types.IExtensionApi,
-  collection: types.IMod,
+  api: IExtensionApi,
+  collection: IMod,
   resolvedRules: IResolvedRule[],
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
   stagingPath: string,
-  game: types.IGame,
+  game: IGame,
   collectionInfo: ICollectionAttributes,
   bundleTags: { [modId: string]: string },
   onProgress: (percent: number, text: string) => void,
@@ -89,7 +104,7 @@ async function rulesToCollectionMods(
         gameId: game.id,
       });
 
-      const modName = util.renderModName(mod, { version: false });
+      const modName = renderModName(mod, { version: false });
       try {
         // This call is relatively likely to fail to do it before the hash calculation to
         // save the user time in case it does fail
@@ -101,8 +116,8 @@ async function rulesToCollectionMods(
           bundleTags[mod.id],
         );
 
-        let hashes: any;
-        let choices: any;
+        let hashes: IFileListItem[];
+        let choices: IChoiceType;
 
         let entries: IEntry[] = [];
 
@@ -148,7 +163,7 @@ async function rulesToCollectionMods(
 
         if (collectionInfo.source?.[mod.id]?.type === "bundle") {
           const tlFiles = await fs.readdirAsync(modPath);
-          const generatedName: string = `Bundled - ${util.sanitizeFilename(util.renderModName(mod, { version: true }))}`;
+          const generatedName: string = `Bundled - ${sanitizeFilename(renderModName(mod, { version: true }))}`;
           const destPath = path.join(collectionPath, BUNDLED_PATH, generatedName);
           try {
             await fs.removeAsync(destPath);
@@ -177,14 +192,12 @@ async function rulesToCollectionMods(
 
         onProgress(Math.floor((finished / total) * 100), modName);
 
-        const dlGame: types.IGame =
-          mod.attributes?.downloadGame !== undefined
-            ? util.getGame(mod.attributes.downloadGame)
-            : game;
+        const dlGame: IGame =
+          mod.attributes?.downloadGame !== undefined ? getGame(mod.attributes.downloadGame) : game;
 
         // workaround where Vortex has no support for the game this download came from
         const domainName =
-          dlGame !== undefined ? util.nexusGameId(dlGame) : mod.attributes?.downloadGame;
+          dlGame !== undefined ? nexusGameId(dlGame) : mod.attributes?.downloadGame;
 
         const res: ICollectionMod = {
           name: modName,
@@ -200,7 +213,7 @@ async function rulesToCollectionMods(
             : undefined,
           author: mod.attributes?.author,
           details: {
-            category: util.resolveCategoryName(mod.attributes?.category, state),
+            category: resolveCategoryName(mod.attributes?.category, state),
             type: mod.type,
           },
           phase: rule.extra?.["phase"] ?? 0,
@@ -232,7 +245,7 @@ async function rulesToCollectionMods(
                 "archive, which is guaranteed to cause issues for the end user.[br][/br][br][/br] Please consider using " +
                 "binary patching or bundle your changes instead.",
               parameters: {
-                modName: util.renderModName(mod),
+                modName: renderModName(mod),
               },
               options: {
                 order: ["bbcode", "message"],
@@ -255,11 +268,7 @@ async function rulesToCollectionMods(
   return result.filter((mod) => mod !== undefined && Object.keys(mod.source).length > 0);
 }
 
-function ruleEnabled(
-  rule: ICollectionModRule,
-  mods: { [modId: string]: types.IMod },
-  collection: types.IMod,
-) {
+function ruleEnabled(rule: ICollectionModRule, mods: { [modId: string]: IMod }, collection: IMod) {
   if (rule === undefined) {
     return false;
   }
@@ -276,8 +285,8 @@ function ruleEnabled(
 
 function extractModRules(
   collectionRules: IResolvedRule[],
-  collection: types.IMod,
-  mods: { [modId: string]: types.IMod },
+  collection: IMod,
+  mods: { [modId: string]: IMod },
   collectionAttributes: ICollectionAttributes,
   bundleTags: { [modId: string]: string },
 ): ICollectionModRule[] {
@@ -287,12 +296,12 @@ function extractModRules(
     collectionRules
       .reduce((prev: ICollectionModRule[], resolvedRule: IResolvedRule) => {
         const { mod } = resolvedRule;
-        const source: types.IModReference = util.makeModReference(mod);
+        const source: IModReference = makeModReference(mod);
         const sourceOrig = JSON.parse(JSON.stringify(source));
 
         // ok, this gets a bit complex now. If the referenced mod gets updated, also make sure
         // the rules referencing it apply to newer versions
-        const mpRule = collection.rules.find((iter) => util.testModReference(mod, iter.reference));
+        const mpRule = collection.rules.find((iter) => testModReference(mod, iter.reference));
         if (
           mpRule !== undefined &&
           (mpRule.reference.versionMatch === undefined ||
@@ -317,15 +326,15 @@ function extractModRules(
 
         return [].concat(
           prev,
-          includedRules.map((input: types.IModRule): ICollectionModRule => {
+          includedRules.map((input: IModRule): ICollectionModRule => {
             if (input.extra?.["automatic"] === true) {
               // don't add rules introduced from a remote source, the assumption being that they would be
               // added on the client system as well and might get updated
               return undefined;
             }
-            const target: types.IModRule = JSON.parse(JSON.stringify(input));
+            const target: IModRule = JSON.parse(JSON.stringify(input));
 
-            const targetRef = util.findModByRef(target.reference, mods);
+            const targetRef = findModByRef(target.reference, mods);
             const targetId = targetRef?.id ?? target.reference.idHint;
             const targetRule = makeTransferrable(mods, collection, target);
 
@@ -355,11 +364,11 @@ function extractModRules(
 }
 
 export async function modToCollection(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   stagingPath: string,
-  collection: types.IMod,
-  mods: { [modId: string]: types.IMod },
+  collection: IMod,
+  mods: { [modId: string]: IMod },
   onProgress: (percent?: number, text?: string) => void,
   onError: (message: string, replace: any, mayIgnore: boolean) => void,
 ): Promise<ICollection> {
@@ -374,7 +383,7 @@ export async function modToCollection(
     .map((rule) => {
       let id = rule.reference.id;
       if (id === undefined) {
-        const mod = util.findModByRef(rule.reference, mods);
+        const mod = findModByRef(rule.reference, mods);
         if (mod !== undefined) {
           id = mod.id;
         }
@@ -396,7 +405,7 @@ export async function modToCollection(
 
   const gameSpecific = await generateGameSpecifics(state, gameId, stagingPath, includedMods, mods);
 
-  const game = util.getGame(gameId);
+  const game = getGame(gameId);
   const discovery = selectors.discoveryByGame(state, gameId);
 
   const gameVersions = game !== undefined ? [await game.getInstalledVersion(discovery)] : [];
@@ -410,10 +419,10 @@ export async function modToCollection(
   const collectionInfo: ICollectionInfo = {
     author: collection.attributes?.uploader ?? "Anonymous",
     authorUrl: collection.attributes?.authorURL ?? "",
-    name: util.renderModName(collection),
+    name: renderModName(collection),
     description: collection.attributes?.shortDescription ?? "",
     installInstructions: collectionAttributes.installInstructions ?? "",
-    domainName: util.nexusGameId(game),
+    domainName: nexusGameId(game),
     gameVersions,
   };
 
@@ -432,11 +441,11 @@ export async function modToCollection(
     return prev;
   }, {});
 
-  const resolvedRules = collection.rules.reduce<IResolvedRule[]>((prev, rule: types.IModRule) => {
+  const resolvedRules = collection.rules.reduce<IResolvedRule[]>((prev, rule: IModRule) => {
     const mod =
       rule.reference.id !== undefined
         ? mods[rule.reference.id]
-        : util.findModByRef(rule.reference, mods);
+        : findModByRef(rule.reference, mods);
 
     if (mod === undefined) {
       onError('Not packaging mod that isn\'t installed: "{{id}}"', { id: rule.reference.id }, true);

--- a/src/renderer/src/extensions/collections/util/transformCollection.ts
+++ b/src/renderer/src/extensions/collections/util/transformCollection.ts
@@ -7,7 +7,7 @@ import { log } from "../../../logging";
 import type { IConditionResult, IDialogContent } from "../../../types/IDialog";
 import type { TFunction } from "../../../util/i18n";
 import type { IGameStored } from "../../gamemode_management/types/IGameStored";
-import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
+import type { IDownloadHint, IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
 import { coerceToSemver } from "../../mod_management/util/coerceToSemver";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import renderModName from "../../mod_management/util/modName";
@@ -21,7 +21,16 @@ import type {
   ICollectionMod,
   ICollectionModRule,
   ICollectionSourceInfo,
+  SourceType,
 } from "../types/ICollection";
+
+// the source types that carry a download hint (a URL/instructions to fetch the
+// mod), as opposed to "nexus"/"bundle" which are resolved differently
+const DOWNLOAD_HINT_MODES: readonly SourceType[] = ["manual", "browse", "direct"];
+
+function isDownloadHintMode(type: SourceType): type is IDownloadHint["mode"] {
+  return DOWNLOAD_HINT_MODES.includes(type);
+}
 
 export function sanitizeExpression(fileName: string): string {
   // drop extension and anything like ".1" or " (1)" at the end which probaby
@@ -207,7 +216,7 @@ export function makeTransferrable(
  * convert a mod entry from a collection into a mod rule
  */
 export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionMod): IModRule {
-  const downloadHint = ["manual", "browse", "direct"].includes(mod.source.type)
+  const downloadHint: IDownloadHint | undefined = isDownloadHintMode(mod.source.type)
     ? {
         url: mod.source.url,
         instructions: mod.source.instructions,

--- a/src/renderer/src/extensions/collections/util/transformCollection.ts
+++ b/src/renderer/src/extensions/collections/util/transformCollection.ts
@@ -4,7 +4,10 @@ import type { ILookupResult } from "modmeta-db";
 import { generate as shortid } from "shortid";
 
 import { log } from "../../../logging";
-import type * as types from "../../../types/api";
+import type { IConditionResult, IDialogContent } from "../../../types/IDialog";
+import type { TFunction } from "../../../util/i18n";
+import type { IGameStored } from "../../gamemode_management/types/IGameStored";
+import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
 import { coerceToSemver } from "../../mod_management/util/coerceToSemver";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import renderModName from "../../mod_management/util/modName";
@@ -43,7 +46,7 @@ export function toInt(input: string | number | undefined | null) {
 }
 
 export function deduceSource(
-  mod: types.IMod,
+  mod: IMod,
   sourceInfo: ICollectionSourceInfo,
   versionMatcher: string,
   metaInfo: ILookupResult[],
@@ -136,10 +139,7 @@ export function generateCollection(
   };
 }
 
-export function makeBiDirRule(
-  source: types.IModReference,
-  rule: types.IModRule,
-): ICollectionModRule {
+export function makeBiDirRule(source: IModReference, rule: IModRule): ICollectionModRule {
   if (rule === undefined) {
     return undefined;
   }
@@ -152,11 +152,11 @@ export function makeBiDirRule(
 }
 
 export function makeTransferrable(
-  mods: { [modId: string]: types.IMod },
-  collection: types.IMod,
-  rule: types.IModRule,
-): types.IModRule {
-  let newRef: types.IModReference = { ...rule.reference };
+  mods: { [modId: string]: IMod },
+  collection: IMod,
+  rule: IModRule,
+): IModRule {
+  let newRef: IModReference = { ...rule.reference };
   const mod = findModByRef(rule.reference, mods);
 
   if (
@@ -206,10 +206,7 @@ export function makeTransferrable(
 /**
  * convert a mod entry from a collection into a mod rule
  */
-export function collectionModToRule(
-  knownGames: types.IGameStored[],
-  mod: ICollectionMod,
-): types.IModRule {
+export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionMod): IModRule {
   const downloadHint = ["manual", "browse", "direct"].includes(mod.source.type)
     ? {
         url: mod.source.url,
@@ -241,7 +238,7 @@ export function collectionModToRule(
       ? mod.source.fileExpression
       : undefined;
 
-  const reference: types.IModReference = {
+  const reference: IModReference = {
     description: mod.name,
     fileMD5: refMD5,
     gameId: convertGameIdReverse(knownGames, mod.domainName),
@@ -271,11 +268,12 @@ export function collectionModToRule(
     };
   }
 
-  const res: types.IModRule = {
+  const res: IModRule = {
     type: mod.optional ? "recommends" : "requires",
     reference,
     fileList: mod.hashes,
     installerChoices: mod.choices,
+    patches: mod.patches,
     downloadHint,
     extra: {
       author: mod.author,
@@ -290,10 +288,9 @@ export function collectionModToRule(
           ? mod.source.instructions
           : undefined,
       phase: mod.phase ?? 0,
-      patches: mod.patches,
       fileOverrides: mod.fileOverrides,
     },
-  } as any;
+  };
 
   if (mod.source.type === "bundle") {
     res.extra.localPath = path.join("bundled", mod.source.fileExpression);
@@ -302,10 +299,7 @@ export function collectionModToRule(
   return res;
 }
 
-export function validateName(
-  t: types.TFunction,
-  content: types.IDialogContent,
-): types.IConditionResult[] {
+export function validateName(t: TFunction, content: IDialogContent): IConditionResult[] {
   const input = content.input[0].value || "";
   if (input.length >= MIN_COLLECTION_NAME_LENGTH && input.length <= MAX_COLLECTION_NAME_LENGTH) {
     return [];

--- a/src/renderer/src/extensions/file_based_loadorder/types/collections.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/types/collections.ts
@@ -1,6 +1,14 @@
 import type { ICollectionInfo, IRevision, SourceType, UpdatePolicy } from "@nexusmods/nexus-api";
 
-import type * as types from "../../../types/api";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+import type { TFunction } from "../../../util/i18n";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IMod,
+  IModReference,
+} from "../../mod_management/types/IMod";
 import type { ILoadOrderEntry, LoadOrder } from "./types";
 
 export interface ILoadOrderEntryExt extends ILoadOrderEntry {
@@ -40,10 +48,9 @@ export interface ICollectionMod {
   optional: boolean;
   domainName: string;
   source: ICollectionSourceInfo;
-  // hashes?: types.IFileListItem[];
-  hashes?: any;
+  hashes?: IFileListItem[];
   // installer-specific data to replicate the choices the author made
-  choices?: any;
+  choices?: IChoiceType;
   instructions?: string;
   author?: string;
   details?: ICollectionModDetails;
@@ -51,9 +58,9 @@ export interface ICollectionMod {
 
 export type RuleType = "before" | "after" | "requires" | "conflicts" | "recommends" | "provides";
 export interface ICollectionModRule {
-  source: types.IModReference;
+  source: IModReference;
   type: RuleType;
-  reference: types.IModReference;
+  reference: IModReference;
 }
 
 export interface ICollection extends Partial<ICollectionLoadOrder> {
@@ -64,22 +71,22 @@ export interface ICollection extends Partial<ICollectionLoadOrder> {
 }
 
 export interface IGameSpecificInterfaceProps {
-  t: types.TFunction;
-  collection: types.IMod;
+  t: TFunction;
+  collection: IMod;
   revisionInfo: IRevision;
 }
 
 export interface ICollectionsGameSupportEntry {
   gameId: string;
   generator: (
-    state: types.IState,
+    state: IState,
     gameId: string,
     stagingPath: string,
     modIds: string[],
-    mods: { [modId: string]: types.IMod },
+    mods: { [modId: string]: IMod },
   ) => Promise<any>;
 
-  parser: (api: types.IExtensionApi, gameId: string, collection: ICollection) => Promise<void>;
+  parser: (api: IExtensionApi, gameId: string, collection: ICollection) => Promise<void>;
 
   interface: (props: IGameSpecificInterfaceProps) => JSX.Element;
 }

--- a/src/renderer/src/extensions/mod_load_order/types/collections.ts
+++ b/src/renderer/src/extensions/mod_load_order/types/collections.ts
@@ -1,6 +1,14 @@
 import type { ICollectionInfo, IRevision, SourceType, UpdatePolicy } from "@nexusmods/nexus-api";
 
-import type * as types from "../../../types/api";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+import type { TFunction } from "../../../util/i18n";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IMod,
+  IModReference,
+} from "../../mod_management/types/IMod";
 import type { ILoadOrder } from "./types";
 
 export interface ICollectionLoadOrder {
@@ -36,10 +44,9 @@ export interface ICollectionMod {
   optional: boolean;
   domainName: string;
   source: ICollectionSourceInfo;
-  // hashes?: types.IFileListItem[];
-  hashes?: any;
+  hashes?: IFileListItem[];
   // installer-specific data to replicate the choices the author made
-  choices?: any;
+  choices?: IChoiceType;
   instructions?: string;
   author?: string;
   details?: ICollectionModDetails;
@@ -47,9 +54,9 @@ export interface ICollectionMod {
 
 export type RuleType = "before" | "after" | "requires" | "conflicts" | "recommends" | "provides";
 export interface ICollectionModRule {
-  source: types.IModReference;
+  source: IModReference;
   type: RuleType;
-  reference: types.IModReference;
+  reference: IModReference;
 }
 
 export interface ICollection extends Partial<ICollectionLoadOrder> {
@@ -60,22 +67,22 @@ export interface ICollection extends Partial<ICollectionLoadOrder> {
 }
 
 export interface IGameSpecificInterfaceProps {
-  t: types.TFunction;
-  collection: types.IMod;
+  t: TFunction;
+  collection: IMod;
   revisionInfo: IRevision;
 }
 
 export interface ICollectionsGameSupportEntry {
   gameId: string;
   generator: (
-    state: types.IState,
+    state: IState,
     gameId: string,
     stagingPath: string,
     modIds: string[],
-    mods: { [modId: string]: types.IMod },
+    mods: { [modId: string]: IMod },
   ) => Promise<any>;
 
-  parser: (api: types.IExtensionApi, gameId: string, collection: ICollection) => Promise<void>;
+  parser: (api: IExtensionApi, gameId: string, collection: ICollection) => Promise<void>;
 
   interface: (props: IGameSpecificInterfaceProps) => JSX.Element;
 }

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -154,7 +154,14 @@ import type { Dependency, IDependency, IDependencyError, IModInfoEx } from "./ty
 import type { IInstallContext } from "./types/IInstallContext";
 import type { IInstallOptions } from "./types/IInstallOptions";
 import type { IInstallResult, IInstruction, InstructionType } from "./types/IInstallResult";
-import type { IFileListItem, IMod, IModAttributes, IModReference, IModRule } from "./types/IMod";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IMod,
+  IModAttributes,
+  IModReference,
+  IModRule,
+} from "./types/IMod";
 import type { IModInstaller, ISupportedInstaller } from "./types/IModInstaller";
 import type { IInstallationDetails, InstallFunc } from "./types/InstallFunc";
 import type { ISupportedResult, ITestSupportedDetails, TestSupported } from "./types/TestSupported";
@@ -169,7 +176,9 @@ import queryGameId from "./util/queryGameId";
 import testModReference, {
   downloadToModRef,
   idOnlyRef,
+  modMatchesInstallSpec,
   referenceEqual,
+  ruleInstallSpec,
   testRefByIdentifiers,
 } from "./util/testModReference";
 
@@ -341,10 +350,9 @@ function findCollectionByDownload(
 
     // Download lookups will not hold any patch/filelist/installerChoices info.
     //  Which is why in this case we want to ensure that we only match using regular reference fields.
-    const matchingRule = collectionMod.rules?.find((rule) => {
-      const { patches, fileList, installerChoices, ...refWithoutExtras } = rule.reference;
-      return testModReference(lookup, refWithoutExtras);
-    });
+    const matchingRule = collectionMod.rules?.find((rule) =>
+      testModReference(lookup, rule.reference),
+    );
 
     if (matchingRule) {
       return { collectionMod, matchingRule, gameId };
@@ -694,9 +702,9 @@ class InstallManager {
       lookupResults: [], // Will be populated if needed
       download: downloadId,
       phase: matchingRule.extra?.phase || 0,
-      patches: matchingRule.extra?.patches ?? matchingRule.reference.patches,
+      patches: ruleInstallSpec(matchingRule).patches,
       installerChoices: matchingRule.installerChoices,
-      fileList: matchingRule.fileList ?? matchingRule.reference.fileList,
+      fileList: matchingRule.fileList,
     };
 
     // Ensure the phase is marked as having downloads finished
@@ -2374,17 +2382,14 @@ class InstallManager {
           const sourceMod = api.getState().persistent.mods[gameId][sourceModId];
           const mods = api.getState().persistent.mods[gameId];
 
-          // Mods with patches are always reinstalled as variants so the
-          // correct diffs are applied to clean files - skip the lookup.
-          const hasPatches =
-            currentDep.patches != null && Object.keys(currentDep.patches).length > 0;
-          const fullReference: IModReference = {
-            ...currentDep.reference,
+          // Reuse an already-installed mod only when it matches the dependency by
+          // identity AND was installed with the same install spec (installer choices,
+          // file list, patches). Otherwise (different or absent spec) install it.
+          const existingMod = findModByRef(currentDep.reference, mods, undefined, {
             installerChoices: currentDep.installerChoices,
-            patches: currentDep.patches,
             fileList: currentDep.fileList,
-          };
-          const existingMod = hasPatches ? undefined : findModByRef(fullReference, mods);
+            patches: currentDep.patches,
+          });
           const modId =
             existingMod != null
               ? existingMod.id
@@ -3113,15 +3118,12 @@ class InstallManager {
         // Check if mod is already installed with matching installer choices and patches
         const gameId = activeGameId(api.getState());
         const mods = api.getState().persistent.mods[gameId] ?? {};
-        const fullReference: IModReference | undefined = mod.rule?.reference
-          ? {
-              ...mod.rule.reference,
-              installerChoices: mod.rule.installerChoices ?? mod.rule.extra?.installerChoices,
-              patches: mod.rule.extra?.patches,
-              fileList: mod.rule.fileList ?? mod.rule.reference?.fileList,
-            }
+        // Identity + install spec: the mod counts as installed only if the wanted
+        // install spec (installer choices / file list / patches) is present, otherwise
+        // it needs (re)installing.
+        const existingMod = mod.rule?.reference
+          ? findModByRef(mod.rule.reference, mods, undefined, ruleInstallSpec(mod.rule))
           : undefined;
-        const existingMod = fullReference && findModByRef(fullReference, mods);
 
         log("debug", "Requeue check", {
           downloadId,
@@ -3992,7 +3994,7 @@ class InstallManager {
     destinationPath: string,
     gameId: string,
     modId: string,
-    choices: any,
+    choices: IChoiceType,
     unattended: boolean,
     details: IInstallationDetails,
   ): Promise<void> {
@@ -4178,7 +4180,7 @@ class InstallManager {
       instructions: IInstruction[];
       overrideInstructions?: IInstruction[];
     },
-    choices: any,
+    choices: IChoiceType,
     unattended: boolean,
     details: IInstallationDetails,
   ) {
@@ -4646,16 +4648,16 @@ class InstallManager {
       };
 
       const mod = mods[0];
-      const modReference: IModReference = {
-        id: mod.id,
-        fileList: installOptions?.fileList,
-        archiveId: mod.archiveId,
-        gameId,
-        installerChoices: installOptions?.choices,
-        patches: installOptions?.patches,
-      };
+      // An unattended reinstall of an already-present mod with a different install spec
+      // (installer choices / file list / patches) means it's being pulled in as a
+      // dependency by another mod or collection.
       const isDependency =
-        installOptions?.unattended === true && testModReference(mods[0], modReference) === false;
+        installOptions?.unattended === true &&
+        !modMatchesInstallSpec(mod, {
+          installerChoices: installOptions?.choices,
+          fileList: installOptions?.fileList,
+          patches: installOptions?.patches,
+        });
       const addendum = isDependency
         ? " and is trying to be reinstalled as a dependency by another mod or collection."
         : ".";
@@ -6080,9 +6082,6 @@ class InstallManager {
             // being installed having a different tag than the rule
             const reference: IModReference = {
               ...dep.reference,
-              fileList: dep.fileList,
-              patches: dep.patches,
-              installerChoices: dep.installerChoices,
               tag: downloads[downloadId].modInfo.referenceTag,
             };
             dep.reference =
@@ -6314,9 +6313,6 @@ class InstallManager {
     dependencies.forEach((dep) => {
       const updatedRef: IModReference = { ...dep.reference };
       updatedRef.idHint = dep.mod?.id;
-      updatedRef.installerChoices = dep.installerChoices;
-      updatedRef.patches = dep.patches;
-      updatedRef.fileList = dep.fileList;
       this.updateModRule(api, gameId, sourceModId, dep, updatedRef, recommended);
     });
     return Promise.resolve();

--- a/src/renderer/src/extensions/mod_management/types/IDependency.ts
+++ b/src/renderer/src/extensions/mod_management/types/IDependency.ts
@@ -1,6 +1,6 @@
 import type { ILookupResult, IModInfo } from "modmeta-db";
 
-import type { IFileListItem, IMod, IModReference } from "./IMod";
+import type { IChoiceType, IFileListItem, IMod, IModPatches, IModReference } from "./IMod";
 
 export interface IModInfoEx extends IModInfo {
   referer?: string | (() => PromiseLike<string>);
@@ -16,8 +16,8 @@ export interface IDependency {
   reference: IModReference;
   lookupResults: ILookupResultEx[];
   fileList?: IFileListItem[];
-  installerChoices?: any;
-  patches?: any;
+  installerChoices?: IChoiceType;
+  patches?: IModPatches;
   mod?: IMod;
   extra?: { [key: string]: any };
   phase?: number;

--- a/src/renderer/src/extensions/mod_management/types/IInstallOptions.ts
+++ b/src/renderer/src/extensions/mod_management/types/IInstallOptions.ts
@@ -1,12 +1,12 @@
-import type { IFileListItem } from "./IMod";
+import type { IChoiceType, IFileListItem, IModPatches } from "./IMod";
 
 export interface IInstallOptions {
   allowAutoEnable?: boolean;
-  choices?: any;
+  choices?: IChoiceType;
   forceInstaller?: string;
   unattended?: boolean;
   fileList?: IFileListItem[];
-  patches?: any;
+  patches?: IModPatches;
   variantNumber?: number;
   profileId?: string;
 }

--- a/src/renderer/src/extensions/mod_management/types/IMod.ts
+++ b/src/renderer/src/extensions/mod_management/types/IMod.ts
@@ -1,8 +1,22 @@
 import type { IReference, IRule } from "modmeta-db";
 
+import type { IChoiceType } from "../../installer_fomod_shared/types/interface";
+
 export type { IReference, IRule };
+// The installer-choices shape is owned by the fomod installer (the only producer
+// today). Re-exported here so the install-customization fields have one import home.
+export type { IChoiceType };
 
 export type ModState = "downloading" | "downloaded" | "installing" | "installed";
+
+/**
+ * Binary patches applied to a mod's files when it is installed as a dependency,
+ * keyed by file path. The value is the hash of the baseline file the patch is
+ * applied against.
+ */
+export interface IModPatches {
+  [filePath: string]: string;
+}
 
 /**
  * Attributes specific to Nexus Mods Collections (when IMod.type === "collection")
@@ -77,8 +91,8 @@ export interface ICommonModAttributes {
   referenceTag?: string;
 
   // Installer and patching
-  installerChoices?: any;
-  patches?: any;
+  installerChoices?: IChoiceType;
+  patches?: IModPatches;
   fileList?: IFileListItem[];
 
   // Version and updates
@@ -190,9 +204,6 @@ export interface IModReference extends IReference {
   // the user chose for the mod.
   description?: string;
   instructions?: string;
-  installerChoices?: any;
-  fileList?: IFileListItem[];
-  patches?: any;
 }
 
 /**
@@ -220,8 +231,10 @@ export interface IDownloadHint {
 export interface IModRule extends IRule {
   reference: IModReference;
   fileList?: IFileListItem[];
-  // the format of these choices is installer-specific
-  installerChoices?: any;
+  installerChoices?: IChoiceType;
+  // binary patches applied to the referenced mod's files when it is installed as a
+  // dependency
+  patches?: IModPatches;
   downloadHint?: IDownloadHint;
   // additional information attached to the rule. This will not have
   // any effect on the resolution of the rule but may be used to

--- a/src/renderer/src/extensions/mod_management/types/InstallFunc.ts
+++ b/src/renderer/src/extensions/mod_management/types/InstallFunc.ts
@@ -1,5 +1,5 @@
 import type { IInstallResult } from "./IInstallResult";
-import type { IModReference } from "./IMod";
+import type { IChoiceType, IModReference } from "./IMod";
 
 export type ProgressDelegate = (perc: number) => void;
 export interface IInstallationDetails {
@@ -17,7 +17,7 @@ export type InstallFunc = (
   destinationPath: string,
   gameId: string,
   progressDelegate: ProgressDelegate,
-  choices?: any,
+  choices?: IChoiceType,
   unattended?: boolean,
   archivePath?: string,
   options?: IInstallationDetails,

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -14,10 +14,10 @@ import { activeGameId } from "../../../util/selectors";
 import { getSafe } from "../../../util/storeHelper";
 import { semverCoerce, truthy } from "../../../util/util";
 import type { IDependency, ILookupResultEx } from "../types/IDependency";
-import type { IDownloadHint, IFileListItem, IMod, IModReference, IModRule } from "../types/IMod";
+import type { IDownloadHint, IModReference, IModRule } from "../types/IMod";
 import { findModByRef } from "./findModByRef";
 import { isFuzzyVersion } from "./isFuzzyVersion";
-import testModReference, { testRefByIdentifiers } from "./testModReference";
+import testModReference, { ruleInstallSpec, testRefByIdentifiers } from "./testModReference";
 import type { IModLookupInfo } from "./testModReference";
 
 interface IBrowserResult {
@@ -314,9 +314,6 @@ export function findDownloadByRef(
 interface IDependencyNode extends IDependency {
   dependencies: IDependencyNode[];
   redundant: boolean;
-  fileList?: IFileListItem[];
-  installerChoices?: any;
-  patches?: any;
   reresolveDownloadHint?: () => Promise<void>;
 }
 
@@ -346,13 +343,7 @@ async function gatherDependenciesGraph(
       fileSize: rule.reference.fileSize,
     });
   }
-  const modReference: IModReference = {
-    ...rule.reference,
-    fileList: rule.fileList,
-    patches: rule.extra?.patches ?? {},
-    installerChoices: rule.installerChoices ?? {},
-  };
-  const mod = findModByRef(modReference, mods);
+  const mod = findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule));
 
   let urlFromHint: IBrowserResult | undefined;
 
@@ -399,7 +390,7 @@ async function gatherDependenciesGraph(
       dependencies: dependencies.filter(Boolean),
       redundant: false,
       extra: rule.extra,
-      patches: rule.extra?.patches ?? {},
+      patches: ruleInstallSpec(rule).patches ?? {},
       installerChoices: rule.installerChoices,
       fileList: rule.fileList,
       phase: rule.extra?.["phase"] ?? 0,

--- a/src/renderer/src/extensions/mod_management/util/findModByRef.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/findModByRef.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for findModByRef, focused on the install-spec consolidation: identity
+ * matching answers "is this mod installed", and the optional installSpec narrows
+ * that to "installed the way this rule asks for" (installer choices / file list /
+ * patches). Several variants of the same mod can be installed at once, so the spec
+ * has to pick the right one.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import type { IMod, IModAttributes, IModReference } from "../types/IMod";
+import { findModByRef } from "./findModByRef";
+
+vi.mock("../../../util/log", () => ({
+  log: vi.fn(),
+}));
+
+const createMod = (id: string, attributes: IModAttributes): IMod => ({
+  id,
+  state: "installed",
+  type: "",
+  installationPath: `mods/${id}`,
+  attributes,
+});
+
+describe("findModByRef", () => {
+  const sharedMD5 = "shared-identity-md5";
+
+  // two installed variants of the same mod: same identity (md5), different patches
+  const variantA = createMod("variant-a", {
+    fileMD5: sharedMD5,
+    fileName: "variant-a.7z",
+    logicalFileName: "Shared.7z",
+    version: "1.0.0",
+    source: "nexus",
+    game: ["skyrimse"],
+    patches: { "a.esp": "hash-a" },
+  });
+  const variantB = createMod("variant-b", {
+    fileMD5: sharedMD5,
+    fileName: "variant-b.7z",
+    logicalFileName: "Shared.7z",
+    version: "1.0.0",
+    source: "nexus",
+    game: ["skyrimse"],
+    patches: { "a.esp": "hash-b" },
+  });
+
+  const mods = { "variant-a": variantA, "variant-b": variantB };
+
+  it("returns a mod matched by identity when no install spec is given", () => {
+    const reference: IModReference = { fileMD5: sharedMD5 };
+    expect(findModByRef(reference, mods)).toBeDefined();
+  });
+
+  it("returns the variant whose install spec matches the requested one", () => {
+    const reference: IModReference = { fileMD5: sharedMD5 };
+
+    expect(findModByRef(reference, mods, undefined, { patches: { "a.esp": "hash-b" } })).toBe(
+      variantB,
+    );
+    expect(findModByRef(reference, mods, undefined, { patches: { "a.esp": "hash-a" } })).toBe(
+      variantA,
+    );
+  });
+
+  it("returns undefined when no installed variant matches the install spec", () => {
+    const reference: IModReference = { fileMD5: sharedMD5 };
+
+    expect(
+      findModByRef(reference, mods, undefined, { patches: { "a.esp": "never-installed" } }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to identity-only matching when the install spec is empty", () => {
+    // an empty spec requests no particular variant, so the first identity match wins.
+    const reference: IModReference = { fileMD5: sharedMD5 };
+    expect(findModByRef(reference, mods, undefined, {})).toBeDefined();
+  });
+
+  it("honours the install spec on the idHint fast-path", () => {
+    // idHint points at variantA, but the spec asks for variantB. The fast-path must not
+    // short-circuit to the wrong variant; it should reject the hint and find the match.
+    const reference: IModReference = { fileMD5: sharedMD5, idHint: "variant-a" } as IModReference;
+
+    expect(findModByRef(reference, mods, undefined, { patches: { "a.esp": "hash-b" } })).toBe(
+      variantB,
+    );
+  });
+
+  it("uses the idHint fast-path when the spec matches the hinted mod", () => {
+    const reference: IModReference = { fileMD5: sharedMD5, idHint: "variant-a" } as IModReference;
+
+    expect(findModByRef(reference, mods, undefined, { patches: { "a.esp": "hash-a" } })).toBe(
+      variantA,
+    );
+  });
+
+  it("honours the install spec on the md5Hint fast-path", () => {
+    const reference: IModReference = { md5Hint: sharedMD5 } as IModReference;
+
+    expect(findModByRef(reference, mods, undefined, { patches: { "a.esp": "hash-b" } })).toBe(
+      variantB,
+    );
+  });
+
+  it("returns undefined for an unknown reference", () => {
+    expect(findModByRef({ fileMD5: "no-such-mod" }, mods)).toBeUndefined();
+  });
+
+  it("returns undefined for a nullish reference", () => {
+    expect(findModByRef(undefined as unknown as IModReference, mods)).toBeUndefined();
+  });
+});

--- a/src/renderer/src/extensions/mod_management/util/findModByRef.ts
+++ b/src/renderer/src/extensions/mod_management/util/findModByRef.ts
@@ -1,12 +1,13 @@
 import { log } from "../../../util/log";
 import type { IMod, IModReference } from "../types/IMod";
 import { isFuzzyVersion } from "./isFuzzyVersion";
-import testModReference from "./testModReference";
+import testModReference, { modMatchesInstallSpec, type IModInstallSpec } from "./testModReference";
 
 export function findModByRef(
   reference: IModReference,
   mods: { [modId: string]: IMod },
   source?: { gameId: string; modId: string },
+  installSpec?: IModInstallSpec,
 ): IMod {
   if (!reference) {
     log("error", "findModByRef called with undefined reference", {
@@ -16,10 +17,19 @@ export function findModByRef(
     return undefined;
   }
   const fuzzy = isFuzzyVersion(reference.versionMatch);
-  if (
-    reference["idHint"] !== undefined &&
-    testModReference(mods[reference["idHint"]], reference, source, fuzzy)
-  ) {
+
+  // When an install spec is given, a candidate must also have been installed with that
+  // spec (installer choices / file list / patches). Checked per candidate because
+  // several variants of the same mod can be installed at once, and only one (if any) is
+  // the requested one.
+  const specMatches = (mod: IMod): boolean =>
+    installSpec == null || modMatchesInstallSpec(mod, installSpec);
+
+  // A candidate matches the reference by identity and by install spec.
+  const matches = (mod: IMod): boolean =>
+    mod != null && testModReference(mod, reference, source, fuzzy) && specMatches(mod);
+
+  if (reference["idHint"] !== undefined && matches(mods[reference["idHint"]])) {
     // fast-path if we have an id from a previous match
     return mods[reference["idHint"]];
   }
@@ -37,21 +47,14 @@ export function findModByRef(
     delete reference.fileMD5;
   }
 
-  if (
-    reference["md5Hint"] !== undefined &&
-    reference.installerChoices === undefined &&
-    reference.patches === undefined &&
-    reference.fileList === undefined
-  ) {
+  if (reference["md5Hint"] !== undefined) {
     const result = Object.keys(mods).find(
-      (dlId) => mods[dlId].attributes?.fileMD5 === reference["md5Hint"],
+      (dlId) => mods[dlId].attributes?.fileMD5 === reference["md5Hint"] && specMatches(mods[dlId]),
     );
     if (result !== undefined) {
       return mods[result];
     }
   }
 
-  return Object.values(mods).find((mod: IMod): boolean =>
-    testModReference(mod, reference, source, fuzzy),
-  );
+  return Object.values(mods).find((mod: IMod): boolean => matches(mod));
 }

--- a/src/renderer/src/extensions/mod_management/util/testModReference.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.test.ts
@@ -21,10 +21,15 @@
 
 import { describe, it, expect, vi } from "vitest";
 
-import type { IMod, IModAttributes, IModReference } from "../types/IMod";
+import type { IMod, IModAttributes, IModReference, IModRule } from "../types/IMod";
 import { coerceToSemver } from "./coerceToSemver";
 import { isFuzzyVersion } from "./isFuzzyVersion";
-import { testModReference, sanitizeExpression } from "./testModReference";
+import {
+  testModReference,
+  sanitizeExpression,
+  modMatchesInstallSpec,
+  ruleInstallSpec,
+} from "./testModReference";
 
 // Mock the log function to avoid console output during tests
 vi.mock("../../../util/log", () => ({
@@ -119,8 +124,13 @@ describe("testModReference", () => {
         source: "nexus",
         game: ["skyrimse"],
         installerChoices: {
-          choice1: "option1",
-          choice2: "option2",
+          type: "fomod",
+          options: [
+            {
+              name: "Main",
+              groups: [{ name: "Group A", choices: [{ name: "Option 1", idx: 0 }] }],
+            },
+          ],
         },
         patches: {
           patch1: "value1",
@@ -497,58 +507,185 @@ describe("testModReference", () => {
     });
   });
 
-  describe("Installer choices and patches matching", () => {
-    it("should match when installer choices and patches are identical", () => {
-      const mod = sampleMods.skyrimse["BSA Version-68139-3-0-1685378500"];
-      const reference: IModReference = {
-        logicalFileName: "BSA_Version.zip",
-        installerChoices: {
-          choice1: "option1",
-          choice2: "option2",
-        },
-        patches: {
-          patch1: "value1",
-          patch2: "value2",
-        },
-      };
+  describe("modMatchesInstallSpec (installer choices, file list, patches)", () => {
+    // The mod's recorded install spec: a fomod installerChoices selection and
+    // patches { patch1: value1, patch2: value2 }.
+    const mod = sampleMods.skyrimse["BSA Version-68139-3-0-1685378500"];
 
-      expect(testModReference(mod, reference)).toBe(true);
+    it("matches when installer choices and patches are identical", () => {
+      expect(
+        modMatchesInstallSpec(mod, {
+          installerChoices: {
+            type: "fomod",
+            options: [
+              {
+                name: "Main",
+                groups: [{ name: "Group A", choices: [{ name: "Option 1", idx: 0 }] }],
+              },
+            ],
+          },
+          patches: { patch1: "value1", patch2: "value2" },
+        }),
+      ).toBe(true);
     });
 
-    it("should fail when installer choices do not match", () => {
-      const mod = sampleMods.skyrimse["BSA Version-68139-3-0-1685378500"];
-      const reference: IModReference = {
-        logicalFileName: "BSA_Version.zip",
-        installerChoices: {
-          choice1: "different_option",
-          choice2: "option2",
-        },
-        patches: {
-          patch1: "value1",
-          patch2: "value2",
-        },
-      };
-
-      expect(testModReference(mod, reference)).toBe(false);
+    it("fails when installer choices do not match", () => {
+      expect(
+        modMatchesInstallSpec(mod, {
+          installerChoices: {
+            type: "fomod",
+            options: [
+              {
+                name: "Main",
+                groups: [{ name: "Group A", choices: [{ name: "Option 2", idx: 1 }] }],
+              },
+            ],
+          },
+          patches: { patch1: "value1", patch2: "value2" },
+        }),
+      ).toBe(false);
     });
 
-    it("should match when patches are identical with matching tag", () => {
-      const mod = sampleMods.skyrimse["BSA Version-68139-3-0-1685378500"];
-      // Add referenceTag to match the tag requirement for patches
-      if (mod.attributes) {
-        mod.attributes.referenceTag = "test-tag";
-      }
+    it("matches identical patches without relying on the reference tag", () => {
+      // tags are shortid-generated and not stable/unique, so variant matching is by
+      // patch content alone.
+      expect(
+        modMatchesInstallSpec(mod, {
+          patches: { patch1: "value1", patch2: "value2" },
+        }),
+      ).toBe(true);
+    });
 
-      const reference: IModReference = {
-        logicalFileName: "BSA_Version.zip",
-        patches: {
-          patch1: "value1",
-          patch2: "value2",
-        },
-        tag: "test-tag",
+    it("fails when patches differ", () => {
+      expect(
+        modMatchesInstallSpec(mod, {
+          patches: { patch1: "DIFFERENT", patch2: "value2" },
+        }),
+      ).toBe(false);
+    });
+
+    it("is satisfied when the rule asks for no particular variant", () => {
+      expect(modMatchesInstallSpec(mod, {})).toBe(true);
+    });
+
+    it("matches on file list", () => {
+      const fileListMod = createMod("file-list-mod", {
+        fileList: [
+          { path: "a.esp", md5: "aaa" },
+          { path: "b.esp", md5: "bbb" },
+        ],
+      });
+
+      expect(
+        modMatchesInstallSpec(fileListMod, {
+          fileList: [
+            { path: "a.esp", md5: "aaa" },
+            { path: "b.esp", md5: "bbb" },
+          ],
+        }),
+      ).toBe(true);
+
+      expect(
+        modMatchesInstallSpec(fileListMod, {
+          fileList: [{ path: "a.esp", md5: "DIFFERENT" }],
+        }),
+      ).toBe(false);
+    });
+
+    it("ignores a spec field that is present but empty", () => {
+      // an empty patches map / file list means "no particular variant requested" for
+      // that dimension, so a mod with no recorded patches still matches.
+      const plainMod = createMod("plain-mod", { fileMD5: "abc" });
+
+      expect(modMatchesInstallSpec(plainMod, { patches: {} })).toBe(true);
+      expect(modMatchesInstallSpec(plainMod, { fileList: [] })).toBe(true);
+    });
+  });
+
+  // Regression guard for the identity / install-spec consolidation: testModReference
+  // answers identity only ("which mod"), never how it was installed. Two installs that
+  // differ solely by installer choices / patches / file list must be indistinguishable
+  // to testModReference; the install-spec dimension lives exclusively in
+  // modMatchesInstallSpec / findModByRef.
+  describe("testModReference ignores install spec (identity only)", () => {
+    const refMD5 = "shared-identity-md5";
+
+    const makeVariant = (id: string, patches: { [k: string]: string }): IMod =>
+      createMod(id, {
+        fileMD5: refMD5,
+        fileName: `${id}.7z`,
+        logicalFileName: "Shared.7z",
+        version: "1.0.0",
+        source: "nexus",
+        game: ["skyrimse"],
+        patches,
+      });
+
+    it("matches a mod by identity regardless of its recorded patches", () => {
+      const reference: IModReference = { fileMD5: refMD5 };
+
+      expect(testModReference(makeVariant("variant-a", { p: "1" }), reference)).toBe(true);
+      expect(testModReference(makeVariant("variant-b", { p: "2" }), reference)).toBe(true);
+    });
+
+    it("treats two installs that differ only by install spec as the same identity", () => {
+      const reference: IModReference = { fileMD5: refMD5 };
+      const variantA = makeVariant("variant-a", { p: "1" });
+      const variantB = makeVariant("variant-b", { p: "2" });
+
+      // identity is equal for both...
+      expect(testModReference(variantA, reference)).toBe(testModReference(variantB, reference));
+      // ...while the install spec is what tells them apart.
+      expect(modMatchesInstallSpec(variantA, { patches: { p: "1" } })).toBe(true);
+      expect(modMatchesInstallSpec(variantB, { patches: { p: "1" } })).toBe(false);
+    });
+  });
+
+  describe("ruleInstallSpec", () => {
+    const baseRule = (over: Partial<IModRule>): IModRule => ({
+      type: "requires",
+      reference: { id: "some-mod" },
+      ...over,
+    });
+
+    it("reads installer choices and file list straight off the rule", () => {
+      const installerChoices = {
+        type: "fomod",
+        options: [{ name: "Main", groups: [{ name: "G", choices: [{ name: "O", idx: 0 }] }] }],
       };
+      const fileList = [{ path: "a.esp", md5: "aaa" }];
 
-      expect(testModReference(mod, reference)).toBe(true);
+      const spec = ruleInstallSpec(baseRule({ installerChoices, fileList }));
+
+      expect(spec.installerChoices).toEqual(installerChoices);
+      expect(spec.fileList).toEqual(fileList);
+    });
+
+    it("reads patches from the first-class rule.patches field", () => {
+      const spec = ruleInstallSpec(baseRule({ patches: { "a.esp": "hash-a" } }));
+      expect(spec.patches).toEqual({ "a.esp": "hash-a" });
+    });
+
+    it("falls back to the legacy rule.extra.patches location", () => {
+      // collection rules persisted before patches became a first-class field stored it
+      // under extra; ruleInstallSpec is the single place that bridges the two so those
+      // rules keep matching without a migration.
+      const spec = ruleInstallSpec(baseRule({ extra: { patches: { "a.esp": "legacy-hash" } } }));
+      expect(spec.patches).toEqual({ "a.esp": "legacy-hash" });
+    });
+
+    it("prefers the first-class field over the legacy location", () => {
+      const spec = ruleInstallSpec(
+        baseRule({
+          patches: { "a.esp": "new-hash" },
+          extra: { patches: { "a.esp": "legacy-hash" } },
+        }),
+      );
+      expect(spec.patches).toEqual({ "a.esp": "new-hash" });
+    });
+
+    it("returns undefined patches when neither location is set", () => {
+      expect(ruleInstallSpec(baseRule({})).patches).toBeUndefined();
     });
   });
 

--- a/src/renderer/src/extensions/mod_management/util/testModReference.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.ts
@@ -6,7 +6,15 @@ import * as semver from "semver";
 
 import { truthy } from "../../../util/util";
 import type { IDownload } from "../../download_management/types/IDownload";
-import type { IMod, IModReference, IFileListItem, IModAttributes } from "../types/IMod";
+import type {
+  IChoiceType,
+  IMod,
+  IModReference,
+  IModRule,
+  IFileListItem,
+  IModAttributes,
+  IModPatches,
+} from "../types/IMod";
 import { coerceToSemver, safeCoerce } from "./coerceToSemver";
 import { isFuzzyVersion } from "./isFuzzyVersion";
 
@@ -25,8 +33,8 @@ export interface IModLookupInfo {
   modId?: string;
   source?: string;
   referenceTag?: string;
-  installerChoices?: any;
-  patches?: any;
+  installerChoices?: IChoiceType;
+  patches?: IModPatches;
   fileList?: IFileListItem[];
 }
 
@@ -82,6 +90,75 @@ export function referenceEqual(lhs: IModReference, rhs: IModReference): boolean 
     return lhs.id === rhs.id;
   }
   return _.isEqual(_.pick(lhs, REFERENCE_FIELDS), _.pick(rhs, REFERENCE_FIELDS));
+}
+
+// A mod's "install spec": not which mod it is, but how it was installed - the
+// installer choices, file list, and binary patches. This is the data that
+// distinguishes the user-facing "variants" of a mod; it is NOT the named variant
+// itself (that is the `mod.attributes.variant` string).
+export interface IModInstallSpec {
+  installerChoices?: IChoiceType;
+  fileList?: IFileListItem[];
+  patches?: IModPatches;
+}
+
+/**
+ * Check whether an installed mod matches a requested install spec: the same installer
+ * choices, file list, and binary patches. This is deliberately separate from
+ * testModReference / findModByRef, which match a mod by IDENTITY only (which mod,
+ * not how it was installed). Identity matching answers "is this mod installed";
+ * install-spec matching answers "was it installed the way this rule asks for".
+ *
+ * Matching is purely by CONTENT (the choices / file list / patch data) and does not
+ * use the reference tag: tags are shortid-generated and are neither stable nor
+ * guaranteed unique, so a tag comparison cannot reliably distinguish installs.
+ */
+export function modMatchesInstallSpec(mod: IMod | IModLookupInfo, spec: IModInstallSpec): boolean {
+  const lookup = (mod as IMod).attributes
+    ? modAttributesToLookupInfo(mod)
+    : (mod as IModLookupInfo);
+
+  if (
+    spec.installerChoices != null &&
+    Object.keys(spec.installerChoices).length > 0 &&
+    !_.isEqualWith(lookup.installerChoices, spec.installerChoices)
+  ) {
+    return false;
+  }
+
+  if (
+    spec.fileList != null &&
+    spec.fileList.length > 0 &&
+    !_.isEqual(spec.fileList, lookup.fileList)
+  ) {
+    return false;
+  }
+
+  if (
+    spec.patches != null &&
+    Object.keys(spec.patches).length > 0 &&
+    !_.isEqual(lookup.patches, spec.patches)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * The install spec (installer choices / file list / patches) a collection rule asks
+ * for. This is the single place that reads a rule's install-spec fields, so the
+ * legacy-location fallback for `patches` lives only here.
+ */
+export function ruleInstallSpec(rule: IModRule): IModInstallSpec {
+  return {
+    installerChoices: rule.installerChoices,
+    fileList: rule.fileList,
+    // `patches` is now a first-class IModRule field; fall back to the old
+    // `rule.extra.patches` location so collection rules persisted before that move
+    // still match without a migration.
+    patches: rule.patches ?? rule.extra?.["patches"],
+  };
 }
 
 /**
@@ -162,6 +239,11 @@ function testRef(
   source?: { gameId: string; modId: string },
   fuzzyVersion?: boolean,
 ): boolean {
+  // A reference identifies WHICH mod is wanted, not how it was installed. Installer
+  // choices, file list and patches (the install spec) are matched separately via
+  // modMatchesInstallSpec / ruleInstallSpec, so a correctly-installed mod is still
+  // recognised here even if it was installed with a different spec.
+
   // Additional safety checks for ref parameter
   if (!ref || typeof ref !== "object" || Array.isArray(ref)) {
     return false;
@@ -182,32 +264,6 @@ function testRef(
     // if the reference doesn't have any marker that _could_ match this mod,
     // return !false!, otherwise we might match any random mod that also has no matching marker
     return false;
-  }
-
-  // Right installer choices?
-  if (
-    ref.installerChoices != null &&
-    Object.keys(ref.installerChoices).length > 0 &&
-    !_.isEqualWith(mod.installerChoices, ref.installerChoices)
-  ) {
-    return false;
-  }
-
-  // Right hashes?
-  if (ref.fileList != null && ref.fileList.length > 0 && !_.isEqual(ref.fileList, mod.fileList)) {
-    return false;
-  }
-
-  // Right patches?
-  const refHasPatches = ref.patches != null && Object.keys(ref.patches).length > 0;
-  const modHasPatches = mod.patches != null && Object.keys(mod.patches).length > 0;
-  if (refHasPatches) {
-    if (!_.isEqual(mod.patches, ref.patches)) {
-      return false;
-    }
-    if (mod?.referenceTag !== ref?.tag) {
-      return false;
-    }
   }
 
   if (ref.tag != null) {
@@ -240,8 +296,7 @@ function testRef(
   } else {
     if (!!ref.fileMD5 && ref.fileMD5 === mod.fileMD5) {
       // We don't have repo info which means that this is an external reference.
-      //  If we reached this point, that means we matched patches/installer choices/fileList
-      //  AND MD5 - this is good enough.
+      //  A matching MD5 identifies the file - this is good enough.
       return true;
     }
   }

--- a/src/renderer/src/types/api.ts
+++ b/src/renderer/src/types/api.ts
@@ -56,9 +56,15 @@ export type {
 export type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
 export type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 export type { IDeploymentManifest } from "../extensions/mod_management/types/IDeploymentManifest";
-export type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
 export type {
+  IModLookupInfo,
+  IModInstallSpec,
+} from "../extensions/mod_management/util/testModReference";
+export type {
+  IChoiceType,
+  IFileListItem,
   IMod,
+  IModPatches,
   IModReference,
   IModRepoId,
   IModRule,

--- a/src/renderer/src/util/api.ts
+++ b/src/renderer/src/util/api.ts
@@ -39,6 +39,7 @@ import { getModSource, getModSources } from "../extensions/mod_management/util/m
 import { removeMods } from "../extensions/mod_management/util/removeMods";
 import sortMods, { CycleError } from "../extensions/mod_management/util/sort";
 import testModReference, {
+  ruleInstallSpec,
   testRefByIdentifiers,
 } from "../extensions/mod_management/util/testModReference";
 import {
@@ -249,6 +250,7 @@ export {
   renderModReference,
   resolveCategoryName,
   resolveCategoryPath,
+  ruleInstallSpec,
   runElevated,
   runThreaded,
   sanitizeCSSId,


### PR DESCRIPTION
A mod reference meant two things at once. In mod_management it identifies WHICH mod (id, md5, logical name, repo, version). Collections also hung installer choices, file list, and patches off the same IModReference, so it encoded HOW the mod was installed too, and testModReference matched on both. That conflated "is this mod installed" with "was it installed the way this rule asks for", leaving no single source of truth for what a rule means and making the matching logic hard to reason about and test.

This makes identity the sole concern of testModReference and moves install-spec matching into dedicated, testable helpers shared by both subsystems.

- testModReference matches by identity only; removed installerChoices/fileList/patches from IModReference.
- Add IModInstallSpec, modMatchesInstallSpec, and ruleInstallSpec (the single reader of a rule's install-spec fields).
- findModByRef takes an optional installSpec to pick the right variant after identity matches (multiple variants of a mod can be installed at once).
- Promote patches to a first-class IModRule field, with a legacy rule.extra.patches fallback in ruleInstallSpec so older rules still match.
- Solidify shared types: installerChoices=IChoiceType, patches=IModPatches, fileList=IFileListItem[] everywhere.
- Convert touched collections/load-order files from **/api barrels to direct imports to avoid transient deps in tests.
- Add regression tests for the decoupling, ruleInstallSpec fallback, and findModByRef variant selection.