### PR TITLE
Updated list to v0.29

### DIFF
--- a/extensions/gamebryo-plugin-management/src/util/masterlist.ts
+++ b/extensions/gamebryo-plugin-management/src/util/masterlist.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 
 import { fs, types, util } from "@nexusmods/vortex-api";
 
-const LOOT_LIST_REVISION = "v0.26";
+const LOOT_LIST_REVISION = "v0.29";
 const DOWNLOAD_THROTTLE_MS = 30 * 60 * 1000; // 30 minutes
 
 function getListUrl(gameId?: string) {


### PR DESCRIPTION

Closes [LAZ-567](https://linear.app/nexus-mods/issue/LAZ-567/update-libloot-data-for-v029-relationships)
Fixes #23444