### PR TITLE
add collection install session test baseline (483 WIP)

### DIFF
--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -8,42 +8,22 @@
 
 import { describe, it, expect, vi } from "vitest";
 
+import { makeDownload, makeMod, makeRule } from "../../../test-utils/builders";
 import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import { modRuleId } from "../../../util/collectionInstallSession";
-import type { IDownload } from "../../download_management/types/IDownload";
 import type { IMod, IModAttributes, IModRule } from "../../mod_management/types/IMod";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 import { buildCollectionItemRows } from "./itemRows";
 
 vi.mock("../../../util/log", () => ({ log: vi.fn() }));
 
-const requiresRule = (over: Partial<IModRule> = {}): IModRule => ({
-  type: "requires",
-  reference: { id: "mod-1", description: "Mod One" },
-  ...over,
-});
+// domain-specific conveniences over the shared builders: a requires-rule referencing
+// "mod-1" by id, and an installed mod whose attributes.name defaults to its id
+const requiresRule = (over: Partial<IModRule> = {}): IModRule =>
+  makeRule({ reference: { id: "mod-1", description: "Mod One" }, ...over });
 
-const installedMod = (id: string, attributes: IModAttributes = {}): IMod => ({
-  id,
-  state: "installed",
-  type: "",
-  installationPath: `mods/${id}`,
-  attributes: { name: id, ...attributes },
-});
-
-const makeDownload = (over: Partial<IDownload> = {}): IDownload => ({
-  id: "dl",
-  state: "started",
-  urls: [],
-  game: ["skyrimse"],
-  modInfo: {},
-  startTime: 0,
-  fileTime: 0,
-  size: 0,
-  received: 0,
-  verified: 0,
-  ...over,
-});
+const installedMod = (id: string, attributes: IModAttributes = {}): IMod =>
+  makeMod({ id, installationPath: `mods/${id}`, attributes: { name: id, ...attributes } });
 
 describe("buildCollectionItemRows", () => {
   it("filters out rules that are not requires/recommends", () => {

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import * as actions from "../actions/collectionInstallTracking";
+import { makeInstallState, makeSession, modsByRule } from "../test-utils/builders";
 // The reducer file exports a default object with { reducers, defaults }.
 // We also need the action creators so we can get their .toString() keys.
 import reducer from "./collectionInstallTracking";
@@ -19,32 +20,6 @@ function reduce(state: any, actionCreator: any, payload: any): any {
   return fn(state, payload);
 }
 
-function makeSession(overrides: Partial<any> = {}): any {
-  return {
-    sessionId: "col1_prof1",
-    collectionId: "col1",
-    profileId: "prof1",
-    gameId: "skyrimse",
-    totalRequired: 3,
-    totalOptional: 1,
-    downloadedCount: 0,
-    installedCount: 0,
-    failedCount: 0,
-    ignoredCount: 0,
-    mods: {},
-    ...overrides,
-  };
-}
-
-function makeState(overrides: Partial<any> = {}): any {
-  return {
-    activeSession: undefined,
-    lastActiveSessionId: undefined,
-    sessionHistory: {},
-    ...overrides,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // adjustCounters — tested indirectly via updateModStatus reducer
 // ---------------------------------------------------------------------------
@@ -52,7 +27,7 @@ function makeState(overrides: Partial<any> = {}): any {
 describe("installTracking reducer", () => {
   describe("startInstallSession", () => {
     it("creates a new active session with computed counters", () => {
-      const state = makeState();
+      const state = makeInstallState();
       const payload = {
         collectionId: "col1",
         profileId: "prof1",
@@ -76,7 +51,7 @@ describe("installTracking reducer", () => {
     });
 
     it("computes zero counters for an empty mods object", () => {
-      const state = makeState();
+      const state = makeInstallState();
       const payload = {
         collectionId: "col1",
         profileId: "prof1",
@@ -95,11 +70,9 @@ describe("installTracking reducer", () => {
   describe("updateModStatus (adjustCounters)", () => {
     it("increments downloadedCount when transitioning from pending to downloading", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "pending", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -112,12 +85,10 @@ describe("installTracking reducer", () => {
 
     it("increments installedCount when transitioning to installed", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "downloading", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "downloading", type: "requires" }]),
         downloadedCount: 1,
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -132,11 +103,9 @@ describe("installTracking reducer", () => {
 
     it("increments failedCount when transitioning to failed", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "pending", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -151,11 +120,9 @@ describe("installTracking reducer", () => {
 
     it("increments ignoredCount when transitioning to ignored", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "pending", type: "recommends", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "recommends" }]),
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -170,12 +137,10 @@ describe("installTracking reducer", () => {
 
     it("decrements failedCount when recovering from failed to downloading", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "failed", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "failed", type: "requires" }]),
         failedCount: 1,
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -189,11 +154,9 @@ describe("installTracking reducer", () => {
 
     it("handles the full lifecycle: pending → downloading → installed", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "pending", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
       });
-      let state = makeState({ activeSession: session });
+      let state = makeInstallState({ activeSession: session });
 
       // pending → downloading
       state = reduce(state, actions.updateModStatus, {
@@ -225,11 +188,9 @@ describe("installTracking reducer", () => {
 
     it("is a no-op when sessionId does not match", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "pending", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "wrong_session",
@@ -241,7 +202,7 @@ describe("installTracking reducer", () => {
     });
 
     it("is a no-op when there is no active session", () => {
-      const state = makeState();
+      const state = makeInstallState();
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -254,13 +215,11 @@ describe("installTracking reducer", () => {
 
     it("correctly handles installed → failed (regression: both counters update)", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "installed", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "installed", type: "requires" }]),
         downloadedCount: 1,
         installedCount: 1,
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.updateModStatus, {
         sessionId: "col1_prof1",
@@ -278,12 +237,10 @@ describe("installTracking reducer", () => {
   describe("markModInstalled", () => {
     it("sets modId, status=installed, endTime and updates counters", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "downloading", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "downloading", type: "requires" }]),
         downloadedCount: 1,
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.markModInstalled, {
         sessionId: "col1_prof1",
@@ -299,11 +256,9 @@ describe("installTracking reducer", () => {
 
     it("is a no-op when sessionId does not match", () => {
       const session = makeSession({
-        mods: {
-          rule1: { status: "downloading", type: "requires", rule: {} },
-        },
+        mods: modsByRule([{ ruleId: "rule1", status: "downloading", type: "requires" }]),
       });
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.markModInstalled, {
         sessionId: "wrong",
@@ -318,7 +273,7 @@ describe("installTracking reducer", () => {
   describe("finishInstallSession", () => {
     it("moves active session to history and clears it", () => {
       const session = makeSession();
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.finishInstallSession, {
         sessionId: "col1_prof1",
@@ -332,7 +287,7 @@ describe("installTracking reducer", () => {
 
     it("is a no-op when sessionId does not match", () => {
       const session = makeSession();
-      const state = makeState({ activeSession: session });
+      const state = makeInstallState({ activeSession: session });
 
       const result = reduce(state, actions.finishInstallSession, {
         sessionId: "wrong",

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared test-data builders for collection install/session tests.
+ *
+ * These consolidate the per-file factories that had been copy-pasted across the
+ * install-session suites (collectionInstallTracking, collectionInstallSession,
+ * itemRows, ...). Each builder returns a fully-valid object with sensible defaults
+ * and accepts a partial override - the Test Data Builder pattern - so a test only
+ * states the fields it cares about.
+ *
+ * Test-only: nothing in the production tree imports this module.
+ */
+import type { IDownload } from "../extensions/download_management/types/IDownload";
+import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
+import type { IProfileMod } from "../extensions/profile_management/types/IProfile";
+import type {
+  CollectionModStatus,
+  ICollectionInstallSession,
+  ICollectionInstallState,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
+
+export function makeReference(overrides: Partial<IModReference> = {}): IModReference {
+  return { tag: "ref-tag", ...overrides };
+}
+
+export function makeRule(overrides: Partial<IModRule> = {}): IModRule {
+  return {
+    type: "requires",
+    reference: { tag: "ref-tag" },
+    ...overrides,
+  };
+}
+
+export function makeMod(overrides: Partial<IMod> = {}): IMod {
+  return {
+    id: "mod-1",
+    state: "installed",
+    type: "",
+    installationPath: "mods/mod-1",
+    attributes: {},
+    ...overrides,
+  };
+}
+
+export function makeDownload(overrides: Partial<IDownload> = {}): IDownload {
+  return {
+    id: "dl-1",
+    state: "started",
+    urls: [],
+    game: ["skyrimse"],
+    modInfo: {},
+    startTime: 0,
+    fileTime: 0,
+    size: 0,
+    received: 0,
+    verified: 0,
+    ...overrides,
+  };
+}
+
+export function makeProfileMod(overrides: Partial<IProfileMod> = {}): IProfileMod {
+  return { enabled: true, enabledTime: 0, ...overrides };
+}
+
+export function makeModInstallInfo(
+  overrides: Partial<ICollectionModInstallInfo> = {},
+): ICollectionModInstallInfo {
+  return {
+    rule: makeRule(),
+    status: "pending",
+    type: "requires",
+    ...overrides,
+  };
+}
+
+export function makeSession(
+  overrides: Partial<ICollectionInstallSession> = {},
+): ICollectionInstallSession {
+  return {
+    sessionId: "col1_prof1",
+    collectionId: "col1",
+    profileId: "prof1",
+    gameId: "skyrimse",
+    // keyed by ruleId
+    mods: {},
+    totalRequired: 0,
+    totalOptional: 0,
+    downloadedCount: 0,
+    installedCount: 0,
+    failedCount: 0,
+    ignoredCount: 0,
+    ...overrides,
+  };
+}
+
+export function makeInstallState(
+  overrides: Partial<ICollectionInstallState> = {},
+): ICollectionInstallState {
+  return {
+    activeSession: undefined,
+    lastActiveSessionId: undefined,
+    // keyed by sessionId
+    sessionHistory: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Assemble a session's `mods` map from a compact list, keyed by an explicit ruleId.
+ * Saves tests from spelling out a full ICollectionModInstallInfo per member mod.
+ */
+export function modsByRule(
+  entries: Array<{ ruleId: string } & Partial<ICollectionModInstallInfo>>,
+): Record<string, ICollectionModInstallInfo> {
+  // keyed by ruleId
+  const result: Record<string, ICollectionModInstallInfo> = {};
+  for (const { ruleId, ...info } of entries) {
+    result[ruleId] = makeModInstallInfo(info);
+  }
+  return result;
+}
+
+export type { CollectionModStatus };

--- a/src/renderer/src/test-utils/sessionStore.ts
+++ b/src/renderer/src/test-utils/sessionStore.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal redux store wired to the real install-tracking reducer, for the
+ * session state-machine tests: a test dispatches the exact typed actions that
+ * InstallManager / InstallDriver dispatch and reads the result back through the
+ * production selectors. No Electron, persistence, or extension registration.
+ *
+ * Test-only: nothing in the production tree imports this module.
+ */
+import { createStore, type Store } from "redux";
+import { createReducer } from "redux-act";
+
+import trackingReducer from "../reducers/collectionInstallTracking";
+import type { ICollectionInstallState } from "../types/collections/ICollectionInstallSession";
+import type { IState } from "../types/IState";
+
+export function createSessionStore(): Store<ICollectionInstallState> {
+  return createStore(createReducer(trackingReducer.reducers, trackingReducer.defaults));
+}
+
+/**
+ * Wrap the install-tracking slice as the minimal IState the collection-session
+ * selectors read - they only touch `state.session.collections`. A full IState is
+ * impractical to construct in a unit test, so the one unavoidable cast lives here
+ * rather than being scattered across every selector assertion.
+ */
+export function asIState(slice: ICollectionInstallState): IState {
+  return { session: { collections: slice } } as unknown as IState;
+}

--- a/src/renderer/src/util/collectionInstallSession.stateMachine.test.ts
+++ b/src/renderer/src/util/collectionInstallSession.stateMachine.test.ts
@@ -1,0 +1,243 @@
+import type { Store } from "redux";
+/**
+ * Session state-machine contract.
+ *
+ * This is the keystone of the install-reliability suite: it dispatches the EXACT
+ * typed actions that InstallManager / InstallDriver dispatch against the real
+ * install-tracking reducer, then asserts completion through the production
+ * selectors. It defines the behaviour the write-path refactor must satisfy - no
+ * Electron, fs, installers, or events involved.
+ *
+ * Scenarios locked in here (from the LAZ-483 matrix): happy path, a failed
+ * required mod still completing, a skipped/ignored required mod honoured, optional
+ * mods never blocking completion, in-progress not yet complete, restart
+ * rehydration reaching the same completion, and interleaved (concurrent) updates
+ * keeping the aggregate counters and isComplete correct.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  finishInstallSession,
+  markModInstalled,
+  startInstallSession,
+  updateModStatus,
+} from "../actions/collectionInstallTracking";
+import { makeMod, makeRule, modsByRule } from "../test-utils/builders";
+import { asIState, createSessionStore } from "../test-utils/sessionStore";
+import type {
+  CollectionModStatus,
+  ICollectionInstallState,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
+import { modRuleId, reconstructModStatus } from "./collectionInstallSession";
+import {
+  getCollectionActiveSession,
+  getCollectionInstallProgress,
+  getCollectionStatusBreakdown,
+} from "./collectionInstallSessionSelectors";
+
+const GAME = "skyrimse";
+
+/** Start a session for the given mods and return the (reducer-computed) session id. */
+function startSession(
+  store: Store<ICollectionInstallState>,
+  mods: Record<string, ICollectionModInstallInfo>,
+  opts: { collectionId?: string; profileId?: string } = {},
+): string {
+  const collectionId = opts.collectionId ?? "col1";
+  const profileId = opts.profileId ?? "prof1";
+  const all = Object.values(mods);
+  store.dispatch(
+    startInstallSession({
+      // the reducer recomputes sessionId from collectionId+profileId; passed only
+      // to satisfy the payload type
+      sessionId: `${collectionId}_${profileId}`,
+      collectionId,
+      profileId,
+      gameId: GAME,
+      mods,
+      totalRequired: all.filter((m) => m.type === "requires").length,
+      totalOptional: all.filter((m) => m.type === "recommends").length,
+    }),
+  );
+  return `${collectionId}_${profileId}`;
+}
+
+describe("collection install session state machine", () => {
+  const progressOf = (store: Store<ICollectionInstallState>) =>
+    getCollectionInstallProgress(asIState(store.getState()));
+
+  it("reaches isComplete once every required mod is installed (happy path)", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "r1", type: "requires" },
+        { ruleId: "r2", type: "requires" },
+      ]),
+    );
+
+    expect(progressOf(store)!.isComplete).toBe(false);
+
+    store.dispatch(updateModStatus(sessionId, "r1", "installing"));
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    expect(progressOf(store)!.isComplete).toBe(false);
+    expect(progressOf(store)!.installProgress).toBe(50);
+
+    store.dispatch(markModInstalled(sessionId, "r2", "mod-2"));
+
+    const progress = progressOf(store)!;
+    expect(progress.isComplete).toBe(true);
+    expect(progress.installProgress).toBe(100);
+    expect(progress.installedCount).toBe(2);
+  });
+
+  it("a failed required mod still lets the collection complete (does not stick at 9X%)", () => {
+    // The original stuck-at-9X% bug: a required mod that can never install leaves the
+    // collection forever incomplete. A failed required mod is terminal and must count
+    // toward completion (the install is "done", just not fully successful).
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "r1", type: "requires" },
+        { ruleId: "r2", type: "requires" },
+      ]),
+    );
+
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    store.dispatch(updateModStatus(sessionId, "r2", "failed"));
+
+    const progress = progressOf(store)!;
+    expect(progress.isComplete).toBe(true);
+    expect(progress.failedCount).toBe(1);
+    // only one of two required mods actually installed
+    expect(progress.installProgress).toBe(50);
+  });
+
+  it("a skipped (ignored) required mod is honoured and counts toward completion", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "r1", type: "requires" },
+        { ruleId: "r2", type: "requires" },
+      ]),
+    );
+
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    store.dispatch(updateModStatus(sessionId, "r2", "ignored"));
+
+    const progress = progressOf(store)!;
+    expect(progress.isComplete).toBe(true);
+    expect(progress.ignoredCount).toBe(1);
+  });
+
+  it("optional (recommends) mods never block completion", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "req", type: "requires" },
+        { ruleId: "opt", type: "recommends" },
+      ]),
+    );
+
+    // the only required mod installs; the optional one stays pending
+    store.dispatch(markModInstalled(sessionId, "req", "mod-req"));
+
+    expect(progressOf(store)!.isComplete).toBe(true);
+  });
+
+  it("is not complete while a required mod is still in progress", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "r1", type: "requires" },
+        { ruleId: "r2", type: "requires" },
+      ]),
+    );
+
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    store.dispatch(updateModStatus(sessionId, "r2", "installing"));
+
+    expect(progressOf(store)!.isComplete).toBe(false);
+  });
+
+  it("keeps the status breakdown consistent under interleaved updates", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(
+      store,
+      modsByRule([
+        { ruleId: "r1", type: "requires" },
+        { ruleId: "r2", type: "requires" },
+        { ruleId: "r3", type: "requires" },
+      ]),
+    );
+
+    // interleave transitions the way concurrent installers would
+    store.dispatch(updateModStatus(sessionId, "r1", "downloading"));
+    store.dispatch(updateModStatus(sessionId, "r2", "downloading"));
+    store.dispatch(updateModStatus(sessionId, "r1", "installing"));
+    store.dispatch(updateModStatus(sessionId, "r3", "downloading"));
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    store.dispatch(updateModStatus(sessionId, "r2", "installing"));
+    store.dispatch(markModInstalled(sessionId, "r2", "mod-2"));
+
+    const breakdown = getCollectionStatusBreakdown(asIState(store.getState()), sessionId);
+    expect(breakdown.required.installed).toBe(2);
+    expect(breakdown.required.downloading).toBe(1); // r3
+    // the two installed plus the one still downloading account for all three
+    const requiredTotal = Object.values(breakdown.required).reduce((a, b) => a + b, 0);
+    expect(requiredTotal).toBe(3);
+  });
+
+  it("archives the session to history on finish", () => {
+    const store = createSessionStore();
+    const sessionId = startSession(store, modsByRule([{ ruleId: "r1", type: "requires" }]));
+    store.dispatch(markModInstalled(sessionId, "r1", "mod-1"));
+    store.dispatch(finishInstallSession(sessionId, true));
+
+    const state = asIState(store.getState());
+    expect(getCollectionActiveSession(state)).toBeUndefined();
+    expect(store.getState().sessionHistory[sessionId]).toBeDefined();
+  });
+
+  it("rehydrates after a restart to the same completion (skip survives, no session)", () => {
+    // state.session.collections is not persisted, so on restart the session is rebuilt
+    // from durable inputs via reconstructModStatus. A pre-restart collection that was
+    // complete (one required installed, one required skipped) must rebuild to complete.
+    const installedRule = makeRule({ reference: { tag: "r1" } });
+    const skippedRule = makeRule({ reference: { tag: "r2" }, ignored: true });
+
+    const rebuiltStatus = (rule: typeof installedRule, mod?: ReturnType<typeof makeMod>) =>
+      reconstructModStatus(rule, mod, undefined);
+
+    const mods: Record<string, ICollectionModInstallInfo> = {
+      [modRuleId(installedRule)]: {
+        rule: installedRule,
+        type: "requires",
+        status: rebuiltStatus(
+          installedRule,
+          makeMod({ state: "installed" }),
+        ) as CollectionModStatus,
+      },
+      [modRuleId(skippedRule)]: {
+        rule: skippedRule,
+        type: "requires",
+        // skipped required mod rehydrates as terminal "ignored", not "pending"
+        status: rebuiltStatus(skippedRule) as CollectionModStatus,
+      },
+    };
+
+    const store = createSessionStore();
+    const sessionId = startSession(store, mods);
+    // mark the installed one as installed (markModInstalled is what sets the count)
+    store.dispatch(markModInstalled(sessionId, modRuleId(installedRule), "mod-1"));
+
+    const progress = progressOf(store)!;
+    expect(mods[modRuleId(skippedRule)].status).toBe("ignored");
+    expect(progress.isComplete).toBe(true);
+  });
+});

--- a/src/renderer/src/util/collectionInstallSession.test.ts
+++ b/src/renderer/src/util/collectionInstallSession.test.ts
@@ -1,43 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { IDownload } from "../extensions/download_management/types/IDownload";
-import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
+import { makeDownload, makeMod, makeRule } from "../test-utils/builders";
 import { reconstructModStatus } from "./collectionInstallSession";
-
-function makeRule(overrides: Partial<IModRule> = {}): IModRule {
-  return {
-    type: "requires",
-    reference: { tag: "abc" },
-    ...overrides,
-  };
-}
-
-function makeMod(overrides: Partial<IMod> = {}): IMod {
-  return {
-    id: "mod-1",
-    state: "installed",
-    type: "",
-    installationPath: "mods/mod-1",
-    attributes: {},
-    ...overrides,
-  };
-}
-
-function makeDownload(overrides: Partial<IDownload> = {}): IDownload {
-  return {
-    id: "dl",
-    state: "started",
-    urls: [],
-    game: ["skyrimse"],
-    modInfo: {},
-    startTime: 0,
-    fileTime: 0,
-    size: 0,
-    received: 0,
-    verified: 0,
-    ...overrides,
-  };
-}
 
 describe("reconstructModStatus", () => {
   it('rehydrates an ignored rule as the terminal "ignored" status so a skip survives a restart', () => {

--- a/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure-unit coverage for the install-session progress selectors that the
+ * state-machine contract suite does not exercise directly: per-phase progress
+ * (getCollectionPhaseProgress) and the required/optional/total split
+ * (getCollectionStatusBreakdown). These read a built session straight off the
+ * state - no store, no dispatch.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  makeInstallState,
+  makeModInstallInfo,
+  makeRule,
+  makeSession,
+} from "../test-utils/builders";
+import { asIState } from "../test-utils/sessionStore";
+import type {
+  CollectionModStatus,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
+import {
+  getCollectionPhaseProgress,
+  getCollectionStatusBreakdown,
+} from "./collectionInstallSessionSelectors";
+
+interface Entry {
+  ruleId: string;
+  phase?: number;
+  type?: "requires" | "recommends";
+  status?: CollectionModStatus;
+}
+
+/** Build a state whose active session contains the given member mods. */
+function stateWith(entries: Entry[]) {
+  // keyed by ruleId
+  const mods: Record<string, ICollectionModInstallInfo> = {};
+  for (const e of entries) {
+    mods[e.ruleId] = makeModInstallInfo({
+      // phase is read off the rule via rulePhase(); tag keeps each rule distinct
+      rule: makeRule({ phase: e.phase ?? 0, reference: { tag: e.ruleId } }),
+      type: e.type ?? "requires",
+      status: e.status ?? "pending",
+    });
+  }
+  const all = Object.values(mods);
+  return asIState(
+    makeInstallState({
+      activeSession: makeSession({
+        mods,
+        totalRequired: all.filter((m) => m.type === "requires").length,
+        totalOptional: all.filter((m) => m.type === "recommends").length,
+      }),
+    }),
+  );
+}
+
+describe("getCollectionPhaseProgress", () => {
+  it("groups mods by phase and reports per-phase completion (required only)", () => {
+    const state = stateWith([
+      { ruleId: "r1", phase: 0, type: "requires", status: "installed" },
+      { ruleId: "r2", phase: 0, type: "requires", status: "failed" },
+      { ruleId: "r3", phase: 1, type: "requires", status: "pending" },
+      { ruleId: "r4", phase: 1, type: "recommends", status: "pending" },
+    ]);
+
+    const phases = getCollectionPhaseProgress(state);
+    expect(phases.map((p) => p.phase)).toEqual([0, 1]);
+
+    const [p0, p1] = phases;
+    // phase 0: one installed + one failed = both required terminal -> complete
+    expect(p0.required).toBe(2);
+    expect(p0.installed).toBe(1);
+    expect(p0.failed).toBe(1);
+    expect(p0.progress).toBe(100);
+    expect(p0.isComplete).toBe(true);
+
+    // phase 1: one required still pending (the recommends one does not count) -> incomplete
+    expect(p1.required).toBe(1);
+    expect(p1.optional).toBe(1);
+    expect(p1.pending).toBe(1);
+    expect(p1.progress).toBe(0);
+    expect(p1.isComplete).toBe(false);
+  });
+
+  it("treats a phase of only optional mods as complete", () => {
+    const state = stateWith([{ ruleId: "opt", phase: 0, type: "recommends", status: "pending" }]);
+    const [p0] = getCollectionPhaseProgress(state);
+    expect(p0.required).toBe(0);
+    expect(p0.isComplete).toBe(true);
+  });
+});
+
+describe("getCollectionStatusBreakdown", () => {
+  it("splits counts across required, optional and total", () => {
+    const state = stateWith([
+      { ruleId: "r1", type: "requires", status: "installed" },
+      { ruleId: "r2", type: "requires", status: "downloading" },
+      { ruleId: "o1", type: "recommends", status: "installed" },
+    ]);
+
+    const breakdown = getCollectionStatusBreakdown(state, "col1_prof1");
+    expect(breakdown.required.installed).toBe(1);
+    expect(breakdown.required.downloading).toBe(1);
+    expect(breakdown.optional.installed).toBe(1);
+    expect(breakdown.total.installed).toBe(2);
+    expect(breakdown.total.downloading).toBe(1);
+  });
+});


### PR DESCRIPTION
- shared test-utils: builders (consolidating the factories that were copy-pasted across the install-session suites) and a real-reducer session store harness.
- a session state-machine contract suite that dispatches the typed tracking actions against the real reducer and asserts completion via the selectors.
- pure-unit coverage for getCollectionPhaseProgress and getCollectionStatusBreakdown.

No behaviour change; this is the contract the upcoming write-path refactor must satisfy. The three existing install-session suites now import the shared builders.

part of LAZ-483