### PR TITLE
Splash screen crops incorrectly since 2.1 was released

### DIFF
--- a/src/main/src/SplashScreen.ts
+++ b/src/main/src/SplashScreen.ts
@@ -62,7 +62,7 @@ class SplashScreen {
         frame: false,
         width: 475,
         height: 166,
-        transparent: false,
+        transparent: !disableGPU,
         show: false,
         resizable: false,
         movable: false,

--- a/src/renderer/src/splash.html
+++ b/src/renderer/src/splash.html
@@ -4,22 +4,31 @@
         <meta charset="UTF-8" />
         <title>Vortex</title>
         <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background-color: transparent;
+            }
+
+            #splash {
+                display: block;
+                width: 100%;
+                height: 100%;
+                object-fit: fill;
+                -webkit-user-drag: none;
+            }
+
             .fade-out {
                 opacity: 1;
-                -webkit-user-drag: none;
             }
         </style>
     </head>
 
-    <body
-        id="bg"
-        style="
-            background-color: transparent;
-            overflow: visible;
-            display: table-cell;
-            overflow: hidden;
-        "
-    >
+    <body id="bg">
         <img id="splash" class="fade-out" src="assets/images/splash.png" />
 
         <script>

--- a/src/renderer/src/splash.html
+++ b/src/renderer/src/splash.html
@@ -4,31 +4,22 @@
         <meta charset="UTF-8" />
         <title>Vortex</title>
         <style>
-            html,
-            body {
-                margin: 0;
-                padding: 0;
-                width: 100%;
-                height: 100%;
-                overflow: hidden;
-                background-color: transparent;
-            }
-
-            #splash {
-                display: block;
-                width: 100%;
-                height: 100%;
-                object-fit: fill;
-                -webkit-user-drag: none;
-            }
-
             .fade-out {
                 opacity: 1;
+                -webkit-user-drag: none;
             }
         </style>
     </head>
 
-    <body id="bg">
+    <body
+        id="bg"
+        style="
+            background-color: transparent;
+            overflow: visible;
+            display: table-cell;
+            overflow: hidden;
+        "
+    >
         <img id="splash" class="fade-out" src="assets/images/splash.png" />
 
         <script>

--- a/src/renderer/src/splash.ts
+++ b/src/renderer/src/splash.ts
@@ -3,8 +3,8 @@ import { ipcRenderer } from "electron";
 ipcRenderer.on("fade-out", () => {
   const splash = document.getElementById("splash");
   if (splash) {
-    splash.setAttribute("transition", "opacity 500ms ease-in-out");
-    splash.setAttribute("style", "opacity: 0");
+    splash.style.transition = "opacity 500ms ease-in-out";
+    splash.style.opacity = "0";
   }
 });
 


### PR DESCRIPTION
transparent: !disableGPU - sets the boundaries correct (Electron 42 frameless-window sizing regression)
splash.ts - fade-out transition fix