### PR TITLE
LAZ-606: Reusable table component

### DIFF
--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -20,6 +20,7 @@ import { PaginationDemo } from "@/ui/components/pagination/PaginationDemo";
 import { PickerDemo } from "@/ui/components/picker/PickerDemo";
 import { PillDemo } from "@/ui/components/pill/PillDemo";
 import { PremiumBadgeDemo } from "@/ui/components/premium_badge/PremiumBadgeDemo";
+import { TableDemo } from "@/ui/components/table/Table.demo";
 import { TabButton } from "@/ui/components/tabs/Tab";
 import { TabBar } from "@/ui/components/tabs/TabBar";
 import { TabPanel } from "@/ui/components/tabs/TabPanel";
@@ -76,6 +77,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
               <TabButton name="Listing" />
 
               <TabButton name="Pagination" />
+
+              <TabButton name="Table" />
 
               <TabButton name="Collection Tile" />
 
@@ -211,6 +214,10 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
 
               <TabPanel name="Pagination">
                 <PaginationDemo />
+              </TabPanel>
+
+              <TabPanel name="Table">
+                <TableDemo />
               </TabPanel>
 
               <TabPanel name="Collection Tile">

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -27,6 +27,7 @@ ui/
 │   ├── picker/          - Picker component
 │   ├── pill/            - Compact rounded label for tags and statuses
 │   ├── premium_badge/   - Premium diamond badge
+│   ├── table/           - Data table (sort, filter, group, column toggle, optional pagination)
 │   ├── tabs/            - Tabbed interface with context-based state
 │   ├── toolbar/         - Horizontal toolbar; groups collapse overflow into a kebab dropdown
 │   └── typography/      - Typography system (heading, title, body)
@@ -323,6 +324,48 @@ import { CollectionTileSkeleton } from "../../ui/components/collectiontile/Colle
 ```tsx
 import { Pagination } from "../../ui/components/pagination/Pagination";
 ```
