### PR TITLE
Fixed the Download Page rendering error

### DIFF
--- a/src/renderer/src/extensions/download_management/reducers/state.test.ts
+++ b/src/renderer/src/extensions/download_management/reducers/state.test.ts
@@ -327,3 +327,26 @@ describe("setDownloadSpeed", () => {
     expect(result.speed).toEqual(42);
   });
 });
+
+describe("setDownloadSpeeds", () => {
+  it("stores the speed history and last speed", () => {
+    const input = { speed: 0, speedHistory: [] };
+    const result = stateReducer.reducers.SET_DOWNLOAD_SPEEDS(input, [1, 2, 3]);
+    expect(result.speedHistory).toEqual([1, 2, 3]);
+    expect(result.speed).toEqual(3);
+  });
+  it("trims to the last NUM_SPEED_DATA_POINTS entries", () => {
+    const input = { speed: 0, speedHistory: [] };
+    const payload = Array.from({ length: 50 }, (_unused, idx) => idx);
+    const result = stateReducer.reducers.SET_DOWNLOAD_SPEEDS(input, payload);
+    expect((result.speedHistory as number[]).length).toEqual(30);
+    expect((result.speedHistory as number[])[0]).toEqual(20);
+    expect(result.speed).toEqual(49);
+  });
+  it("normalizes a non-array payload to an empty history", () => {
+    const input = { speed: 5, speedHistory: [1, 2] };
+    const result = stateReducer.reducers.SET_DOWNLOAD_SPEEDS(input, { foo: "bar" });
+    expect(result.speedHistory).toEqual([]);
+    expect(result.speed).toEqual(0);
+  });
+});

--- a/src/renderer/src/extensions/download_management/reducers/state.ts
+++ b/src/renderer/src/extensions/download_management/reducers/state.ts
@@ -184,8 +184,12 @@ export const stateReducer: IReducerSpec = {
       return setSafe(temp, ["speedHistory"], speeds);
     },
     [action.setDownloadSpeeds as any]: (state, payload) => {
-      const temp = setSafe(state, ["speed"], payload[payload.length - 1]);
-      return setSafe(temp, ["speedHistory"], payload);
+      let speeds = Array.isArray(payload) ? payload.slice() : [];
+      if (speeds.length > NUM_SPEED_DATA_POINTS) {
+        speeds = speeds.slice(speeds.length - NUM_SPEED_DATA_POINTS);
+      }
+      const temp = setSafe(state, ["speed"], speeds[speeds.length - 1] ?? 0);
+      return setSafe(temp, ["speedHistory"], speeds);
     },
     [action.removeDownload as any]: (state, payload) => deleteOrNop(state, ["files", payload.id]),
     [action.removeDownloadSilent as any]: (state, payload) =>
@@ -246,6 +250,19 @@ export const stateReducer: IReducerSpec = {
     files: {},
   },
   verifiers: {
+    speedHistory: {
+      // A corrupted speedHistory (non-array, or longer than NUM_SPEED_DATA_POINTS)
+      // used to crash the Downloads page render. Repair it on hydration so affected
+      // users self-heal instead of staying broken even after the render-path fix.
+      description: () => "Download speed history stored incorrectly will be repaired.",
+      type: "array",
+      repair: (input) => {
+        if (!Array.isArray(input)) {
+          return [];
+        }
+        return input.slice(-NUM_SPEED_DATA_POINTS);
+      },
+    },
     files: {
       // shouldn't be reported atm
       description: () => "Severe! Invalid list of archives",

--- a/src/renderer/src/extensions/download_management/views/DownloadGraph.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadGraph.tsx
@@ -39,11 +39,18 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
   }
 
   public render(): JSX.Element {
-    const { t, maxBandwidth, speeds } = this.props;
+    const { t, maxBandwidth } = this.props;
+    // speedHistory comes straight from persisted state and has been seen to be
+    // corrupted (non-array, or longer than NUM_SPEED_DATA_POINTS). Normalize it
+    // once here so neither Math.max(...speeds) nor convertData can throw and take
+    // the whole Downloads page down via the page-level error boundary.
+    const speeds = Array.isArray(this.props.speeds)
+      ? this.props.speeds.slice(-NUM_SPEED_DATA_POINTS)
+      : [];
     const data = this.convertData(speeds);
 
     let showLimit: boolean = false;
-    let maxData = Math.max(...speeds);
+    let maxData = speeds.length > 0 ? Math.max(...speeds) : 0;
     if (maxBandwidth !== 0 && maxBandwidth !== null && maxData * 1.5 > maxBandwidth) {
       maxData = maxBandwidth * 1.2;
       showLimit = true;
@@ -136,7 +143,7 @@ class DownloadGraph extends ComponentEx<IProps, IComponentState> {
   }*/
 
   private convertData(speeds: number[]): any {
-    const padded = Array(NUM_SPEED_DATA_POINTS - speeds.length)
+    const padded = Array(Math.max(0, NUM_SPEED_DATA_POINTS - speeds.length))
       .fill(0)
       .concat(speeds);
     return padded.map((value: number, idx: number) => ({


### PR DESCRIPTION
Fixes #23457
Closes [LAZ-573](https://linear.app/nexus-mods/issue/LAZ-573/downloads-page-crashes-with-failed-to-render)