### PR TITLE
Small E2E fixes and improvements

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -18,7 +18,6 @@
     "targets": {
       "dev": {
         "cache": false,
-        "continuous": true,
         "dependsOn": [
           {
             "target": "build",
@@ -38,7 +37,6 @@
       },
       "e2e": {
         "cache": false,
-        "continuous": true,
         "dependsOn": [
           {
             "target": "build",
@@ -48,7 +46,6 @@
       },
       "e2e:headed": {
         "cache": false,
-        "continuous": true,
         "dependsOn": [
           {
             "target": "build",

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -15,6 +15,7 @@ import { cleanupFakeGame } from "../fixtures/game-setup/fake-game";
 import {
   type DiagnosticsTeardown,
   instrumentNexusPage,
+  instrumentVortexInstance,
   instrumentVortexWindow,
 } from "../helpers/diagnostics";
 import { manageGame, type ManagedGame } from "../helpers/games";
@@ -296,13 +297,14 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
             snapshotDirs.push(snapshotBase);
 
             const app = await launchVortexApp(snapshotBase, { timeout: Timeouts.SNAPSHOT });
-            let teardown: DiagnosticsTeardown | undefined;
+            const instanceTeardown = instrumentVortexInstance(snapshotBase, "snapshot");
+            let windowTeardown: DiagnosticsTeardown | undefined;
             let storageStatePath: string | undefined;
             let failed = false;
 
             try {
               const window = await setupMainWindow(app, Timeouts.SNAPSHOT);
-              teardown = await instrumentVortexWindow(app, window, snapshotBase, "snapshot");
+              windowTeardown = await instrumentVortexWindow(app, window, "snapshot");
               const loginResult = await loginToNexus(window, user, {
                 skipSteps: true,
                 keepBrowser: true,
@@ -322,7 +324,8 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
               failed = true;
               throw e;
             } finally {
-              if (teardown !== undefined) await teardown(testInfo, failed);
+              await instanceTeardown(testInfo, failed);
+              if (windowTeardown !== undefined) await windowTeardown(testInfo, failed);
               // Clean close flushes DuckDB WAL so state.v2 is consistent on disk.
               await closeElectronApp(app);
             }
@@ -385,10 +388,16 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
   },
 
   vortexWindow: async ({ vortexApp, vortexUserDataDir }, use, testInfo) => {
-    const mainWindow = await setupMainWindow(vortexApp, Timeouts.LIFECYCLE);
-    const teardown = await instrumentVortexWindow(vortexApp, mainWindow, vortexUserDataDir, "main");
-    await use(mainWindow);
-    await teardown(testInfo);
+    const instanceTeardown = instrumentVortexInstance(vortexUserDataDir, "main");
+    let windowTeardown: DiagnosticsTeardown | undefined;
+    try {
+      const mainWindow = await setupMainWindow(vortexApp, Timeouts.LIFECYCLE);
+      windowTeardown = await instrumentVortexWindow(vortexApp, mainWindow, "main");
+      await use(mainWindow);
+    } finally {
+      await instanceTeardown(testInfo);
+      if (windowTeardown !== undefined) await windowTeardown(testInfo);
+    }
   },
 
   nexusStorageState: async ({ workerAuthSnapshots, nexusUser }, use, testInfo) => {

--- a/packages/e2e/src/helpers/diagnostics.ts
+++ b/packages/e2e/src/helpers/diagnostics.ts
@@ -57,43 +57,29 @@ export async function startTracing(page: Page): Promise<StopTracing | undefined>
   };
 }
 
-/** Attach failure diagnostics for a Vortex Electron app: vortex.log + a screenshot. */
-async function attachElectronDiagnostics(
-  app: ElectronApplication,
-  userDataDir: string,
-  testInfo: TestInfo,
-  prefix: string,
-): Promise<void> {
-  const logPath = path.join(userDataDir, "userData", "vortex.log");
-  await testInfo.attach(`${prefix}-vortex.log`, { path: logPath }).catch(() => {});
-
-  // capturePage() reads directly from the renderer and works while the window is
-  // hidden (VORTEX_E2E_HEADLESS=1); page.screenshot() would hang waiting for a
-  // compositor frame that a hidden BrowserWindow never produces.
-  const base64 = await app
-    .evaluate(async ({ BrowserWindow }) => {
-      const win = BrowserWindow.getAllWindows().find((w) =>
-        w.webContents.getURL().includes("index.html"),
-      );
-      if (!win) return null;
-      return (await win.webContents.capturePage()).toPNG().toBase64();
-    })
-    .catch(() => null);
-  if (base64 !== null) {
-    await testInfo
-      .attach(`${prefix}-screenshot.png`, {
-        body: Buffer.from(base64, "base64"),
-        contentType: "image/png",
-      })
-      .catch(() => {});
-  }
+/**
+ * Instrument a Vortex instance before a window is available: returns a teardown
+ * that attaches vortex.log from disk on failure. Requires only the userDataDir,
+ * so it is safe to register before launching the Electron process and will still
+ * fire if setupMainWindow (or even app launch) throws.
+ *
+ * All attachment names are prefixed so a single test can hold artifacts from
+ * multiple instrumented surfaces without name collisions.
+ */
+export function instrumentVortexInstance(userDataDir: string, prefix: string): DiagnosticsTeardown {
+  return async (testInfo, failed = false) => {
+    if (shouldDiagnose(testInfo, failed)) {
+      const logPath = path.join(userDataDir, "userData", "vortex.log");
+      await testInfo.attach(`${prefix}-vortex.log`, { path: logPath }).catch(() => {});
+    }
+  };
 }
 
 /**
  * Instrument a Vortex Electron window: start tracing immediately and return a
- * teardown that attaches the trace and, on failure, vortex.log + a screenshot.
- * Every Vortex launch goes through this so fixture-setup failures (e.g. the
- * worker auth-snapshot build) still produce artifacts on the triggering test.
+ * teardown that attaches the trace and, on failure, a screenshot. Log attachment
+ * is handled separately by instrumentVortexInstance, which must always be called
+ * alongside this one.
  *
  * All attachment names are prefixed so a single test can hold artifacts from
  * multiple instrumented surfaces (snapshot build, its own window, the nexus
@@ -102,7 +88,6 @@ async function attachElectronDiagnostics(
 export async function instrumentVortexWindow(
   app: ElectronApplication,
   window: Page,
-  userDataDir: string,
   prefix: string,
 ): Promise<DiagnosticsTeardown> {
   const stopTracing = await startTracing(window);
@@ -111,7 +96,26 @@ export async function instrumentVortexWindow(
       console.error("Failed to stop tracing:", e),
     );
     if (shouldDiagnose(testInfo, failed)) {
-      await attachElectronDiagnostics(app, userDataDir, testInfo, prefix);
+      // capturePage() reads directly from the renderer and works while the window is
+      // hidden (VORTEX_E2E_HEADLESS=1); page.screenshot() would hang waiting for a
+      // compositor frame that a hidden BrowserWindow never produces.
+      const base64 = await app
+        .evaluate(async ({ BrowserWindow }) => {
+          const win = BrowserWindow.getAllWindows().find((w) =>
+            w.webContents.getURL().includes("index.html"),
+          );
+          if (!win) return null;
+          return (await win.webContents.capturePage()).toPNG().toBase64();
+        })
+        .catch(() => null);
+      if (base64 !== null) {
+        await testInfo
+          .attach(`${prefix}-screenshot.png`, {
+            body: Buffer.from(base64, "base64"),
+            contentType: "image/png",
+          })
+          .catch(() => {});
+      }
     }
   };
 }

--- a/packages/e2e/src/vortex-instance.ts
+++ b/packages/e2e/src/vortex-instance.ts
@@ -67,9 +67,22 @@ export function prepareVortexInstance(rootDir?: string): VortexInstanceSetup {
 
 /**
  * Removes the isolated instance directory created by prepareVortexInstance().
+ *
+ * On Windows, file handles (e.g. DuckDB WAL) may still be open briefly after
+ * the Electron process exits, causing EPERM on rmSync. Retry with backoff so
+ * transient handle release doesn't fail the test.
  */
 export function cleanupVortexInstance(userDataDir: string): void {
-  fs.rmSync(userDataDir, { recursive: true, force: true });
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+      return;
+    } catch (e: unknown) {
+      if (attempt === maxAttempts) throw e;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, attempt * 200);
+    }
+  }
 }
 
 // Script mode: launch a Vortex instance and wait for it to exit.


### PR DESCRIPTION
- Removes `continuous: true` from nx targets
- Always attach logs, even on app startup failure
- Retry transient FS errors on cleanup, hopefully fixing some flaky behavior on Windows