### PR TITLE
SkyrimVR (and other compatibleDownloads games) install to wrong game

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -3990,7 +3990,7 @@ interface IStateVerifier {
     // (undocumented)
     noUndefined?: boolean;
     // (undocumented)
-    repair?: (input: any, def: any) => any;
+    repair?: (input: any, def: any, context?: IVerifierRepairContext) => any;
     // (undocumented)
     required?: boolean;
     // (undocumented)
@@ -4322,6 +4322,16 @@ interface IValidateKeyData {
 interface IValidationResult {
     // (undocumented)
     invalid: IInvalidResult[];
+}
+
+// @public (undocumented)
+interface IVerifierRepairContext {
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    parent?: unknown;
+    // (undocumented)
+    parentKey?: string;
 }
 
 // @public (undocumented)
@@ -6159,6 +6169,7 @@ declare namespace types {
         IApiFuncOptions,
         IExtensionApiExtension,
         IExtensionApi,
+        IVerifierRepairContext,
         IStateVerifier,
         VerifierDrop,
         VerifierDropParent,

--- a/src/renderer/src/IPCDownloadAdapter.test.ts
+++ b/src/renderer/src/IPCDownloadAdapter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
+import { expandCompatibleGameIds } from "./IPCDownloadAdapter";
+
+function game(id: string, compatibleDownloads?: string[]): IGameStored {
+  return {
+    id,
+    name: id,
+    requiredFiles: [],
+    executable: `${id}.exe`,
+    ...(compatibleDownloads !== undefined ? { details: { compatibleDownloads } } : {}),
+  };
+}
+
+describe("expandCompatibleGameIds", () => {
+  // Skyrim VR borrows skyrimse downloads via `details.compatibleDownloads`.
+  const skyrimse = game("skyrimse");
+  const skyrimvr = game("skyrimvr", ["skyrimse"]);
+  const fallout4 = game("fallout4", ["fallout4london"]);
+  const games = [skyrimse, skyrimvr, fallout4];
+
+  it("appends games that declare the download's game as a compatible source", () => {
+    // A skyrimse-domain download, while skyrimvr is one of the managed games,
+    // must list skyrimvr so the install handler can target it (APP-506).
+    expect(expandCompatibleGameIds(games, "skyrimse")).toEqual(["skyrimse", "skyrimvr"]);
+  });
+
+  it("keeps the download's own game id first for path resolution", () => {
+    // download.game[0] drives the on-disk download path, so the base id must stay first.
+    expect(expandCompatibleGameIds(games, "skyrimse")[0]).toBe("skyrimse");
+  });
+
+  it("returns only the game id when nothing declares it compatible", () => {
+    expect(expandCompatibleGameIds(games, "fallout4")).toEqual(["fallout4"]);
+  });
+
+  it("ignores games whose details/compatibleDownloads are absent", () => {
+    expect(expandCompatibleGameIds([skyrimse, game("oblivion")], "skyrimse")).toEqual(["skyrimse"]);
+  });
+
+  it("dedupes if the source game also declares itself compatible", () => {
+    const selfRef = game("xcom2", ["xcom2"]);
+    expect(expandCompatibleGameIds([selfRef], "xcom2")).toEqual(["xcom2"]);
+  });
+
+  it("matches multiple borrowing games", () => {
+    const skyrimvrAlt = game("skyrimvr-alt", ["skyrimse"]);
+    expect(expandCompatibleGameIds([...games, skyrimvrAlt], "skyrimse")).toEqual([
+      "skyrimse",
+      "skyrimvr",
+      "skyrimvr-alt",
+    ]);
+  });
+
+  it("preserves the undefined id (no managed game) as the sole entry", () => {
+    expect(expandCompatibleGameIds(games, undefined)).toEqual([undefined]);
+  });
+});

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -34,6 +34,7 @@ import {
 } from "./extensions/download_management/actions/state";
 import { downloadPathForGame } from "./extensions/download_management/selectors";
 import { knownGames } from "./extensions/gamemode_management/selectors";
+import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
 import { nexusIdsFromDownloadId } from "./extensions/nexus_integration/selectors";
 import { convertGameIdReverse } from "./extensions/nexus_integration/util/convertGameId";
 import { makeModAndFileUIDs } from "./extensions/nexus_integration/util/UIDs";
@@ -77,6 +78,22 @@ function toInternalGameId(api: IExtensionApi, gameId: string | undefined): strin
   if (gameId === undefined) return undefined;
   const state = api.getState();
   return convertGameIdReverse(knownGames(state), gameId) || gameId;
+}
+
+/**
+ * Expand a download's game id to also include every known game that declares it as a
+ * compatible download source via `details.compatibleDownloads`
+ */
+export function expandCompatibleGameIds(
+  games: IGameStored[],
+  gameId: string | undefined,
+): Array<string | undefined> {
+  const compatible = games
+    .filter((game) =>
+      ((game.details?.compatibleDownloads as string[] | undefined) ?? []).includes(gameId),
+    )
+    .map((game) => game.id);
+  return Array.from(new Set([gameId, ...compatible]));
 }
 
 type StoredDownloadInfo = {
@@ -257,7 +274,7 @@ export class IPCDownloadAdapter {
     // Mod downloads triggered by a collection install carry the parent collection's id
     // under `modInfo.nexus.parentCollectionId` (see InstallManager.downloadURL).
     // Cast narrows away the `[key: string]: any` index signature on nexus.
-    const parentCollectionId = download?.modInfo?.nexus?.parentCollectionId as string | undefined;
+    const parentCollectionId = download?.modInfo?.nexus?.parentCollectionId;
     const modCollectionId =
       isCollection || parentCollectionId === undefined ? null : parentCollectionId;
 
@@ -472,6 +489,11 @@ export class IPCDownloadAdapter {
     const gameId = toInternalGameId(this.#api, modInfo.game ?? activeGameId(state));
     const dlPath = downloadPathForGame(state, gameId);
 
+    // Include games that can consume this download (e.g. Skyrim VR <- skyrimse) so
+    // the install handler targets the actively managed game rather than the base
+    // game. See expandCompatibleGameIds.
+    const gameIds = expandCompatibleGameIds(knownGames(state), gameId);
+
     // The per-game subfolder may not exist yet - ensureDownloadsDirectory only
     // creates the active game's folder, but downloads can target any game
     // (SITE_ID extension downloads, compatible domains, collection downloads, etc.).
@@ -558,7 +580,7 @@ export class IPCDownloadAdapter {
 
       // Create the Redux record. nexus_integration's onChangeDownloads watches
       // downloads.files and triggers metadata enrichment when nexus.ids is present.
-      this.#api.store.dispatch(initDownload(downloadId, rawUrls, modInfo, [gameId]));
+      this.#api.store.dispatch(initDownload(downloadId, rawUrls, modInfo, gameIds));
       // Set localPath to the temp name so the UI has something to display.
       this.#api.store.dispatch(setDownloadFilePath(downloadId, tempName));
       // All IPC downloads support pause via checkpoint. DownloadView checks


### PR DESCRIPTION
Closes [LAZ-591](https://linear.app/nexus-mods/issue/LAZ-591/v21-skyrimvr-and-other-compatibledownloads-games-install-to-wrong-game)
Fixes #23467