### PR TITLE
fix getCollectionModByReference modId namespace bug (483 WIP)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -1298,13 +1298,7 @@ const getCollectionLastActiveSessionId: (state: IState) => string | undefined;
 const getCollectionLastCompletedSession: (state: IState) => ICollectionInstallSession | undefined;
 
 // @public
-const getCollectionModByReference: (state: IState, searchParams: {
-    tag?: string;
-    modId?: string;
-    fileMD5?: string;
-    fileId?: string;
-    logicalFileName?: string;
-}) => ICollectionModInstallInfo | undefined;
+const getCollectionModByReference: (state: IState, lookup: IModLookupInfo) => ICollectionModInstallInfo | undefined;
 
 // @public
 const getCollectionModsByPhase: (state: IState) => Map<number, ICollectionModInstallInfo[]>;

--- a/src/renderer/src/extensions/download_management/views/DownloadView.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadView.tsx
@@ -48,6 +48,7 @@ import { truthy } from "../../../util/util";
 import MainPage from "../../../views/MainPage";
 import type { IGameStored } from "../../gamemode_management/types/IGameStored";
 import type { IInstallOptions } from "../../mod_management/types/IInstallOptions";
+import { lookupFromDownload } from "../../mod_management/util/dependencies";
 import { convertGameIdReverse } from "../../nexus_integration/util/convertGameId";
 import { setShowDLDropzone, setShowDLGraph } from "../actions/settings";
 import { finishDownload, setDownloadTime } from "../actions/state";
