### PR TITLE
Update Button to brand/appearance props (LAZ-577)

### DIFF
--- a/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -282,8 +282,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 />
 
                 <Button
-                  buttonType="tertiary"
-                  filled="weak"
+                  brand="neutral"
+                  appearance="moderate"
                   leftIconPath={mdiMagnify}
                   size="sm"
                   title={t("common:actions.search")}
@@ -294,8 +294,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
               <div className="flex justify-between">
                 <div className="flex items-center gap-x-2">
                   <Button
-                    buttonType="tertiary"
-                    filled="weak"
+                    brand="neutral"
+                    appearance="moderate"
                     leftIconPath={mdiRefresh}
                     size="sm"
                     title={t("collection:browse.refresh")}
@@ -329,8 +329,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 isLoading={loading}
                 noResultsChildren={
                   <Button
-                    buttonType="tertiary"
-                    filled="weak"
+                    brand="neutral"
+                    appearance="moderate"
                     leftIconPath={mdiOpenInNew}
                     size="sm"
                     onClick={() =>
@@ -381,8 +381,8 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
               title={t("collection:browse.modsComingSoon.title")}
             >
               <Button
-                buttonType="tertiary"
-                filled="weak"
+                brand="neutral"
+                appearance="moderate"
                 leftIconPath={mdiOpenInNew}
                 size="sm"
                 onClick={() =>

--- a/src/renderer/src/extensions/health_check/components/feedback_modal/FeedbackModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/feedback_modal/FeedbackModal.tsx
@@ -49,12 +49,18 @@ export const FeedbackModal = ({
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-x-2">
-        <Button buttonType="tertiary" className="w-full" filled="weak" size="sm" onClick={onClose}>
+        <Button
+          brand="neutral"
+          appearance="moderate"
+          className="w-full"
+          size="sm"
+          onClick={onClose}
+        >
           {t("detail::feedback_modal::buttons::cancel")}
         </Button>
 
         <Button
-          buttonType="primary"
+          brand="primary"
           className="w-full"
           size="sm"
           onClick={() => {

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ModRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ModRequirement.tsx
@@ -56,8 +56,8 @@ export const ModRequirement = ({
             {mod.externalRequirement ? (
               mod.modUrl ? (
                 <Button
-                  buttonType="tertiary"
-                  filled="weak"
+                  brand="neutral"
+                  appearance="moderate"
                   leftIconPath={mdiWeb}
                   rightIconPath={mdiOpenInNew}
                   size="sm"
@@ -70,8 +70,8 @@ export const ModRequirement = ({
               <>
                 {mod.modUrl ? (
                   <Button
-                    buttonType="tertiary"
-                    filled="weak"
+                    brand="neutral"
+                    appearance="moderate"
                     leftIcon={<img alt="" src="assets/images/nexus.svg" />}
                     size="sm"
                     onClick={() => window.api.shell.openUrl(mod.modUrl)}
@@ -81,8 +81,8 @@ export const ModRequirement = ({
                 ) : null}
 
                 <Button
-                  buttonType="secondary"
-                  filled="strong"
+                  brand="neutral"
+                  appearance="strong"
                   leftIconPath={mdiDownload}
                   rightIcon={showPremiumBadge && <PremiumBadge />}
                   size="sm"
@@ -107,8 +107,8 @@ export const ModRequirement = ({
             </Typography>
 
             <Button
-              buttonType="tertiary"
-              filled="weak"
+              brand="neutral"
+              appearance="moderate"
               leftIconPath={mdiCheck}
               size="sm"
               onClick={onConfirmInstall}

--- a/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
@@ -59,9 +59,9 @@ export const PremiumModal = ({
 
       <div className="mt-4 grid grid-cols-2 gap-x-2">
         <Button
-          buttonType="tertiary"
+          brand="neutral"
+          appearance="moderate"
           className="w-full"
-          filled="weak"
           size="sm"
           onClick={onDownload}
         >
@@ -69,7 +69,7 @@ export const PremiumModal = ({
         </Button>
 
         <Button
-          buttonType="premium"
+          brand="premium"
           className="w-full"
           leftIconPath={mdiDiamondStone}
           size="sm"

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -182,8 +182,8 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
 
             <div>
               <Button
-                buttonType="tertiary"
-                filled="weak"
+                brand="neutral"
+                appearance="moderate"
                 leftIconPath={mdiArrowLeft}
                 size="sm"
                 onClick={onBack}
@@ -207,7 +207,7 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
                 </div>
               </div>
 
-              <Button buttonType="premium" size="sm" onClick={goPremium}>
+              <Button brand="premium" size="sm" onClick={goPremium}>
                 {t("premium::banner::button")}
               </Button>
             </div>
@@ -246,8 +246,8 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
 
                 <div className="shrink-0">
                   <Button
-                    buttonType="tertiary"
-                    filled="weak"
+                    brand="neutral"
+                    appearance="moderate"
                     leftIconPath={isHidden ? mdiEye : mdiEyeOff}
                     size="sm"
                     title={isHidden ? t("common:::unhide") : t("common:::hide")}
@@ -278,9 +278,9 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
 
             <div className="flex shrink-0 gap-x-2">
               <Button
-                buttonType="tertiary"
+                brand="neutral"
+                appearance="moderate"
                 disabled={givenFeedBack}
-                filled="weak"
                 leftIconPath={mdiThumbUp}
                 size="sm"
                 title={t("common:::helpful")}
@@ -288,9 +288,9 @@ function HealthCheckDetailPage({ mod, api, onBack, onDownloadMod }: IHealthCheck
               />
 
               <Button
-                buttonType="tertiary"
+                brand="neutral"
+                appearance="moderate"
                 disabled={givenFeedBack}
-                filled="weak"
                 leftIconPath={mdiThumbDown}
                 size="sm"
                 title={t("common:::not_helpful")}

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -73,8 +73,8 @@ const Mod = ({
       </div>
 
       <Button
-        buttonType="tertiary"
-        filled="weak"
+        brand="neutral"
+        appearance="moderate"
         leftIconPath={isHidden ? mdiEye : mdiEyeOff}
         size="sm"
         title={isHidden ? t("common:::unhide") : t("common:::hide")}
@@ -193,8 +193,8 @@ function HealthCheckPage({ api, onRefresh, onDownloadRequirement }: IHealthCheck
 
             <div className="flex shrink-0 gap-x-2">
               <Button
-                buttonType="tertiary"
-                filled="weak"
+                brand="neutral"
+                appearance="moderate"
                 leftIconPath={mdiRefresh}
                 size="sm"
                 title={t("common:::refresh")}
@@ -202,8 +202,8 @@ function HealthCheckPage({ api, onRefresh, onDownloadRequirement }: IHealthCheck
               />
 
               <Button
-                buttonType="tertiary"
-                filled="weak"
+                brand="neutral"
+                appearance="moderate"
                 leftIconPath={mdiCog}
                 size="sm"
                 title={t("common:::settings")}
@@ -229,12 +229,12 @@ function HealthCheckPage({ api, onRefresh, onDownloadRequirement }: IHealthCheck
               </TabBar>
 
               <Button
-                buttonType="tertiary"
+                brand="neutral"
+                appearance="moderate"
                 disabled={
                   (selectedTab === "active" && !activeCount) ||
                   (selectedTab === "hidden" && !hiddenCount)
                 }
-                filled="weak"
                 leftIconPath={selectedTab === "active" ? mdiEyeOff : mdiEye}
                 size="sm"
                 onClick={selectedTab === "active" ? hideAllActive : unhideAll}

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -8,7 +8,7 @@ Components adapted from the web team's "next" project for use in Vortex.
 ui/
 ├── components/
 │   ├── bullet/          - Small rotated-square dot used as an inline marker/separator
-│   ├── button/          - Button system (primary, secondary, tertiary, success, premium)
+│   ├── button/          - Button system (brand × appearance matrix)
 │   ├── collectiontile/  - Collection card with image, metadata, and actions
 │   ├── dropdown/        - Dropdown menu (Headless UI Menu)
 │   ├── form/            - Form components
@@ -71,7 +71,7 @@ Components use `nxm-` prefixed CSS class names to avoid conflicts with existing 
 
 ```tsx
 // Class naming pattern: nxm-{component}-{variant}-{modifier}
-<button className="nxm-button nxm-button-primary" />
+<button className="nxm-button nxm-button-primary nxm-button-strong" />
 <span className="nxm-tab-button nxm-tab-button-selected" />
 ```
 
@@ -88,29 +88,40 @@ joinClasses(["nxm-button", className], {
 
 ### Button
 
-**Defaults:** `buttonType="primary"`, `size="md"` — only set these when you need something different.
+Styled as a `brand` × `appearance` matrix: `brand` picks the colour family, `appearance` picks the prominence (solid fill → text-only).
+
+**Defaults:** `brand="primary"`, `appearance="strong"`, `size="md"` — only set these when you need something different.
 
 ```tsx
 import { Button } from "../../ui/components/button/Button";
 
-// Uses defaults (primary, md) — no need to specify
+// Uses defaults (primary, strong, md) — a solid primary button
 <Button>Click Me</Button>
 
 // Only override what differs from the default
 <Button size="xs">Small</Button>
-<Button buttonType="secondary" filled="strong">Filled</Button>
-<Button buttonType="success">Saved</Button>
+<Button brand="neutral" appearance="subdued">Outlined</Button>
+<Button brand="neutral" appearance="weak">Quiet</Button>
+<Button brand="success">Saved</Button>
 
 // With icons
 import { mdiDownload } from "@mdi/js";
 <Button leftIconPath={mdiDownload}>Download</Button>
 
+// Icon-only (collapses to a square — always pass an aria-label)
+<Button aria-label="Download" leftIconPath={mdiDownload} />
+
 // Loading state
 <Button isLoading>Processing...</Button>
 ```
 
-**Types:** `primary`, `secondary`, `tertiary`, `success`, `premium`
+**Brands:** `primary`, `info`, `neutral`, `success`, `premium`
+**Appearances:** `strong` (solid fill), `moderate` (subtle surface), `subdued` (outline), `weak` (text only)
 **Sizes:** `xs`, `sm`, `md`
+
+A button with no `children`/`customContent` but an icon renders icon-only (square). Every brand supports every appearance; `success`/`premium` derive their full ramps to match. `appearance` defaults to `strong` so a bare `<Button>` is a solid primary button.
+
+> **Migration note:** the old `buttonType`/`filled` props were replaced by `brand`/`appearance`. `secondary`→`neutral`+`subdued`, `tertiary`→`neutral`+`weak`, `filled="strong"`→`appearance="strong"`, `filled="weak"`→`appearance="moderate"`.
 
 ### Icon
 

--- a/src/renderer/src/ui/components/button/Button.test.tsx
+++ b/src/renderer/src/ui/components/button/Button.test.tsx
@@ -45,9 +45,14 @@ describe("Button", () => {
       expect(getButton()).toHaveAttribute("type", "button");
     });
 
-    it("applies primary class by default", () => {
+    it("applies primary brand class by default", () => {
       render(<Button>Click</Button>);
       expect(getButton()).toHaveClass("nxm-button-primary");
+    });
+
+    it("applies strong appearance class by default", () => {
+      render(<Button>Click</Button>);
+      expect(getButton()).toHaveClass("nxm-button-strong");
     });
 
     it("applies nxm-button base class always", () => {
@@ -56,60 +61,37 @@ describe("Button", () => {
     });
   });
 
-  describe("buttonType", () => {
+  describe("brand", () => {
     it.each([
       ["primary", "nxm-button-primary"],
+      ["info", "nxm-button-info"],
+      ["neutral", "nxm-button-neutral"],
       ["success", "nxm-button-success"],
       ["premium", "nxm-button-premium"],
-    ] as const)('applies correct class for buttonType="%s"', (type, cls) => {
-      render(<Button buttonType={type}>Click</Button>);
+    ] as const)('applies correct class for brand="%s"', (brand, cls) => {
+      render(<Button brand={brand}>Click</Button>);
+      expect(getButton()).toHaveClass(cls);
+    });
+  });
+
+  describe("appearance", () => {
+    it.each([
+      ["weak", "nxm-button-weak"],
+      ["subdued", "nxm-button-subdued"],
+      ["moderate", "nxm-button-moderate"],
+      ["strong", "nxm-button-strong"],
+    ] as const)('applies correct class for appearance="%s"', (appearance, cls) => {
+      render(<Button appearance={appearance}>Click</Button>);
       expect(getButton()).toHaveClass(cls);
     });
 
-    it("applies secondary class when no filled prop", () => {
-      render(<Button buttonType="secondary">Click</Button>);
-      expect(getButton()).toHaveClass("nxm-button-secondary");
-    });
-
-    it("applies secondary filled-strong class", () => {
+    it("combines brand and appearance classes", () => {
       render(
-        <Button buttonType="secondary" filled="strong">
+        <Button appearance="subdued" brand="neutral">
           Click
         </Button>,
       );
-      expect(getButton()).toHaveClass("nxm-button-secondary-filled-strong");
-    });
-
-    it("applies secondary filled-weak class", () => {
-      render(
-        <Button buttonType="secondary" filled="weak">
-          Click
-        </Button>,
-      );
-      expect(getButton()).toHaveClass("nxm-button-secondary-filled-weak");
-    });
-
-    it("applies tertiary class when no filled prop", () => {
-      render(<Button buttonType="tertiary">Click</Button>);
-      expect(getButton()).toHaveClass("nxm-button-tertiary");
-    });
-
-    it("applies tertiary filled-strong class", () => {
-      render(
-        <Button buttonType="tertiary" filled="strong">
-          Click
-        </Button>,
-      );
-      expect(getButton()).toHaveClass("nxm-button-tertiary-filled-strong");
-    });
-
-    it("applies tertiary filled-weak class", () => {
-      render(
-        <Button buttonType="tertiary" filled="weak">
-          Click
-        </Button>,
-      );
-      expect(getButton()).toHaveClass("nxm-button-tertiary-filled-weak");
+      expect(getButton()).toHaveClass("nxm-button-neutral", "nxm-button-subdued");
     });
   });
 

--- a/src/renderer/src/ui/components/button/Button.tsx
+++ b/src/renderer/src/ui/components/button/Button.tsx
@@ -1,11 +1,3 @@
-/**
- * Button Component
- * Adapted from web team's "next" project for Vortex
- *
- * Provides a consistent button system with multiple types, sizes, and states.
- * Uses shared CSS classes from button.css (nxm-button-*) for styling.
- */
-
 import { mdiCircleOutline, mdiLoading } from "@mdi/js";
 import React, {
   type ButtonHTMLAttributes,
@@ -20,83 +12,21 @@ import { Icon } from "@/ui/components/icon/Icon";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import type { XOr } from "@/ui/utils/types";
 
-export type ButtonType = "primary" | "secondary" | "tertiary" | "success" | "premium";
+export type ButtonBrand = "primary" | "info" | "neutral" | "success" | "premium";
+export type ButtonAppearance = "weak" | "subdued" | "moderate" | "strong";
 
-type BaseButtonProps = {
-  buttonType?: ButtonType;
-  filled?: "strong" | "weak";
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  brand?: ButtonBrand;
+  appearance?: ButtonAppearance;
   isLoading?: boolean;
   size?: "xs" | "sm" | "md";
   children?: string;
   customContent?: ReactNode;
-} & XOr<{ leftIconPath?: string }, { leftIcon?: ReactNode }> &
-  XOr<{ rightIconPath?: string }, { rightIcon?: ReactNode }>;
-
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   disabled?: boolean;
   href?: never;
   isExternal?: never;
-} & BaseButtonProps;
-
-const getButtonClasses = ({
-  buttonType,
-  disabled,
-  filled,
-  iconOnly,
-  size,
-}: {
-  buttonType: ButtonType;
-  disabled: boolean;
-  filled?: ButtonProps["filled"];
-  iconOnly: boolean;
-  size: Required<ButtonProps>["size"];
-}) => {
-  const classes = [
-    "nxm-button",
-    {
-      "nxm-button-disabled": disabled,
-      "nxm-button-icon-only": iconOnly,
-      "nxm-button-xs": size === "xs",
-      "nxm-button-sm": size === "sm",
-    },
-  ];
-
-  switch (buttonType) {
-    case "primary":
-      classes.push("nxm-button-primary");
-      break;
-    case "secondary":
-      if (filled) {
-        classes.push(
-          filled === "strong"
-            ? "nxm-button-secondary-filled-strong"
-            : "nxm-button-secondary-filled-weak",
-        );
-      } else {
-        classes.push("nxm-button-secondary");
-      }
-      break;
-    case "tertiary":
-      if (filled) {
-        classes.push(
-          filled === "strong"
-            ? "nxm-button-tertiary-filled-strong"
-            : "nxm-button-tertiary-filled-weak",
-        );
-      } else {
-        classes.push("nxm-button-tertiary");
-      }
-      break;
-    case "success":
-      classes.push("nxm-button-success");
-      break;
-    case "premium":
-      classes.push("nxm-button-premium");
-      break;
-  }
-
-  return classes;
-};
+} & XOr<{ leftIconPath?: string }, { leftIcon?: ReactNode }> &
+  XOr<{ rightIconPath?: string }, { rightIcon?: ReactNode }>;
 
 const ButtonIcon = ({
   icon,
@@ -136,12 +66,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       "aria-disabled": ariaDisabled,
-      buttonType = "primary",
+      appearance = "strong",
+      brand = "primary",
       children,
       className,
       customContent,
       disabled,
-      filled,
       isExternal,
       isLoading = false,
       leftIcon,
@@ -149,25 +79,25 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       rightIcon,
       rightIconPath,
       size = "md",
+      type,
       ...props
     },
     ref,
   ) => (
     <button
       aria-disabled={ariaDisabled}
-      className={joinClasses([
-        ...getButtonClasses({
-          buttonType,
-          disabled: !!disabled || !!ariaDisabled || isLoading,
-          filled,
-          iconOnly: !customContent && !children,
-          size,
-        }),
-        className || "",
-      ])}
+      className={joinClasses(
+        ["nxm-button", `nxm-button-${brand}`, `nxm-button-${appearance}`, className],
+        {
+          "nxm-button-disabled": !!disabled || !!ariaDisabled || isLoading,
+          "nxm-button-icon-only": !customContent && !children,
+          "nxm-button-xs": size === "xs",
+          "nxm-button-sm": size === "sm",
+        },
+      )}
       disabled={disabled || isLoading}
       ref={ref}
-      type={props.type ?? "button"}
+      type={type ?? "button"}
       {...props}
     >
       {customContent ?? (

--- a/src/renderer/src/ui/components/button/ButtonDemo.tsx
+++ b/src/renderer/src/ui/components/button/ButtonDemo.tsx
@@ -7,7 +7,12 @@ import { mdiCheck, mdiChevronRight, mdiCog, mdiDownload } from "@mdi/js";
 import React, { useState } from "react";
 
 import { Typography } from "../typography/Typography";
-import { Button } from "./Button";
+import { Button, type ButtonAppearance, type ButtonBrand } from "./Button";
+
+const BRANDS: ButtonBrand[] = ["primary", "info", "neutral", "success", "premium"];
+const APPEARANCES: ButtonAppearance[] = ["strong", "moderate", "subdued", "weak"];
+
+const titleCase = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
 export const ButtonDemo = () => {
   const [loadingStates, setLoadingStates] = useState<Record<string, boolean>>({});
@@ -25,108 +30,66 @@ export const ButtonDemo = () => {
         </Typography>
 
         <Typography appearance="subdued">
-          A consistent button system with multiple types, sizes, and states including icon support.
+          A consistent button system with a brand × appearance matrix, multiple sizes, and states
+          including icon support.
         </Typography>
       </div>
 
       <div className="space-y-4">
         <Typography as="h3" typographyType="heading-xs">
-          Primary Buttons
+          Brand × Appearance
+        </Typography>
+
+        {BRANDS.map((brand) => (
+          <div className="space-y-2" key={brand}>
+            <Typography appearance="subdued" typographyType="body-sm">
+              {titleCase(brand)}
+            </Typography>
+
+            <div className="flex flex-wrap items-center gap-4">
+              {APPEARANCES.map((appearance) => (
+                <React.Fragment key={appearance}>
+                  <Button appearance={appearance} brand={brand}>
+                    {titleCase(appearance)}
+                  </Button>
+
+                  <Button
+                    appearance={appearance}
+                    aria-label={`${titleCase(brand)} ${titleCase(appearance)} icon only`}
+                    brand={brand}
+                    leftIconPath={mdiCog}
+                  />
+                </React.Fragment>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Sizes
         </Typography>
 
         <div className="flex flex-wrap items-center gap-4">
-          <Button>Primary Medium</Button>
+          <Button size="md">Medium</Button>
 
-          <Button size="sm">Primary Small</Button>
+          <Button size="sm">Small</Button>
 
+          <Button size="xs">Extra Small</Button>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          States
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
           <Button disabled={true}>Disabled</Button>
 
           <Button isLoading={loadingStates.primary} onClick={() => handleLoadingClick("primary")}>
             Click for Loading
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <Typography as="h3" typographyType="heading-xs">
-          Secondary Buttons
-        </Typography>
-
-        <div className="flex flex-wrap items-center gap-4">
-          <Button buttonType="secondary">Secondary Medium</Button>
-
-          <Button buttonType="secondary" size="sm">
-            Secondary Small
-          </Button>
-
-          <Button buttonType="secondary" filled="strong">
-            Filled Strong
-          </Button>
-
-          <Button buttonType="secondary" filled="weak">
-            Filled Weak
-          </Button>
-
-          <Button buttonType="secondary" disabled={true}>
-            Disabled
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <Typography as="h3" typographyType="heading-xs">
-          Tertiary Buttons
-        </Typography>
-
-        <div className="flex flex-wrap items-center gap-4">
-          <Button buttonType="tertiary">Tertiary Medium</Button>
-
-          <Button buttonType="tertiary" size="sm">
-            Tertiary Small
-          </Button>
-
-          <Button buttonType="tertiary" filled="strong">
-            Filled Strong
-          </Button>
-
-          <Button buttonType="tertiary" filled="weak">
-            Filled Weak
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <Typography as="h3" typographyType="heading-xs">
-          Success Buttons
-        </Typography>
-
-        <div className="flex flex-wrap items-center gap-4">
-          <Button buttonType="success">Success Medium</Button>
-
-          <Button buttonType="success" size="sm">
-            Success Small
-          </Button>
-
-          <Button buttonType="success" disabled={true}>
-            Disabled
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <Typography as="h3" typographyType="heading-xs">
-          Premium Buttons
-        </Typography>
-
-        <div className="flex flex-wrap items-center gap-4">
-          <Button buttonType="premium">Premium Medium</Button>
-
-          <Button buttonType="premium" size="sm">
-            Premium Small
-          </Button>
-
-          <Button buttonType="premium" disabled={true}>
-            Disabled
           </Button>
         </div>
       </div>
@@ -149,37 +112,52 @@ export const ButtonDemo = () => {
 
       <div className="space-y-4">
         <Typography as="h3" typographyType="heading-xs">
-          Responsive Buttons
-        </Typography>
-
-        <Typography appearance="subdued" typographyType="body-sm">
-          These buttons change size based on screen width. Try resizing the window!
-        </Typography>
-
-        <div className="flex flex-wrap items-center gap-4">
-          <Button size="sm">Responsive (sm on mobile, md on desktop)</Button>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <Typography as="h3" typographyType="heading-xs">
           Buttons with Icons
         </Typography>
 
         <div className="flex flex-wrap items-center gap-4">
           <Button leftIconPath={mdiDownload}>Download</Button>
 
-          <Button buttonType="secondary" rightIconPath={mdiChevronRight}>
+          <Button brand="neutral" appearance="subdued" rightIconPath={mdiChevronRight}>
             Next
           </Button>
 
-          <Button buttonType="success" leftIconPath={mdiCheck} size="sm">
+          <Button brand="success" leftIconPath={mdiCheck} size="sm">
             Confirm
           </Button>
 
-          <Button buttonType="tertiary" leftIconPath={mdiCog}>
+          <Button brand="neutral" appearance="weak" leftIconPath={mdiCog}>
             Settings
           </Button>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Icon Only
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          Buttons with an icon and no label collapse to a square. Always provide an aria-label.
+        </Typography>
+
+        <div className="flex flex-wrap items-center gap-4">
+          {APPEARANCES.map((appearance) => (
+            <Button
+              appearance={appearance}
+              aria-label={`Settings (${appearance})`}
+              key={appearance}
+              leftIconPath={mdiCog}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Button aria-label="Settings (md)" leftIconPath={mdiCog} size="md" />
+
+          <Button aria-label="Settings (sm)" leftIconPath={mdiCog} size="sm" />
+
+          <Button aria-label="Settings (xs)" leftIconPath={mdiCog} size="xs" />
         </div>
       </div>
     </div>

--- a/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collectiontile/CollectionTile.tsx
@@ -214,7 +214,8 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
       <div className="flex shrink-0 items-center gap-x-2 rounded-b bg-surface-translucent-low px-3 py-2">
         {!canBeAdded || pending ? (
           <Button
-            buttonType="tertiary"
+            brand="neutral"
+            appearance="weak"
             disabled={true}
             leftIconPath={!isLoggedIn ? undefined : mdiCheck}
             size="xs"
@@ -228,7 +229,13 @@ export const CollectionTile: ComponentType<CollectionTileProps> = ({
           </Button>
         )}
 
-        <Button buttonType="tertiary" leftIconPath={mdiOpenInNew} size="xs" onClick={onViewPage}>
+        <Button
+          brand="neutral"
+          appearance="weak"
+          leftIconPath={mdiOpenInNew}
+          size="xs"
+          onClick={onViewPage}
+        >
           View page
         </Button>
       </div>

--- a/src/renderer/src/ui/components/dropdown/DropdownDemo.tsx
+++ b/src/renderer/src/ui/components/dropdown/DropdownDemo.tsx
@@ -40,7 +40,7 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} buttonType="secondary">
+            <Menu.Button as={Button} brand="neutral" appearance="subdued">
               Options
             </Menu.Button>
 
@@ -62,7 +62,7 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} buttonType="secondary">
+            <Menu.Button as={Button} brand="neutral" appearance="subdued">
               Actions
             </Menu.Button>
 
@@ -102,7 +102,8 @@ export const DropdownDemo = () => {
           <Dropdown>
             <Menu.Button
               as={Button}
-              buttonType="secondary"
+              brand="neutral"
+              appearance="subdued"
               leftIconPath={mdiDotsVertical}
               size="sm"
             />
@@ -131,7 +132,7 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} buttonType="secondary">
+            <Menu.Button as={Button} brand="neutral" appearance="subdued">
               With Disabled
             </Menu.Button>
 

--- a/src/renderer/src/ui/components/listing/ListingDemo.tsx
+++ b/src/renderer/src/ui/components/listing/ListingDemo.tsx
@@ -67,8 +67,9 @@ export const ListingDemo = () => {
 
         <div className="flex flex-wrap gap-2">
           <Button
-            buttonType="secondary"
-            {...(isLoading ? { filled: "strong" } : {})}
+            brand="neutral"
+            appearance="subdued"
+            {...(isLoading ? { appearance: "strong" } : {})}
             size="sm"
             onClick={() => {
               setIsLoading(!isLoading);
@@ -79,8 +80,9 @@ export const ListingDemo = () => {
           </Button>
 
           <Button
-            buttonType="secondary"
-            {...(isError ? { filled: "strong" } : {})}
+            brand="neutral"
+            appearance="subdued"
+            {...(isError ? { appearance: "strong" } : {})}
             size="sm"
             onClick={() => {
               setIsError(!isError);
@@ -91,8 +93,9 @@ export const ListingDemo = () => {
           </Button>
 
           <Button
-            buttonType="secondary"
-            {...(isEmpty ? { filled: "strong" } : {})}
+            brand="neutral"
+            appearance="subdued"
+            {...(isEmpty ? { appearance: "strong" } : {})}
             size="sm"
             onClick={() => {
               setIsEmpty(!isEmpty);
@@ -183,7 +186,7 @@ export const ListingDemo = () => {
                   No mods installed yet
                 </Typography>
 
-                <Button buttonType="secondary" size="sm">
+                <Button brand="neutral" appearance="subdued" size="sm">
                   Browse mods
                 </Button>
               </div>

--- a/src/renderer/src/ui/components/modal/ModalDemo.tsx
+++ b/src/renderer/src/ui/components/modal/ModalDemo.tsx
@@ -38,7 +38,7 @@ export const ModalDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap gap-4">
-          <Button buttonType="secondary" onClick={() => setBasicOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setBasicOpen(true)}>
             Open Basic Modal
           </Button>
         </div>
@@ -50,7 +50,7 @@ export const ModalDemo = () => {
           </Typography>
 
           <div className="mt-4 flex justify-end gap-2">
-            <Button buttonType="secondary" onClick={() => setBasicOpen(false)}>
+            <Button brand="neutral" appearance="subdued" onClick={() => setBasicOpen(false)}>
               Cancel
             </Button>
 
@@ -65,15 +65,15 @@ export const ModalDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap gap-4">
-          <Button buttonType="secondary" onClick={() => setSizeSmOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setSizeSmOpen(true)}>
             Small (sm)
           </Button>
 
-          <Button buttonType="secondary" onClick={() => setSizeLgOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setSizeLgOpen(true)}>
             Large (lg)
           </Button>
 
-          <Button buttonType="secondary" onClick={() => setSizeXlOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setSizeXlOpen(true)}>
             Extra Large (xl)
           </Button>
         </div>
@@ -103,7 +103,7 @@ export const ModalDemo = () => {
           </Typography>
 
           <div className="mt-4 flex justify-end gap-2">
-            <Button buttonType="secondary" onClick={() => setSizeLgOpen(false)}>
+            <Button brand="neutral" appearance="subdued" onClick={() => setSizeLgOpen(false)}>
               Cancel
             </Button>
 
@@ -122,7 +122,7 @@ export const ModalDemo = () => {
           </Typography>
 
           <div className="mt-4 flex justify-end gap-2">
-            <Button buttonType="secondary" onClick={() => setSizeXlOpen(false)}>
+            <Button brand="neutral" appearance="subdued" onClick={() => setSizeXlOpen(false)}>
               Close
             </Button>
           </div>
@@ -139,7 +139,7 @@ export const ModalDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap gap-4">
-          <Button buttonType="secondary" onClick={() => setNoCloseOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setNoCloseOpen(true)}>
             Open Without Close Button
           </Button>
         </div>
@@ -171,7 +171,7 @@ export const ModalDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap gap-4">
-          <Button buttonType="secondary" onClick={() => setFocusOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setFocusOpen(true)}>
             Open With Initial Focus
           </Button>
         </div>
@@ -187,7 +187,7 @@ export const ModalDemo = () => {
           </Typography>
 
           <div className="mt-4 flex justify-end gap-2">
-            <Button buttonType="secondary" onClick={() => setFocusOpen(false)}>
+            <Button brand="neutral" appearance="subdued" onClick={() => setFocusOpen(false)}>
               Cancel
             </Button>
 
@@ -208,7 +208,7 @@ export const ModalDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap gap-4">
-          <Button buttonType="secondary" onClick={() => setCustomOpen(true)}>
+          <Button brand="neutral" appearance="subdued" onClick={() => setCustomOpen(true)}>
             Open Custom Layout
           </Button>
         </div>
@@ -221,7 +221,7 @@ export const ModalDemo = () => {
             </Typography>
 
             <div className="mt-4 flex justify-end gap-2">
-              <Button buttonType="secondary" onClick={() => setCustomOpen(false)}>
+              <Button brand="neutral" appearance="subdued" onClick={() => setCustomOpen(false)}>
                 Close
               </Button>
             </div>

--- a/src/renderer/src/ui/components/no_results/NoResults.tsx
+++ b/src/renderer/src/ui/components/no_results/NoResults.tsx
@@ -56,8 +56,8 @@ export const NoResults = ({
       ? children
       : isError && (
           <Button
-            buttonType="tertiary"
-            filled="weak"
+            brand="neutral"
+            appearance="moderate"
             leftIconPath={mdiOpenInNew}
             size="sm"
             onClick={() =>

--- a/src/renderer/src/ui/components/pagination/JumpToPage.tsx
+++ b/src/renderer/src/ui/components/pagination/JumpToPage.tsx
@@ -54,7 +54,13 @@ export const JumpToPage = ({
         }}
       />
 
-      <Button aria-disabled={!isValid} buttonType="secondary" filled="weak" size="sm" type="submit">
+      <Button
+        aria-disabled={!isValid}
+        brand="neutral"
+        appearance="moderate"
+        size="sm"
+        type="submit"
+      >
         Go
       </Button>
     </form>

--- a/src/renderer/src/views/AppLayout.tsx
+++ b/src/renderer/src/views/AppLayout.tsx
@@ -28,7 +28,7 @@ const LayoutSwitcher = () => {
 
   return (
     <Button
-      buttonType="primary"
+      brand="primary"
       className="fixed right-4 bottom-4 z-toast"
       leftIconPath={useModernLayout ? mdiMonitor : mdiMonitorShimmer}
       size="sm"

--- a/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
@@ -27,8 +27,8 @@ export const NotificationActions: FC<NotificationActionsProps> = ({
     <div className="flex gap-x-1">
       {actions?.map((action: INotificationAction) => (
         <Button
-          buttonType="tertiary"
-          filled="weak"
+          brand="neutral"
+          appearance="moderate"
           key={action.title ?? action.icon}
           size="xs"
           onClick={onActionClick(action.title)}
@@ -38,7 +38,7 @@ export const NotificationActions: FC<NotificationActionsProps> = ({
       ))}
 
       {collapsed > 1 && onExpand && (
-        <Button buttonType="tertiary" filled="weak" size="xs" onClick={onExpand}>
+        <Button brand="neutral" appearance="moderate" size="xs" onClick={onExpand}>
           {t("{{ count }} More", { count: collapsed - 1 })}
         </Button>
       )}

--- a/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
@@ -29,7 +29,8 @@ export const NotificationControls: FC<NotificationControlsProps> = ({
     <div className="relative flex shrink-0 items-start gap-x-1">
       {allowSuppress && (
         <Button
-          buttonType="tertiary"
+          brand="neutral"
+          appearance="weak"
           leftIconPath={mdiEyeOff}
           size="xs"
           title={t("Never show again")}
@@ -39,7 +40,8 @@ export const NotificationControls: FC<NotificationControlsProps> = ({
 
       {!noDismiss && (
         <Button
-          buttonType="tertiary"
+          brand="neutral"
+          appearance="weak"
           leftIconPath={mdiClose}
           size="xs"
           title={collapsed > 1 ? t("Dismiss All") : t("Dismiss")}

--- a/src/renderer/src/views/components/Header/PremiumIndicator.tsx
+++ b/src/renderer/src/views/components/Header/PremiumIndicator.tsx
@@ -39,12 +39,7 @@ export const PremiumIndicator: FC = () => {
 
   if (showAd) {
     return (
-      <Button
-        buttonType="premium"
-        leftIconPath={mdiDiamondStone}
-        size="sm"
-        onClick={handleGoPremium}
-      >
+      <Button brand="premium" leftIconPath={mdiDiamondStone} size="sm" onClick={handleGoPremium}>
         {t("Go premium")}
       </Button>
     );

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -48,10 +48,10 @@ const PlayButton: FC<PlayButtonProps> = ({
   return (
     <div className="relative w-full">
       <Button
-        buttonType="secondary"
+        brand="neutral"
+        appearance="strong"
         className="w-full transition-all"
         disabled={disabled}
-        filled="strong"
         leftIconPath={mdiPlay}
         onClick={onClick}
       >

--- a/src/renderer/src/views/pages/Tools/ToolRow.tsx
+++ b/src/renderer/src/views/pages/Tools/ToolRow.tsx
@@ -103,7 +103,8 @@ export const ToolRow: FC<ToolRowProps> = ({
           <>
             <div className="flex gap-x-2">
               <Button
-                buttonType="tertiary"
+                brand="neutral"
+                appearance="weak"
                 disabled={isFirst}
                 leftIconPath={mdiArrowUp}
                 size="sm"
@@ -112,7 +113,8 @@ export const ToolRow: FC<ToolRowProps> = ({
               />
 
               <Button
-                buttonType="tertiary"
+                brand="neutral"
+                appearance="weak"
                 disabled={isLast}
                 leftIconPath={mdiArrowDown}
                 size="sm"
@@ -128,7 +130,8 @@ export const ToolRow: FC<ToolRowProps> = ({
         <div className="flex gap-x-2">
           {!starter.isGame && !isPrimary && (
             <Button
-              buttonType="tertiary"
+              brand="neutral"
+              appearance="weak"
               disabled={!isPinned && pinDisabled}
               leftIconPath={isPinned ? mdiPinOff : mdiPin}
               size="sm"
@@ -146,7 +149,8 @@ export const ToolRow: FC<ToolRowProps> = ({
           <Dropdown>
             <Menu.Button
               as={Button}
-              buttonType="tertiary"
+              brand="neutral"
+              appearance="weak"
               leftIconPath={mdiDotsVertical}
               size="sm"
             />
@@ -180,9 +184,9 @@ export const ToolRow: FC<ToolRowProps> = ({
         <Divider />
 
         <Button
-          buttonType="secondary"
+          brand="neutral"
+          appearance="strong"
           disabled={!isValid}
-          filled="strong"
           leftIconPath={mdiPlay}
           size="sm"
           title={t("Launch tool")}

--- a/src/renderer/src/views/pages/Tools/index.tsx
+++ b/src/renderer/src/views/pages/Tools/index.tsx
@@ -184,8 +184,8 @@ export const ToolsPage: FC = () => {
             <Panel
               actions={() => (
                 <Button
-                  buttonType="tertiary"
-                  filled="weak"
+                  brand="neutral"
+                  appearance="moderate"
                   leftIconPath={mdiPlus}
                   size="sm"
                   title={t("Add tool")}

--- a/src/stylesheets/ui/elements/button.css
+++ b/src/stylesheets/ui/elements/button.css
@@ -33,25 +33,9 @@
         &:is(a, :enabled):not(.nxm-button-disabled) {
             cursor: pointer;
 
-            &:before {
-                inset: 0;
-                opacity: 0;
-                z-index: -1;
-                content: "";
-                position: absolute;
-                pointer-events: none;
-                border-radius: inherit;
-                transition-property: opacity;
-                transition-timing-function: var(--default-transition-timing-function);
-                transition-duration: var(--default-transition-duration);
-            }
-
-            &:hover,
-            &:focus-visible,
-            &[aria-expanded="true"] {
-                &:before {
-                    opacity: 1;
-                }
+            &:focus-visible {
+                outline: 2px solid var(--color-focus-subdued);
+                outline-offset: 2px;
             }
         }
 
@@ -85,124 +69,235 @@
         }
     }
 
+    /*
+     * Appearance structure (brand-independent).
+     * The "strong" appearance is a solid brand fill (background set per brand
+     * below); the others sit on shared translucent surfaces and only differ by
+     * the brand text colour.
+     */
+    .nxm-button-strong {
+        color: var(--color-neutral-inverted);
+    }
+
+    .nxm-button-moderate {
+        background-color: var(--color-surface-translucent-mid);
+
+        &:is(a, :enabled):not(.nxm-button-disabled) {
+            &:hover,
+            &:focus-visible,
+            &[aria-expanded="true"] {
+                background-color: var(--color-surface-translucent-high);
+            }
+
+            &:active {
+                background-color: var(--color-surface-translucent-low);
+            }
+        }
+    }
+
+    .nxm-button-subdued,
+    .nxm-button-weak {
+        &:is(a, :enabled):not(.nxm-button-disabled) {
+            &:hover,
+            &:focus-visible,
+            &[aria-expanded="true"] {
+                background-color: var(--color-surface-translucent-mid);
+            }
+
+            &:active {
+                background-color: var(--color-surface-translucent-low);
+            }
+        }
+    }
+
+    /* Outlines: only the "subdued" appearance carries a border. */
+    .nxm-button-subdued {
+        border: 1px solid var(--color-stroke-weak);
+    }
+
+    /*
+     * Per-brand colours. Colour brands share one ramp (moderate -> strong on
+     * hover -> subdued on pressed), used as the fill for "strong" and as the
+     * text colour for the other appearances.
+     */
     .nxm-button-primary {
-        color: var(--color-neutral-inverted);
-        background-color: var(--color-primary-moderate);
+        &.nxm-button-strong {
+            background-color: var(--color-primary-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled):before {
-            background-color: var(--color-translucent-200);
-        }
-    }
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    background-color: var(--color-primary-strong);
+                }
 
-    .nxm-button-secondary,
-    .nxm-button-secondary-filled-strong,
-    .nxm-button-secondary-filled-weak {
-        border-width: 1px;
-        border-style: solid;
-    }
-
-    .nxm-button-secondary {
-        color: var(--color-translucent-moderate);
-        border-color: var(--color-stroke-weak);
-
-        &:is(a, :enabled):not(.nxm-button-disabled) {
-            &:before {
-                background-color: var(--color-surface-translucent-mid);
-            }
-
-            &:hover {
-                color: var(--color-translucent-strong);
-                border-color: var(--color-stroke-moderate);
+                &:active {
+                    background-color: var(--color-primary-subdued);
+                }
             }
         }
-    }
 
-    .nxm-button-secondary-filled-strong {
-        color: var(--color-neutral-inverted);
-        border-color: var(--color-stroke-moderate);
-        background-color: var(--color-neutral-strong);
+        &:is(.nxm-button-moderate, .nxm-button-subdued, .nxm-button-weak) {
+            color: var(--color-primary-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled) {
-            &:before {
-                background-color: var(--color-translucent-dark-200);
-            }
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    color: var(--color-primary-strong);
+                }
 
-            &:hover {
-                border-color: var(--color-stroke-strong);
+                &:active {
+                    color: var(--color-primary-subdued);
+                }
             }
         }
     }
 
-    .nxm-button-secondary-filled-weak {
-        color: var(--color-neutral-moderate);
-        border-color: var(--color-stroke-moderate);
-        background-color: var(--color-neutral-800);
+    .nxm-button-info {
+        &.nxm-button-strong {
+            background-color: var(--color-info-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled) {
-            &:before {
-                background-color: var(--color-translucent-200);
-            }
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    background-color: var(--color-info-strong);
+                }
 
-            &:hover {
-                color: var(--color-neutral-strong);
-                border-color: var(--color-stroke-strong);
-            }
-        }
-    }
-
-    .nxm-button-tertiary {
-        color: var(--color-translucent-moderate);
-
-        &:is(a, :enabled):not(.nxm-button-disabled) {
-            &:before {
-                background-color: var(--color-surface-translucent-mid);
-            }
-
-            &:hover {
-                color: var(--color-translucent-strong);
+                &:active {
+                    background-color: var(--color-info-subdued);
+                }
             }
         }
-    }
 
-    .nxm-button-tertiary-filled-strong {
-        color: var(--color-neutral-inverted);
-        background-color: var(--color-neutral-strong);
+        &:is(.nxm-button-moderate, .nxm-button-subdued, .nxm-button-weak) {
+            color: var(--color-info-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled):before {
-            background-color: var(--color-translucent-dark-200);
-        }
-    }
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    color: var(--color-info-strong);
+                }
 
-    .nxm-button-tertiary-filled-weak {
-        color: var(--color-neutral-moderate);
-        background-color: var(--color-translucent-100);
-
-        &:is(a, :enabled):not(.nxm-button-disabled) {
-            &:before {
-                background-color: var(--color-translucent-200);
-            }
-
-            &:hover {
-                color: var(--color-neutral-strong);
+                &:active {
+                    color: var(--color-info-subdued);
+                }
             }
         }
     }
 
     .nxm-button-success {
-        color: var(--color-neutral-inverted);
-        background-color: var(--color-success-moderate);
+        &.nxm-button-strong {
+            background-color: var(--color-success-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled):before {
-            background-color: var(--color-translucent-200);
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    background-color: var(--color-success-strong);
+                }
+
+                &:active {
+                    background-color: var(--color-success-subdued);
+                }
+            }
+        }
+
+        &:is(.nxm-button-moderate, .nxm-button-subdued, .nxm-button-weak) {
+            color: var(--color-success-moderate);
+
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    color: var(--color-success-strong);
+                }
+
+                &:active {
+                    color: var(--color-success-subdued);
+                }
+            }
         }
     }
 
     .nxm-button-premium {
-        color: var(--color-neutral-strong);
-        background-color: var(--color-premium-moderate);
+        /*
+         * Premium's solid fill carries light text (not the inverted dark default),
+         * so its fill must darken on interaction rather than brighten — otherwise
+         * the light label washes out against the lighter "strong" violet.
+         */
+        &.nxm-button-strong {
+            color: var(--color-neutral-strong);
+            background-color: var(--color-premium-moderate);
 
-        &:is(a, :enabled):not(.nxm-button-disabled):before {
-            background-color: var(--color-translucent-200);
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    background-color: var(--color-premium-subdued);
+                }
+
+                &:active {
+                    background-color: var(--color-premium-weak);
+                }
+            }
+        }
+
+        &:is(.nxm-button-moderate, .nxm-button-subdued, .nxm-button-weak) {
+            color: var(--color-premium-moderate);
+
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    color: var(--color-premium-strong);
+                }
+
+                &:active {
+                    color: var(--color-premium-subdued);
+                }
+            }
+        }
+    }
+
+    /*
+     * Neutral is the odd brand out: its solid fill darkens (strong -> weak)
+     * rather than brightening, "moderate" keeps a constant solid text colour,
+     * and "subdued"/"weak" use the translucent neutral text ramp.
+     */
+    .nxm-button-neutral {
+        &.nxm-button-strong {
+            background-color: var(--color-neutral-strong);
+
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    background-color: var(--color-neutral-subdued);
+                }
+
+                &:active {
+                    background-color: var(--color-neutral-weak);
+                }
+            }
+        }
+
+        &.nxm-button-moderate {
+            color: var(--color-neutral-moderate);
+        }
+
+        &:is(.nxm-button-subdued, .nxm-button-weak) {
+            color: var(--color-translucent-moderate);
+
+            &:is(a, :enabled):not(.nxm-button-disabled) {
+                &:hover,
+                &:focus-visible,
+                &[aria-expanded="true"] {
+                    color: var(--color-translucent-strong);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
 Reworks the UI Button to a brand × appearance model matching the Figma spec.

###  What changed
- Renamed props: buttonType → brand, filled → appearance.
- brand: primary | info | neutral | success | premium (secondary/tertiary collapsed into neutral, info added).
- appearance: weak | subdued | moderate | strong (defaults to strong, so a bare <Button> is unchanged).
- Every brand supports every appearance; success/premium ramps derived to match.
- button.css rewritten to the new matrix, one nested selector per brand.
- Migrated all 19 call sites, refreshed the demo (brand×appearance grid + icon-only examples), tests, and ui/README.md. 