### PR TITLE
Fix boken typography test

### DIFF
--- a/src/renderer/src/ui/components/typography/TypographyLink.test.tsx
+++ b/src/renderer/src/ui/components/typography/TypographyLink.test.tsx
@@ -27,14 +27,9 @@ describe("TypographyLink", () => {
       expect(screen.getByText("Open page")).toBeInTheDocument();
     });
 
-    it("renders customContent instead of children when provided", () => {
-      render(
-        <TypographyLink customContent={<span data-testid="custom">x</span>}>
-          ignored
-        </TypographyLink>,
-      );
+    it("renders customContent when provided", () => {
+      render(<TypographyLink customContent={<span data-testid="custom">x</span>} />);
       expect(screen.getByTestId("custom")).toBeInTheDocument();
-      expect(screen.queryByText("ignored")).not.toBeInTheDocument();
     });
 
     it("renders left and right icons from paths", () => {


### PR DESCRIPTION
Test was passing both children and customContent which isn't possible due to a type check.