+
+### Table
+
+Reusable, column-driven data table. Declare the columns and pass the data; sorting, per-column filtering, column show/hide, grouping, optional pagination and an empty state are handled internally.
+
+**Defaults:** filters and the column toggle auto-enable when a column opts in; pagination is **off** unless `pageSize` is set; headers are always left-aligned.
+
+```tsx
+import { Table } from "../../ui/components/table/Table";
+import type { IColumnDef } from "../../ui/components/table/Table.types";
+
+const columns: Array<IColumnDef<Mod>> = [
+    { id: "name", header: "Name", getValue: (m) => m.name, sortable: true, filter: { type: "text" } },
+    {
+        id: "category",
+        header: "Category",
+        getValue: (m) => m.category,
+        groupable: true,
+        filter: { type: "select", options: [{ label: "UI", value: "UI" }] },
+    },
+    {
+        id: "downloads",
+        header: "Downloads",
+        getValue: (m) => m.downloads,
+        sortable: true,
+        align: "right",
+        cell: (m) => m.downloads.toLocaleString(),
+    },
+];
+
+// No pageSize → renders every row, no pager
+<Table columns={columns} data={mods} getRowId={(m) => m.id} />
+
+// With pagination
+<Table columns={columns} data={mods} getRowId={(m) => m.id} pageSize={50} />
+```
+
+**`ITableProps` fields:** `columns`, `data`, `getRowId` (required); `pageSize` (set to paginate), `caption`, `enableFilters`, `enableColumnToggle`, `emptyState`, `className`.
+
+**`IColumnDef` fields:** `id`, `header` (required); `getValue` (value used for sorting/filtering and the default cell), `cell` (custom renderer), `sortable`/`sortFn`, `filter` (`text` or `select`), `align` (body cells — headers are always left), `width`, `hideable`/`defaultHidden` (column toggle), `groupable`/`groupValue`/`groupLabel`.
+
+**Notes:** grouping is one column at a time — collapsible groups across the full dataset, with the pager hidden while active. Columns use fixed widths, so when their total exceeds the container the table scrolls horizontally. All interactive state lives in the `useTableState` hook.
 
 ### Listing / ListingLoader / NoResults
 

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -361,11 +361,11 @@ const columns: Array<IColumnDef<Mod>> = [
 <Table columns={columns} data={mods} getRowId={(m) => m.id} pageSize={50} />
 ```
 
-**`ITableProps` fields:** `columns`, `data`, `getRowId` (required); `pageSize` (set to paginate), `caption`, `enableFilters`, `enableColumnToggle`, `emptyState`, `className`.
+**`ITableProps` fields:** `columns`, `data`, `getRowId` (required); `pageSize` (set to paginate), `caption`, `enableFilters`, `enableColumnToggle`, `enableColumnResize` (default `true`), `columnWidths` / `onColumnWidthsChange` (restore/persist resized widths), `emptyState`, `className`.
 
-**`IColumnDef` fields:** `id`, `header` (required); `getValue` (value used for sorting/filtering and the default cell), `cell` (custom renderer), `sortable`/`sortFn`, `filter` (`text` or `select`), `align` (body cells — headers are always left), `width`, `hideable`/`defaultHidden` (column toggle), `groupable`/`groupValue`/`groupLabel`.
+**`IColumnDef` fields:** `id`, `header` (required); `getValue` (value used for sorting/filtering and the default cell), `cell` (custom renderer), `sortable`/`sortFn`, `filter` (`text` or `select`), `align` (body cells — headers are always left), `width`, `resizable` (drag-to-resize, default `true`), `hideable`/`defaultHidden` (column toggle), `groupable`/`groupValue`/`groupLabel`.
 
-**Notes:** grouping is one column at a time — collapsible groups across the full dataset, with the pager hidden while active. Columns use fixed widths, so when their total exceeds the container the table scrolls horizontally. All interactive state lives in the `useTableState` hook.
+**Notes:** grouping is one column at a time — collapsible groups across the full dataset, with the pager hidden while active. Columns use fixed widths, so when their total exceeds the container the table scrolls horizontally. Users can drag a header's right edge to resize a column (never narrower than its configured `width`) via the `useColumnResize` hook, and the column menu offers a "Reset column widths" action. The table itself stays state-store-agnostic: pass `columnWidths` to restore widths and handle `onColumnWidthsChange` (fired on resize-end and reset with the full px map) to persist them. All interactive state lives in the `useTableState` hook.
 
 ### Listing / ListingLoader / NoResults
 

--- a/src/renderer/src/ui/components/dropdown/DropdownTitle.tsx
+++ b/src/renderer/src/ui/components/dropdown/DropdownTitle.tsx
@@ -1,0 +1,13 @@
+import React, { type HTMLAttributes } from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export const DropdownTitle = ({
+  children,
+  className,
+  ...props
+}: Omit<HTMLAttributes<HTMLDivElement>, "children"> & { children: string }) => (
+  <div className={joinClasses(["nxm-dropdown-title", className])} {...props}>
+    {children}
+  </div>
+);

--- a/src/renderer/src/ui/components/table/Table.demo.tsx
+++ b/src/renderer/src/ui/components/table/Table.demo.tsx
@@ -55,6 +55,17 @@ const buildMods = (count: number): IDemoMod[] =>
     endorsed: index % 3 === 0,
   }));
 
+// Stand-in for widths a user previously dragged and we restored from
+// persistence — deliberately wider than the columns' configured widths so the
+// custom sizing (and the enabled "Reset column widths" action) is obvious.
+const PRESET_COLUMN_WIDTHS: Record<string, number> = {
+  status: 180,
+  name: 360,
+  version: 160,
+  category: 220,
+  endorsed: 160,
+};
+
 export const TableDemo = () => {
   const data = useMemo(() => buildMods(60), []);
 
@@ -190,6 +201,7 @@ export const TableDemo = () => {
         align: "right",
         width: "140px",
         hideable: false,
+        resizable: false,
         cell: () => (
           <Button appearance="moderate" brand="neutral" leftIconPath={mdiDelete} size="xs">
             Remove
@@ -210,17 +222,48 @@ export const TableDemo = () => {
         <Typography appearance="subdued">
           Reusable, column-driven data table. Supports click-to-sort headers, per-column text and
           select filters, grouping by a column, showing/hiding columns via the gear menu, and
-          pagination. This demo paginates a 60-row dataset; only the current page is in the DOM.
+          pagination. This demo paginates a 60-row dataset; only the current page is in the DOM. It
+          also loads with mock preset column widths (as if restored from persistence), so the gear
+          menu's "Reset column widths" action is enabled — use it to snap columns back to their
+          defaults.
         </Typography>
       </div>
 
       <Table
         caption="Mods"
         columns={columns}
+        columnWidths={PRESET_COLUMN_WIDTHS}
         data={data}
         getRowId={(row) => row.id}
         pageSize={15}
+        onColumnWidthsChange={(widths) => {
+          // A consumer would persist this map (e.g. per table id); here we just
+          // log it so the design-system demo stays self-contained.
+          // eslint-disable-next-line no-console
+          console.log("[TableDemo] column widths changed:", widths);
+        }}
       />
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Without column resizing
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          Drag a header's right edge to resize columns. Resizing is on by default; pass
+          `enableColumnResize={false}` to disable it for the whole table, or `resizable: false` on a
+          single column (as on the Actions column above).
+        </Typography>
+
+        <Table
+          caption="Mods (fixed columns)"
+          columns={columns}
+          data={data}
+          enableColumnResize={false}
+          getRowId={(row) => row.id}
+          pageSize={5}
+        />
+      </div>
 
       <div className="space-y-4">
         <Typography as="h3" typographyType="heading-xs">
@@ -254,6 +297,12 @@ export const TableDemo = () => {
           <li>Sorting, filtering, column visibility and pagination are handled internally</li>
 
           <li>Set hideable: false to pin a column (e.g. Actions) in the column toggle</li>
+
+          <li>
+            Drag a header's right edge to resize a column (no narrower than its configured width);
+            disable per-column with resizable: false (e.g. Actions) or for the whole table with
+            enableColumnResize={"{false}"}. The gear menu has a "Reset column widths" action
+          </li>
 
           <li>
             Hover a groupable header (Status, Category, Endorsed) and click the group icon to group

--- a/src/renderer/src/ui/components/table/Table.demo.tsx
+++ b/src/renderer/src/ui/components/table/Table.demo.tsx
@@ -1,0 +1,273 @@
+/**
+ * Table Demo Component
+ * Demonstrates the reusable Table: sorting, per-column filtering, column
+ * show/hide and pagination over a large mock dataset.
+ */
+
+import {
+  mdiCheckCircle,
+  mdiCloudDownload,
+  mdiDelete,
+  mdiThumbUp,
+  mdiThumbUpOutline,
+} from "@mdi/js";
+import React, { useMemo } from "react";
+
+import { Button } from "../button/Button";
+import { Icon } from "../icon/Icon";
+import { Typography } from "../typography/Typography";
+import { Table } from "./Table";
+import type { IColumnDef } from "./Table.types";
+
+interface IDemoMod {
+  id: string;
+  name: string;
+  status: "Enabled" | "Disabled";
+  version: string;
+  hasUpdate: boolean;
+  category: string;
+  author: string;
+  size: string;
+  downloads: number;
+  updated: string;
+  endorsed: boolean;
+}
+
+const CATEGORIES = ["Animation", "Armour", "Audio", "Gameplay", "Patches", "UI", "Weapons"];
+const STATUSES: Array<IDemoMod["status"]> = ["Enabled", "Disabled"];
+const AUTHORS = ["Arthhh", "Bethesda", "Elianora", "FadingSignal", "PsychoMachina", "SkyUI Team"];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"];
+
+// Deterministically generate a sizeable dataset so the demo exercises sorting,
+// filtering and pagination across thousands of rows without any randomness.
+const buildMods = (count: number): IDemoMod[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `mod-${index}`,
+    name: `Mod name goes here ${index + 1}`,
+    status: STATUSES[index % STATUSES.length],
+    version: `${(index % 3) + 1}.${index % 5}.${index % 10}`,
+    hasUpdate: index % 4 === 0,
+    category: CATEGORIES[index % CATEGORIES.length],
+    author: AUTHORS[index % AUTHORS.length],
+    size: `${((index % 40) + 1) * 5} MB`,
+    downloads: (index * 1373) % 100000,
+    updated: `${MONTHS[index % MONTHS.length]} 2026`,
+    endorsed: index % 3 === 0,
+  }));
+
+export const TableDemo = () => {
+  const data = useMemo(() => buildMods(60), []);
+
+  const columns = useMemo<Array<IColumnDef<IDemoMod>>>(
+    () => [
+      {
+        id: "status",
+        header: "Status",
+        getValue: (row) => row.status,
+        sortable: true,
+        groupable: true,
+        width: "140px",
+        filter: {
+          type: "select",
+          options: STATUSES.map((status) => ({ label: status, value: status })),
+        },
+        cell: (row) => (
+          <span className="inline-flex items-center gap-x-1">
+            <Icon
+              className={row.status === "Enabled" ? "text-success-strong" : "text-neutral-subdued"}
+              path={mdiCheckCircle}
+              size="sm"
+            />
+
+            {row.status}
+          </span>
+        ),
+      },
+      {
+        id: "name",
+        header: "Mod name",
+        getValue: (row) => row.name,
+        sortable: true,
+        width: "240px",
+        filter: { type: "text" },
+        cell: (row) => <span className="truncate">{row.name}</span>,
+      },
+      {
+        id: "version",
+        header: "Version",
+        getValue: (row) => row.version,
+        sortable: true,
+        align: "right",
+        width: "120px",
+        filter: { type: "text" },
+        cell: (row) => (
+          <span className="inline-flex items-center justify-end gap-x-1">
+            <Typography
+              appearance={row.hasUpdate ? "strong" : "moderate"}
+              as="span"
+              brand={row.hasUpdate ? "primary" : "neutral"}
+              typographyType="body-sm"
+            >
+              {row.version}
+            </Typography>
+
+            {row.hasUpdate && (
+              <Icon className="text-primary-strong" path={mdiCloudDownload} size="sm" />
+            )}
+          </span>
+        ),
+      },
+      {
+        id: "category",
+        header: "Category",
+        getValue: (row) => row.category,
+        sortable: true,
+        groupable: true,
+        width: "160px",
+        filter: {
+          type: "select",
+          options: CATEGORIES.map((category) => ({ label: category, value: category })),
+        },
+      },
+      {
+        id: "author",
+        header: "Author",
+        getValue: (row) => row.author,
+        sortable: true,
+        groupable: true,
+        defaultHidden: true,
+        width: "160px",
+        filter: { type: "text" },
+      },
+      {
+        id: "size",
+        header: "Size",
+        getValue: (row) => row.size,
+        sortable: true,
+        defaultHidden: true,
+        align: "right",
+        width: "110px",
+      },
+      {
+        id: "downloads",
+        header: "Downloads",
+        getValue: (row) => row.downloads,
+        sortable: true,
+        defaultHidden: true,
+        align: "right",
+        width: "130px",
+        cell: (row) => row.downloads.toLocaleString(),
+      },
+      {
+        id: "updated",
+        header: "Updated",
+        getValue: (row) => row.updated,
+        sortable: true,
+        defaultHidden: true,
+        width: "140px",
+      },
+      {
+        id: "endorsed",
+        header: "Endorsed",
+        getValue: (row) => row.endorsed,
+        sortable: true,
+        groupable: true,
+        groupValue: (row) => (row.endorsed ? "Endorsed" : "Not endorsed"),
+        align: "center",
+        width: "120px",
+        cell: (row) => (
+          <Icon
+            className={row.endorsed ? "text-success-strong" : "text-neutral-subdued"}
+            path={row.endorsed ? mdiThumbUp : mdiThumbUpOutline}
+            size="sm"
+            title={row.endorsed ? "Endorsed" : "Not endorsed"}
+          />
+        ),
+      },
+      {
+        id: "actions",
+        header: "Actions",
+        align: "right",
+        width: "140px",
+        hideable: false,
+        cell: () => (
+          <Button appearance="moderate" brand="neutral" leftIconPath={mdiDelete} size="xs">
+            Remove
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-sm bg-surface-mid p-4">
+        <Typography as="h2" typographyType="heading-sm">
+          Table
+        </Typography>
+
+        <Typography appearance="subdued">
+          Reusable, column-driven data table. Supports click-to-sort headers, per-column text and
+          select filters, grouping by a column, showing/hiding columns via the gear menu, and
+          pagination. This demo paginates a 60-row dataset; only the current page is in the DOM.
+        </Typography>
+      </div>
+
+      <Table
+        caption="Mods"
+        columns={columns}
+        data={data}
+        getRowId={(row) => row.id}
+        pageSize={15}
+      />
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Empty state
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          With no data the table renders a default empty message; pass an `emptyState` node to
+          customise it.
+        </Typography>
+
+        <Table caption="No mods" columns={columns} data={[]} getRowId={(row) => row.id} />
+
+        <Table
+          caption="No mods (custom)"
+          columns={columns}
+          data={[]}
+          emptyState={<Typography appearance="subdued">No mods match your filters yet.</Typography>}
+          getRowId={(row) => row.id}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Design Notes
+        </Typography>
+
+        <Typography appearance="subdued" as="ul" className="list-inside list-disc space-y-2">
+          <li>Columns are defined declaratively via IColumnDef; cells fall back to getValue</li>
+
+          <li>Sorting, filtering, column visibility and pagination are handled internally</li>
+
+          <li>Set hideable: false to pin a column (e.g. Actions) in the column toggle</li>
+
+          <li>
+            Hover a groupable header (Status, Category, Endorsed) and click the group icon to group
+            rows; grouping shows collapsible group headers and hides the pager
+          </li>
+
+          <li>
+            Author, Size, Downloads and Updated are hidden by default (defaultHidden) — enable them
+            in the gear menu to push the table past the container and see horizontal scrolling
+          </li>
+
+          <li>Pagination bounds the rendered rows; virtualization is tracked separately</li>
+        </Typography>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/table/Table.test.tsx
+++ b/src/renderer/src/ui/components/table/Table.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, cleanup, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { Table } from "./Table";
 import type { IColumnDef } from "./Table.types";
@@ -124,6 +124,37 @@ describe("Table", () => {
     await userEvent.click(screen.getByRole("option", { name: "Category" }));
 
     expect(screen.queryByRole("columnheader", { name: "Category" })).not.toBeInTheDocument();
+  });
+
+  it("offers a reset-widths action in the column menu, disabled until a column is resized", async () => {
+    renderTable();
+    await userEvent.click(screen.getByRole("button", { name: /manage columns/i }));
+
+    // No column has been resized yet, so resetting is a no-op and disabled.
+    expect(screen.getByRole("button", { name: /reset column widths/i })).toBeDisabled();
+  });
+
+  it("omits the reset-widths action when column resizing is disabled", async () => {
+    renderTable({ enableColumnResize: false });
+    await userEvent.click(screen.getByRole("button", { name: /manage columns/i }));
+
+    expect(screen.queryByRole("button", { name: /reset column widths/i })).not.toBeInTheDocument();
+  });
+
+  it("enables reset for restored widths and reports an empty map when cleared", async () => {
+    const onColumnWidthsChange = vi.fn();
+    renderTable({ columnWidths: { name: 300 }, onColumnWidthsChange });
+    await userEvent.click(screen.getByRole("button", { name: /manage columns/i }));
+
+    // Restored widths count as custom widths, so resetting is available.
+    const reset = screen.getByRole("button", { name: /reset column widths/i });
+    expect(reset).toBeEnabled();
+
+    await userEvent.click(reset);
+
+    // Reset reports the cleared map and dismisses the menu.
+    expect(onColumnWidthsChange).toHaveBeenCalledWith({});
+    expect(screen.queryByRole("button", { name: /reset column widths/i })).not.toBeInTheDocument();
   });
 
   it("renders the empty state when no rows match", async () => {

--- a/src/renderer/src/ui/components/table/Table.test.tsx
+++ b/src/renderer/src/ui/components/table/Table.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, it, expect, afterEach } from "vitest";
+
+import { Table } from "./Table";
+import type { IColumnDef } from "./Table.types";
+
+afterEach(() => {
+  cleanup();
+});
+
+interface IRow {
+  id: string;
+  name: string;
+  category: string;
+  version: number;
+}
+
+const ROWS: IRow[] = [
+  { id: "1", name: "Charlie", category: "UI", version: 3 },
+  { id: "2", name: "Alpha", category: "Audio", version: 1 },
+  { id: "3", name: "Bravo", category: "UI", version: 2 },
+];
+
+const COLUMNS: Array<IColumnDef<IRow>> = [
+  {
+    id: "name",
+    header: "Name",
+    getValue: (row) => row.name,
+    sortable: true,
+    filter: { type: "text" },
+  },
+  {
+    id: "category",
+    header: "Category",
+    getValue: (row) => row.category,
+    groupable: true,
+    filter: {
+      type: "select",
+      options: [
+        { label: "UI", value: "UI" },
+        { label: "Audio", value: "Audio" },
+      ],
+    },
+  },
+  {
+    id: "version",
+    header: "Version",
+    getValue: (row) => row.version,
+    sortable: true,
+  },
+];
+
+const renderTable = (props: Partial<React.ComponentProps<typeof Table<IRow>>> = {}) =>
+  render(
+    <Table columns={COLUMNS} data={ROWS} getRowId={(row) => row.id} pageSize={50} {...props} />,
+  );
+
+// Returns the text of the first body cell of each rendered data row, in order.
+const bodyFirstColumn = () =>
+  screen
+    .getAllByRole("row")
+    // Drop the two header rows (header + filter row).
+    .slice(2)
+    .map((row) => within(row).getAllByRole("cell")[0]?.textContent);
+
+describe("Table", () => {
+  it("renders a row per data item plus header and filter rows", () => {
+    renderTable();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    // 1 header row + 1 filter row + 3 data rows.
+    expect(screen.getAllByRole("row")).toHaveLength(5);
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+  });
+
+  it("falls back to getValue when no cell renderer is supplied", () => {
+    renderTable();
+    expect(screen.getByRole("cell", { name: "Audio" })).toBeInTheDocument();
+  });
+
+  it("sorts ascending then descending when a sortable header is clicked", async () => {
+    renderTable();
+    const sortButton = screen.getByRole("button", { name: /name/i });
+
+    await userEvent.click(sortButton);
+    expect(bodyFirstColumn()).toEqual(["Alpha", "Bravo", "Charlie"]);
+
+    await userEvent.click(sortButton);
+    expect(bodyFirstColumn()).toEqual(["Charlie", "Bravo", "Alpha"]);
+  });
+
+  it("filters rows with a text filter (case-insensitive substring)", async () => {
+    renderTable();
+    await userEvent.type(screen.getByRole("textbox", { name: /filter by name/i }), "al");
+    expect(bodyFirstColumn()).toEqual(["Alpha"]);
+  });
+
+  it("filters rows with a select filter", async () => {
+    renderTable();
+    await userEvent.click(screen.getByRole("button", { name: /filter by category/i }));
+    await userEvent.click(screen.getByRole("option", { name: "UI" }));
+    expect(bodyFirstColumn()).toEqual(["Charlie", "Bravo"]);
+  });
+
+  it("paginates and only renders the current page", () => {
+    renderTable({ pageSize: 2 });
+    expect(bodyFirstColumn()).toHaveLength(2);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeInTheDocument();
+  });
+
+  it("does not paginate when pageSize is omitted", () => {
+    render(<Table columns={COLUMNS} data={ROWS} getRowId={(row) => row.id} />);
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).not.toBeInTheDocument();
+    // Every row renders.
+    expect(bodyFirstColumn()).toEqual(["Charlie", "Alpha", "Bravo"]);
+  });
+
+  it("hides a column through the column toggle", async () => {
+    renderTable();
+    expect(screen.getByRole("columnheader", { name: "Category" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /manage columns/i }));
+    await userEvent.click(screen.getByRole("option", { name: "Category" }));
+
+    expect(screen.queryByRole("columnheader", { name: "Category" })).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state when no rows match", async () => {
+    renderTable();
+    await userEvent.type(screen.getByRole("textbox", { name: /filter by name/i }), "zzz");
+    expect(screen.getByText("No results found.")).toBeInTheDocument();
+  });
+
+  it("groups rows by a column and hides the pager", async () => {
+    renderTable({ pageSize: 2 });
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /group by category/i }));
+
+    // Two group headers (UI, Audio), and the pager is gone.
+    expect(screen.getByRole("button", { name: "UI group, 2 rows" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Audio group, 1 row" })).toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).not.toBeInTheDocument();
+    // All matching rows render despite pageSize 2 (grouping bypasses paging).
+    expect(screen.getByRole("cell", { name: "Charlie" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Bravo" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Alpha" })).toBeInTheDocument();
+  });
+
+  it("collapses and expands a group", async () => {
+    renderTable();
+    await userEvent.click(screen.getByRole("button", { name: /group by category/i }));
+    expect(screen.getByRole("cell", { name: "Alpha" })).toBeInTheDocument();
+
+    // Collapse the Audio group -> its only row (Alpha) disappears.
+    await userEvent.click(screen.getByRole("button", { name: "Audio group, 1 row" }));
+    expect(screen.queryByRole("cell", { name: "Alpha" })).not.toBeInTheDocument();
+
+    // Expand again -> row returns.
+    await userEvent.click(screen.getByRole("button", { name: "Audio group, 1 row" }));
+    expect(screen.getByRole("cell", { name: "Alpha" })).toBeInTheDocument();
+  });
+
+  it("toggles grouping off when the active group column is clicked again", async () => {
+    renderTable({ pageSize: 2 });
+    const groupButton = screen.getByRole("button", { name: /group by category/i });
+
+    await userEvent.click(groupButton);
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).not.toBeInTheDocument();
+
+    await userEvent.click(groupButton);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/ui/components/table/Table.tsx
+++ b/src/renderer/src/ui/components/table/Table.tsx
@@ -1,0 +1,245 @@
+import { mdiArrowDown, mdiArrowUp, mdiFormatListGroup, mdiUnfoldMoreHorizontal } from "@mdi/js";
+import React, { useMemo } from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+import { Input } from "../form/input/Input";
+import { Icon } from "../icon/Icon";
+import { Pagination } from "../pagination/Pagination";
+import type { IColumnDef, IColumnFilter, ITableProps } from "./Table.types";
+import { TableColumnToggle } from "./TableColumnToggle";
+import { TableFilterSelect } from "./TableFilterSelect";
+import { TableGroupRow } from "./TableGroupRow";
+import { TableEmptyRow, TableRow } from "./TableRow";
+import { useTableState } from "./useTableState.hook";
+
+const sortIconPath = (state: "asc" | "desc" | "none") => {
+  if (state === "asc") {
+    return mdiArrowUp;
+  }
+  if (state === "desc") {
+    return mdiArrowDown;
+  }
+
+  return mdiUnfoldMoreHorizontal;
+};
+
+const ColumnFilterControl = <T,>({
+  column,
+  filter,
+  value,
+  onChange,
+}: {
+  column: IColumnDef<T>;
+  filter: IColumnFilter<T>;
+  value: string;
+  onChange: (value: string) => void;
+}) => {
+  const label = `Filter by ${column.header}`;
+  const id = `nxm-table-filter-${column.id}`;
+
+  if (filter.type === "select") {
+    return (
+      <TableFilterSelect
+        id={id}
+        label={label}
+        options={filter.options}
+        placeholder={filter.placeholder ?? "Select..."}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  }
+
+  return (
+    <Input
+      hideLabel={true}
+      id={id}
+      label={label}
+      placeholder={filter.placeholder ?? "Filter..."}
+      size="sm"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+};
+
+export const Table = <T,>({
+  columns,
+  data,
+  getRowId,
+  pageSize,
+  caption,
+  className,
+  enableFilters,
+  enableColumnToggle,
+  emptyState,
+}: ITableProps<T>) => {
+  const {
+    visibleColumns,
+    hiddenColumnIds,
+    pageData,
+    groups,
+    groupByColumnId,
+    collapsedGroups,
+    sort,
+    filters,
+    currentPage,
+    totalRecords,
+    toggleSort,
+    setColumnFilter,
+    setColumnHidden,
+    toggleGroupBy,
+    setGroupCollapsed,
+    setPage,
+  } = useTableState({ columns, data, pageSize });
+
+  const showFilters = enableFilters ?? columns.some((column) => !!column.filter);
+  const showColumnToggle =
+    enableColumnToggle ?? columns.some((column) => column.hideable !== false);
+
+  const lastColumnId = visibleColumns[visibleColumns.length - 1]?.id;
+  const colCount = visibleColumns.length;
+
+  const captionId = useMemo(
+    () => (caption ? `nxm-table-caption-${caption.replace(/\s+/g, "-").toLowerCase()}` : undefined),
+    [caption],
+  );
+
+  const isEmpty = groups ? groups.length === 0 : pageData.length === 0;
+
+  return (
+    <div className={joinClasses(["nxm-table-wrapper", className])}>
+      <div className="nxm-table-scroll">
+        <table aria-describedby={captionId} className="nxm-table">
+          {!!caption && (
+            <caption className="sr-only" id={captionId}>
+              {caption}
+            </caption>
+          )}
+
+          <colgroup>
+            {visibleColumns.map((column) => (
+              <col key={column.id} style={column.width ? { width: column.width } : undefined} />
+            ))}
+          </colgroup>
+
+          <thead className="nxm-table-head">
+            <tr>
+              {visibleColumns.map((column) => {
+                const sortState = sort?.columnId === column.id ? sort.direction : ("none" as const);
+                const ariaSort =
+                  sort?.columnId === column.id
+                    ? sort.direction === "asc"
+                      ? "ascending"
+                      : "descending"
+                    : "none";
+
+                return (
+                  <th
+                    aria-sort={column.sortable ? ariaSort : undefined}
+                    className="nxm-table-th"
+                    key={column.id}
+                    scope="col"
+                  >
+                    <div className="nxm-table-th-content">
+                      {column.sortable ? (
+                        <button
+                          className="nxm-table-sort"
+                          type="button"
+                          onClick={() => toggleSort(column.id)}
+                        >
+                          {column.header}
+
+                          <Icon
+                            className={joinClasses("nxm-table-sort-icon", {
+                              "nxm-table-sort-icon-active": sortState !== "none",
+                            })}
+                            path={sortIconPath(sortState)}
+                            size="sm"
+                          />
+                        </button>
+                      ) : (
+                        column.header
+                      )}
+
+                      {column.groupable && (
+                        <button
+                          aria-label={`Group by ${column.header}`}
+                          aria-pressed={groupByColumnId === column.id}
+                          className={joinClasses("nxm-table-group", {
+                            "nxm-table-group-active": groupByColumnId === column.id,
+                          })}
+                          title={`Group by ${column.header}`}
+                          type="button"
+                          onClick={() => toggleGroupBy(column.id)}
+                        >
+                          <Icon path={mdiFormatListGroup} size="sm" />
+                        </button>
+                      )}
+
+                      {showColumnToggle && column.id === lastColumnId && (
+                        <TableColumnToggle
+                          columns={columns}
+                          hiddenColumnIds={hiddenColumnIds}
+                          onToggleColumn={setColumnHidden}
+                        />
+                      )}
+                    </div>
+                  </th>
+                );
+              })}
+            </tr>
+
+            {showFilters && (
+              <tr className="nxm-table-filter-row">
+                {visibleColumns.map((column) => (
+                  <th className="nxm-table-filter-cell" key={column.id} scope="col">
+                    {column.filter && (
+                      <ColumnFilterControl
+                        column={column}
+                        filter={column.filter}
+                        value={filters[column.id] ?? ""}
+                        onChange={(value) => setColumnFilter(column.id, value)}
+                      />
+                    )}
+                  </th>
+                ))}
+              </tr>
+            )}
+          </thead>
+
+          <tbody className="nxm-table-body">
+            {isEmpty && <TableEmptyRow colSpan={colCount} emptyState={emptyState} />}
+
+            {groups
+              ? groups.map((group) => (
+                  <TableGroupRow
+                    collapsed={collapsedGroups.has(group.key)}
+                    colSpan={colCount}
+                    columns={visibleColumns}
+                    getRowId={getRowId}
+                    group={group}
+                    key={group.key || "__empty"}
+                    onToggleCollapsed={(collapsed) => setGroupCollapsed(group.key, collapsed)}
+                  />
+                ))
+              : pageData.map((row) => (
+                  <TableRow columns={visibleColumns} key={getRowId(row)} row={row} />
+                ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!groups && !!pageSize && (
+        <Pagination
+          className="nxm-table-pagination"
+          currentPage={currentPage}
+          recordsPerPage={pageSize}
+          totalRecords={totalRecords}
+          onPaginationUpdate={(page) => setPage(page)}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/table/Table.tsx
+++ b/src/renderer/src/ui/components/table/Table.tsx
@@ -11,7 +11,21 @@ import { TableColumnToggle } from "./TableColumnToggle";
 import { TableFilterSelect } from "./TableFilterSelect";
 import { TableGroupRow } from "./TableGroupRow";
 import { TableEmptyRow, TableRow } from "./TableRow";
+import { useColumnResize } from "./useColumnResize.hook";
 import { useTableState } from "./useTableState.hook";
+
+/**
+ * Reads a column's configured `width` as a pixel number so it can act as the
+ * resize floor. Non-pixel widths (e.g. `"20%"`) and undefined return undefined,
+ * falling back to the resize hook's default minimum.
+ */
+const parsePxWidth = (width: string | undefined): number | undefined => {
+  if (!width) {
+    return undefined;
+  }
+  const match = /^(\d+(?:\.\d+)?)px$/.exec(width.trim());
+  return match ? Number(match[1]) : undefined;
+};
 
 const sortIconPath = (state: "asc" | "desc" | "none") => {
   if (state === "asc") {
@@ -73,6 +87,9 @@ export const Table = <T,>({
   className,
   enableFilters,
   enableColumnToggle,
+  enableColumnResize = true,
+  columnWidths: initialColumnWidths,
+  onColumnWidthsChange,
   emptyState,
 }: ITableProps<T>) => {
   const {
@@ -94,6 +111,11 @@ export const Table = <T,>({
     setPage,
   } = useTableState({ columns, data, pageSize });
 
+  const { columnWidths, handleResizeStart, hasCustomWidths, resetColumnWidths } = useColumnResize({
+    initialWidths: initialColumnWidths,
+    onChange: onColumnWidthsChange,
+  });
+
   const showFilters = enableFilters ?? columns.some((column) => !!column.filter);
   const showColumnToggle =
     enableColumnToggle ?? columns.some((column) => column.hideable !== false);
@@ -108,10 +130,25 @@ export const Table = <T,>({
 
   const isEmpty = groups ? groups.length === 0 : pageData.length === 0;
 
+  // Once columns have custom widths, every visible column is pinned to an
+  // explicit pixel width (see useColumnResize). Sizing the table to their exact
+  // sum lets it grow past the container — so widening one column scrolls
+  // horizontally rather than stealing width from the others. A `width: auto`
+  // table would instead be capped at the container and redistribute the deficit.
+  const resizedWidths = visibleColumns.map((column) => columnWidths[column.id]);
+  const tableWidth =
+    hasCustomWidths && resizedWidths.every((width) => typeof width === "number")
+      ? resizedWidths.reduce((sum, width) => sum + width, 0)
+      : undefined;
+
   return (
     <div className={joinClasses(["nxm-table-wrapper", className])}>
       <div className="nxm-table-scroll">
-        <table aria-describedby={captionId} className="nxm-table">
+        <table
+          aria-describedby={captionId}
+          className="nxm-table"
+          style={tableWidth ? { width: tableWidth } : undefined}
+        >
           {!!caption && (
             <caption className="sr-only" id={captionId}>
               {caption}
@@ -119,9 +156,10 @@ export const Table = <T,>({
           )}
 
           <colgroup>
-            {visibleColumns.map((column) => (
-              <col key={column.id} style={column.width ? { width: column.width } : undefined} />
-            ))}
+            {visibleColumns.map((column) => {
+              const width = columnWidths[column.id] ?? column.width;
+              return <col key={column.id} style={width ? { width } : undefined} />;
+            })}
           </colgroup>
 
           <thead className="nxm-table-head">
@@ -139,6 +177,7 @@ export const Table = <T,>({
                   <th
                     aria-sort={column.sortable ? ariaSort : undefined}
                     className="nxm-table-th"
+                    data-column-id={column.id}
                     key={column.id}
                     scope="col"
                   >
@@ -180,12 +219,22 @@ export const Table = <T,>({
 
                       {showColumnToggle && column.id === lastColumnId && (
                         <TableColumnToggle
+                          canResetWidths={hasCustomWidths}
                           columns={columns}
                           hiddenColumnIds={hiddenColumnIds}
+                          onResetWidths={enableColumnResize ? resetColumnWidths : undefined}
                           onToggleColumn={setColumnHidden}
                         />
                       )}
                     </div>
+
+                    {enableColumnResize && column.resizable !== false && (
+                      <span
+                        aria-hidden={true}
+                        className="nxm-table-resize-handle"
+                        onPointerDown={handleResizeStart(column.id, parsePxWidth(column.width))}
+                      />
+                    )}
                   </th>
                 );
               })}

--- a/src/renderer/src/ui/components/table/Table.types.ts
+++ b/src/renderer/src/ui/components/table/Table.types.ts
@@ -53,6 +53,8 @@ export interface IColumnDef<T> {
   align?: "left" | "center" | "right";
   /** Explicit column width as a CSS value (e.g. `"120px"`, `"20%"`). */
   width?: string;
+  /** Whether the user may drag the column edge to resize it. Default `true`. */
+  resizable?: boolean;
   /** Whether the user may hide the column via the column toggle. Default `true`. */
   hideable?: boolean;
   /** Whether the column starts hidden. Default `false`. */
@@ -103,6 +105,22 @@ export interface ITableProps<T> {
    * least one column is hideable.
    */
   enableColumnToggle?: boolean;
+  /**
+   * Allows users to resize columns by dragging the header edge. Defaults to
+   * `true`. Individual columns can opt out with `resizable: false`.
+   */
+  enableColumnResize?: boolean;
+  /**
+   * Initial user-set column widths in pixels, keyed by column id (e.g. values
+   * restored from persistence). Applied on top of each column's `width`.
+   */
+  columnWidths?: Record<string, number>;
+  /**
+   * Called with the complete column-width map (whole px, keyed by column id)
+   * whenever the user finishes resizing a column or resets the widths. An empty
+   * map means "no custom widths". Wire this to persistence to remember widths.
+   */
+  onColumnWidthsChange?: (widths: Record<string, number>) => void;
   /** Node rendered when there are no rows to display. */
   emptyState?: ReactNode;
 }

--- a/src/renderer/src/ui/components/table/Table.types.ts
+++ b/src/renderer/src/ui/components/table/Table.types.ts
@@ -1,0 +1,108 @@
+import type { ReactNode } from "react";
+
+export type ISortDirection = "asc" | "desc";
+
+export interface ISortState {
+  columnId: string;
+  direction: ISortDirection;
+}
+
+/** A primitive value a column can sort and filter on. */
+export type ICellValue = string | number | boolean | null | undefined;
+
+export type IColumnFilter<T> =
+  | {
+      type: "text";
+      placeholder?: string;
+      /**
+       * Custom match. Defaults to a case-insensitive substring match against
+       * `String(getValue(row))`.
+       */
+      predicate?: (row: T, query: string) => boolean;
+    }
+  | {
+      type: "select";
+      placeholder?: string;
+      options: Array<{ label: string; value: string }>;
+      /**
+       * Custom match. Defaults to `String(getValue(row)) === value`.
+       */
+      predicate?: (row: T, value: string) => boolean;
+    };
+
+export interface IColumnDef<T> {
+  /** Stable, unique identifier for the column. */
+  id: string;
+  /** Header label, also used as the accessible name for the column. */
+  header: string;
+  /**
+   * Extracts the primitive value used for default sorting, filtering and cell
+   * rendering. Omit when the column is purely presentational (e.g. an actions
+   * column) and provide `cell` instead.
+   */
+  getValue?: (row: T) => ICellValue;
+  /** Custom cell renderer. Falls back to `String(getValue(row))`. */
+  cell?: (row: T) => ReactNode;
+  /** Enables click-to-sort on the header. */
+  sortable?: boolean;
+  /** Custom comparator. Defaults to comparing `getValue` ascending. */
+  sortFn?: (a: T, b: T) => number;
+  /** Renders a filter control in the filter row beneath the header. */
+  filter?: IColumnFilter<T>;
+  /** Horizontal alignment for the body cells. Headers are always left. Default `left`. */
+  align?: "left" | "center" | "right";
+  /** Explicit column width as a CSS value (e.g. `"120px"`, `"20%"`). */
+  width?: string;
+  /** Whether the user may hide the column via the column toggle. Default `true`. */
+  hideable?: boolean;
+  /** Whether the column starts hidden. Default `false`. */
+  defaultHidden?: boolean;
+  /** Shows a group-by toggle on the header so rows can be grouped by this column. */
+  groupable?: boolean;
+  /**
+   * Group key for a row when grouping by this column. Rows sharing a key form a
+   * group. Defaults to `String(getValue(row) ?? "")`; an empty key is the
+   * "Unspecified" group.
+   */
+  groupValue?: (row: T) => string;
+  /** Display label for a group key. Defaults to the key (or "Unspecified" when empty). */
+  groupLabel?: (key: string) => string;
+}
+
+export interface ITableGroup<T> {
+  /** Group key (the raw `groupValue`; empty string for the "Unspecified" bucket). */
+  key: string;
+  /** Display label for the group header. */
+  label: string;
+  /** Rows belonging to this group, in sorted order. */
+  rows: T[];
+}
+
+export interface ITableProps<T> {
+  /** Column definitions, in display order. */
+  columns: Array<IColumnDef<T>>;
+  /** Full dataset. The table handles filtering, sorting and pagination. */
+  data: T[];
+  /** Returns a stable key for a row. */
+  getRowId: (row: T) => string;
+  /**
+   * Rows rendered per page. When set, the table paginates and shows a pager;
+   * when omitted, pagination is disabled and all rows render.
+   */
+  pageSize?: number;
+  /** Accessible caption describing the table. */
+  caption?: string;
+  className?: string;
+  /**
+   * Renders the per-column filter row. Defaults to `true` when at least one
+   * column defines a `filter`.
+   */
+  enableFilters?: boolean;
+  /**
+   * Renders the column toggle (gear) control. Defaults to `true` when at
+   * least one column is hideable.
+   */
+  enableColumnToggle?: boolean;
+  /** Node rendered when there are no rows to display. */
+  emptyState?: ReactNode;
+}

--- a/src/renderer/src/ui/components/table/TableColumnToggle.tsx
+++ b/src/renderer/src/ui/components/table/TableColumnToggle.tsx
@@ -1,20 +1,22 @@
 import { Listbox as HeadlessListbox } from "@headlessui/react";
-import { mdiCog } from "@mdi/js";
+import { mdiArrowExpandHorizontal, mdiCog } from "@mdi/js";
 import React from "react";
 
 import { DropdownTitle } from "@/ui/components/dropdown/DropdownTitle";
 
 import { Button } from "../button/Button";
+import { Icon } from "../icon/Icon";
 import { Listbox } from "../listbox/Listbox";
 import { ListboxOption } from "../listbox/ListboxOption";
 import { ListboxOptions } from "../listbox/ListboxOptions";
-import { Typography } from "../typography/Typography";
 import type { IColumnDef } from "./Table.types";
 
 interface ITableColumnToggleProps<T> {
   columns: Array<IColumnDef<T>>;
   hiddenColumnIds: Set<string>;
   onToggleColumn: (columnId: string, hidden: boolean) => void;
+  onResetWidths?: () => void;
+  canResetWidths?: boolean;
 }
 
 /**
@@ -28,6 +30,8 @@ export const TableColumnToggle = <T,>({
   columns,
   hiddenColumnIds,
   onToggleColumn,
+  onResetWidths,
+  canResetWidths = false,
 }: ITableColumnToggleProps<T>) => {
   const hideableColumns = columns.filter((column) => column.hideable !== false);
   const visibleIds = hideableColumns
@@ -85,6 +89,35 @@ export const TableColumnToggle = <T,>({
             value={column.id}
           />
         ))}
+
+        {onResetWidths && (
+          <>
+            <span className="nxm-dropdown-divider" />
+
+            <button
+              className="nxm-dropdown-item"
+              disabled={!canResetWidths}
+              type="button"
+              onClick={(event) => {
+                onResetWidths();
+                // This is a multi-select Listbox, so it stays open on clicks and
+                // v1 exposes no programmatic close. Mimic Escape (handled by
+                // Listbox.Options) to dismiss the menu after resetting.
+                event.currentTarget.dispatchEvent(
+                  new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+                );
+              }}
+            >
+              <Icon
+                className="nxm-dropdown-item-icon"
+                path={mdiArrowExpandHorizontal}
+                size="none"
+              />
+
+              <span className="nxm-dropdown-item-label">Reset column widths</span>
+            </button>
+          </>
+        )}
       </ListboxOptions>
     </Listbox>
   );

--- a/src/renderer/src/ui/components/table/TableColumnToggle.tsx
+++ b/src/renderer/src/ui/components/table/TableColumnToggle.tsx
@@ -1,0 +1,91 @@
+import { Listbox as HeadlessListbox } from "@headlessui/react";
+import { mdiCog } from "@mdi/js";
+import React from "react";
+
+import { DropdownTitle } from "@/ui/components/dropdown/DropdownTitle";
+
+import { Button } from "../button/Button";
+import { Listbox } from "../listbox/Listbox";
+import { ListboxOption } from "../listbox/ListboxOption";
+import { ListboxOptions } from "../listbox/ListboxOptions";
+import { Typography } from "../typography/Typography";
+import type { IColumnDef } from "./Table.types";
+
+interface ITableColumnToggleProps<T> {
+  columns: Array<IColumnDef<T>>;
+  hiddenColumnIds: Set<string>;
+  onToggleColumn: (columnId: string, hidden: boolean) => void;
+}
+
+/**
+ * Gear control that opens a multi-select {@link Listbox} for showing and
+ * hiding columns. The selected options are the currently-visible columns, so
+ * each row shows a tick when its column is on. Non-hideable columns are
+ * omitted and the last visible column cannot be hidden, so the table never
+ * collapses to nothing.
+ */
+export const TableColumnToggle = <T,>({
+  columns,
+  hiddenColumnIds,
+  onToggleColumn,
+}: ITableColumnToggleProps<T>) => {
+  const hideableColumns = columns.filter((column) => column.hideable !== false);
+  const visibleIds = hideableColumns
+    .filter((column) => !hiddenColumnIds.has(column.id))
+    .map((column) => column.id);
+
+  if (hideableColumns.length === 0) {
+    return null;
+  }
+
+  // Listbox hands back the full next selection; translate the single changed
+  // entry into a show/hide toggle and refuse to hide the final column.
+  const handleChange = (nextIds: string[]) => {
+    if (nextIds.length === 0) {
+      return;
+    }
+
+    const added = nextIds.find((id) => !visibleIds.includes(id));
+    if (added) {
+      onToggleColumn(added, false);
+      return;
+    }
+
+    const removed = visibleIds.find((id) => !nextIds.includes(id));
+    if (removed) {
+      onToggleColumn(removed, true);
+    }
+  };
+
+  return (
+    <Listbox
+      className="nxm-table-column-toggle"
+      multiple={true}
+      value={visibleIds}
+      onChange={handleChange}
+    >
+      <HeadlessListbox.Button
+        appearance="weak"
+        aria-label="Manage columns"
+        as={Button}
+        brand="neutral"
+        leftIconPath={mdiCog}
+        size="sm"
+        title="Manage columns"
+      />
+
+      <ListboxOptions className="right-0 left-auto">
+        <DropdownTitle>Columns</DropdownTitle>
+
+        {hideableColumns.map((column) => (
+          <ListboxOption
+            disabled={visibleIds.length === 1 && visibleIds.includes(column.id)}
+            key={column.id}
+            label={column.header}
+            value={column.id}
+          />
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  );
+};

--- a/src/renderer/src/ui/components/table/TableFilterSelect.tsx
+++ b/src/renderer/src/ui/components/table/TableFilterSelect.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { Listbox } from "../listbox/Listbox";
+import { ListboxButton } from "../listbox/ListboxButton";
+import { ListboxOption } from "../listbox/ListboxOption";
+import { ListboxOptions } from "../listbox/ListboxOptions";
+
+interface ITableFilterSelectProps {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  options: Array<{ label: string; value: string }>;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Select-style filter built on the shared {@link Listbox}. The placeholder is
+ * modelled as an empty-value option, so picking it clears the filter. The
+ * Listbox button matches the small text {@link Input} height out of the box.
+ */
+export const TableFilterSelect = ({
+  id,
+  label,
+  placeholder,
+  value,
+  options,
+  onChange,
+}: ITableFilterSelectProps) => {
+  const allOptions = [{ label: placeholder, value: "" }, ...options];
+  const selected = allOptions.find((option) => option.value === value);
+
+  return (
+    <Listbox className="w-full" value={value} onChange={onChange}>
+      <ListboxButton aria-label={label} className="w-full justify-between" id={id}>
+        {selected?.label ?? placeholder}
+      </ListboxButton>
+
+      <ListboxOptions className="right-auto left-0 w-full">
+        {allOptions.map((option) => (
+          <ListboxOption key={option.value} label={option.label} value={option.value} />
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  );
+};

--- a/src/renderer/src/ui/components/table/TableGroupRow.tsx
+++ b/src/renderer/src/ui/components/table/TableGroupRow.tsx
@@ -1,0 +1,59 @@
+import { mdiChevronDown, mdiChevronRight } from "@mdi/js";
+import React, { Fragment } from "react";
+
+import { Icon } from "../icon/Icon";
+import type { IColumnDef, ITableGroup } from "./Table.types";
+import { TableRow } from "./TableRow";
+
+interface ITableGroupRowProps<T> {
+  group: ITableGroup<T>;
+  columns: Array<IColumnDef<T>>;
+  colSpan: number;
+  collapsed: boolean;
+  getRowId: (row: T) => string;
+  onToggleCollapsed: (collapsed: boolean) => void;
+}
+
+/**
+ * Collapsible group header row plus the group's data rows. Rendered once per
+ * group when the table is grouped by a column.
+ */
+export const TableGroupRow = <T,>({
+  group,
+  columns,
+  colSpan,
+  collapsed,
+  getRowId,
+  onToggleCollapsed,
+}: ITableGroupRowProps<T>) => {
+  const rowLabel = group.rows.length === 1 ? "row" : "rows";
+
+  return (
+    <Fragment>
+      <tr>
+        <td className="nxm-table-group-cell" colSpan={colSpan}>
+          <button
+            aria-expanded={!collapsed}
+            aria-label={`${group.label} group, ${group.rows.length} ${rowLabel}`}
+            className="nxm-table-group-toggle"
+            type="button"
+            onClick={() => onToggleCollapsed(!collapsed)}
+          >
+            <Icon
+              className="nxm-table-group-icon"
+              path={collapsed ? mdiChevronRight : mdiChevronDown}
+              size="sm"
+            />
+
+            <span className="nxm-table-group-label">{group.label}</span>
+
+            <span className="nxm-table-group-count">{group.rows.length}</span>
+          </button>
+        </td>
+      </tr>
+
+      {!collapsed &&
+        group.rows.map((row) => <TableRow columns={columns} key={getRowId(row)} row={row} />)}
+    </Fragment>
+  );
+};

--- a/src/renderer/src/ui/components/table/TableRow.tsx
+++ b/src/renderer/src/ui/components/table/TableRow.tsx
@@ -1,0 +1,42 @@
+import React, { type ReactNode } from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+import { Typography } from "../typography/Typography";
+import type { IColumnDef } from "./Table.types";
+
+interface ITableRowProps<T> {
+  columns: Array<IColumnDef<T>>;
+  row: T;
+}
+
+export const TableRow = <T,>({ columns, row }: ITableRowProps<T>) => (
+  <tr className="nxm-table-row">
+    {columns.map((column) => (
+      <td
+        className={joinClasses("nxm-table-td", {
+          "nxm-table-cell-center": column.align === "center",
+          "nxm-table-cell-right": column.align === "right",
+        })}
+        key={column.id}
+      >
+        <div className="nxm-table-cell-inner">
+          {column.cell ? column.cell(row) : String(column.getValue?.(row) ?? "")}
+        </div>
+      </td>
+    ))}
+  </tr>
+);
+
+interface ITableEmptyRowProps {
+  colSpan: number;
+  emptyState?: ReactNode;
+}
+
+export const TableEmptyRow = ({ colSpan, emptyState }: ITableEmptyRowProps) => (
+  <tr>
+    <td className="nxm-table-empty" colSpan={colSpan}>
+      {emptyState ?? <Typography appearance="subdued">No results found.</Typography>}
+    </td>
+  </tr>
+);

--- a/src/renderer/src/ui/components/table/useColumnResize.hook.ts
+++ b/src/renderer/src/ui/components/table/useColumnResize.hook.ts
@@ -1,0 +1,134 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Smallest width (px) a column can be dragged down to. */
+const MIN_COLUMN_WIDTH = 48;
+
+interface IDragState {
+  columnId: string;
+  startX: number;
+  startWidth: number;
+  currentWidth: number;
+}
+
+interface IUseColumnResizeOptions {
+  /**
+   * Widths (px) to start from, keyed by column id — e.g. values restored from
+   * persistence. Read once when the hook mounts.
+   */
+  initialWidths?: Record<string, number>;
+  /**
+   * Fires with the complete width map (rounded to whole px) whenever a resize
+   * finishes or the widths are reset. The caller can persist this however it
+   * likes; an empty map means "no custom widths".
+   */
+  onChange?: (widths: Record<string, number>) => void;
+}
+
+const roundWidths = (widths: Record<string, number>): Record<string, number> =>
+  Object.fromEntries(Object.entries(widths).map(([id, width]) => [id, Math.round(width)]));
+
+/**
+ * Manages user-driven column resizing via a drag handle in the header. Widths
+ * are tracked in pixels, keyed by column id, and applied to the table's
+ * `<col>` elements. `onChange` reports the full width map once a drag finishes
+ * or the widths are reset, so it can be persisted by the caller.
+ */
+export const useColumnResize = ({ initialWidths, onChange }: IUseColumnResizeOptions = {}) => {
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(
+    () => initialWidths ?? {},
+  );
+  const dragRef = useRef<IDragState | null>(null);
+
+  // Mirror the latest widths and callback in refs so the pointer handlers (set
+  // up once) always see current values without being re-created each render.
+  const widthsRef = useRef(columnWidths);
+  useEffect(() => {
+    widthsRef.current = columnWidths;
+  }, [columnWidths]);
+
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const handleResizeStart = useCallback(
+    // `minWidth` is the smallest width (px) the column can be dragged to —
+    // typically the column's configured width, so it can't shrink below its
+    // initial size.
+    (columnId: string, minWidth: number = MIN_COLUMN_WIDTH) =>
+      (event: ReactPointerEvent<HTMLElement>) => {
+        // Don't let the drag trigger the header's sort/group buttons.
+        event.preventDefault();
+        event.stopPropagation();
+
+        const th = event.currentTarget.closest("th");
+        const table = event.currentTarget.closest("table");
+        if (!th || !table) {
+          return;
+        }
+
+        // Pin every column to its current rendered width up-front. The table
+        // uses `table-layout: fixed; width: 100%`, so without this the browser
+        // redistributes the remaining columns the instant one is given an
+        // explicit width — making the grabbed edge jump away from the cursor.
+        // Measuring all columns first means their widths already sum to the
+        // table width, so nothing reflows on drag start.
+        const measured: Record<string, number> = {};
+        table.querySelectorAll<HTMLElement>("th[data-column-id]").forEach((cell) => {
+          const id = cell.dataset.columnId;
+          if (id) {
+            measured[id] = cell.getBoundingClientRect().width;
+          }
+        });
+
+        const startWidth = measured[columnId] ?? th.getBoundingClientRect().width;
+        const floor = Math.min(minWidth, startWidth);
+        dragRef.current = { columnId, startX: event.clientX, startWidth, currentWidth: startWidth };
+
+        // Keep any previously resized widths; backfill the rest from the live
+        // measurements so the whole table is now explicitly sized.
+        setColumnWidths((current) => ({ ...measured, ...current }));
+
+        document.body.classList.add("nxm-table-resizing");
+
+        const handleMove = (moveEvent: PointerEvent) => {
+          const drag = dragRef.current;
+          if (!drag) {
+            return;
+          }
+          const next = Math.max(floor, drag.startWidth + (moveEvent.clientX - drag.startX));
+          drag.currentWidth = next;
+          setColumnWidths((current) => ({ ...current, [drag.columnId]: next }));
+        };
+
+        const handleEnd = () => {
+          const drag = dragRef.current;
+          dragRef.current = null;
+          document.body.classList.remove("nxm-table-resizing");
+          document.removeEventListener("pointermove", handleMove);
+          document.removeEventListener("pointerup", handleEnd);
+          if (drag) {
+            // Report the full, current map (with the just-dragged column's final
+            // width) so it can be persisted as a unit.
+            onChangeRef.current?.(
+              roundWidths({ ...widthsRef.current, [drag.columnId]: drag.currentWidth }),
+            );
+          }
+        };
+
+        document.addEventListener("pointermove", handleMove);
+        document.addEventListener("pointerup", handleEnd);
+      },
+    [],
+  );
+
+  const resetColumnWidths = useCallback(() => {
+    setColumnWidths({});
+    onChangeRef.current?.({});
+  }, []);
+
+  const hasCustomWidths = Object.keys(columnWidths).length > 0;
+
+  return { columnWidths, handleResizeStart, hasCustomWidths, resetColumnWidths };
+};

--- a/src/renderer/src/ui/components/table/useTableState.hook.ts
+++ b/src/renderer/src/ui/components/table/useTableState.hook.ts
@@ -1,0 +1,234 @@
+import { useMemo, useState } from "react";
+
+import type {
+  ICellValue,
+  IColumnDef,
+  ISortDirection,
+  ISortState,
+  ITableGroup,
+} from "./Table.types";
+
+const UNSPECIFIED_LABEL = "Unspecified";
+
+const groupKeyOf = <T>(column: IColumnDef<T>, row: T): string =>
+  column.groupValue ? column.groupValue(row) : String(column.getValue?.(row) ?? "");
+
+interface IUseTableStateArgs<T> {
+  columns: Array<IColumnDef<T>>;
+  data: T[];
+  /** Page size; when omitted, all rows render and pagination is disabled. */
+  pageSize?: number;
+}
+
+const compareValues = (a: ICellValue, b: ICellValue): number => {
+  // Nullish values always sort last regardless of direction.
+  if (a == null && b == null) {
+    return 0;
+  }
+  if (a == null) {
+    return 1;
+  }
+  if (b == null) {
+    return -1;
+  }
+
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+
+  return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
+};
+
+const matchesFilter = <T>(column: IColumnDef<T>, row: T, value: string): boolean => {
+  const { filter } = column;
+  if (!filter) {
+    return true;
+  }
+
+  if (filter.predicate) {
+    return filter.predicate(row, value);
+  }
+
+  const cellValue = column.getValue?.(row);
+
+  if (filter.type === "text") {
+    return String(cellValue ?? "")
+      .toLowerCase()
+      .includes(value.toLowerCase());
+  }
+
+  return String(cellValue ?? "") === value;
+};
+
+export const useTableState = <T>({ columns, data, pageSize }: IUseTableStateArgs<T>) => {
+  const [sort, setSort] = useState<ISortState | null>(null);
+  const [filters, setFilters] = useState<Record<string, string>>({});
+  const [page, setPage] = useState(1);
+  const [groupByColumnId, setGroupByColumnId] = useState<string | null>(null);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
+  const [hiddenColumnIds, setHiddenColumnIds] = useState<Set<string>>(
+    () => new Set(columns.filter((column) => column.defaultHidden).map((column) => column.id)),
+  );
+
+  const visibleColumns = useMemo(
+    () => columns.filter((column) => !hiddenColumnIds.has(column.id)),
+    [columns, hiddenColumnIds],
+  );
+
+  const filteredData = useMemo(() => {
+    const activeFilters = Object.entries(filters).filter(([, value]) => value !== "");
+    if (activeFilters.length === 0) {
+      return data;
+    }
+
+    return data.filter((row) =>
+      activeFilters.every(([columnId, value]) => {
+        const column = columns.find((candidate) => candidate.id === columnId);
+        return column ? matchesFilter(column, row, value) : true;
+      }),
+    );
+  }, [columns, data, filters]);
+
+  const sortedData = useMemo(() => {
+    if (!sort) {
+      return filteredData;
+    }
+
+    const column = columns.find((candidate) => candidate.id === sort.columnId);
+    if (!column) {
+      return filteredData;
+    }
+
+    const comparator =
+      column.sortFn ?? ((a: T, b: T) => compareValues(column.getValue?.(a), column.getValue?.(b)));
+
+    // Copy before sorting so the source data array is never mutated.
+    const sorted = [...filteredData].sort(comparator);
+    return sort.direction === "desc" ? sorted.reverse() : sorted;
+  }, [columns, filteredData, sort]);
+
+  const totalRecords = sortedData.length;
+  const totalPages = pageSize ? Math.max(1, Math.ceil(totalRecords / pageSize)) : 1;
+  // Clamp the page when filtering/sorting shrinks the result set below it.
+  const currentPage = Math.min(page, totalPages);
+
+  const pageData = useMemo(() => {
+    // No page size → pagination is disabled, render every row.
+    if (!pageSize) {
+      return sortedData;
+    }
+    const start = (currentPage - 1) * pageSize;
+    return sortedData.slice(start, start + pageSize);
+  }, [sortedData, currentPage, pageSize]);
+
+  // When grouping is active, build ordered groups across the whole (filtered +
+  // sorted) dataset — grouping bypasses pagination. Groups appear in the order
+  // their first row is encountered; the empty "Unspecified" bucket sorts last.
+  const groups = useMemo<Array<ITableGroup<T>> | null>(() => {
+    if (!groupByColumnId) {
+      return null;
+    }
+
+    const column = columns.find((candidate) => candidate.id === groupByColumnId);
+    if (!column) {
+      return null;
+    }
+
+    const byKey = new Map<string, T[]>();
+    for (const row of sortedData) {
+      const key = groupKeyOf(column, row);
+      const bucket = byKey.get(key);
+      if (bucket) {
+        bucket.push(row);
+      } else {
+        byKey.set(key, [row]);
+      }
+    }
+
+    const entries = [...byKey.entries()].sort(([a], [b]) => {
+      if (a === b) {
+        return 0;
+      }
+      // Keep the empty "Unspecified" bucket at the end.
+      if (a === "") {
+        return 1;
+      }
+      if (b === "") {
+        return -1;
+      }
+      return 0;
+    });
+
+    return entries.map(([key, rows]) => ({
+      key,
+      label:
+        key === ""
+          ? (column.groupLabel?.("") ?? UNSPECIFIED_LABEL)
+          : (column.groupLabel?.(key) ?? key),
+      rows,
+    }));
+  }, [columns, groupByColumnId, sortedData]);
+
+  const toggleGroupBy = (columnId: string) => {
+    setGroupByColumnId((current) => (current === columnId ? null : columnId));
+    setCollapsedGroups(new Set());
+  };
+
+  const setGroupCollapsed = (groupKey: string, collapsed: boolean) => {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (collapsed) {
+        next.add(groupKey);
+      } else {
+        next.delete(groupKey);
+      }
+      return next;
+    });
+  };
+
+  const toggleSort = (columnId: string) => {
+    setSort((current) => {
+      if (current?.columnId !== columnId) {
+        return { columnId, direction: "asc" };
+      }
+      const next: ISortDirection = current.direction === "asc" ? "desc" : "asc";
+      return { columnId, direction: next };
+    });
+  };
+
+  const setColumnFilter = (columnId: string, value: string) => {
+    setFilters((current) => ({ ...current, [columnId]: value }));
+    setPage(1);
+  };
+
+  const setColumnHidden = (columnId: string, hidden: boolean) => {
+    setHiddenColumnIds((current) => {
+      const next = new Set(current);
+      if (hidden) {
+        next.add(columnId);
+      } else {
+        next.delete(columnId);
+      }
+      return next;
+    });
+  };
+
+  return {
+    visibleColumns,
+    hiddenColumnIds,
+    pageData,
+    groups,
+    groupByColumnId,
+    collapsedGroups,
+    sort,
+    filters,
+    currentPage,
+    totalRecords,
+    toggleSort,
+    setColumnFilter,
+    setColumnHidden,
+    toggleGroupBy,
+    setGroupCollapsed,
+    setPage,
+  };
+};

--- a/src/stylesheets/ui/elements/dropdown.css
+++ b/src/stylesheets/ui/elements/dropdown.css
@@ -81,6 +81,19 @@
         background-color: var(--color-surface-translucent-mid);
     }
 
+    .nxm-dropdown-title {
+        width: 100%;
+        padding-block: calc(var(--spacing) * 1.5);
+        padding-inline: calc(var(--spacing) * 3);
+
+        text-transform: uppercase;
+        font-size: var(--text-2xs);
+        color: var(--color-neutral-subdued);
+        line-height: var(--text-2xs--line-height);
+        letter-spacing: var(--tracking-widest);
+        font-weight: var(--font-weight-semibold);
+    }
+
     .nxm-dropdown-item {
         width: 100%;
         display: flex;

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -7,5 +7,6 @@
 @import "./pagination.css";
 @import "./pill.css";
 @import "./scrollbar.css";
+@import "./table.css";
 @import "./tab.css";
 @import "./toolbar.css";

--- a/src/stylesheets/ui/elements/table.css
+++ b/src/stylesheets/ui/elements/table.css
@@ -1,0 +1,200 @@
+@layer components {
+    .nxm-table-wrapper {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--spacing) * 4);
+    }
+
+    .nxm-table-scroll {
+        overflow: auto;
+        /*
+           min height to prevent dropdowns being cropped, we can probably remove
+           this when we update headless to v2 and make use of portal
+        */
+        min-height: calc(var(--spacing) * 164);
+    }
+
+    .nxm-table {
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: fixed;
+        color: var(--color-neutral-strong);
+        font-size: var(--text-body-sm);
+        line-height: var(--text-body-sm--line-height);
+        letter-spacing: var(--text-body-sm--letter-spacing);
+
+        /* Override the global Bootstrap table background-color */
+        background-color: transparent;
+    }
+
+    /* Header --------------------------------------------------------------- */
+
+    .nxm-table-th {
+        white-space: nowrap;
+        vertical-align: middle;
+        color: var(--color-neutral-moderate);
+        font-weight: var(--font-weight-semibold);
+        padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
+    }
+
+    .nxm-table-th-content {
+        display: flex;
+        align-items: center;
+        gap: calc(var(--spacing) * 2);
+    }
+
+    .nxm-table-sort {
+        color: inherit;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: calc(var(--spacing) * 1);
+
+        transition-property: color;
+        transition-timing-function: var(--default-transition-timing-function);
+        transition-duration: var(--default-transition-duration);
+
+        &:hover,
+        &:focus-visible {
+            color: var(--color-neutral-strong);
+
+            .nxm-table-sort-icon {
+                opacity: 1;
+            }
+        }
+
+        .nxm-table-sort-icon {
+            opacity: 0;
+            flex-shrink: 0;
+            color: var(--color-neutral-subdued);
+
+            &.nxm-table-sort-icon-active {
+                opacity: 1;
+                color: var(--color-neutral-strong);
+            }
+        }
+    }
+
+    .nxm-table-group {
+        opacity: 0;
+        cursor: pointer;
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        margin-inline-start: auto;
+        color: var(--color-neutral-subdued);
+
+        transition-property: opacity, color;
+        transition-timing-function: var(--default-transition-timing-function);
+        transition-duration: var(--default-transition-duration);
+
+        &:hover,
+        &:focus-visible {
+            opacity: 1;
+            color: var(--color-neutral-strong);
+        }
+
+        .nxm-table-th-content:hover & {
+            opacity: 1;
+        }
+
+        &.nxm-table-group-active {
+            opacity: 1;
+            color: var(--color-primary-strong);
+        }
+    }
+
+    /* Filter row ----------------------------------------------------------- */
+
+    .nxm-table-filter-cell {
+        vertical-align: top;
+        font-weight: var(--font-weight-normal);
+        padding: 0 calc(var(--spacing) * 3) calc(var(--spacing) * 2);
+    }
+
+    /* Body ----------------------------------------------------------------- */
+
+    .nxm-table-row {
+        transition-property: background-color;
+        transition-timing-function: var(--default-transition-timing-function);
+        transition-duration: var(--default-transition-duration);
+
+        &:hover {
+            background-color: var(--color-translucent-dark-300);
+        }
+    }
+
+    .nxm-table-td {
+        padding: calc(var(--spacing) * 2.5) calc(var(--spacing) * 3);
+        vertical-align: middle;
+    }
+
+    .nxm-table-cell-inner {
+        display: flex;
+        align-items: center;
+        gap: calc(var(--spacing) * 1);
+        min-width: 0;
+    }
+
+    .nxm-table-cell-center .nxm-table-cell-inner {
+        justify-content: center;
+    }
+
+    .nxm-table-cell-right .nxm-table-cell-inner {
+        justify-content: flex-end;
+    }
+
+    .nxm-table-empty {
+        text-align: center;
+        padding: calc(var(--spacing) * 8) calc(var(--spacing) * 3);
+    }
+
+    /* Group header rows ---------------------------------------------------- */
+
+    .nxm-table-group-cell {
+        padding: 0;
+        border-top: 2px solid transparent;
+    }
+
+    .nxm-table-group-toggle {
+        width: 100%;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: calc(var(--spacing) * 2);
+        padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
+
+        text-align: left;
+        font-weight: var(--font-weight-semibold);
+        background-color: var(--color-translucent-50);
+
+        &:hover {
+            background-color: var(--color-translucent-100);
+        }
+
+        .nxm-table-group-icon {
+            flex-shrink: 0;
+            color: var(--color-neutral-subdued);
+        }
+
+        .nxm-table-group-label {
+            min-width: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            color: var(--color-translucent-strong);
+        }
+
+        .nxm-table-group-count {
+            color: var(--color-neutral-subdued);
+            font-weight: var(--font-weight-semibold);
+        }
+    }
+
+    /* Column toggle -------------------------------------------------------- */
+
+    .nxm-table-column-toggle {
+        margin-inline-start: auto;
+    }
+}

--- a/src/stylesheets/ui/elements/table.css
+++ b/src/stylesheets/ui/elements/table.css
@@ -12,7 +12,7 @@
            min height to prevent dropdowns being cropped, we can probably remove
            this when we update headless to v2 and make use of portal
         */
-        min-height: calc(var(--spacing) * 164);
+        min-height: calc(var(--spacing) * 96);
     }
 
     .nxm-table {
@@ -31,6 +31,7 @@
     /* Header --------------------------------------------------------------- */
 
     .nxm-table-th {
+        position: relative;
         white-space: nowrap;
         vertical-align: middle;
         color: var(--color-neutral-moderate);
@@ -44,6 +45,47 @@
         gap: calc(var(--spacing) * 2);
     }
 
+    .nxm-table-resize-handle {
+        top: 0;
+        height: 100%;
+        user-select: none;
+        touch-action: none;
+        cursor: col-resize;
+        position: absolute;
+        inset-inline-end: 0;
+        width: calc(var(--spacing) * 2);
+
+        /* The grip line, centred within the wider hit area. Hidden until the
+           header cell is hovered. */
+        &::after {
+            top: 25%;
+            width: 1px;
+            height: 50%;
+            content: "";
+            position: absolute;
+            inset-inline-end: 0;
+            background-color: transparent;
+
+            transition-property: background-color;
+            transition-duration: var(--default-transition-duration);
+            transition-timing-function: var(--default-transition-timing-function);
+        }
+
+        .nxm-table-th:hover &::after {
+            background-color: var(--color-translucent-200);
+        }
+
+        &:hover::after {
+            background-color: var(--color-primary-strong);
+        }
+    }
+
+    /* Applied to <body> while a column is being dragged. */
+    .nxm-table-resizing {
+        cursor: col-resize;
+        user-select: none;
+    }
+
     .nxm-table-sort {
         color: inherit;
         cursor: pointer;
@@ -52,8 +94,8 @@
         gap: calc(var(--spacing) * 1);
 
         transition-property: color;
-        transition-timing-function: var(--default-transition-timing-function);
         transition-duration: var(--default-transition-duration);
+        transition-timing-function: var(--default-transition-timing-function);
 
         &:hover,
         &:focus-visible {
@@ -86,8 +128,8 @@
         color: var(--color-neutral-subdued);
 
         transition-property: opacity, color;
-        transition-timing-function: var(--default-transition-timing-function);
         transition-duration: var(--default-transition-duration);
+        transition-timing-function: var(--default-transition-timing-function);
 
         &:hover,
         &:focus-visible {
@@ -117,8 +159,8 @@
 
     .nxm-table-row {
         transition-property: background-color;
-        transition-timing-function: var(--default-transition-timing-function);
         transition-duration: var(--default-transition-duration);
+        transition-timing-function: var(--default-transition-timing-function);
 
         &:hover {
             background-color: var(--color-translucent-dark-300);


### PR DESCRIPTION
### Summary                                                   

Adds a reusable, column-driven Table to the design system. You declare columns and pass data; the table handles the rest.

- Sorting — click-to-sort headers
- Filtering — per-column text and select filters
- Grouping — group by a column into collapsible groups
- Column show/hide — via a gear menu (defaultHidden supported)
- Pagination — opt-in via pageSize
- Empty state — default message or a custom node

State lives in the useTableState hook; rendering is split into small components (TableRow, TableGroupRow, etc.). Includes a demo on the design-system page, unit tests, and README docs.