### PR TITLE
Rendering errors are now reported

### DIFF
--- a/src/renderer/src/controls/ErrorBoundary.tsx
+++ b/src/renderer/src/controls/ErrorBoundary.tsx
@@ -5,7 +5,7 @@ import { Alert, Button } from "react-bootstrap";
 import type { WithTranslation } from "react-i18next";
 
 import { getApplication } from "../util/application";
-import { didIgnoreError, isOutdated } from "../util/errorHandling";
+import { didIgnoreError, isOutdated, reportRenderError } from "../util/errorHandling";
 import { genHash } from "../util/genHash";
 import { renderError } from "../util/message";
 import { ComponentEx, translate } from "./ComponentEx";
@@ -60,6 +60,7 @@ class ErrorBoundary extends ComponentEx<IErrorBoundaryProps, IErrorBoundaryState
   }
 
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    reportRenderError(error, errorInfo);
     if (this.props.canDisplayError === false) {
       this.context.api.sendNotification({
         type: "error",

--- a/src/renderer/src/util/errorHandling.test.ts
+++ b/src/renderer/src/util/errorHandling.test.ts
@@ -1,0 +1,91 @@
+import { recordErrorOnSpan } from "@vortex/shared/telemetry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { genHash } from "./genHash";
+import { log } from "./log";
+
+// reportRenderError logs to vortex.log and emits an OTel error span. We assert
+// on those two side effects, so stub their leaf dependencies:
+//  - ./log captures the log() call
+//  - @vortex/shared/telemetry.recordErrorOnSpan is the leaf recordErrorSpan
+//    funnels into (a no-op tracer still drives applyErrorToSpan -> here)
+//  - ./genHash is mocked so we control which errors are considered duplicates
+//  - ./application avoids reading real app state for the version string
+vi.mock("./log", () => ({ log: vi.fn() }));
+vi.mock("./genHash", () => ({ genHash: vi.fn() }));
+vi.mock("./application", () => ({ getApplication: () => ({ version: "1.2.3" }) }));
+vi.mock("@vortex/shared/telemetry", () => ({ recordErrorOnSpan: vi.fn() }));
+
+import { reportRenderError } from "./errorHandling";
+
+const errorInfo = { componentStack: "\n    in Foo\n    in Bar" };
+
+describe("reportRenderError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Each test uses unique hashes (see makeHash) so the module-level dedupe
+    // Set never carries state across tests.
+  });
+
+  // Generate a hash unique to the running test to isolate the shared dedupe Set.
+  let hashCounter = 0;
+  const makeHash = () => `hash-${++hashCounter}`;
+
+  it("logs the error and component stack to vortex.log", () => {
+    vi.mocked(genHash).mockReturnValue(makeHash());
+    const error = new Error("boom");
+
+    reportRenderError(error, errorInfo);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith("error", "render failure", {
+      error: error.stack,
+      componentStack: errorInfo.componentStack,
+    });
+  });
+
+  it("emits an OTel error span", () => {
+    vi.mocked(genHash).mockReturnValue(makeHash());
+    const error = new Error("boom");
+
+    reportRenderError(error, errorInfo);
+
+    expect(recordErrorOnSpan).toHaveBeenCalledTimes(1);
+    const [, recordedError] = vi.mocked(recordErrorOnSpan).mock.calls[0];
+    expect(recordedError).toBe(error);
+  });
+
+  it("dedupes repeated catches of the same error by hash", () => {
+    vi.mocked(genHash).mockReturnValue(makeHash());
+    const error = new Error("boom");
+
+    reportRenderError(error, errorInfo);
+    reportRenderError(error, errorInfo);
+    reportRenderError(error, errorInfo);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(recordErrorOnSpan).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports distinct errors separately", () => {
+    vi.mocked(genHash).mockReturnValueOnce(makeHash()).mockReturnValueOnce(makeHash());
+
+    reportRenderError(new Error("one"), errorInfo);
+    reportRenderError(new Error("two"), errorInfo);
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(recordErrorOnSpan).toHaveBeenCalledTimes(2);
+  });
+
+  it("tolerates a missing component stack", () => {
+    vi.mocked(genHash).mockReturnValue(makeHash());
+    const error = new Error("boom");
+
+    reportRenderError(error, { componentStack: null });
+
+    expect(log).toHaveBeenCalledWith("error", "render failure", {
+      error: error.stack,
+      componentStack: undefined,
+    });
+  });
+});

--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -20,6 +20,7 @@ import type { IError } from "../types/IError";
 import { getApplication } from "./application";
 import { COMPANY_ID } from "./constants";
 import { UserCanceled } from "./CustomErrors";
+import { genHash } from "./genHash";
 import getVortexPath from "./getVortexPath";
 import { fallbackTFunc } from "./i18n";
 import { log } from "./log";
@@ -559,4 +560,34 @@ export function recordErrorSpan(
       },
     );
   }
+}
+
+// Hashes of render errors already reported via reportRenderError. React error
+// boundaries re-invoke componentDidCatch on every re-render of a failing tree,
+// so we dedupe to avoid flooding the log and telemetry with identical entries.
+const reportedRenderErrors = new Set<string>();
+
+/**
+ * Record a render-phase error caught by a React error boundary. Writes the
+ * error and its component stack to vortex.log (so user-supplied logs identify
+ * the failing component) and emits an OTel error span (so render crashes show
+ * up in Datadog). Deduped by error hash to survive boundary re-catches.
+ */
+export function reportRenderError(
+  error: Error,
+  errorInfo: { componentStack?: string | null },
+): void {
+  const hash = genHash(error);
+  if (reportedRenderErrors.has(hash)) {
+    return;
+  }
+  reportedRenderErrors.add(hash);
+
+  const componentStack = errorInfo?.componentStack ?? undefined;
+  log("error", "render failure", { error: error.stack, componentStack });
+  recordErrorSpan(
+    "Component render failure",
+    error,
+    componentStack ? { componentStack } : undefined,
+  );
 }

--- a/src/renderer/src/views/MainPageContainer.tsx
+++ b/src/renderer/src/views/MainPageContainer.tsx
@@ -20,7 +20,7 @@ import ExtensionGate from "../controls/ExtensionGate";
 import Icon from "../controls/Icon";
 import type { IMainPage } from "../types/IMainPage";
 import { getApplication } from "../util/application";
-import { didIgnoreError, isOutdated } from "../util/errorHandling";
+import { didIgnoreError, isOutdated, reportRenderError } from "../util/errorHandling";
 import { genHash } from "../util/genHash";
 import { log } from "../util/log";
 
@@ -56,6 +56,7 @@ class PageErrorBoundary extends Component<IErrorBoundaryProps, IErrorBoundarySta
   }
 
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    reportRenderError(error, errorInfo);
     this.setState({ error, errorInfo });
   }
 


### PR DESCRIPTION
Also added dedup logic
Closes [LAZ-574](https://linear.app/nexus-mods/issue/LAZ-574/render-errors-caught-by-react-error-boundaries-are-invisible-to)