### PR TITLE
fixed TypographyLink children/customContent as a precedence pair

### DIFF
--- a/src/renderer/src/ui/components/typography/TypographyLink.tsx
+++ b/src/renderer/src/ui/components/typography/TypographyLink.tsx
@@ -1,7 +1,7 @@
 import React, { type ButtonHTMLAttributes, type ReactNode, type Ref } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
-import type { ResponsiveScreenSizes, XOr } from "@/ui/utils/types";
+import type { ResponsiveScreenSizes } from "@/ui/utils/types";
 
 import { Icon, type IconSize } from "../icon/Icon";
 import {
@@ -29,8 +29,7 @@ export type ITypographyLinkProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   rightIconPath?: string;
   typographyType?: ITypographyLinkTypes | ITypographyLinkTypeObject;
   variant?: "primary" | "secondary" | "none";
-} & XOr<{ children?: string }, { customContent: ReactNode }> &
-  ITypographyColour;
+} & { children?: string; customContent?: ReactNode } & ITypographyColour;
 
 // On hover, the colour shifts one step toward `strong`; `strong` (already the
 // lightest) dims to `moderate` instead, so every appearance gives feedback.


### PR DESCRIPTION
`children` and `customContent` were typed with `XOr`, making them mutually exclusive. But the component defines a precedence relationship — `customContent` overrides `children` via the `??` fallback; so passing both is valid and is exactly what the "renders customContent instead of children" test exercises. `XOr` made that test fail to typecheck.

Replace the `XOr` wrapper with a plain optional pair (`{ children?: string; customContent?: ReactNode }`), matching the existing precedent in DropdownItem, Pill, Button, etc.