### PR TITLE
Collection Mods tab opens wrong mod page when mods share the same author

### DIFF
--- a/extensions/collections/src/views/CollectionPageView/CollectionModDetails.tsx
+++ b/extensions/collections/src/views/CollectionPageView/CollectionModDetails.tsx
@@ -36,7 +36,7 @@ function CollectionModDetails(props: ICollectionModDetails) {
 
   const visitPage = React.useCallback(() => {
     util.opn(`${NEXUS_BASE_URL}/${domainName}/mods/${modId}`);
-  }, [uploaderId]);
+  }, [domainName, modId]);
 
   return (
     <div className="installing-mod-overview">


### PR DESCRIPTION
Fixes #23514
Closes [LAZ-608](https://linear.app/nexus-mods/issue/LAZ-608/collection-mods-tab-opens-wrong-mod-page-when-mods-share-the-same)