### PR TITLE
added resync session from reality, live ignore, radial spin (483 WIP)

### DIFF
--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -7,14 +7,10 @@ import Bluebird from "bluebird";
 
 import * as installActions from "../../../actions/collectionInstallTracking";
 import { log } from "../../../logging";
-import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import type { IState } from "../../../types/IState";
-import {
-  generateCollectionSessionId,
-  modRuleId,
-  reconstructModStatus,
-} from "../../../util/collectionInstallSession";
+import { generateCollectionSessionId, modRuleId } from "../../../util/collectionInstallSession";
+import { reconstructSessionMods } from "../../../util/collectionSessionReconstruct";
 import Debouncer from "../../../util/Debouncer";
 import { getSafe, setSafe } from "../../../util/storeHelper";
 import { batchDispatch } from "../../../util/util";
@@ -28,13 +24,11 @@ import { getGame } from "../../gamemode_management/util/getGame";
 import { addModRule, setFileOverride, setModAttribute } from "../../mod_management/actions/mods";
 import { installPathForGame } from "../../mod_management/selectors";
 import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
-import { findDownloadByRef } from "../../mod_management/util/dependencies";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
 import renderModName from "../../mod_management/util/modName";
 import testModReference, {
   ruleInstallSpec,
-  rulePhase,
   testRefByIdentifiers,
 } from "../../mod_management/util/testModReference";
 import { nexusIdsFromDownloadId } from "../../nexus_integration/selectors";
