### PR TITLE
InstallManager the single collection-session lifecycle writer (483 WIP)

### DIFF
--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -1471,7 +1471,9 @@ function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
       });
       const isDependency = dependency !== undefined;
       if (isDependency) {
-        driver.markModInstalledInTracking(dependency, modId);
+        // "installed" is recorded on the session by InstallManager (the single lifecycle
+        // writer) when the dependency loop installs or reuses the mod; here we only wire
+        // the collection's bidirectional mod rules onto the freshly installed mod.
         const modRules = await driver.infoCache.getCollectionModRules(
           revisionId,
           collection,

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -4,14 +4,10 @@ import * as path from "path";
 import * as nexusApi from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 import Bluebird from "bluebird";
-import * as _ from "lodash";
 
 import * as installActions from "../../../actions/collectionInstallTracking";
 import { log } from "../../../logging";
-import type {
-  CollectionModStatus,
-  ICollectionModInstallInfo,
-} from "../../../types/collections/ICollectionInstallSession";
+import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import type { IState } from "../../../types/IState";
 import {
@@ -27,13 +23,12 @@ import {
   CollectionsInstallationFailedEvent,
   CollectionsInstallationStartedEvent,
 } from "../../analytics/mixpanel/MixpanelEvents";
-import type { IDownload } from "../../download_management/types/IDownload";
 import { discoveryByGame } from "../../gamemode_management/selectors";
 import { getGame } from "../../gamemode_management/util/getGame";
 import { addModRule, setFileOverride, setModAttribute } from "../../mod_management/actions/mods";
 import { installPathForGame } from "../../mod_management/selectors";
 import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
-import { findDownloadByRef, lookupFromDownload } from "../../mod_management/util/dependencies";
+import { findDownloadByRef } from "../../mod_management/util/dependencies";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
 import renderModName from "../../mod_management/util/modName";
@@ -89,23 +84,11 @@ class InstallDriver {
   private mTimeStarted: number;
   private mPostprocessing: boolean = false;
 
-  private mStateUpdates: any[] = [];
-  private mModStatusDebouncer: Debouncer = new Debouncer(
-    () => {
-      const actions = this.mStateUpdates.slice();
-      this.mStateUpdates = [];
-      batchDispatch(this.mApi.store, actions);
-      return Bluebird.resolve();
-    },
-    100,
-    false,
-    false,
-  );
-
-  // Throttle the progress notification to avoid flooding Redux/UI on every
-  // single mod event.  Tracking dispatches (mModStatusDebouncer) are unaffected.
-  // reset=false keeps it from starving, triggerImmediately=true shows instant
-  // feedback on the first event.
+  // Throttle the progress notification to avoid flooding Redux/UI on every single mod
+  // event. (Session status writes are dispatched directly now - InstallManager is the
+  // single lifecycle writer, so the driver's remaining writes are low-frequency and there
+  // is no dispatch storm to batch.) reset=false keeps it from starving,
+  // triggerImmediately=true shows instant feedback on the first event.
   private mProgressDebouncer: Debouncer = new Debouncer(
     () => {
       if (this.mProfile && this.mGameId && this.mCollection) {
@@ -128,44 +111,6 @@ class InstallDriver {
     return this.mDependentMods.filter((m) => m.type === "recommends");
   }
 
-  public updateModTracking(rule: IModRule, status: CollectionModStatus) {
-    if (!this.mTrackingEnabled || !this.mCurrentSessionId) {
-      return;
-    }
-
-    if (status === "installed") {
-      // 'installed' status should be set via markModInstalledInTracking
-      log("warn", "use markModInstalledInTracking to set status to installed");
-      return;
-    }
-
-    const ruleId = modRuleId(rule);
-
-    // Check current status to prevent downgrades from terminal states
-    const state = this.mApi.getState();
-    const currentSession = state.session["collections"]?.activeSession;
-    const currentStatus = currentSession?.mods?.[ruleId]?.status;
-
-    // Don't downgrade from terminal states (installed, skipped, failed)
-    const terminalStates: CollectionModStatus[] = ["installed", "ignored", "failed"];
-    if (currentStatus && terminalStates.includes(currentStatus)) {
-      return;
-    }
-
-    this.mStateUpdates.push(installActions.updateModStatus(this.mCurrentSessionId, ruleId, status));
-    this.mModStatusDebouncer.schedule();
-  }
-
-  public markModInstalledInTracking(rule: IModRule, modId: string) {
-    if (!this.mTrackingEnabled || !this.mCurrentSessionId) {
-      return;
-    }
-
-    const ruleId = modRuleId(rule);
-    this.mStateUpdates.push(installActions.markModInstalled(this.mCurrentSessionId, ruleId, modId));
-    this.mModStatusDebouncer.schedule();
-  }
-
   /**
    * Mark a collection rule as ignored. Updates the transient install session and
    * persists the decision durably via the rule's `ignored` flag. The session lives
@@ -176,12 +121,23 @@ class InstallDriver {
    * checks already treat ignored rules as resolved.
    */
   private markRuleIgnored(rule: IModRule) {
-    this.updateModTracking(rule, "ignored");
-
-    if (this.mGameId !== undefined && this.mCollection !== undefined) {
-      this.mApi.store.dispatch(
-        addModRule(this.mGameId, this.mCollection.id, { ...rule, ignored: true }),
+    // user-initiated skip: write the session status and the durable flag together. Both
+    // are low-frequency, so they dispatch directly (no batching debouncer needed now that
+    // InstallManager is the single lifecycle writer). This intentionally does NOT go
+    // through planSessionWrite's protection: ignoring a mod is an explicit user decision
+    // that must take effect even if the mod already reached a terminal state (e.g. the
+    // user wants to stop the collection re-pulling it and then remove it manually).
+    const actions: any[] = [];
+    if (this.mTrackingEnabled && this.mCurrentSessionId) {
+      actions.push(
+        installActions.updateModStatus(this.mCurrentSessionId, modRuleId(rule), "ignored"),
       );
+    }
+    if (this.mGameId !== undefined && this.mCollection !== undefined) {
+      actions.push(addModRule(this.mGameId, this.mCollection.id, { ...rule, ignored: true }));
+    }
+    if (actions.length > 0) {
+      batchDispatch(this.mApi.store, actions);
     }
   }
 
@@ -190,8 +146,7 @@ class InstallDriver {
       return;
     }
 
-    this.mStateUpdates.push(installActions.finishInstallSession(this.mCurrentSessionId, success));
-    this.mModStatusDebouncer.schedule();
+    this.mApi.store.dispatch(installActions.finishInstallSession(this.mCurrentSessionId, success));
     this.mCurrentSessionId = undefined;
   }
 
@@ -228,20 +183,13 @@ class InstallDriver {
 
     this.mInfoCache = new InfoCache(api);
 
-    api.onAsync("will-install-mod", (gameId: string, archiveId: string, modId: string) => {
+    api.onAsync("will-install-mod", (_gameId: string, archiveId: string, _modId: string) => {
       const state: IState = api.store.getState();
       const download = state.persistent.downloads.files[archiveId];
       if (download !== undefined) {
         this.mInstallingMod = download.localPath;
-        // mark the mod as installing on the session so the UI reflects the live phase
-        // (the install/extraction phase is otherwise indistinguishable from "downloaded")
-        const lookup = lookupFromDownload(download);
-        const matchingRule = this.mDependentMods.find((rule) =>
-          testModReference(lookup, rule.reference),
-        );
-        if (matchingRule !== undefined) {
-          this.updateModTracking(matchingRule, "installing");
-        }
+        // the "installing" session status is now written by InstallManager directly
+        // (the in-process write path), so the driver no longer translates this event
       }
       return Bluebird.resolve();
     });
@@ -279,8 +227,8 @@ class InstallDriver {
           this.mInstalledMods.push(mod);
         }
 
-        // Mark as installed in tracking
-        this.markModInstalledInTracking(dependent, modId);
+        // the "installed" session status is now written by InstallManager directly
+        // (the in-process write path); the driver keeps the patch/attribute side effects
 
         if (
           this.mCollection?.installationPath !== undefined &&
@@ -309,25 +257,10 @@ class InstallDriver {
       this.triggerUpdate();
     });
 
-    api.events.on("did-finish-download", (downloadId: string, downloadState: string) => {
-      // not checking whether the download is actually part of this collection because
-      // that check may be more expensive than the ui update
+    api.events.on("did-finish-download", () => {
+      // progress UI only - the "downloaded" session status is written by InstallManager.
+      // Not gated on collection membership: the check would cost more than the UI refresh.
       this.mProgressDebouncer.schedule();
-
-      // Update mod status to 'downloaded' when download completes successfully
-      if (downloadState === "finished") {
-        const state = api.getState();
-        const download = state.persistent.downloads.files[downloadId];
-        if (download) {
-          const lookup = lookupFromDownload(download);
-          const matchingRule = this.mDependentMods.find((rule) => {
-            return testModReference(lookup, rule.reference);
-          });
-          if (matchingRule) {
-            this.updateModTracking(matchingRule, "downloaded");
-          }
-        }
-      }
     });
 
     api.events.on(
@@ -374,47 +307,8 @@ class InstallDriver {
       },
     );
 
-    api.onStateChange(
-      ["persistent", "downloads", "files"],
-      (prev: Record<string, IDownload>, current: Record<string, IDownload>) => {
-        if (this.mDependentMods.length === 0) return;
-
-        const newIds = Object.keys(current).filter((id) => prev?.[id] === undefined);
-        for (const dlId of newIds) {
-          const download = current[dlId];
-          if (!download) continue;
-
-          const lookup = lookupFromDownload(download);
-          const matchingRule = this.mDependentMods.find((rule) => {
-            return testModReference(lookup, rule.reference);
-          });
-
-          const isBundled = matchingRule?.extra?.localPath != null;
-          if (matchingRule && !isBundled) {
-            this.updateModTracking(matchingRule, "downloading");
-          }
-        }
-      },
-    );
-
-    api.events.on("did-import-downloads", (dlIds: string[]) => {
-      // Update tracking for bundled mods that were just imported
-      const state = api.getState();
-      const downloads = state.persistent.downloads.files;
-
-      dlIds.forEach((dlId) => {
-        const download = downloads[dlId];
-        if (download) {
-          const lookup = lookupFromDownload(download);
-          const matchingRule = this.mDependentMods.find((rule) => {
-            return testModReference(lookup, rule.reference);
-          });
-          if (matchingRule) {
-            this.updateModTracking(matchingRule, "downloaded");
-          }
-        }
-      });
-    });
+    // "downloading" (new downloads) and "downloaded" (imported/bundled downloads) are
+    // now written by InstallManager, the single lifecycle writer for the session.
 
     api.events.on("collection-mod-skipped", (reference: IModReference) => {
       // Update tracking when a mod download is skipped (for both free and premium users)
@@ -862,8 +756,6 @@ class InstallDriver {
     if (this.mCollection !== undefined) {
       this.mApi.dismissNotification(INSTALLING_NOTIFICATION_ID + this.mCollection.id);
 
-      // Flush pending tracking updates before cleanup so they aren't lost
-      this.mModStatusDebouncer.runNow(() => undefined);
       // Cancel any pending progress notification — the notification is about
       // to be dismissed anyway and we don't want it to fire after cleanup.
       this.mProgressDebouncer.clear();

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -61,6 +61,7 @@ import { generate as shortid } from "shortid";
  * See AGENTS-COLLECTIONS.md for architectural overview.
  */
 import { removeDownload, setDownloadModInfo, startActivity, stopActivity } from "../../actions";
+import { markModInstalled, updateModStatus } from "../../actions/collectionInstallTracking";
 import {
   type IConditionResult,
   type IDialogContent,
@@ -82,6 +83,8 @@ import {
   getCollectionStatusBreakdown,
   isCollectionPhaseComplete,
 } from "../../util/collectionInstallSessionSelectors";
+import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
+import { sessionWriteForDependency } from "../../util/collectionSessionWrite";
 import ConcurrencyLimiter from "../../util/ConcurrencyLimiter";
 import {
   DataInvalid,
@@ -707,6 +710,11 @@ class InstallManager {
       download: downloadId,
       phase: rulePhase(matchingRule),
     };
+
+    // record that this collection mod's download is available, coupled to the install
+    // queueing below so we never mark "downloaded" for a download we then don't install
+    // (no-op outside an active collection session)
+    this.writeCollectionSession(dependency.reference, { type: "status", status: "downloaded" });
 
     // Ensure the phase is marked as having downloads finished
     // This is needed when downloads complete after initial dependency processing
@@ -2391,6 +2399,14 @@ class InstallManager {
             fileList: currentDep.fileList,
             patches: currentDep.patches,
           });
+          if (existingMod == null) {
+            // about to actually install (not reusing an existing mod): mark installing so
+            // the collection session reflects the live install phase
+            this.writeCollectionSession(currentDep.reference, {
+              type: "status",
+              status: "installing",
+            });
+          }
           const modId =
             existingMod != null
               ? existingMod.id
@@ -2419,6 +2435,11 @@ class InstallManager {
 
           if (modId) {
             this.mActiveInstalls.delete(installKey);
+
+            // record the successful install on the collection session (no-op outside an
+            // active collection session). This is the sole writer of the "installed"
+            // status, covering both a freshly installed mod and a reused existing one.
+            this.writeCollectionSession(currentDep.reference, { type: "installed", modId });
 
             // Apply any extra attributes
             this.applyExtraFromRule(api, gameId, modId, {
@@ -2505,6 +2526,10 @@ class InstallManager {
           } else if (!isCanceled) {
             // Max retries exceeded, clean up and show error
             this.mDependencyRetryCount.delete(installKey);
+            // record the terminal failure on the collection session so the install can
+            // still complete (a failed required mod is decided, not pending) and the UI
+            // shows it as failed rather than stuck
+            this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
             this.showDependencyError(
               api,
               sourceModId,
@@ -5746,6 +5771,10 @@ class InstallManager {
     };
 
     const queueDownload = (dep: IDependency): Promise<string> => {
+      // mark the dependency as downloading on the collection session (no-op outside an
+      // active collection session). Bundled mods are imported, not queued here, so they
+      // are naturally excluded - matching the old driver's bundled skip.
+      this.writeCollectionSession(dep.reference, { type: "status", status: "downloading" });
       if (dep.reference.tag !== undefined) {
         queuedDownloads.push(dep.reference);
       }
@@ -6119,6 +6148,13 @@ class InstallManager {
                     freshDownloads[downloadId]?.state === "finished" &&
                     freshDownloads[downloadId]?.size > 0
                   ) {
+                    // already-finished/imported (incl. bundled) downloads bypass
+                    // handleDownloadFinished, so record "downloaded" here too (no-op
+                    // outside an active collection session)
+                    this.writeCollectionSession(dep.reference, {
+                      type: "status",
+                      status: "downloaded",
+                    });
                     this.queueInstallation(
                       api,
                       dep,
@@ -7212,6 +7248,28 @@ class InstallManager {
     }
 
     return null;
+  }
+
+  /**
+   * Record a dependency install outcome on the active collection session. This is the
+   * direct, in-process write path: the orchestrator already knows which dependency it is
+   * processing, so it matches the rule by reference and dispatches the resulting tracking
+   * action. Additive to the existing api.events.emit calls - it does not replace them.
+   * A no-op when there is no active session, no rule matches, or the write is redundant.
+   */
+  private writeCollectionSession(
+    reference: IModReference,
+    outcome: CollectionInstallOutcome,
+  ): void {
+    const plan = sessionWriteForDependency(this.mApi.getState(), reference, outcome);
+    if (plan === null) {
+      return;
+    }
+    const action =
+      plan.write.kind === "markInstalled"
+        ? markModInstalled(plan.sessionId, plan.ruleId, plan.write.modId)
+        : updateModStatus(plan.sessionId, plan.ruleId, plan.write.status);
+    this.mApi.store.dispatch(action);
   }
 
   /**

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -254,6 +254,26 @@ describe("installTracking reducer", () => {
       expect(result.activeSession.installedCount).toBe(1);
     });
 
+    it("decrements failedCount when a failed mod is retried to installed", () => {
+      // planSessionWrite allows failed -> installed (retry revert), so markModInstalled
+      // must clear the prior failure from the aggregate, not just bump installedCount.
+      const session = makeSession({
+        mods: modsByRule([{ ruleId: "rule1", status: "failed", type: "requires" }]),
+        failedCount: 1,
+      });
+      const state = makeInstallState({ activeSession: session });
+
+      const result = reduce(state, actions.markModInstalled, {
+        sessionId: "col1_prof1",
+        ruleId: "rule1",
+        modId: "actual-mod-id",
+      });
+
+      expect(result.activeSession.mods.rule1.status).toBe("installed");
+      expect(result.activeSession.installedCount).toBe(1);
+      expect(result.activeSession.failedCount).toBe(0);
+    });
+
     it("is a no-op when sessionId does not match", () => {
       const session = makeSession({
         mods: modsByRule([{ ruleId: "rule1", status: "downloading", type: "requires" }]),

--- a/src/renderer/src/reducers/collectionInstallTracking.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.ts
@@ -115,10 +115,11 @@ const collectionInstallReducer = {
         Date.now(),
       );
 
-      // Incremental counter update
+      // Incremental counter update. Merge ALL counters: a retry can revert failed ->
+      // installed (planSessionWrite allows it), and that transition must decrement
+      // failedCount, not just bump installedCount.
       const counters = adjustCounters(state.activeSession, oldStatus, "installed");
-      newState = setSafe(newState, ["activeSession", "downloadedCount"], counters.downloadedCount);
-      newState = setSafe(newState, ["activeSession", "installedCount"], counters.installedCount);
+      newState = merge(newState, ["activeSession"], counters);
 
       return newState;
     },

--- a/src/renderer/src/types/collections/ICollectionInstallSession.ts
+++ b/src/renderer/src/types/collections/ICollectionInstallSession.ts
@@ -11,10 +11,9 @@ import type { IModRule, ModState } from "../../extensions/mod_management/types/I
 export type CollectionModStatus =
   | keyof Pick<Record<ModState, true>, "downloading" | "downloaded" | "installing" | "installed">
   | "pending" // not yet processed
-  // installation failed. NOTE: not yet wired up - the UI renders this status but nothing
-  // sets it on the session yet, so a failed mod currently surfaces as "pending" rather
-  // than "failed". The install-failure path still needs to call updateModTracking(rule,
-  // "failed").
+  // installation failed (retries exhausted). Written by InstallManager on the
+  // retries-exhausted branch; counts toward completion so a failed required mod does not
+  // leave the collection stuck, and is revertible if the mod is later retried.
   | "failed"
   | "ignored" // excluded by user choice (skipped during install or manually ignored)
   | "optional"; // optional mod not selected

--- a/src/renderer/src/util/collectionInstallSession.ts
+++ b/src/renderer/src/util/collectionInstallSession.ts
@@ -1,5 +1,5 @@
 import type { IDownload } from "../extensions/download_management/types/IDownload";
-import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
+import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
 import type { CollectionModStatus } from "../types/collections/ICollectionInstallSession";
 
 export function generateCollectionSessionId(collectionId: string, profileId: string): string {
@@ -9,17 +9,24 @@ export function generateCollectionSessionId(collectionId: string, profileId: str
   return `${collectionId}_${profileId}`;
 }
 
-export function modRuleId(input: IModRule): string {
+/**
+ * Stable identity of a mod reference: the rule's tag if present, else the first available
+ * content identifier. This is the reference half of modRuleId, shared so that matching a
+ * dependency back to its session rule uses the exact same notion of identity as the key.
+ */
+export function referenceId(reference: IModReference): string | undefined {
   return (
-    input.type +
-    "_" +
-    (input.reference.tag ||
-      input.reference.fileMD5 ||
-      input.reference.id ||
-      input.reference.logicalFileName ||
-      input.reference.fileExpression ||
-      input.reference.description)
+    reference.tag ||
+    reference.fileMD5 ||
+    reference.id ||
+    reference.logicalFileName ||
+    reference.fileExpression ||
+    reference.description
   );
+}
+
+export function modRuleId(input: IModRule): string {
+  return input.type + "_" + referenceId(input.reference);
 }
 
 /**

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit coverage for the install-session WRITE side: the pure write planner and the
+ * reference->write resolver against an active session.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  makeInstallState,
+  makeModInstallInfo,
+  makeReference,
+  makeRule,
+  makeSession,
+} from "../test-utils/builders";
+import { asIState } from "../test-utils/sessionStore";
+import type {
+  CollectionModStatus,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
+import { planSessionWrite, sessionWriteForDependency } from "./collectionSessionWrite";
+
+describe("planSessionWrite", () => {
+  it("records reaching installed via markInstalled, over any in-progress or failed state", () => {
+    expect(planSessionWrite("pending", { type: "installed", modId: "m1" })).toEqual({
+      kind: "markInstalled",
+      modId: "m1",
+    });
+    expect(planSessionWrite("failed", { type: "installed", modId: "m1" })).toEqual({
+      kind: "markInstalled",
+      modId: "m1",
+    });
+  });
+
+  it("does NOT let an automatic installed override a user ignore (ignore is final)", () => {
+    expect(planSessionWrite("ignored", { type: "installed", modId: "m1" })).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("does not override a user ignore with an automatic in-progress status", () => {
+    expect(planSessionWrite("ignored", { type: "status", status: "downloading" })).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("writes an in-progress status when the mod is pending / in-progress", () => {
+    expect(planSessionWrite("pending", { type: "status", status: "downloading" })).toEqual({
+      kind: "updateStatus",
+      status: "downloading",
+    });
+    expect(planSessionWrite(undefined, { type: "status", status: "installing" })).toEqual({
+      kind: "updateStatus",
+      status: "installing",
+    });
+  });
+
+  it("does not downgrade a completed install with a late in-progress event", () => {
+    expect(planSessionWrite("installed", { type: "status", status: "downloading" })).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("lets a failed mod revert when it is retried", () => {
+    // failed is not sticky: a requeue/retry must be able to move it forward again
+    expect(planSessionWrite("failed", { type: "status", status: "installing" })).toEqual({
+      kind: "updateStatus",
+      status: "installing",
+    });
+  });
+});
+
+describe("sessionWriteForDependency", () => {
+  // each session mod's rule reference carries a tag === ruleId; a dependency reference
+  // carrying the same tag matches it by referenceId.
+  const refForTag = (tag: string) => makeReference({ tag });
+
+  function stateWith(
+    entries: Array<{ ruleId: string; status?: CollectionModStatus }>,
+  ): ReturnType<typeof asIState> {
+    // keyed by ruleId
+    const mods: Record<string, ICollectionModInstallInfo> = {};
+    for (const e of entries) {
+      mods[e.ruleId] = makeModInstallInfo({
+        rule: makeRule({ reference: { tag: e.ruleId } }),
+        status: e.status ?? "pending",
+      });
+    }
+    return asIState(makeInstallState({ activeSession: makeSession({ mods }) }));
+  }
+
+  it("resolves an in-progress status write for the matched rule", () => {
+    const state = stateWith([{ ruleId: "r1", status: "pending" }]);
+    expect(
+      sessionWriteForDependency(state, refForTag("r1"), { type: "status", status: "installing" }),
+    ).toEqual({
+      sessionId: "col1_prof1",
+      ruleId: "r1",
+      write: { kind: "updateStatus", status: "installing" },
+    });
+  });
+
+  it("resolves a markInstalled write for an installed outcome", () => {
+    const state = stateWith([{ ruleId: "r1", status: "downloading" }]);
+    expect(
+      sessionWriteForDependency(state, refForTag("r1"), { type: "installed", modId: "mod-1" }),
+    ).toEqual({
+      sessionId: "col1_prof1",
+      ruleId: "r1",
+      write: { kind: "markInstalled", modId: "mod-1" },
+    });
+  });
+
+  it("returns null when there is no active session", () => {
+    const empty = asIState(makeInstallState());
+    expect(
+      sessionWriteForDependency(empty, refForTag("r1"), { type: "status", status: "installing" }),
+    ).toBeNull();
+  });
+
+  it("returns null when no rule matches the reference", () => {
+    const state = stateWith([{ ruleId: "r1", status: "pending" }]);
+    expect(
+      sessionWriteForDependency(state, refForTag("nope"), { type: "status", status: "installing" }),
+    ).toBeNull();
+  });
+
+  it("returns null when the write would override a user-ignored mod", () => {
+    const state = stateWith([{ ruleId: "r1", status: "ignored" }]);
+    expect(
+      sessionWriteForDependency(state, refForTag("r1"), { type: "installed", modId: "mod-1" }),
+    ).toBeNull();
+  });
+});

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -1,0 +1,105 @@
+/**
+ * Planning + resolving writes to the collection install session. This is the WRITE side
+ * of the session (the read side is collectionInstallSessionSelectors). It is internal to
+ * the install flow - InstallManager (and the driver, for user skips) use it directly; it
+ * is deliberately NOT re-exported through the public api barrels.
+ */
+import type { IModReference } from "../extensions/mod_management/types/IMod";
+import type { CollectionModStatus } from "../types/collections/ICollectionInstallSession";
+import type { IState } from "../types/IState";
+import { referenceId } from "./collectionInstallSession";
+import { getCollectionActiveSession } from "./collectionInstallSessionSelectors";
+
+/**
+ * An install lifecycle outcome to record against a session mod. "installed" is its own
+ * variant (it carries the modId), so the status variant excludes it - an installed status
+ * is unrepresentable as a plain status update.
+ */
+export type CollectionInstallOutcome =
+  | { type: "status"; status: Exclude<CollectionModStatus, "installed"> }
+  | { type: "installed"; modId: string };
+
+/** What writing an outcome should do to the session (or nothing). */
+export type CollectionSessionWrite =
+  | { kind: "updateStatus"; status: CollectionModStatus }
+  | { kind: "markInstalled"; modId: string }
+  | { kind: "none" };
+
+/**
+ * Decide how an automatic install outcome should be written to a session mod, given that
+ * mod's current status. This is the single source of the automatic write rules (the user
+ * skip path, markRuleIgnored, deliberately bypasses it - see below):
+ *
+ * - "ignored" is the user's final word: no automatic write overrides it. The user changes
+ *   it by un-ignoring/resuming; markRuleIgnored sets it directly (bypassing this planner)
+ *   precisely so an explicit skip CAN override a prior installed/in-progress state.
+ * - reaching "installed" wins over any in-progress or failed state (recorded via
+ *   markModInstalled, which carries the modId) - but not over a user "ignored".
+ * - a completed install ("installed") is not downgraded by a late/stray in-progress event.
+ * - "failed" is intentionally NOT sticky: a requeue/retry can revert it forward, and it
+ *   still counts toward completion separately (see getCollectionInstallProgress).
+ */
+export function planSessionWrite(
+  currentStatus: CollectionModStatus | undefined,
+  outcome: CollectionInstallOutcome,
+): CollectionSessionWrite {
+  if (currentStatus === "ignored") {
+    return { kind: "none" };
+  }
+  if (outcome.type === "installed") {
+    return { kind: "markInstalled", modId: outcome.modId };
+  }
+  if (currentStatus === "installed") {
+    return { kind: "none" };
+  }
+  return { kind: "updateStatus", status: outcome.status };
+}
+
+/** A resolved session write: which session/rule to update and how. */
+export interface IResolvedSessionWrite {
+  sessionId: string;
+  ruleId: string;
+  // never "none" - a no-op resolves to a null result instead
+  write: Exclude<CollectionSessionWrite, { kind: "none" }>;
+}
+
+/**
+ * Resolve how an install lifecycle outcome should be written to the active session,
+ * given the reference of the dependency the outcome is about. The orchestrator
+ * (InstallManager) always has the dependency in hand, so the rule is matched by
+ * reference identity (referenceId, the same identity the session-mods key uses) rather
+ * than by lookup. Combines the active-session lookup, rule matching and planSessionWrite
+ * into one step so a writer can record progress with a single call. The returned ruleId
+ * is the session-mods key.
+ *
+ * Returns null when there is no active session, no rule matches the reference, or the
+ * write would be a no-op (e.g. a downgrade from a protected state).
+ */
+export function sessionWriteForDependency(
+  state: IState,
+  reference: IModReference,
+  outcome: CollectionInstallOutcome,
+): IResolvedSessionWrite | null {
+  const session = getCollectionActiveSession(state);
+  if (session === undefined) {
+    return null;
+  }
+  const target = referenceId(reference);
+  if (target === undefined) {
+    // a reference with no identifying field can't be matched to a specific rule; bail
+    // rather than aliasing onto another id-less rule (undefined === undefined)
+    return null;
+  }
+  const entry = Object.entries(session.mods).find(
+    ([, info]) => referenceId(info.rule.reference) === target,
+  );
+  if (entry === undefined) {
+    return null;
+  }
+  const [ruleId, info] = entry;
+  const write = planSessionWrite(info.status, outcome);
+  if (write.kind === "none") {
+    return null;
+  }
+  return { sessionId: session.sessionId, ruleId, write };
+}


### PR DESCRIPTION
The collection install session was written by two components on different clocks: InstallManager (synchronously) and InstallDriver (100ms-debounced), which could race and downgrade an in-flight status.

InstallManager now owns the full lifecycle - downloading/downloaded/installing /installed/failed - via writeCollectionSession, additive to the existing api.events.emit calls. InstallDriver no longer writes those (its tracking debouncer, updateModTracking and markModInstalledInTracking are removed); it keeps only the user "ignored" decision and session start/finish.

The write rules live in a new internal util/collectionSessionWrite (planSessionWrite + sessionWriteForDependency): "ignored" is the user's final word (no automatic write overrides it), "installed" wins over in-progress/failed but not over ignored, and a late event can't downgrade a completed install. "failed" is now written (retries exhausted) and is revertible by a retry.

Also fixes markModInstalled dropping the failedCount/ignoredCount adjustment, so a failed mod retried to installed no longer leaves a phantom failure count.

part of LAZ-483