### PR TITLE
Add Toolbar design-system components

### DIFF
--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -25,6 +25,7 @@ import { TabBar } from "@/ui/components/tabs/TabBar";
 import { TabPanel } from "@/ui/components/tabs/TabPanel";
 import { TabProvider } from "@/ui/components/tabs/tabs.context";
 import { TabsDemo } from "@/ui/components/tabs/TabsDemo";
+import { ToolbarDemo } from "@/ui/components/toolbar/Toolbar.demo";
 import { Typography } from "@/ui/components/typography/Typography";
 import { TypographyDemo } from "@/ui/components/typography/TypographyDemo";
 import { TypographyLinkDemo } from "@/ui/components/typography/TypographyLinkDemo";
@@ -77,6 +78,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
               <TabButton name="Pagination" />
 
               <TabButton name="Collection Tile" />
+
+              <TabButton name="Toolbar" />
             </TabBar>
 
             <div className="mt-6">
@@ -212,6 +215,10 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
 
               <TabPanel name="Collection Tile">
                 <CollectionTileDemo api={api} />
+              </TabPanel>
+
+              <TabPanel name="Toolbar">
+                <ToolbarDemo />
               </TabPanel>
             </div>
           </TabProvider>

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -28,6 +28,7 @@ ui/
 │   ├── pill/            - Compact rounded label for tags and statuses
 │   ├── premium_badge/   - Premium diamond badge
 │   ├── tabs/            - Tabbed interface with context-based state
+│   ├── toolbar/         - Horizontal toolbar; groups collapse overflow into a kebab dropdown
 │   └── typography/      - Typography system (heading, title, body)
 ├── lib/
 │   └── icon_paths/      - 34 custom Nexus Mods SVG icon paths