@@ -391,17 +392,14 @@ class DownloadView extends ComponentEx<IDownloadViewProps, IComponentState> {
     return (
       downloadIds.find((downloadId) => {
         const download = this.getDownload(downloadId);
-        const tag = download?.modInfo?.referenceTag;
-        const identifiers = this.extractIds(download);
-        if (!identifiers) {
+        if (download === undefined) {
           return false;
         }
         return (
-          getCollectionModByReference(this.context.api.store.getState(), {
-            tag,
-            fileId: identifiers.fileId,
-            modId: identifiers.modId,
-          }) != null
+          getCollectionModByReference(
+            this.context.api.store.getState(),
+            lookupFromDownload(download),
+          ) != null
         );
       }) == null // couldn't find it - allow actions
     );

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -371,12 +371,7 @@ function findCollectionByDownload(
     return null;
   }
 
-  const matchingRule = getCollectionModByReference(state, {
-    tag: download.modInfo?.referenceTag,
-    fileMD5: download.fileMD5,
-    fileId: download.modInfo?.nexus?.ids?.fileId?.toString(),
-    logicalFileName: download.localPath,
-  });
+  const matchingRule = getCollectionModByReference(state, lookupFromDownload(download));
   if (!matchingRule) {
     log("debug", "No matching rule found in collection for download", {
       downloadId: download.id,

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -11,6 +11,7 @@
  */
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
+import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
 import type { IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type {
   CollectionModStatus,
@@ -60,6 +61,10 @@ export function makeDownload(overrides: Partial<IDownload> = {}): IDownload {
 
 export function makeProfileMod(overrides: Partial<IProfileMod> = {}): IProfileMod {
   return { enabled: true, enabledTime: 0, ...overrides };
+}
+
+export function makeLookup(overrides: Partial<IModLookupInfo> = {}): IModLookupInfo {
+  return { fileMD5: "", fileSizeBytes: 0, fileName: "", version: "", ...overrides };
 }
 
 export function makeModInstallInfo(

--- a/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   makeInstallState,
+  makeLookup,
   makeModInstallInfo,
   makeRule,
   makeSession,
@@ -19,6 +20,7 @@ import type {
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
 import {
+  getCollectionModByReference,
   getCollectionPhaseProgress,
   getCollectionStatusBreakdown,
 } from "./collectionInstallSessionSelectors";
@@ -104,5 +106,72 @@ describe("getCollectionStatusBreakdown", () => {
     expect(breakdown.optional.installed).toBe(1);
     expect(breakdown.total.installed).toBe(2);
     expect(breakdown.total.downloading).toBe(1);
+  });
+});
+
+describe("getCollectionModByReference", () => {
+  // build a session keyed by ruleId; each entry gives the rule's reference and optionally an
+  // installed Vortex mod id or a bundled localPath
+  function sessionWith(
+    entries: Record<
+      string,
+      { reference?: Record<string, any>; modId?: string; localPath?: string }
+    >,
+  ) {
+    const mods: Record<string, ICollectionModInstallInfo> = {};
+    for (const [ruleId, e] of Object.entries(entries)) {
+      mods[ruleId] = makeModInstallInfo({
+        rule: makeRule({
+          reference: e.reference ?? { tag: ruleId },
+          ...(e.localPath != null ? { extra: { localPath: e.localPath } } : {}),
+        }),
+        modId: e.modId,
+        status: "installed",
+      });
+    }
+    return asIState(makeInstallState({ activeSession: makeSession({ mods }) }));
+  }
+
+  it("matches a session rule by its reference tag", () => {
+    const state = sessionWith({ r1: { reference: { tag: "tag-1" } } });
+    expect(getCollectionModByReference(state, makeLookup({ referenceTag: "tag-1" }))).toBeDefined();
+  });
+
+  it("matches an external reference by fileMD5", () => {
+    const state = sessionWith({ r1: { reference: { fileMD5: "md5-aaa" } } });
+    expect(getCollectionModByReference(state, makeLookup({ fileMD5: "md5-aaa" }))).toBeDefined();
+  });
+
+  it("matches a bundled mod by its archive file name", () => {
+    const state = sessionWith({ r1: { localPath: "Bundled Mod.7z" } });
+    expect(
+      getCollectionModByReference(state, makeLookup({ fileName: "Bundled Mod.7z" })),
+    ).toBeDefined();
+  });
+
+  it("returns undefined when no reference matches the lookup", () => {
+    const state = sessionWith({ r1: { reference: { tag: "tag-1" } } });
+    expect(
+      getCollectionModByReference(state, makeLookup({ referenceTag: "other" })),
+    ).toBeUndefined();
+  });
+
+  it("matches on reference identity, never the installed Vortex mod id", () => {
+    // the entry's modId is the installed Vortex id; a lookup carrying that value (but not the
+    // rule's reference) must NOT match - the removed fast-path used to compare exactly this
+    const state = sessionWith({ r1: { reference: { tag: "tag-1" }, modId: "12345" } });
+    expect(
+      getCollectionModByReference(state, makeLookup({ referenceTag: "12345" })),
+    ).toBeUndefined();
+    expect(getCollectionModByReference(state, makeLookup({ referenceTag: "tag-1" }))?.modId).toBe(
+      "12345",
+    );
+  });
+
+  it("returns undefined when there is no active session", () => {
+    const empty = asIState(makeInstallState());
+    expect(
+      getCollectionModByReference(empty, makeLookup({ referenceTag: "tag-1" })),
+    ).toBeUndefined();
   });
 });

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -4,7 +4,8 @@ import { createSelector } from "reselect";
 
 import { activeDownloads } from "../extensions/download_management/selectors";
 import { modsForActiveGame } from "../extensions/mod_management/selectors";
-import { rulePhase } from "../extensions/mod_management/util/testModReference";
+import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+import testModReference, { rulePhase } from "../extensions/mod_management/util/testModReference";
 import type {
   ICollectionInstallState,
   ICollectionInstallSession,
@@ -136,53 +137,30 @@ export const getCollectionActiveSessionMod = (
 };
 
 /**
- * Search for a mod in the active collection by mod reference details
- * This is useful when you have deployment information and need to find the corresponding collection rule
- * @param searchParams Object containing mod identifiers to search by
+ * Search for a mod in the active collection that a download corresponds to.
+ * @param lookup Canonical lookup info for the download (use lookupFromDownload)
  * @returns The mod installation info or undefined if not found
+ *
+ * Matches each session rule's reference with the shared testModReference matcher (the same
+ * identity logic the dependency resolver uses), so there is one notion of reference identity
+ * and no separate "find by modId" path: the session stores the installed Vortex mod id,
+ * which is a different namespace than the Nexus ids a download carries.
  */
 export const getCollectionModByReference = (
   state: IState,
-  searchParams: {
-    tag?: string;
-    modId?: string;
-    fileMD5?: string;
-    fileId?: string;
-    logicalFileName?: string;
-  },
+  lookup: IModLookupInfo,
 ): ICollectionModInstallInfo | undefined => {
   const mods = getCollectionActiveSessionMods(state);
 
-  // First try to find by modId if provided (most direct match)
-  if (searchParams.modId) {
-    const byModId = Object.values(mods).find((mod) => mod.modId === searchParams.modId);
-    if (byModId) return byModId;
-  }
-
-  // Fall back to searching by rule reference fields
   return Object.values(mods).find((mod) => {
+    // bundled mods ship inside the collection archive and have no resolvable reference, so
+    // they are matched by archive file name (lookup.fileName is the download's localPath)
     const isBundled = mod.rule?.extra?.localPath != null;
     if (isBundled) {
-      return (
-        path.basename(mod.rule.extra.localPath) ===
-        path.basename(
-          searchParams.logicalFileName,
-          path.extname(searchParams.logicalFileName || ""),
-        )
-      );
+      return path.basename(mod.rule.extra.localPath) === path.basename(lookup.fileName ?? "");
     }
 
-    const ref = mod.rule?.reference;
-    if (!ref) return false;
-
-    // Check each available identifier
-    if (searchParams.tag && ref.tag === searchParams.tag) return true;
-    if (searchParams.fileMD5 && ref.fileMD5 === searchParams.fileMD5) return true;
-    if (searchParams.fileId && ref.repo?.fileId === searchParams.fileId) return true;
-    if (searchParams.logicalFileName && ref.logicalFileName === searchParams.logicalFileName)
-      return true;
-
-    return false;
+    return mod.rule?.reference != null && testModReference(lookup, mod.rule.reference);
   });
 };
 


### PR DESCRIPTION
The selector had a dead "find by modId" fast-path comparing the caller-supplied Nexus mod id against the installed Vortex mod id (different namespaces, never matched). Replace the hand-rolled per-field matcher with the shared testModReference over an IModLookupInfo, so there is one notion of reference identity and no mod-id confusion.

- getCollectionModByReference(state, lookup: IModLookupInfo); both callers (DownloadView, InstallManager) pass lookupFromDownload(download).
- fix the bundled-mod branch: symmetric basename compare (the old asymmetric one stripped the extension from only one side and never matched a real archive).
- add a makeLookup test-utils builder + selector tests (incl. a regression that a value equal to the installed Vortex mod id does not match).
- regenerate etc/vortex.api.md for the new signature.

This is the first bug found as part of the tests-first approach.

part of LAZ-483