### PR TITLE
Remove request timeout

### DIFF
--- a/src/main/src/downloading/downloader.test.integration.ts
+++ b/src/main/src/downloading/downloader.test.integration.ts
@@ -873,44 +873,9 @@ describe("download", () => {
       const dest = path.join(tmp.dir, "output");
 
       const timeout: TimeoutOptions = {
-        request: 30_000,
         lookup: 5_000,
         connect: 5_000,
         stall: 200,
-      };
-
-      await expect(
-        download(
-          route.url,
-          dest,
-          {
-            resolver: urlResolver,
-            chunker: staticChunker(),
-          },
-          {
-            timeout,
-          },
-        ),
-      ).rejects.toMatchObject({
-        payload: { code: "network-timeout" },
-      });
-    }, 1_000);
-
-    it("rejects with a network timeout when the request timeout elapses", async () => {
-      using route = server.route(
-        withHooks(
-          serveFile({ body: LARGE_FILE, acceptRanges: false }),
-          delayAt("onRequest", 5_000),
-        ),
-      );
-      await using tmp = await makeTmpDir();
-      const dest = path.join(tmp.dir, "output");
-
-      const timeout: TimeoutOptions = {
-        request: 200,
-        lookup: 5_000,
-        connect: 5_000,
-        stall: 5_000,
       };
 
       await expect(
@@ -936,7 +901,6 @@ describe("download", () => {
       const dest = path.join(tmp.dir, "output");
 
       const timeout: TimeoutOptions = {
-        request: 30_000,
         lookup: 5_000,
         connect: 5_000,
         stall: 5_000,
@@ -973,7 +937,6 @@ describe("download", () => {
       const dest = path.join(tmp.dir, "output");
 
       const timeout: TimeoutOptions = {
-        request: 30_000,
         lookup: 5_000,
         connect: 5_000,
         stall: 200,
@@ -1007,10 +970,9 @@ describe("download", () => {
       const dest = path.join(tmp.dir, "output");
 
       const timeout: TimeoutOptions = {
-        request: 2_000,
-        lookup: 5_000,
-        connect: 5_000,
-        stall: 5_000,
+        lookup: 2_000,
+        connect: 2_000,
+        stall: 2_000,
       };
 
       const abortController = new AbortController();

--- a/src/main/src/downloading/downloader.ts
+++ b/src/main/src/downloading/downloader.ts
@@ -34,10 +34,6 @@ export type Checkpoint = {
 
 export type TimeoutOptions = {
   // TODO: use Temporal API
-
-  /** Hard upper limit for the entire duration of a single HTTP request (ms). */
-  request: number;
-
   /** Timeout for DNS lookup (ms). */
   lookup: number;
 
@@ -352,7 +348,6 @@ function createGotTimeoutOptions(timeout?: TimeoutOptions): GotTimeoutOptions | 
     secureConnect: timeout.connect,
     socket: timeout.stall,
     response: timeout.stall,
-    request: timeout.request,
   };
 }
 

--- a/src/main/src/downloading/manager.ts
+++ b/src/main/src/downloading/manager.ts
@@ -49,7 +49,6 @@ export const defaultTimeout: () => TimeoutOptions = () => ({
   lookup: 5_000,
   connect: 30_000,
   stall: 15_000,
-  request: 3 * 60 * 60_000,
 });
 
 export type DownloadManagerOptions = {


### PR DESCRIPTION
The `request` field for timeouts on `got` is for the entire request duration. As pointed out previously, that isn't exactly ideal as it puts a hard limit on all requests.

Since there is no benefit to using the `request` field, we can just remove it. Our existing resilience strategies (other timeouts and retries) are sufficient enough.

Closes LAZ-575