### PR TITLE
feat: add workflow to upload stable releases to R2

### DIFF
--- a/.github/workflows/upload-release-to-r2.yml
+++ b/.github/workflows/upload-release-to-r2.yml
@@ -1,0 +1,25 @@
+name: Upload Release to R2
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: platform-cluster
+    steps:
+      - name: Download release asset
+        run: gh release download ${{ github.event.release.tag_name }} --pattern "vortex-setup-*.exe"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to R2
+        run: aws s3 cp $(ls vortex-setup-*.exe) s3://nexusmodsapp/ --endpoint-url "${{ secrets.NEXUSMODS_R2_ENDPOINT }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.NEXUSMODSAPP_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.NEXUSMODSAPP_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto

--- a/.github/workflows/upload-release-to-r2.yml
+++ b/.github/workflows/upload-release-to-r2.yml
@@ -3,17 +3,23 @@ name: Upload Release to R2
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v2.1.1)"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   upload:
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
     runs-on: platform-cluster
     steps:
       - name: Download release asset
-        run: gh release download ${{ github.event.release.tag_name }} --pattern "vortex-setup-*.exe"
+        run: gh release download ${{ github.event.release.tag_name || inputs.tag }} --pattern "vortex-setup-*.exe"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Adds a new workflow (`upload-release-to-r2.yml`) that triggers when a GitHub release is published
- Skips pre-releases (beta/alpha)
- Downloads the installer asset from the release and uploads it to the `nexusmodsapp` R2 bucket using the S3-compatible API

Closes PLAENG-65