@@ -103,7 +97,6 @@ class InstallDriver {
 
   // Collection installation tracking
   private mCurrentSessionId: string;
-  private mTrackingEnabled: boolean = true;
   private get requiredMods() {
     return this.mDependentMods.filter((m) => m.type === "requires");
   }
@@ -128,7 +121,7 @@ class InstallDriver {
     // that must take effect even if the mod already reached a terminal state (e.g. the
     // user wants to stop the collection re-pulling it and then remove it manually).
     const actions: any[] = [];
-    if (this.mTrackingEnabled && this.mCurrentSessionId) {
+    if (this.mCurrentSessionId) {
       actions.push(
         installActions.updateModStatus(this.mCurrentSessionId, modRuleId(rule), "ignored"),
       );
@@ -142,7 +135,7 @@ class InstallDriver {
   }
 
   private completeInstallationTracking(success: boolean) {
-    if (!this.mTrackingEnabled || !this.mCurrentSessionId) {
+    if (!this.mCurrentSessionId) {
       return;
     }
 
@@ -608,14 +601,6 @@ class InstallDriver {
     return ["disclaimer", "installing"].indexOf(this.mStep) !== -1;
   }
 
-  public enableTracking(enabled: boolean = true) {
-    this.mTrackingEnabled = enabled;
-  }
-
-  public get isTrackingEnabled(): boolean {
-    return this.mTrackingEnabled;
-  }
-
   public get currentSessionId(): string | undefined {
     return this.mCurrentSessionId;
   }
@@ -957,54 +942,31 @@ class InstallDriver {
       this.mInstallDone = false;
     }
 
-    if (this.mTrackingEnabled) {
-      const collectionId = collection.id;
-      const optional = required.filter((r) => r.type === "recommends");
-      const totalOptional = optional.length;
-      const totalRequired = required.length - optional.length;
+    const collectionId = collection.id;
+    const optional = required.filter((r) => r.type === "recommends");
+    const totalOptional = optional.length;
+    const totalRequired = required.length - optional.length;
 
-      // Generate unique session ID
-      this.mCurrentSessionId = generateCollectionSessionId(collectionId, profile.id);
+    // Generate unique session ID
+    this.mCurrentSessionId = generateCollectionSessionId(collectionId, profile.id);
 
-      const downloads = state.persistent.downloads.files;
+    const downloads = state.persistent.downloads.files;
 
-      // the session's per-rule mod info, keyed by rule id
-      const sessionModInfo: Record<string, ICollectionModInstallInfo> = Object.fromEntries(
-        required.map((rule) => {
-          const ruleId = modRuleId(rule);
-          const mod = findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule));
-          const dlId = findDownloadByRef(rule.reference, downloads);
-          const status = reconstructModStatus(
-            rule,
-            mod,
-            dlId != null ? downloads[dlId] : undefined,
-          );
+    // the session's per-rule mod info, keyed by rule id, reconstructed from reality
+    const sessionModInfo = reconstructSessionMods({ rules: required, mods, downloads });
 
-          return [
-            ruleId,
-            {
-              rule,
-              status,
-              type: rule.type as "requires" | "recommends",
-              phase: rulePhase(rule),
-            },
-          ];
-        }),
-      );
-
-      // Dispatch start session action (omitting computed properties)
-      this.mApi.store.dispatch(
-        installActions.startInstallSession({
-          sessionId: this.mCurrentSessionId,
-          collectionId,
-          profileId: profile.id,
-          gameId: this.mGameId,
-          mods: sessionModInfo,
-          totalRequired,
-          totalOptional,
-        }),
-      );
-    }
+    // Dispatch start session action (omitting computed properties)
+    this.mApi.store.dispatch(
+      installActions.startInstallSession({
+        sessionId: this.mCurrentSessionId,
+        collectionId,
+        profileId: profile.id,
+        gameId: this.mGameId,
+        mods: sessionModInfo,
+        totalRequired,
+        totalOptional,
+      }),
+    );
 
     log("info", "starting install of collection", {
       totalMods: required.length,

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionItemStatus.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionItemStatus.tsx
@@ -19,18 +19,20 @@ class CollectionItemStatus extends React.Component<ICollectionItemStatusProps, {
     const { t, download, mod } = this.props;
     const recommended = mod.collectionRule.type === "recommends";
 
-    const radial = (titleKey: string) => {
-      const progressBarData = {
-        min: 0,
-        max: 100,
-        value: (mod.progress ?? 0) * 100,
-        class: "collection-install-progress",
-      };
+    // fraction omitted -> indeterminate spin (used when progress isn't known, e.g. the
+    // install/extraction phase, which is not tracked per-mod); a static value there would
+    // read as a stall, the exact thing this view is meant to avoid
+    const radial = (titleKey: string, fraction?: number) => {
+      const data =
+        fraction === undefined
+          ? []
+          : [{ min: 0, max: 100, value: fraction * 100, class: "collection-install-progress" }];
       return (
         <div className="collection-status-progress">
           <RadialProgressT
             className="collection-progress-radial"
-            data={[progressBarData]}
+            data={data}
+            spin={fraction === undefined}
             totalRadius={32}
           />
 
@@ -63,8 +65,7 @@ class CollectionItemStatus extends React.Component<ICollectionItemStatusProps, {
           </div>
         );
       case "installing":
-        // install/extraction progress is not tracked per-mod yet, so the radial is
-        // indeterminate (0) for now
+        // install/extraction progress is not tracked per-mod, so spin (indeterminate)
         return radial("Installing...");
       case "downloading":
         if (download?.state === "paused") {
@@ -85,7 +86,7 @@ class CollectionItemStatus extends React.Component<ICollectionItemStatusProps, {
             </div>
           );
         }
-        return radial("Downloading...");
+        return radial("Downloading...", mod.progress ?? 0);
       case "failed":
         return (
           <div className="collection-status-failed">

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionProgress.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionProgress.tsx
@@ -47,6 +47,10 @@ export interface ICollectionProgressProps {
   onCancel: () => void;
   onPause: () => void;
   onResume: () => void;
+  onResync: () => void;
+  // disabled while an install or deployment is in flight, so a manual resync can't race
+  // InstallManager's own writes
+  resyncDisabled: boolean;
 }
 
 interface ICompState {
@@ -79,6 +83,8 @@ class CollectionProgress extends ComponentEx<ICollectionProgressProps, ICompStat
       onCancel,
       onPause,
       onResume,
+      onResync,
+      resyncDisabled,
     } = this.props;
 
     const group = (mod: ICollectionItemRow, download?: IDownload): string => {
@@ -165,6 +171,21 @@ class CollectionProgress extends ComponentEx<ICollectionProgressProps, ICompStat
                       onClick={onPause}
                     />
                   ) : null}
+
+                  <tooltip.IconButton
+                    className="btn-embed btn-refresh"
+                    icon="refresh"
+                    disabled={resyncDisabled}
+                    tooltip={
+                      resyncDisabled
+                        ? t("Available once the current install and deployment have finished")
+                        : t(
+                            "Refresh the install status from disk if it looks out of date, " +
+                              "e.g. after manually removing or re-downloading a mod",
+                          )
+                    }
+                    onClick={onResync}
+                  />
 
                   <tooltip.IconButton
                     className="btn-embed btn-cancel"

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
@@ -30,6 +30,10 @@ import type { INotification } from "../../../../types/INotification";
 import type { IOverlay, IState } from "../../../../types/IState";
 import type { ITableAttribute } from "../../../../types/ITableAttribute";
 import { getCollectionActiveSession } from "../../../../util/collectionInstallSessionSelectors";
+import {
+  resyncCollectionSessionFromReality,
+  resyncCollectionSessionRules,
+} from "../../../../util/collectionSessionReconstruct";
 import { ProcessCanceled, UserCanceled } from "../../../../util/CustomErrors";
 import { showError } from "../../../../util/message";
 import { getSafe } from "../../../../util/storeHelper";
@@ -552,6 +556,10 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
       this.mInstalling = undefined;
     }
 
+    // a collection install (this one or another) is in flight; gates Resume ("installing
+    // something else") and disables Resync so a manual resync can't race InstallManager
+    const installInFlight = driver.collection !== undefined && !driver.installDone;
+
     const selection =
       (this.mInstalling && driver.collectionInfo !== undefined
         ? revisionInfo?.modFiles?.map?.((file) => ({
@@ -645,10 +653,12 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
               onResume={
                 this.mInstalling
                   ? undefined
-                  : driver.collection !== undefined && !driver.installDone
+                  : installInFlight
                     ? null // installing something else
                     : this.resume
               }
+              onResync={this.resync}
+              resyncDisabled={installInFlight || (activity.mods ?? []).length > 0}
             />
           </FlexLayout.Fixed>
         )}
@@ -684,6 +694,10 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
 
   private resume = () => {
     this.props.onResume(this.props.collection.id);
+  };
+
+  private resync = () => {
+    resyncCollectionSessionFromReality(this.context.api);
   };
 
   private setEnabled = (enable: boolean) => {
@@ -808,39 +822,33 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
   };
 
   private ignoreSelected = (modIds: string[]) => {
-    const { collection, profile } = this.props;
-    const { itemRows } = this.props;
-
-    batchDispatch(
-      this.context.api.store,
-      modIds.reduce((prev: Redux.Action[], modId: string) => {
-        prev.push(
-          addModRule(profile.gameId, collection.id, {
-            ...itemRows[modId].collectionRule,
-            ignored: true,
-          } as any),
-        );
-        return prev;
-      }, []),
-    );
+    this.setRulesIgnored(modIds, true);
   };
 
   private unignoreSelected = (modIds: string[]) => {
-    const { collection, profile } = this.props;
-    const { itemRows } = this.props;
+    this.setRulesIgnored(modIds, false);
+  };
+
+  // toggle the durable `ignored` flag on the selected rules AND realign the active session
+  // from reality for just those rules. The session is the source of truth while installing,
+  // so without the second step an ignore/unignore made mid-install would not show until the
+  // install finished (the row would keep its stale session status).
+  private setRulesIgnored = (modIds: string[], ignored: boolean) => {
+    const { collection, profile, itemRows } = this.props;
+
+    const rules = modIds
+      .filter((modId) => itemRows[modId] !== undefined)
+      .map((modId) => ({ ...itemRows[modId].collectionRule, ignored }) as IModRule);
+    if (rules.length === 0) {
+      return;
+    }
 
     batchDispatch(
       this.context.api.store,
-      modIds.reduce((prev: Redux.Action[], modId: string) => {
-        prev.push(
-          addModRule(profile.gameId, collection.id, {
-            ...itemRows[modId].collectionRule,
-            ignored: false,
-          } as any),
-        );
-        return prev;
-      }, []),
+      rules.map((rule) => addModRule(profile.gameId, collection.id, rule as any)),
     );
+    // pass the rules carrying the new flag - the session holds a stale snapshot
+    resyncCollectionSessionRules(this.context.api, rules);
   };
 
   private installManually = (modIds: string[]) => {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -405,6 +405,27 @@ function filterDependencyRules(rules: IModRule[]): IModRule[] {
 }
 
 /**
+ * Whether the collection rule behind a resolved dependency has since been marked ignored.
+ * filterDependencyRules drops ignored rules ONCE, at gather time; this re-reads the durable
+ * flag so a mod the user ignores mid-install (after the dependency list was gathered) is not
+ * installed after the fact.
+ */
+function isDependencyRuleIgnored(
+  state: IState,
+  gameId: string,
+  sourceModId: string,
+  reference: IModReference,
+): boolean {
+  const rules = state.persistent.mods[gameId]?.[sourceModId]?.rules ?? [];
+  return rules.some(
+    (rule) =>
+      rule.ignored === true &&
+      ["requires", "recommends"].includes(rule.type) &&
+      referenceEqual(rule.reference, reference),
+  );
+}
+
+/**
  * Helper: Check if dependency installation was canceled via event and handle early return
  * Returns true if should continue, false if canceled
  */
@@ -2385,6 +2406,20 @@ class InstallManager {
               downloadId,
             });
             this.mActiveInstalls.delete(installKey);
+            return;
+          }
+
+          // Honour a mid-install ignore: the gathered dependency list is a snapshot from
+          // install start, but the user may have ignored this mod since (flipping the
+          // durable rule.ignored flag). Skip installing it; the phase poller settles the
+          // phase (ignored counts as complete and is excluded from requeue), and the
+          // session already shows it ignored.
+          if (isDependencyRuleIgnored(api.getState(), gameId, sourceModId, currentDep.reference)) {
+            log("info", "skipping install: dependency ignored mid-install", {
+              ref: renderModReference(currentDep.reference),
+            });
+            this.mActiveInstalls.delete(installKey);
+            this.mDependencyRetryCount.delete(installKey);
             return;
           }
 

--- a/src/renderer/src/util/collectionSessionReconstruct.test.ts
+++ b/src/renderer/src/util/collectionSessionReconstruct.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit coverage for the session reconstruction helpers: building a session's per-rule
+ * info from reality (reconstructSessionMods) and diffing the live session against it
+ * (planSessionResync). The dispatching orchestrator resyncCollectionSessionFromReality is
+ * thin wiring over these two and is exercised in-app / at the driver-seam layer.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
+import { makeMod, makeModInstallInfo, makeRule } from "../test-utils/builders";
+import type { ICollectionModInstallInfo } from "../types/collections/ICollectionInstallSession";
+import { modRuleId } from "./collectionInstallSession";
+import { planSessionResync, reconstructSessionMods } from "./collectionSessionReconstruct";
+
+// a requires-rule referencing a mod by id, matched the same way itemRows tests do
+const requiresRule = (over: Partial<IModRule> = {}): IModRule =>
+  makeRule({ reference: { id: "mod-1" }, ...over });
+
+// an installed mod whose attributes.name defaults to its id (so findModByRef matches)
+const installedMod = (id: string, over: Partial<IMod> = {}): IMod =>
+  makeMod({ id, installationPath: `mods/${id}`, attributes: { name: id }, ...over });
+
+describe("reconstructSessionMods", () => {
+  it("derives an installed mod: status installed, modId set to the matched mod", () => {
+    const rule = requiresRule({ reference: { id: "mod-1" } });
+    const result = reconstructSessionMods({
+      rules: [rule],
+      mods: { "mod-1": installedMod("mod-1") },
+      downloads: {},
+    });
+
+    const info = result[modRuleId(rule)];
+    expect(info.status).toBe("installed");
+    expect(info.modId).toBe("mod-1");
+    expect(info.type).toBe("requires");
+  });
+
+  it("reports an in-progress mod's own lifecycle state and records no modId until installed", () => {
+    const rule = requiresRule({ reference: { id: "mod-1" } });
+    const result = reconstructSessionMods({
+      rules: [rule],
+      mods: { "mod-1": installedMod("mod-1", { state: "installing" }) },
+      downloads: {},
+    });
+
+    const info = result[modRuleId(rule)];
+    expect(info.status).toBe("installing");
+    // modId is recorded only for the installed status (per the type contract)
+    expect(info.modId).toBeUndefined();
+  });
+
+  it("treats an ignored rule as ignored regardless of an installed copy", () => {
+    const rule = requiresRule({ reference: { id: "mod-1" }, ignored: true });
+    const result = reconstructSessionMods({
+      rules: [rule],
+      mods: { "mod-1": installedMod("mod-1") },
+      downloads: {},
+    });
+
+    const info = result[modRuleId(rule)];
+    expect(info.status).toBe("ignored");
+    // ignored wins before a mod is consulted, so no modId is recorded
+    expect(info.modId).toBeUndefined();
+  });
+
+  it("falls back to pending with no modId when nothing matches", () => {
+    const rule = requiresRule({ reference: { id: "absent" } });
+    const result = reconstructSessionMods({ rules: [rule], mods: {}, downloads: {} });
+
+    const info = result[modRuleId(rule)];
+    expect(info.status).toBe("pending");
+    expect(info.modId).toBeUndefined();
+  });
+
+  it("ignores rules that are not requires/recommends", () => {
+    const result = reconstructSessionMods({
+      rules: [requiresRule(), { type: "before", reference: { id: "x" } }],
+      mods: {},
+      downloads: {},
+    });
+
+    expect(Object.keys(result)).toEqual([modRuleId(requiresRule())]);
+  });
+});
+
+describe("planSessionResync", () => {
+  // build a current/reconstructed mods map keyed by ruleId from compact entries
+  const mods = (
+    entries: Record<string, Partial<ICollectionModInstallInfo>>,
+  ): Record<string, ICollectionModInstallInfo> =>
+    Object.fromEntries(Object.entries(entries).map(([id, info]) => [id, makeModInstallInfo(info)]));
+
+  it("returns nothing when every entry already matches reality", () => {
+    const current = mods({ r1: { status: "installed", modId: "m1" }, r2: { status: "pending" } });
+    const reconstructed = mods({
+      r1: { status: "installed", modId: "m1" },
+      r2: { status: "pending" },
+    });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([]);
+  });
+
+  it("emits a status write when an entry's status drifted", () => {
+    const current = mods({ r1: { status: "installing" } });
+    const reconstructed = mods({ r1: { status: "pending" } });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([
+      { ruleId: "r1", status: "pending" },
+    ]);
+  });
+
+  it("emits a markInstalled write (carrying modId) when reality is installed", () => {
+    const current = mods({ r1: { status: "downloading" } });
+    const reconstructed = mods({ r1: { status: "installed", modId: "m1" } });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([
+      { ruleId: "r1", status: "installed", modId: "m1" },
+    ]);
+  });
+
+  it("treats a changed modId on an already-installed entry as drift", () => {
+    const current = mods({ r1: { status: "installed", modId: "old" } });
+    const reconstructed = mods({ r1: { status: "installed", modId: "new" } });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([
+      { ruleId: "r1", status: "installed", modId: "new" },
+    ]);
+  });
+
+  it("does not re-write an installed entry whose modId still matches", () => {
+    const current = mods({ r1: { status: "installed", modId: "m1" } });
+    const reconstructed = mods({ r1: { status: "installed", modId: "m1" } });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([]);
+  });
+
+  it("moves an entry off a protected state when reality no longer agrees", () => {
+    // resync overrides protection: an installed mod the user removed out of band must be
+    // allowed to revert (planSessionWrite would have blocked this; resync deliberately does not)
+    const current = mods({ r1: { status: "installed", modId: "m1" } });
+    const reconstructed = mods({ r1: { status: "pending" } });
+
+    expect(planSessionResync(current, reconstructed)).toEqual([
+      { ruleId: "r1", status: "pending" },
+    ]);
+  });
+
+  it("leaves session entries with no reconstruction counterpart untouched", () => {
+    const current = mods({ r1: { status: "installing" } });
+    const reconstructed = mods({}); // r1 absent
+
+    expect(planSessionResync(current, reconstructed)).toEqual([]);
+  });
+});

--- a/src/renderer/src/util/collectionSessionReconstruct.ts
+++ b/src/renderer/src/util/collectionSessionReconstruct.ts
@@ -1,0 +1,186 @@
+/**
+ * Reconstructing the collection install session from reality (the read side derives status
+ * per row; this builds/realigns the whole session). Lives in core alongside the rest of the
+ * session utilities (collectionInstallSession, collectionInstallSessionSelectors,
+ * collectionSessionWrite) rather than inside the collections extension, so any caller can
+ * rebuild or resync a session without depending on the driver instance.
+ */
+import * as installActions from "../actions/collectionInstallTracking";
+import type { IDownload } from "../extensions/download_management/types/IDownload";
+import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
+import { findDownloadByRef } from "../extensions/mod_management/util/dependencies";
+import { findModByRef } from "../extensions/mod_management/util/findModByRef";
+import { ruleInstallSpec, rulePhase } from "../extensions/mod_management/util/testModReference";
+import { log } from "../logging";
+import type { ICollectionModInstallInfo } from "../types/collections/ICollectionInstallSession";
+import type { IExtensionApi } from "../types/IExtensionContext";
+import { modRuleId, reconstructModStatus } from "./collectionInstallSession";
+import { getCollectionActiveSession } from "./collectionInstallSessionSelectors";
+import { batchDispatch } from "./util";
+
+/**
+ * Build the session's per-rule install info from reality: for every required/recommended
+ * rule, resolve the installed mod (matched by reference AND install spec, the same match
+ * the dependency loop uses) and the rule's download, then derive the status via
+ * reconstructModStatus. Keyed by rule id.
+ *
+ * This is the single reconstruction used both when a session first starts (or resumes
+ * after a restart, where the non-persisted session must be rebuilt from durable inputs)
+ * and by the manual resync, so the two can never derive status differently.
+ */
+export function reconstructSessionMods(params: {
+  rules: IModRule[];
+  // keyed by mod id
+  mods: Record<string, IMod>;
+  // keyed by download id
+  downloads: Record<string, IDownload>;
+}): Record<string, ICollectionModInstallInfo> {
+  const { rules, mods, downloads } = params;
+
+  return Object.fromEntries(
+    rules
+      .filter((rule) => rule.type === "requires" || rule.type === "recommends")
+      .map((rule) => {
+        const mod = findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule));
+        const dlId = findDownloadByRef(rule.reference, downloads);
+        const status = reconstructModStatus(rule, mod, dlId != null ? downloads[dlId] : undefined);
+
+        const info: ICollectionModInstallInfo = {
+          rule,
+          status,
+          type: rule.type as "requires" | "recommends",
+          phase: rulePhase(rule),
+        };
+        // modId is "the installed mod reference (if installed)" - record it only for the
+        // installed status (the only state planSessionResync carries a modId for)
+        if (mod !== undefined && status === "installed") {
+          info.modId = mod.id;
+        }
+
+        return [modRuleId(rule), info];
+      }),
+  );
+}
+
+/** A single status correction the resync should dispatch against the session. */
+export interface ISessionResyncWrite {
+  ruleId: string;
+  status: ICollectionModInstallInfo["status"];
+  // set only when status is "installed", so the caller records the matched mod id
+  modId?: string;
+}
+
+/**
+ * Diff the live session mods against the reconstruction from reality and return only the
+ * entries that drifted. An "installed" entry whose modId no longer matches reality also
+ * counts as drift (the row would link to a stale mod). Rules present in the session but
+ * not in the reconstruction are left untouched.
+ *
+ * Unlike planSessionWrite (the automatic write path), this does not protect terminal
+ * states: resync is an explicit user recovery where reality is authoritative, so it will
+ * move a session entry off "installed"/"ignored" when reality no longer agrees.
+ */
+export function planSessionResync(
+  // keyed by rule id
+  currentMods: Record<string, ICollectionModInstallInfo>,
+  // keyed by rule id
+  reconstructed: Record<string, ICollectionModInstallInfo>,
+): ISessionResyncWrite[] {
+  const writes: ISessionResyncWrite[] = [];
+
+  for (const [ruleId, current] of Object.entries(currentMods)) {
+    const next = reconstructed[ruleId];
+    if (next === undefined) {
+      continue;
+    }
+
+    const installedWithMod = next.status === "installed" && next.modId !== undefined;
+    const modIdChanged = installedWithMod && next.modId !== current.modId;
+    if (next.status === current.status && !modIdChanged) {
+      continue;
+    }
+
+    writes.push(
+      installedWithMod
+        ? { ruleId, status: next.status, modId: next.modId }
+        : { ruleId, status: next.status },
+    );
+  }
+
+  return writes;
+}
+
+/**
+ * Reconstruct the given rules from reality, diff them against the active session and
+ * dispatch only the corrections. Returns the number of entries corrected (0 when there is
+ * no active session or nothing drifted). Shared core of the two resync entry points.
+ *
+ * Like markRuleIgnored, it writes directly (bypassing planSessionWrite): reality is
+ * authoritative here, so it overrides even otherwise-protected states.
+ */
+function applySessionResync(api: IExtensionApi, rules: IModRule[]): number {
+  const state = api.getState();
+  const session = getCollectionActiveSession(state);
+  if (session === undefined) {
+    return 0;
+  }
+
+  const reconstructed = reconstructSessionMods({
+    rules,
+    mods: state.persistent.mods[session.gameId] ?? {},
+    downloads: state.persistent.downloads.files,
+  });
+  const writes = planSessionResync(session.mods, reconstructed);
+
+  if (writes.length === 0) {
+    return 0;
+  }
+
+  const actions = writes.map((write) =>
+    write.modId !== undefined
+      ? installActions.markModInstalled(session.sessionId, write.ruleId, write.modId)
+      : installActions.updateModStatus(session.sessionId, write.ruleId, write.status),
+  );
+  batchDispatch(api.store, actions);
+
+  return writes.length;
+}
+
+/**
+ * Manual recovery: rebuild the WHOLE active session's per-mod statuses from reality
+ * (installed mods + downloads + each rule's durable ignored flag) and dispatch the
+ * differences.
+ *
+ * The session is a precomputed cache that is deliberately NOT recomputed on every state
+ * change (recomputing per row from multiple slices was the cost of the old modsEx cache).
+ * It can therefore drift from reality if the user acts out of band mid-install (uninstall
+ * a member, delete an archive, re-download). This is the explicit, on-demand way to realign
+ * it without a hot-path selector storm.
+ */
+export function resyncCollectionSessionFromReality(api: IExtensionApi): number {
+  const state = api.getState();
+  const session = getCollectionActiveSession(state);
+  if (session === undefined) {
+    return 0;
+  }
+  // reconstruct from the collection mod's CURRENT rules (the durable source of truth), not
+  // the session's rule snapshots. The session captures each rule at start and never refreshes
+  // it, so reading the live rules picks up flags the user changed mid-install (e.g. ignored)
+  // instead of reverting them.
+  const rules = state.persistent.mods[session.gameId]?.[session.collectionId]?.rules ?? [];
+  const changed = applySessionResync(api, rules);
+  log("info", "resync collection session from reality", { changed });
+  return changed;
+}
+
+/**
+ * Realign the active session for a SPECIFIC set of rules from reality. Used when the user
+ * toggles a per-mod decision mid-install (ignore / stop ignoring) and the session - the
+ * source of truth while installing - must immediately reflect it without waiting for the
+ * install to finish. Pass the rules carrying their NEW flag value (the session holds a
+ * stale snapshot). Only the named rules are touched, so this does not perturb other
+ * in-flight mods.
+ */
+export function resyncCollectionSessionRules(api: IExtensionApi, rules: IModRule[]): number {
+  return applySessionResync(api, rules);
+}


### PR DESCRIPTION
Make the redux install session (the source of truth while installing) behave correctly and recoverably in the collection view.

- resync from reality: new core util collectionSessionReconstruct (reconstructSessionMods, shared with InstallDriver.startImpl; planSessionResync; resyncCollectionSessionFromReality / resyncCollectionSessionRules). A gated collection-level button rebuilds the session on demand from the durable mods, downloads and collection rules; disabled while an install or deployment is in flight so it cannot race InstallManager.
- ignore mid-install now takes effect immediately: the Ignore / Stop-Ignoring buttons sync the active session status (not just the durable flag), and InstallManager re-reads rule.ignored at the install chokepoint so a newly-ignored mod is not installed.
- the per-mod "installing" radial spins (indeterminate) instead of a static value, since install progress is not tracked per-mod.
- remove the dead always-true mTrackingEnabled flag and its accessors.

part of LAZ-483