@@ -194,6 +195,35 @@ function MyTabs() {
 
 **Keyboard:** Arrow Left/Right (navigate, wraps), Home/End (jump to first/last)
 **Tab types:** `primary` (default), `secondary` (count displayed with parentheses)
+
+### Toolbar
+
+Horizontal toolbar made of one or more rounded `ToolbarGroup` "pills". A group is **data-driven**: pass it an array of `IToolbarAction` descriptors and it renders each as an icon `Button`. When a group has more than `maxVisible` actions (default `7`), the trailing slot becomes a kebab (`⋮`) menu and the overflow actions move into its dropdown — the same descriptor renders as a `Button` while visible and a `DropdownItem` once collapsed.
+
+**Defaults:** `maxVisible={7}`. Pass `maxVisible={null}` to disable collapsing and always render every action.
+
+```tsx
+import { Toolbar } from "../../ui/components/toolbar/Toolbar";
+import { type IToolbarAction, ToolbarGroup } from "../../ui/components/toolbar/ToolbarGroup";
+import { mdiFolderOpenOutline, mdiHistory, mdiRefresh } from "@mdi/js";
+
+const actions: IToolbarAction[] = [
+    { label: "Open mods folder", iconPath: mdiFolderOpenOutline, onClick: openFolder },
+    { label: "History", iconPath: mdiHistory, onClick: showHistory },
+    { label: "Refresh", iconPath: mdiRefresh, onClick: refresh, disabled: isBusy },
+];
+
+<Toolbar>
+    <ToolbarGroup actions={actions} />
+
+    {/* Never collapse — show every action regardless of count */}
+    <ToolbarGroup actions={contextualActions} maxVisible={null} />
+</Toolbar>;
+```
+
+**`IToolbarAction` fields:** `label` (required — the accessible name, dropdown label, and button text when `showLabel`), `iconPath`, `onClick`, `disabled`, `brand` (defaults to `neutral`), `showLabel` (render the label as visible button text instead of icon-only, e.g. a "1 selected" pill).
+
+Actions are keyed internally by `label`, so labels should be unique within a group. The kebab is generated automatically — callers never author it.
 
 ### Form Components
 

--- a/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
@@ -1,0 +1,90 @@
+/**
+ * Toolbar Demo Component
+ * Demonstrates the Toolbar / ToolbarGroup layout with icon-only buttons.
+ */
+
+import {
+  mdiCallMerge,
+  mdiCheck,
+  mdiClose,
+  mdiCloudDownloadOutline,
+  mdiDeleteOutline,
+  mdiEyeOutline,
+  mdiFolderOpenOutline,
+  mdiHistory,
+  mdiLabelOutline,
+  mdiPaw,
+  mdiPawOutline,
+  mdiPlaylistCheck,
+  mdiPlusCircleOutline,
+  mdiRefresh,
+} from "@mdi/js";
+import React from "react";
+
+import { Typography } from "../typography/Typography";
+import { Toolbar } from "./Toolbar";
+import { type IToolbarAction, ToolbarGroup } from "./ToolbarGroup";
+
+const generalActions: IToolbarAction[] = [
+  { label: "Install mod", iconPath: mdiPlusCircleOutline },
+  { label: "Open mods folder", iconPath: mdiFolderOpenOutline },
+  { label: "History", iconPath: mdiHistory },
+  { label: "Refresh", iconPath: mdiRefresh },
+  { label: "Categories", iconPath: mdiLabelOutline },
+  { label: "Manage rules", iconPath: mdiPlaylistCheck },
+];
+
+const contextualActions: IToolbarAction[] = [
+  { label: "1 selected", iconPath: mdiClose, showLabel: true },
+  { label: "Remove", iconPath: mdiDeleteOutline },
+  { label: "Refresh", iconPath: mdiRefresh },
+  { label: "Download updates", iconPath: mdiCloudDownloadOutline, brand: "info" },
+  { label: "Enable", iconPath: mdiCheck },
+  { label: "Disable", iconPath: mdiClose },
+];
+
+// More than `maxVisible` (7) actions: the first six render as buttons and the
+// rest collapse into the trailing kebab dropdown.
+const overflowActions: IToolbarAction[] = [
+  ...generalActions,
+  { label: "Combine", iconPath: mdiCallMerge },
+  { label: "Highlight", iconPath: mdiEyeOutline },
+  { label: "Track", iconPath: mdiPaw },
+  { label: "Untrack", iconPath: mdiPawOutline },
+];
+
+export const ToolbarDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        Toolbar
+      </Typography>
+
+      <Typography appearance="subdued">
+        A horizontal toolbar made of one or more rounded groups of related controls. Groups share a
+        raised surface; controls are typically icon-only buttons.
+      </Typography>
+    </div>
+
+    <Toolbar>
+      <ToolbarGroup actions={generalActions} />
+
+      <ToolbarGroup actions={contextualActions} />
+    </Toolbar>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Overflow
+      </Typography>
+
+      <Typography appearance="subdued">
+        When a group has more than <code>maxVisible</code> (7) actions, the trailing slot becomes a
+        kebab menu and the remaining actions move into its dropdown.
+      </Typography>
+    </div>
+
+    <Toolbar>
+      <ToolbarGroup actions={overflowActions} />
+    </Toolbar>
+  </div>
+);

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { Toolbar } from "./Toolbar";
+import { ToolbarGroup, type IToolbarAction } from "./ToolbarGroup";
+
+// --- Helpers ---
+
+afterEach(() => {
+  cleanup();
+});
+
+const makeActions = (count: number): IToolbarAction[] =>
+  Array.from({ length: count }, (_, i) => ({ label: `Action ${i + 1}`, iconPath: "mdi-test" }));
+
+const getKebab = () => screen.getByRole("button", { name: /more actions/i });
+
+// --- Tests ---
+
+describe("Toolbar", () => {
+  it('renders a container with role="toolbar"', () => {
+    render(<Toolbar>content</Toolbar>);
+    expect(screen.getByRole("toolbar")).toBeInTheDocument();
+  });
+
+  it("renders its children", () => {
+    render(
+      <Toolbar>
+        <span data-testid="child" />
+      </Toolbar>,
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("merges custom className with the base class", () => {
+    render(<Toolbar className="my-class">content</Toolbar>);
+    expect(screen.getByRole("toolbar")).toHaveClass("nxm-toolbar", "my-class");
+  });
+
+  it("passes through arbitrary HTML attributes", () => {
+    render(<Toolbar data-testid="bar">content</Toolbar>);
+    expect(screen.getByTestId("bar")).toBeInTheDocument();
+  });
+});
+
+describe("ToolbarGroup", () => {
+  describe("rendering", () => {
+    it("renders one button per action when under the limit", () => {
+      render(<ToolbarGroup actions={makeActions(3)} />);
+      expect(screen.getAllByRole("button")).toHaveLength(3);
+      expect(screen.getByRole("button", { name: "Action 1" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Action 3" })).toBeInTheDocument();
+    });
+
+    it("renders an icon-only button (label as aria-label, not visible text)", () => {
+      render(<ToolbarGroup actions={[{ label: "Refresh", iconPath: "mdi-test" }]} />);
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+      expect(screen.queryByText("Refresh")).not.toBeInTheDocument();
+    });
+
+    it("renders visible label text when showLabel is set", () => {
+      render(<ToolbarGroup actions={[{ label: "1 selected", showLabel: true }]} />);
+      expect(screen.getByText("1 selected")).toBeInTheDocument();
+    });
+
+    it("defaults actions to the neutral brand", () => {
+      render(<ToolbarGroup actions={[{ label: "Plain", iconPath: "mdi-test" }]} />);
+      expect(screen.getByRole("button", { name: "Plain" })).toHaveClass("nxm-button-neutral");
+    });
+
+    it("applies a custom brand", () => {
+      render(<ToolbarGroup actions={[{ label: "Info", iconPath: "mdi-test", brand: "info" }]} />);
+      expect(screen.getByRole("button", { name: "Info" })).toHaveClass("nxm-button-info");
+    });
+
+    it("merges custom className with the base group class", () => {
+      const { container } = render(<ToolbarGroup actions={makeActions(1)} className="my-group" />);
+      expect(container.firstChild).toHaveClass("nxm-toolbar-group", "my-group");
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls an action's onClick when its button is clicked", async () => {
+      const onClick = vi.fn();
+      render(<ToolbarGroup actions={[{ label: "Go", iconPath: "mdi-test", onClick }]} />);
+      await userEvent.click(screen.getByRole("button", { name: "Go" }));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("disables a button and suppresses its onClick when the action is disabled", async () => {
+      const onClick = vi.fn();
+      render(
+        <ToolbarGroup
+          actions={[{ label: "Nope", iconPath: "mdi-test", onClick, disabled: true }]}
+        />,
+      );
+      const button = screen.getByRole("button", { name: "Nope" });
+      expect(button).toBeDisabled();
+      await userEvent.click(button);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("overflow", () => {
+    it("does not render a kebab when the action count is within maxVisible", () => {
+      render(<ToolbarGroup actions={makeActions(7)} />);
+      expect(screen.getAllByRole("button")).toHaveLength(7);
+      expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+    });
+
+    it("collapses the tail into a kebab once maxVisible is exceeded", () => {
+      render(<ToolbarGroup actions={makeActions(8)} />);
+      // 6 visible action buttons + the kebab = 7 slots.
+      expect(screen.getAllByRole("button")).toHaveLength(7);
+      expect(screen.getByRole("button", { name: "Action 6" })).toBeInTheDocument();
+      expect(getKebab()).toBeInTheDocument();
+      // Overflow actions are not rendered until the menu opens.
+      expect(screen.queryByText("Action 7")).not.toBeInTheDocument();
+      expect(screen.queryByText("Action 8")).not.toBeInTheDocument();
+    });
+
+    it("reveals the overflow actions when the kebab is opened", async () => {
+      render(<ToolbarGroup actions={makeActions(8)} />);
+      await userEvent.click(getKebab());
+      expect(screen.getByText("Action 7")).toBeInTheDocument();
+      expect(screen.getByText("Action 8")).toBeInTheDocument();
+    });
+
+    it("calls an overflowed action's onClick from the dropdown", async () => {
+      const onClick = vi.fn();
+      const actions = [...makeActions(7), { label: "Overflowed", iconPath: "mdi-test", onClick }];
+      render(<ToolbarGroup actions={actions} />);
+      await userEvent.click(getKebab());
+      await userEvent.click(screen.getByText("Overflowed"));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("respects a custom maxVisible", () => {
+      render(<ToolbarGroup actions={makeActions(5)} maxVisible={3} />);
+      // 2 visible action buttons + the kebab = 3 slots.
+      expect(screen.getAllByRole("button")).toHaveLength(3);
+      expect(screen.getByRole("button", { name: "Action 2" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Action 3" })).not.toBeInTheDocument();
+      expect(getKebab()).toBeInTheDocument();
+    });
+
+    it("never collapses when maxVisible is null", () => {
+      render(<ToolbarGroup actions={makeActions(10)} maxVisible={null} />);
+      expect(screen.getAllByRole("button")).toHaveLength(10);
+      expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/src/ui/components/toolbar/Toolbar.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.tsx
@@ -1,0 +1,18 @@
+import React, { type HTMLAttributes, type ReactNode } from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export interface IToolbarProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+/**
+ * Horizontal container for one or more {@link ToolbarGroup}s. Lays the groups
+ * out in a row with consistent spacing; the visual "pill" surface lives on the
+ * groups, not the toolbar itself.
+ */
+export const Toolbar = ({ children, className, ...props }: IToolbarProps) => (
+  <div className={joinClasses(["nxm-toolbar", className])} role="toolbar" {...props}>
+    {children}
+  </div>
+);

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -1,0 +1,90 @@
+import { Menu } from "@headlessui/react";
+import { mdiDotsVertical } from "@mdi/js";
+import React, { type HTMLAttributes } from "react";
+
+import { Button, type ButtonBrand } from "@/ui/components/button/Button";
+import { Dropdown } from "@/ui/components/dropdown/Dropdown";
+import { DropdownItem } from "@/ui/components/dropdown/DropdownItem";
+import { DropdownItems } from "@/ui/components/dropdown/DropdownItems";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export interface IToolbarAction {
+  label: string;
+  iconPath?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  brand?: ButtonBrand;
+  showLabel?: boolean;
+}
+
+export type IToolbarGroupProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
+  actions: IToolbarAction[];
+  /**
+   * Maximum number of slots to show before collapsing the tail into a kebab
+   * dropdown. When there are more actions than this, the last slot becomes the
+   * kebab and every remaining action moves into it. Pass `null` to disable
+   * collapsing and always render every action.
+   */
+  maxVisible?: number | null;
+};
+
+/**
+ * A rounded "pill" cluster of related toolbar controls sharing a single raised
+ * surface. Renders up to `max` slots; any overflow collapses into a kebab
+ * dropdown occupying the final slot.
+ */
+export const ToolbarGroup = ({
+  actions,
+  className,
+  maxVisible = 7,
+  ...props
+}: IToolbarGroupProps) => {
+  const overflows = maxVisible != null && actions.length > maxVisible;
+  const visible = overflows ? actions.slice(0, maxVisible - 1) : actions;
+  const hidden = overflows ? actions.slice(maxVisible - 1) : [];
+
+  return (
+    <div className={joinClasses(["nxm-toolbar-group", className])} {...props}>
+      {visible.map((action) => (
+        <Button
+          appearance="weak"
+          aria-label={!action.showLabel ? action.label : undefined}
+          brand={action.brand ?? "neutral"}
+          disabled={action.disabled}
+          key={action.label}
+          leftIconPath={action.iconPath}
+          size="sm"
+          onClick={action.onClick}
+        >
+          {action.showLabel ? action.label : undefined}
+        </Button>
+      ))}
+
+      {!!hidden.length && (
+        <Dropdown>
+          <Menu.Button
+            appearance="weak"
+            aria-label="More actions"
+            as={Button}
+            brand="neutral"
+            leftIconPath={mdiDotsVertical}
+            size="sm"
+          />
+
+          <DropdownItems className="right-0 left-auto">
+            {hidden.map((action) => (
+              <DropdownItem
+                disabled={action.disabled}
+                key={action.label}
+                leftIconPath={action.iconPath}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </DropdownItem>
+            ))}
+          </DropdownItems>
+        </Dropdown>
+      )}
+    </div>
+  );
+};

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -8,3 +8,4 @@
 @import "./pill.css";
 @import "./scrollbar.css";
 @import "./tab.css";
+@import "./toolbar.css";

--- a/src/stylesheets/ui/elements/toolbar.css
+++ b/src/stylesheets/ui/elements/toolbar.css
@@ -1,0 +1,17 @@
+@layer components {
+    .nxm-toolbar {
+        display: flex;
+        align-items: center;
+        column-gap: calc(var(--spacing) * 2);
+    }
+
+    .nxm-toolbar-group {
+        display: flex;
+        align-items: center;
+        column-gap: calc(var(--spacing) * 2);
+
+        padding: calc(var(--spacing) * 1);
+        border-radius: var(--radius-lg);
+        background-color: var(--color-surface-mid);
+    }
+}


### PR DESCRIPTION
Adds Toolbar and ToolbarGroup primitives to the `ui/components` design system.

ToolbarGroup is data-driven: it takes an array of IToolbarAction descriptors rather than children. Each action renders as an icon Button, and once a group exceeds maxVisible actions (default 7) the trailing slot becomes a kebab (⋮) menu with the overflow moved into its dropdown - the same descriptor renders as a Button while visible and a DropdownItem once collapsed. Pass maxVisible={null} to disable collapsing entirely.

Included:
- Toolbar / ToolbarGroup components + nxm-toolbar styles
- A Toolbar.demo with a basic example and an overflow example, surfaced under a new Toolbar tab on the Design System dev page 
- README docs for the components and the IToolbarAction API
  
No production views consume these yet; this lands the reusable primitives and their showcase only.