### PR TITLE
unify event-based collection skip + add InstallDriver orchestration tests (483 WIP)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -3488,6 +3488,22 @@ interface IReducerSpec<T = {
     };
 }
 
+// @public
+interface IReferenceIdentifiers {
+    // (undocumented)
+    condition?: () => boolean;
+    // (undocumented)
+    fileId?: number;
+    // (undocumented)
+    fileIds?: string[];
+    // (undocumented)
+    fileNames?: string[];
+    // (undocumented)
+    gameId: string;
+    // (undocumented)
+    modId?: number;
+}
+
 // @public (undocumented)
 interface IRegisteredExtension {
     // (undocumented)
@@ -5985,14 +6001,7 @@ function testModReference(mod: IMod | IModLookupInfo, reference: IModReference, 
 }, fuzzyVersion?: boolean): boolean;
 
 // @public (undocumented)
-function testRefByIdentifiers(identifiers: {
-    gameId: string;
-    modId?: number;
-    fileId?: number;
-    fileNames?: string[];
-    fileIds?: string[];
-    condition?: () => boolean;
-}, ref: IModReference): boolean;
+function testRefByIdentifiers(identifiers: IReferenceIdentifiers, ref: IModReference): boolean;
 
 // @public (undocumented)
 type TestSupported = (files: string[], gameId: string, archivePath?: string, details?: ITestSupportedDetails) => PromiseLike<ISupportedResult>;
@@ -6125,6 +6134,7 @@ declare namespace types {
         IGameStored,
         IDeploymentManifest,
         IModLookupInfo,
+        IReferenceIdentifiers,
         IChoiceType,
         IFileListItem,
         IMod,

--- a/packages/vortex-api/docs/EVENTS.md
+++ b/packages/vortex-api/docs/EVENTS.md
@@ -155,7 +155,6 @@ Register event handlers inside `context.once()` to ensure all extensions are loa
 | `did-install-collection`          | -                                  | Collection was installed            |
 | `did-download-collection`         | -                                  | Collection was downloaded           |
 | `collection-postprocess-complete` | -                                  | Collection post-processing done     |
-| `collection-mod-skipped`          | -                                  | A mod in the collection was skipped |
 | `submit-collection`               | -                                  | Submit collection to Nexus          |
 | `update-conflicts-and-rules`      | -                                  | Async. Update collection conflicts  |
 

--- a/src/renderer/src/extensions/collections/actions/persistent.ts
+++ b/src/renderer/src/extensions/collections/actions/persistent.ts
@@ -10,9 +10,18 @@ export const updateCollectionInfo = createAction(
   }),
 );
 
+// A revision as we cache it: optional fields with a reduced `collection` (the full collection is
+// cached separately via updateCollectionInfo and rehydrated from the slug on read), so we can
+// store an { id, slug } collection pointer without supplying a full ICollection. The clean fix
+// is to make `IRevision.collection` partial upstream in node-nexus-api (where IRevision is
+// defined); that repo is out of scope for LAZ-483, so we model the reduced shape here.
+type PartialRevisionInfo = Partial<Omit<IRevision, "collection">> & {
+  collection?: Partial<ICollection>;
+};
+
 export const updateRevisionInfo = createAction(
   "UPDATE_REVISION_INFO",
-  (revisionId: number, revisionInfo: Partial<IRevision>, timestamp: number) => ({
+  (revisionId: number, revisionInfo: PartialRevisionInfo, timestamp: number) => ({
     revisionId,
     revisionInfo,
     timestamp,

--- a/src/renderer/src/extensions/collections/postprocessCollection.ts
+++ b/src/renderer/src/extensions/collections/postprocessCollection.ts
@@ -2,33 +2,35 @@ import * as _ from "lodash";
 
 import * as actions from "../../actions";
 import { log } from "../../logging";
-import type * as types from "../../types/api";
-import * as util from "../../util/api";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import { batchDispatch, toPromise } from "../../util/util";
+import type { IMod, IModRule } from "../mod_management/types/IMod";
+import { findModByRef } from "../mod_management/util/findModByRef";
+import testModReference from "../mod_management/util/testModReference";
 import type { ICollection } from "./types/ICollection";
 import type { IExtensionFeature } from "./util/extension";
 import { findExtensions } from "./util/extension";
 import { parseGameSpecifics } from "./util/gameSupport";
 
 function applyCollectionRules(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   collection: ICollection,
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
 ) {
   const batch = (collection.modRules ?? []).reduce((prev, rule) => {
-    const sourceMod = util.findModByRef(rule.source, mods);
+    const sourceMod = findModByRef(rule.source, mods);
     if (sourceMod !== undefined) {
-      const destMod = util.findModByRef(rule.reference, mods);
+      const destMod = findModByRef(rule.reference, mods);
 
       let exists: boolean = false;
       if (destMod !== undefined) {
         // replace existing rules between these two mods
         const exSourceRules = (sourceMod.rules ?? []).filter(
-          (iter) =>
-            ["before", "after"].includes(iter.type) &&
-            util.testModReference(destMod, iter.reference),
+          (iter: IModRule) =>
+            ["before", "after"].includes(iter.type) && testModReference(destMod, iter.reference),
         );
-        exSourceRules.forEach((exSourceRule) => {
+        exSourceRules.forEach((exSourceRule: IModRule) => {
           const copy = JSON.parse(JSON.stringify(exSourceRule));
           delete copy.reference.idHint;
           if (!exists && _.isEqual(copy, rule)) {
@@ -38,11 +40,10 @@ function applyCollectionRules(
           }
         });
         const exDestRules = (destMod.rules ?? []).filter(
-          (iter) =>
-            ["before", "after"].includes(iter.type) &&
-            util.testModReference(sourceMod, iter.reference),
+          (iter: IModRule) =>
+            ["before", "after"].includes(iter.type) && testModReference(sourceMod, iter.reference),
         );
-        exDestRules.forEach((exDestRule) => {
+        exDestRules.forEach((exDestRule: IModRule) => {
           prev.push(actions.removeModRule(gameId, destMod.id, exDestRule));
         });
         rule.reference = {
@@ -64,7 +65,7 @@ function applyCollectionRules(
     return prev;
   }, []);
 
-  util.batchDispatch(api.store, batch);
+  batchDispatch(api.store, batch);
 }
 
 /**
@@ -73,17 +74,17 @@ function applyCollectionRules(
  * exists
  */
 export async function postprocessCollection(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
-  collectionMod: types.IMod,
+  collectionMod: IMod,
   collection: ICollection,
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
 ) {
   log("info", "postprocess collection");
   applyCollectionRules(api, gameId, collection, mods);
   try {
     // TODO: replace this with a call to the awaitModsDeployment API extension method
-    await util.toPromise((cb) =>
+    await toPromise((cb) =>
       api.events.emit("deploy-mods", cb, undefined, undefined, {
         isCollectionPostprocessCall: true,
       }),

--- a/src/renderer/src/extensions/collections/util/InfoCache.ts
+++ b/src/renderer/src/extensions/collections/util/InfoCache.ts
@@ -4,9 +4,12 @@ import type { ICollection, IRevision } from "@nexusmods/nexus-api";
 import { getErrorCode, unknownToError } from "@vortex/shared";
 
 import { log } from "../../../logging";
-import type * as types from "../../../types/api";
-import * as util from "../../../util/api";
+import type { IExtensionApi, ThunkStore } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
 import * as selectors from "../../../util/selectors";
+import { getSafe } from "../../../util/storeHelper";
+import { batchDispatch } from "../../../util/util";
+import type { IMod } from "../../mod_management/types/IMod";
 import { updateCollectionInfo, updateRevisionInfo } from "../actions/persistent";
 import { CACHE_EXPIRE_MS, MOD_TYPE } from "../constants";
 import type { ICollectionModRule } from "../types/ICollection";
@@ -20,16 +23,16 @@ import { readCollection } from "./readCollection";
  * behavior were to change, the way InfoCache gets used would become invalid!
  */
 class InfoCache {
-  private mApi: types.IExtensionApi;
+  private mApi: IExtensionApi;
   private mCacheRevRequests: { [revId: string]: Promise<IRevision> } = {};
   private mCacheColRequests: { [revId: string]: Promise<ICollection> } = {};
   private mCacheColRules: { [revId: string]: Promise<ICollectionModRule[]> } = {};
 
-  constructor(api: types.IExtensionApi) {
+  constructor(api: IExtensionApi) {
     this.mApi = api;
   }
 
-  public async getCollectionModRules(revisionId: number, collection: types.IMod, gameId: string) {
+  public async getCollectionModRules(revisionId: number, collection: IMod, gameId: string) {
     const cacheId = revisionId ?? collection.id;
     if (this.mCacheColRules[cacheId] === undefined) {
       this.mCacheColRules[cacheId] = this.cacheCollectionModRules(revisionId, collection, gameId);
@@ -39,11 +42,10 @@ class InfoCache {
   }
 
   public async getCollectionInfo(slug: string, forceFetch?: boolean): Promise<ICollection> {
-    const { store } = this.mApi;
     if (slug === undefined) {
       return;
     }
-    const collections = store.getState().persistent.collections.collections ?? {};
+    const collections = this.mApi.getState().persistent.collections?.collections ?? {};
     if (
       forceFetch ||
       collections[slug]?.timestamp === undefined ||
@@ -71,7 +73,7 @@ class InfoCache {
       log("debug", "dropping outdated collections cache", {
         ids: collectionDrops,
       });
-      util.batchDispatch(
+      batchDispatch(
         store,
         collectionDrops.map((coll) => updateCollectionInfo(coll, undefined, undefined)),
       );
@@ -81,7 +83,7 @@ class InfoCache {
       log("debug", "dropping outdated revision cache", {
         ids: revisionDrops,
       });
-      util.batchDispatch(
+      batchDispatch(
         store,
         revisionDrops.map((rev) => updateRevisionInfo(Number(rev), undefined, undefined)),
       );
@@ -104,10 +106,9 @@ class InfoCache {
     collectionSlug: string,
     revisionNumber: number,
     fetchBehavior: "allow" | "avoid" | "force" = "allow",
-  ): Promise<IRevision> {
-    const { store } = this.mApi;
+  ): Promise<IRevision | undefined> {
     const revisions: { [id: string]: { info: IRevision; timestamp: number } } =
-      store.getState().persistent.collections.revisions ?? {};
+      this.mApi.getState().persistent.collections.revisions ?? {};
     if (
       fetchBehavior === "force" ||
       revisions[revisionId]?.timestamp === undefined ||
@@ -118,7 +119,7 @@ class InfoCache {
     }
 
     if (!revisions[revisionId]?.info?.collection) {
-      return Promise.resolve(undefined);
+      return;
     }
 
     const collectionInfo = await this.getCollectionInfo(revisions[revisionId].info.collection.slug);
@@ -132,7 +133,8 @@ class InfoCache {
   }
 
   private fetchRevisionInfo(
-    revisions,
+    // keyed by revision id
+    revisions: Record<string, { info: IRevision; timestamp: number }>,
     revisionId: number,
     collectionSlug: string,
     revisionNumber: number,
@@ -152,17 +154,11 @@ class InfoCache {
 
   private async cacheCollectionModRules(
     revisionId: number,
-    collection: types.IMod,
+    collection: IMod,
     gameId: string,
   ): Promise<ICollectionModRule[]> {
-    const store = this.mApi.store;
-    const state = store.getState();
-
-    const mods: { [modId: string]: types.IMod } = util.getSafe(
-      state,
-      ["persistent", "mods", gameId],
-      {},
-    );
+    const state = this.mApi.getState();
+    const mods: { [modId: string]: IMod } = getSafe(state, ["persistent", "mods", gameId], {});
     const colMod =
       collection ??
       Object.values(mods).find(
@@ -208,9 +204,9 @@ class InfoCache {
   }
 
   private updateRevisionCacheState(
-    store: types.ThunkStore<any>,
+    store: ThunkStore<IState>,
     revisionId: number,
-    revisionInfo: any,
+    revisionInfo: IRevision,
     now: number,
   ): void {
     // we cache revision info and collection info separately to reduce duplication
@@ -218,6 +214,8 @@ class InfoCache {
     store.dispatch(
       updateCollectionInfo(revisionInfo.collection.id.toString(), revisionInfo.collection, now),
     );
+    // the full collection is cached separately above; the revision keeps only an { id, slug }
+    // pointer (getRevisionInfo rehydrates the full collection from the slug on read)
     store.dispatch(
       updateRevisionInfo(
         revisionId,

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Orchestration tests for InstallDriver, driven through the fake-api harness
+ * (test-utils/builders makeDriverHarness). The driver is a singleton reacting to a global
+ * event bus while mutating a single redux install session, so the tests are grouped by the
+ * USER JOURNEY that exercises a given event surface (session lifecycle, premium install,
+ * churn, completion decision) rather than by individual handler. Each journey states only the
+ * member rule that distinguishes it and reuses the shared builders for everything else.
+ *
+ * Skip attribution (premium/automatic and free-user) is no longer the driver's concern - it
+ * moved to markCollectionMemberSkipped (see collectionSkip.test.ts).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  makeCollectionModInfo,
+  makeDownload,
+  makeDriverHarness,
+  makeFileListItem,
+  makeInstallerChoices,
+  makeMod,
+  makePatches,
+  makeReference,
+  makeRule,
+  resetHarnessRegistries,
+} from "../../../test-utils/builders";
+import { modRuleId } from "../../../util/collectionInstallSession";
+import type { IDownload } from "../../download_management/types/IDownload";
+import type { IMod, IModRule } from "../../mod_management/types/IMod";
+import type { IProfile } from "../../profile_management/types/IProfile";
+import { MOD_TYPE } from "../constants";
+import { applyPatches } from "./binaryPatching";
+import InstallDriver from "./InstallDriver";
+
+// applyPatches is a single named collaborator that does binary file patching (fs). Stubbing it
+// at that boundary lets the member install-spec path run without touching disk while we still
+// assert it is invoked with the rule's patch info.
+vi.mock("./binaryPatching", () => ({ applyPatches: vi.fn() }));
+
+const GAME_ID = "skyrimse";
+
+const profile = {
+  id: "prof-1",
+  gameId: GAME_ID,
+  modState: {},
+  name: "test",
+} as unknown as IProfile;
+
+interface ICollectionFixture {
+  collection: IMod;
+  download: IDownload;
+}
+
+// Compose a collection mod + its finished archive download from the shared builders, deriving
+// archiveId / installationPath / localPath from the id so each journey states only its member
+// rule. The download's modInfo omits collectionSlug, so initCollectionInfo short-circuits
+// instead of hitting the network.
+function makeCollectionFixture(opts: {
+  id: string;
+  rule: IModRule;
+  collectionId?: number;
+}): ICollectionFixture {
+  const { id, rule, collectionId = 1 } = opts;
+  const archiveId = `dl-${id}`;
+  const collection = makeMod({
+    id,
+    type: MOD_TYPE,
+    archiveId,
+    installationPath: `mods/${id}`,
+    rules: [rule],
+  });
+  const download = makeDownload({
+    id: archiveId,
+    state: "finished",
+    localPath: `${id}.7z`,
+    modInfo: makeCollectionModInfo({ collectionId, gameId: GAME_ID }),
+  });
+  return { collection, download };
+}
+
+function harnessFor(fixture: ICollectionFixture) {
+  return makeDriverHarness(InstallDriver, {
+    mods: { [GAME_ID]: { [fixture.collection.id]: fixture.collection } },
+    downloads: { [fixture.download.id]: fixture.download },
+    profiles: { [profile.id]: profile },
+  });
+}
+
+// Build the harness and run start(profile, collection), returning the started harness.
+async function started(fixture: ICollectionFixture) {
+  const h = harnessFor(fixture);
+  await h.driver.start(profile, fixture.collection);
+  return h;
+}
+
+afterEach(() => {
+  resetHarnessRegistries();
+  vi.clearAllMocks();
+});
+
+// a tag-identified required member (no description, so a member did-install-mod skips the
+// install-spec side-effects, which are covered by the install-spec journey)
+const memberRule: IModRule = makeRule({
+  type: "requires",
+  reference: makeReference({ tag: "mod-a" }),
+});
+const defaultFixture = makeCollectionFixture({ id: "col-1", rule: memberRule });
+const installedMemberMod: IMod = makeMod({
+  id: "installed-a",
+  attributes: { referenceTag: "mod-a" },
+});
+
+describe("InstallDriver session lifecycle", () => {
+  it("constructs in the prepare step", () => {
+    const h = makeDriverHarness(InstallDriver);
+    expect(h.driver.step).toBe("prepare");
+  });
+
+  it("start() opens an active session that tracks the collection's member rule", async () => {
+    const h = await started(defaultFixture);
+
+    const session = h.getState().session.collections.activeSession;
+    expect(session).toBeDefined();
+    expect(session?.collectionId).toBe("col-1");
+    expect(session?.mods[modRuleId(memberRule)]).toBeDefined();
+    expect(h.driver.currentSessionId).toBe(session?.sessionId);
+  });
+
+  it("refuses to start a second collection while one is still installing", async () => {
+    const h = await started(defaultFixture);
+    const firstSessionId = h.driver.currentSessionId;
+
+    const other = makeMod({ id: "col-2", type: MOD_TYPE, archiveId: "dl-2" });
+    await h.driver.start(profile, other);
+
+    // the active session is still the first collection's; the second start was rejected
+    expect(h.driver.currentSessionId).toBe(firstSessionId);
+    expect(h.getState().session.collections.activeSession?.collectionId).toBe("col-1");
+  });
+});
+
+describe("InstallDriver premium install journey", () => {
+  it("counts a member mod toward installedMods when it finishes installing", async () => {
+    const h = await started(defaultFixture);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
+    });
+
+    h.emit("did-install-mod", GAME_ID, defaultFixture.download.id, installedMemberMod.id);
+
+    expect(h.driver.installedMods.map((mod) => mod.id)).toContain(installedMemberMod.id);
+  });
+
+  it("is idempotent for a duplicate did-install-mod (counts the member once)", async () => {
+    // churn / out-of-order: the same install event can arrive more than once
+    const h = await started(defaultFixture);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
+    });
+
+    h.emit("did-install-mod", GAME_ID, defaultFixture.download.id, installedMemberMod.id);
+    h.emit("did-install-mod", GAME_ID, defaultFixture.download.id, installedMemberMod.id);
+
+    expect(h.driver.installedMods.filter((mod) => mod.id === installedMemberMod.id)).toHaveLength(
+      1,
+    );
+  });
+
+  it("applies the rule's install spec to a member mod when it finishes installing", async () => {
+    // a member with a description triggers the side-effect block: the rule's patches /
+    // installer choices / file list are applied + stamped onto the installed mod
+    const installerChoices = makeInstallerChoices();
+    const patches = makePatches();
+    const fileList = [makeFileListItem()];
+    const sfxRule: IModRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-sfx", description: "Mod SFX" }),
+      installerChoices,
+      patches,
+      fileList,
+    });
+    const sfx = makeCollectionFixture({ id: "col-sfx", rule: sfxRule, collectionId: 2 });
+    const installedSfxMod = makeMod({
+      id: "installed-sfx",
+      attributes: { referenceTag: "mod-sfx" },
+    });
+
+    const h = await started(sfx);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installedSfxMod.id] = installedSfxMod;
+    });
+
+    h.emit("did-install-mod", GAME_ID, sfx.download.id, installedSfxMod.id);
+
+    // binary patches applied against the installed mod (applyPatches is stubbed)
+    expect(applyPatches).toHaveBeenCalledWith(
+      expect.anything(),
+      sfx.collection,
+      GAME_ID,
+      "Mod SFX",
+      installedSfxMod.id,
+      patches,
+    );
+    // the install spec is stamped onto the mod (read back through the real mods reducer)
+    const installed = h.getState().persistent.mods[GAME_ID][installedSfxMod.id];
+    expect(installed.attributes?.installerChoices).toEqual(installerChoices);
+    expect(installed.attributes?.patches).toEqual(patches);
+    expect(installed.attributes?.fileList).toEqual(fileList);
+  });
+});
+
+describe("InstallDriver churn (events from non-members / other collections)", () => {
+  it("does not let a non-member mod's did-install-mod touch the active install", async () => {
+    // a standalone mod (or a different collection's mod) finishing install must not be
+    // attributed to the active collection. Use the description-bearing sfx collection so that a
+    // mis-attribution WOULD run the install-spec side-effects (a stamped attribute / dispatch),
+    // making the "no change" assertions load-bearing rather than vacuous.
+    const sfxRule: IModRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-sfx", description: "Mod SFX" }),
+      installerChoices: makeInstallerChoices(),
+    });
+    const sfx = makeCollectionFixture({ id: "col-sfx", rule: sfxRule, collectionId: 2 });
+    const h = await started(sfx);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID]["foreign"] = makeMod({
+        id: "foreign",
+        attributes: { referenceTag: "not-a-member" },
+      });
+    });
+    const dispatchedBefore = h.dispatched.length;
+
+    h.emit("did-install-mod", GAME_ID, sfx.download.id, "foreign");
+
+    expect(h.driver.installedMods).toHaveLength(0);
+    expect(h.dispatched.length).toBe(dispatchedBefore);
+    expect(h.getState().persistent.mods[GAME_ID]["foreign"].attributes?.installerChoices).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("InstallDriver completion decision", () => {
+  // isInstallComplete is the completion DECISION, split out of onDidInstallDependencies so it
+  // is testable without the postprocessing side-effect (staging path / readCollection). The
+  // collection reaches review only when this returns true.
+
+  it("reports complete once every required member is installed", async () => {
+    const h = await started(defaultFixture);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
+    });
+
+    expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+
+  it("reports incomplete while a required member is still missing", async () => {
+    const h = await started(defaultFixture);
+
+    expect(h.driver.isInstallComplete(false)).toBe(false);
+  });
+
+  it("treats an ignored required member as resolved", async () => {
+    // a member that was skipped (durable ignored flag) must not block completion, even though
+    // it was never installed - otherwise a skipped required mod leaves the collection stuck
+    const ignoredRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-ign" }),
+      ignored: true,
+    });
+    const h = await started(makeCollectionFixture({ id: "col-ign", rule: ignoredRule }));
+
+    expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+});

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -1,35 +1,37 @@
 /**
- * Orchestration tests for InstallDriver, driven through the fake-api harness
- * (test-utils/builders makeDriverHarness). The driver is a singleton reacting to a global
- * event bus while mutating a single redux install session, so the tests are grouped by the
- * USER JOURNEY that exercises a given event surface (session lifecycle, premium install,
- * churn, completion decision) rather than by individual handler. Each journey states only the
- * member rule that distinguishes it and reuses the shared builders for everything else.
+ * Orchestration tests for InstallDriver, driven through the fake-api harness via the
+ * driverTest `makeDriver` fixture. The driver is a singleton reacting to a global event bus
+ * while mutating a single redux install session, so the tests are grouped by the USER JOURNEY
+ * that exercises a given event surface (session lifecycle, premium install, churn, completion
+ * decision) rather than by individual handler. Each journey states only the member rule that
+ * distinguishes it and reuses the shared builders for everything else.
+ *
+ * The harness lifecycle (build + start + the worker-global registry/mock teardown) comes from
+ * the shared driverTest/harnessTest fixtures, so there is no hand-written afterEach to forget.
  *
  * Skip attribution (premium/automatic and free-user) is no longer the driver's concern - it
  * moved to markCollectionMemberSkipped (see collectionSkip.test.ts).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
 import {
+  type IDriverHarness,
   makeCollectionModInfo,
   makeDownload,
-  makeDriverHarness,
   makeFileListItem,
   makeInstallerChoices,
   makeMod,
   makePatches,
   makeReference,
   makeRule,
-  resetHarnessRegistries,
 } from "../../../test-utils/builders";
+import { test as driverTest } from "../../../test-utils/driverTest";
 import { modRuleId } from "../../../util/collectionInstallSession";
 import type { IDownload } from "../../download_management/types/IDownload";
 import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import type { IProfile } from "../../profile_management/types/IProfile";
 import { MOD_TYPE } from "../constants";
 import { applyPatches } from "./binaryPatching";
-import InstallDriver from "./InstallDriver";
 
 // applyPatches is a single named collaborator that does binary file patching (fs). Stubbing it
 // at that boundary lets the member install-spec path run without touching disk while we still
@@ -77,24 +79,24 @@ function makeCollectionFixture(opts: {
   return { collection, download };
 }
 
-function harnessFor(fixture: ICollectionFixture) {
-  return makeDriverHarness(InstallDriver, {
-    mods: { [GAME_ID]: { [fixture.collection.id]: fixture.collection } },
-    downloads: { [fixture.download.id]: fixture.download },
-    profiles: { [profile.id]: profile },
-  });
-}
-
-// Build the harness and run start(profile, collection), returning the started harness.
-async function started(fixture: ICollectionFixture) {
-  const h = harnessFor(fixture);
-  await h.driver.start(profile, fixture.collection);
-  return h;
-}
-
-afterEach(() => {
-  resetHarnessRegistries();
-  vi.clearAllMocks();
+// extend the shared harness test with a driver fixture: build the harness for a collection
+// fixture, run start(), and hand back the started harness (registry/mock teardown is inherited)
+const test = driverTest.extend<{
+  startCollection: (fixture: ICollectionFixture) => Promise<IDriverHarness>;
+}>({
+  // build the harness via the inherited makeDriver fixture, run start(), and hand back the
+  // started harness (the registry/mock teardown is inherited from harnessTest)
+  startCollection: async ({ makeDriver }, use) => {
+    await use(async (fixture: ICollectionFixture) => {
+      const h = makeDriver({
+        mods: { [GAME_ID]: { [fixture.collection.id]: fixture.collection } },
+        downloads: { [fixture.download.id]: fixture.download },
+        profiles: { [profile.id]: profile },
+      });
+      await h.driver.start(profile, fixture.collection);
+      return h;
+    });
+  },
 });
 
 // a tag-identified required member (no description, so a member did-install-mod skips the
@@ -110,13 +112,15 @@ const installedMemberMod: IMod = makeMod({
 });
 
 describe("InstallDriver session lifecycle", () => {
-  it("constructs in the prepare step", () => {
-    const h = makeDriverHarness(InstallDriver);
+  test("constructs in the prepare step", ({ makeDriver }) => {
+    const h = makeDriver();
     expect(h.driver.step).toBe("prepare");
   });
 
-  it("start() opens an active session that tracks the collection's member rule", async () => {
-    const h = await started(defaultFixture);
+  test("start() opens an active session that tracks the collection's member rule", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(defaultFixture);
 
     const session = h.getState().session.collections.activeSession;
     expect(session).toBeDefined();
@@ -125,8 +129,10 @@ describe("InstallDriver session lifecycle", () => {
     expect(h.driver.currentSessionId).toBe(session?.sessionId);
   });
 
-  it("refuses to start a second collection while one is still installing", async () => {
-    const h = await started(defaultFixture);
+  test("refuses to start a second collection while one is still installing", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(defaultFixture);
     const firstSessionId = h.driver.currentSessionId;
 
     const other = makeMod({ id: "col-2", type: MOD_TYPE, archiveId: "dl-2" });
@@ -139,8 +145,10 @@ describe("InstallDriver session lifecycle", () => {
 });
 
 describe("InstallDriver premium install journey", () => {
-  it("counts a member mod toward installedMods when it finishes installing", async () => {
-    const h = await started(defaultFixture);
+  test("counts a member mod toward installedMods when it finishes installing", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(defaultFixture);
     h.setState((draft) => {
       draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
     });
@@ -150,9 +158,11 @@ describe("InstallDriver premium install journey", () => {
     expect(h.driver.installedMods.map((mod) => mod.id)).toContain(installedMemberMod.id);
   });
 
-  it("is idempotent for a duplicate did-install-mod (counts the member once)", async () => {
+  test("is idempotent for a duplicate did-install-mod (counts the member once)", async ({
+    startCollection,
+  }) => {
     // churn / out-of-order: the same install event can arrive more than once
-    const h = await started(defaultFixture);
+    const h = await startCollection(defaultFixture);
     h.setState((draft) => {
       draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
     });
@@ -165,7 +175,9 @@ describe("InstallDriver premium install journey", () => {
     );
   });
 
-  it("applies the rule's install spec to a member mod when it finishes installing", async () => {
+  test("applies the rule's install spec to a member mod when it finishes installing", async ({
+    startCollection,
+  }) => {
     // a member with a description triggers the side-effect block: the rule's patches /
     // installer choices / file list are applied + stamped onto the installed mod
     const installerChoices = makeInstallerChoices();
@@ -184,7 +196,7 @@ describe("InstallDriver premium install journey", () => {
       attributes: { referenceTag: "mod-sfx" },
     });
 
-    const h = await started(sfx);
+    const h = await startCollection(sfx);
     h.setState((draft) => {
       draft.persistent.mods[GAME_ID][installedSfxMod.id] = installedSfxMod;
     });
@@ -209,7 +221,9 @@ describe("InstallDriver premium install journey", () => {
 });
 
 describe("InstallDriver churn (events from non-members / other collections)", () => {
-  it("does not let a non-member mod's did-install-mod touch the active install", async () => {
+  test("does not let a non-member mod's did-install-mod touch the active install", async ({
+    startCollection,
+  }) => {
     // a standalone mod (or a different collection's mod) finishing install must not be
     // attributed to the active collection. Use the description-bearing sfx collection so that a
     // mis-attribution WOULD run the install-spec side-effects (a stamped attribute / dispatch),
@@ -220,7 +234,7 @@ describe("InstallDriver churn (events from non-members / other collections)", ()
       installerChoices: makeInstallerChoices(),
     });
     const sfx = makeCollectionFixture({ id: "col-sfx", rule: sfxRule, collectionId: 2 });
-    const h = await started(sfx);
+    const h = await startCollection(sfx);
     h.setState((draft) => {
       draft.persistent.mods[GAME_ID]["foreign"] = makeMod({
         id: "foreign",
@@ -244,8 +258,8 @@ describe("InstallDriver completion decision", () => {
   // is testable without the postprocessing side-effect (staging path / readCollection). The
   // collection reaches review only when this returns true.
 
-  it("reports complete once every required member is installed", async () => {
-    const h = await started(defaultFixture);
+  test("reports complete once every required member is installed", async ({ startCollection }) => {
+    const h = await startCollection(defaultFixture);
     h.setState((draft) => {
       draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
     });
@@ -253,13 +267,15 @@ describe("InstallDriver completion decision", () => {
     expect(h.driver.isInstallComplete(false)).toBe(true);
   });
 
-  it("reports incomplete while a required member is still missing", async () => {
-    const h = await started(defaultFixture);
+  test("reports incomplete while a required member is still missing", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(defaultFixture);
 
     expect(h.driver.isInstallComplete(false)).toBe(false);
   });
 
-  it("treats an ignored required member as resolved", async () => {
+  test("treats an ignored required member as resolved", async ({ startCollection }) => {
     // a member that was skipped (durable ignored flag) must not block completion, even though
     // it was never installed - otherwise a skipped required mod leaves the collection stuck
     const ignoredRule = makeRule({
@@ -267,7 +283,7 @@ describe("InstallDriver completion decision", () => {
       reference: makeReference({ tag: "mod-ign" }),
       ignored: true,
     });
-    const h = await started(makeCollectionFixture({ id: "col-ign", rule: ignoredRule }));
+    const h = await startCollection(makeCollectionFixture({ id: "col-ign", rule: ignoredRule }));
 
     expect(h.driver.isInstallComplete(false)).toBe(true);
   });

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -23,9 +23,8 @@ import { discoveryByGame } from "../../gamemode_management/selectors";
 import { getGame } from "../../gamemode_management/util/getGame";
 import { addModRule, setFileOverride, setModAttribute } from "../../mod_management/actions/mods";
 import { installPathForGame } from "../../mod_management/selectors";
-import type { IMod, IModReference, IModRule } from "../../mod_management/types/IMod";
+import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findModByRef } from "../../mod_management/util/findModByRef";
-import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
 import renderModName from "../../mod_management/util/modName";
 import testModReference, {
   ruleInstallSpec,
@@ -102,36 +101,6 @@ class InstallDriver {
   }
   private get recommendedMods() {
     return this.mDependentMods.filter((m) => m.type === "recommends");
-  }
-
-  /**
-   * Mark a collection rule as ignored. Updates the transient install session and
-   * persists the decision durably via the rule's `ignored` flag. The session lives
-   * in state.session (not persisted), so without the durable flag a mid-install
-   * restart would rehydrate an ignored required mod as "pending" and the collection
-   * could never reach completion. startImpl()'s reconstruction reads `ignored` to
-   * restore the "ignored" status; the unfulfilled-rules and dependency-completion
-   * checks already treat ignored rules as resolved.
-   */
-  private markRuleIgnored(rule: IModRule) {
-    // user-initiated skip: write the session status and the durable flag together. Both
-    // are low-frequency, so they dispatch directly (no batching debouncer needed now that
-    // InstallManager is the single lifecycle writer). This intentionally does NOT go
-    // through planSessionWrite's protection: ignoring a mod is an explicit user decision
-    // that must take effect even if the mod already reached a terminal state (e.g. the
-    // user wants to stop the collection re-pulling it and then remove it manually).
-    const actions: any[] = [];
-    if (this.mCurrentSessionId) {
-      actions.push(
-        installActions.updateModStatus(this.mCurrentSessionId, modRuleId(rule), "ignored"),
-      );
-    }
-    if (this.mGameId !== undefined && this.mCollection !== undefined) {
-      actions.push(addModRule(this.mGameId, this.mCollection.id, { ...rule, ignored: true }));
-    }
-    if (actions.length > 0) {
-      batchDispatch(this.mApi.store, actions);
-    }
   }
 
   private completeInstallationTracking(success: boolean) {
@@ -256,75 +225,12 @@ class InstallDriver {
       this.mProgressDebouncer.schedule();
     });
 
-    api.events.on(
-      "free-user-skipped-download",
-      (identifiers: {
-        gameId: string;
-        modId?: number;
-        fileId?: number;
-        fileNames?: string[];
-        fileIds?: string[];
-      }) => {
-        const sanitize = (fileName: string) => fileName.toLowerCase().replace(/[^a-z]+/gi, "");
-        const rule = this.mDependentMods.find((r) => {
-          const condition = () => {
-            // So this is shit, but we need to account for the fact that the fileId may never match
-            //  due to incorrect update chains.
-            if (r.reference.versionMatch != null && isFuzzyVersion(r.reference.versionMatch)) {
-              if (
-                identifiers.modId == null ||
-                r.reference.repo?.modId !== identifiers.modId.toString()
-              ) {
-                return false;
-              }
-              const nameSet = new Set(identifiers.fileNames.map(sanitize));
-              if (identifiers.fileNames) {
-                if (!nameSet.has(sanitize(r.reference.logicalFileName))) {
-                  return false;
-                }
-              }
-              // If we made it this far, we have the correct modId and logicalFileName
-              //  should be good enough...
-              return true;
-            }
-          };
-          return testRefByIdentifiers({ ...identifiers, condition } as any, r.reference);
-        });
-        if (rule) {
-          this.markRuleIgnored(rule);
-        } else {
-          log("error", "could not find rule for skipped free user download", {
-            identifiers,
-          });
-        }
-      },
-    );
-
     // "downloading" (new downloads) and "downloaded" (imported/bundled downloads) are
     // now written by InstallManager, the single lifecycle writer for the session.
 
-    api.events.on("collection-mod-skipped", (reference: IModReference) => {
-      // Update tracking when a mod download is skipped (for both free and premium users)
-      const matchingRule = this.mDependentMods.find((rule) => {
-        // Match by tag (most reliable) or other identifiers
-        if (reference.tag && rule.reference.tag === reference.tag) {
-          return true;
-        }
-        if (reference.fileMD5 && rule.reference.fileMD5 === reference.fileMD5) {
-          return true;
-        }
-        if (
-          reference.logicalFileName &&
-          rule.reference.logicalFileName === reference.logicalFileName
-        ) {
-          return true;
-        }
-        return false;
-      });
-      if (matchingRule) {
-        this.markRuleIgnored(matchingRule);
-      }
-    });
+    // A skipped collection member (premium/automatic via InstallManager, or a free user via
+    // nexus_integration) is now marked ignored at the skip site via markCollectionMemberSkipped;
+    // the driver no longer listens for `collection-mod-skipped` / `free-user-skipped-download`.
 
     api.events.on(
       "will-install-dependencies",
@@ -624,6 +530,37 @@ class InstallDriver {
       this.mRevisionInfo?.collection;
   }
 
+  /**
+   * Whether the active collection has nothing left to install: every required rule (and, on the
+   * recommendations pass, every recommended rule too) is either installed or explicitly ignored.
+   * This is the completion DECISION, deliberately separate from the postprocessing side-effect
+   * (finalizeInstalledCollection) so it can be unit-tested without the staging-path / fs
+   * infrastructure. The two passes differ as before: the required pass demands an installed
+   * state, the recommendations pass only that the mod is present.
+   */
+  public isInstallComplete(recommendations: boolean): boolean {
+    if (this.mCollection === undefined || this.mGameId === undefined) {
+      return false;
+    }
+    const mods = this.mApi.getState().persistent.mods[this.mGameId] ?? {};
+    const rules = this.mCollection.rules ?? [];
+    if (!recommendations) {
+      const isInstalled = (rule: IModRule) => {
+        const mod = findModByRef(rule.reference, mods);
+        return mod != null && mod.state === "installed";
+      };
+      return !rules.some(
+        (rule) => rule.type === "requires" && rule.ignored !== true && !isInstalled(rule),
+      );
+    }
+    return !rules.some(
+      (rule) =>
+        ["requires", "recommends"].includes(rule.type) &&
+        rule.ignored !== true &&
+        findModByRef(rule.reference, mods) === undefined,
+    );
+  }
+
   private async onDidInstallDependencies(gameId: string, modId: string, recommendations: boolean) {
     const mods = this.mApi.getState().persistent.mods[gameId];
 
@@ -638,15 +575,7 @@ class InstallDriver {
 
       if (this.mCollection !== undefined) {
         if (!recommendations) {
-          const isInstalled = (rule: any) => {
-            const mod = findModByRef(rule.reference, mods);
-            return mod != null && mod?.state === "installed";
-          };
-          const filter = (rule) =>
-            rule.type === "requires" && rule["ignored"] !== true && isInstalled(rule) === false;
-
-          const incomplete = (this.mCollection.rules ?? []).find(filter);
-          if (incomplete === undefined) {
+          if (this.isInstallComplete(false)) {
             await this.initCollectionInfo();
             this.mStep = "review";
           } else {
@@ -658,17 +587,10 @@ class InstallDriver {
           this.triggerUpdate();
         } else {
           // We finished installing optional mods for the current collection - reset everything.
-          const filter = (rule) =>
-            ["requires", "recommends"].includes(rule.type) &&
-            rule["ignored"] !== true &&
-            findModByRef(rule.reference, mods) === undefined;
-
-          const incomplete = (this.mCollection.rules ?? []).find(filter);
-
           this.mProgressDebouncer.clear();
           this.mApi.dismissNotification(INSTALLING_NOTIFICATION_ID + modId);
 
-          if (incomplete === undefined) {
+          if (this.isInstallComplete(true)) {
             // revisit review screen
             await this.initCollectionInfo();
             this.mStep = "review";
@@ -680,59 +602,76 @@ class InstallDriver {
       }
     }
 
-    const stagingPath = installPathForGame(this.mApi.getState(), gameId);
+    await this.finalizeInstalledCollection(gameId, modId, mods);
+  }
+
+  /**
+   * Postprocessing side-effect after a dependency-install round: read the collection.json from
+   * the staging folder and apply its mod rules, then emit completion analytics. Kept separate
+   * from the completion DECISION (isInstallComplete) so the decision needs no fs/staging-path
+   * infrastructure. Errors here are expected on the platform where the collection was authored,
+   * so they are swallowed (with a failure-analytics debounce). The staging-path lookup is inside
+   * the try so a path-resolution failure follows the same swallow path.
+   */
+  private async finalizeInstalledCollection(
+    gameId: string,
+    modId: string,
+    mods: Record<string, IMod>,
+  ) {
     const mod = mods[modId];
-    if (mod !== undefined && mod.type === MOD_TYPE) {
-      try {
-        const collectionInfo: ICollection = await readCollection(
-          this.mApi,
-          path.join(stagingPath, mod.installationPath, "collection.json"),
-        );
+    if (mod === undefined || mod.type !== MOD_TYPE) {
+      return;
+    }
+    try {
+      const stagingPath = installPathForGame(this.mApi.getState(), gameId);
+      const collectionInfo: ICollection = await readCollection(
+        this.mApi,
+        path.join(stagingPath, mod.installationPath, "collection.json"),
+      );
 
-        // Signal postprocessing and yield to the event loop so the review
-        // dialog can render before the heavy deployment/parsing work begins.
-        this.mPostprocessing = true;
-        this.triggerUpdate();
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      // Signal postprocessing and yield to the event loop so the review
+      // dialog can render before the heavy deployment/parsing work begins.
+      this.mPostprocessing = true;
+      this.triggerUpdate();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-        await postprocessCollection(this.mApi, gameId, mod, collectionInfo, mods);
+      await postprocessCollection(this.mApi, gameId, mod, collectionInfo, mods);
 
-        this.mPostprocessing = false;
+      this.mPostprocessing = false;
 
-        // Refresh again so that postprocessing changes are reflected in the UI.
-        // (and have the finalization step cleared)
-        this.triggerUpdate();
+      // Refresh again so that postprocessing changes are reflected in the UI.
+      // (and have the finalization step cleared)
+      this.triggerUpdate();
 
-        /* COLLECTIONS COMPLETED ANALYTICS */
+      /* COLLECTIONS COMPLETED ANALYTICS */
 
-        const nexusIds = nexusIdsFromDownloadId(this.mApi.getState(), this.mCollection.archiveId);
+      const nexusIds = nexusIdsFromDownloadId(this.mApi.getState(), this.mCollection.archiveId);
 
-        const duration_ms = Date.now() - this.mTimeStarted;
+      const duration_ms = Date.now() - this.mTimeStarted;
 
-        this.mApi.events.emit(
-          "analytics-track-mixpanel-event",
-          new CollectionsInstallationCompletedEvent(
-            nexusIds.collectionId,
-            nexusIds.revisionId,
-            nexusIds.numericGameId,
-            this.installedMods.length,
-            duration_ms,
-          ),
-        );
+      this.mApi.events.emit(
+        "analytics-track-mixpanel-event",
+        new CollectionsInstallationCompletedEvent(
+          nexusIds.collectionId,
+          nexusIds.revisionId,
+          nexusIds.numericGameId,
+          this.installedMods.length,
+          duration_ms,
+        ),
+      );
 
-        // this.mApi.events.emit('analytics-track-event-with-payload', 'Collection Installation Completed', {
-        //   collection_slug: this.collectionSlug,
-        //   collection_revision_number: this.revisionNumber
-        // });
-      } catch (err) {
-        this.mPostprocessing = false;
-        log(
-          "info",
-          "Failed to apply mod rules from collection. This is normal if this is the " +
-            "platform where the collection has been created.",
-        );
-        this.mDebounce.schedule(undefined, this.collectionSlug, this.revisionNumber, err);
-      }
+      // this.mApi.events.emit('analytics-track-event-with-payload', 'Collection Installation Completed', {
+      //   collection_slug: this.collectionSlug,
+      //   collection_revision_number: this.revisionNumber
+      // });
+    } catch (err) {
+      this.mPostprocessing = false;
+      log(
+        "info",
+        "Failed to apply mod rules from collection. This is normal if this is the " +
+          "platform where the collection has been created.",
+      );
+      this.mDebounce.schedule(undefined, this.collectionSlug, this.revisionNumber, err);
     }
   }
 

--- a/src/renderer/src/extensions/collections/util/gameSupport/gamebryo.tsx
+++ b/src/renderer/src/extensions/collections/util/gameSupport/gamebryo.tsx
@@ -8,10 +8,15 @@ import { useSelector, useStore } from "react-redux";
 
 import { Spinner, tooltip } from "../../../../controls/api";
 import { log } from "../../../../logging";
-import type * as types from "../../../../types/api";
-import * as util from "../../../../util/api";
+import type { IExtensionApi } from "../../../../types/IExtensionContext";
+import type { IState } from "../../../../types/IState";
 import * as fs from "../../../../util/fs";
+import type { TFunction } from "../../../../util/i18n";
 import * as selectors from "../../../../util/selectors";
+import { getSafe } from "../../../../util/storeHelper";
+import { batchDispatch } from "../../../../util/util";
+import type { IMod } from "../../../mod_management/types/IMod";
+import { findModByRef } from "../../../mod_management/util/findModByRef";
 import type { ICollection } from "../../types/ICollection";
 import type { IExtendedInterfaceProps } from "../../types/IExtendedInterfaceProps";
 
@@ -22,7 +27,7 @@ interface IGamebryoLO {
 }
 
 function getEnabledPlugins(
-  state: types.IState,
+  state: IState,
   plugins: string[],
 ): Array<{ name: string; enabled: boolean }> {
   const gamebryoLO: { [id: string]: IGamebryoLO } = state["loadOrder"];
@@ -72,7 +77,7 @@ export interface ICollectionGamebryo {
 async function getIncludedPlugins(
   gameId: string,
   stagingPath: string,
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
   modIds: string[],
 ): Promise<string[]> {
   const extensions = ["fallout4", "skyrimse"].includes(gameId)
@@ -105,11 +110,11 @@ async function getIncludedPlugins(
 }
 
 export async function generate(
-  state: types.IState,
+  state: IState,
   gameId: string,
   stagingPath: string,
   modIds: string[],
-  mods: { [modId: string]: types.IMod },
+  mods: { [modId: string]: IMod },
 ): Promise<ICollectionGamebryo> {
   const includedPlugins: string[] = await getIncludedPlugins(gameId, stagingPath, mods, modIds);
 
@@ -139,10 +144,10 @@ function refName(iter: string | { name: string }): string {
 }
 
 export async function parser(
-  api: types.IExtensionApi,
+  api: IExtensionApi,
   gameId: string,
   collection: ICollection,
-  collectionMod: types.IMod,
+  collectionMod: IMod,
 ) {
   const state: IStateWithLootLists = api.getState();
 
@@ -162,7 +167,7 @@ export async function parser(
 
   // set up groups and their rules (skipped if user opted out)
   if (!skipPluginRules && Array.isArray(collection.pluginRules?.groups)) {
-    util.batchDispatch(
+    batchDispatch(
       api.store,
       collection.pluginRules.groups.reduce((prev, group) => {
         const isNew =
@@ -192,7 +197,7 @@ export async function parser(
 
   const collectionModIds = collectionMod.rules
     .filter((rule) => ["requires", "recommends"].includes(rule.type))
-    .map((rule) => util.findModByRef(rule.reference, mods))
+    .map((rule) => findModByRef(rule.reference, mods))
     .filter((mod) => !!mod)
     .map((mod) => mod.id);
 
@@ -202,7 +207,7 @@ export async function parser(
     collection.plugins.find((plugin) => plugin.name === pluginName && plugin.enabled) !== undefined;
 
   // set up plugins and their rules
-  util.batchDispatch(
+  batchDispatch(
     api.store,
     includedPlugins.map((plugin) => {
       return {
@@ -228,7 +233,7 @@ export async function parser(
     return;
   }
 
-  util.batchDispatch(
+  batchDispatch(
     api.store,
     (collection.pluginRules?.plugins ?? []).reduce((prev, plugin) => {
       const existing = userlist.plugins.find(
@@ -250,7 +255,7 @@ export async function parser(
         (plugin[type] || []).forEach((ref) => {
           const match = (iter) => refName(iter).toUpperCase() === ref.toUpperCase();
 
-          if (util.getSafe(existing, [lootType], []).find(match) === undefined) {
+          if (getSafe(existing, [lootType], []).find(match) === undefined) {
             prev.push({
               type: "ADD_USERLIST_RULE",
               payload: {
@@ -328,7 +333,7 @@ interface ILOOTList {
   groups: ILOOTGroup[];
 }
 
-type IStateWithLootLists = types.IState & {
+type IStateWithLootLists = IState & {
   userlist?: ILOOTList;
   masterlist?: ILOOTList;
 };
@@ -349,7 +354,7 @@ function ruleId(rule: string | ILootReference): string {
   }
 }
 
-function ruleType(t: types.TFunction, type: string): string {
+function ruleType(t: TFunction, type: string): string {
   switch (type) {
     case "after":
       return t("after");
@@ -374,12 +379,12 @@ function renderRefName(rule: IRule): string {
 }
 
 interface IPluginRuleProps {
-  t: types.TFunction;
+  t: TFunction;
   rule: IRule;
   onRemove: (rule: IRule) => void;
 }
 
-function renderType(t: types.TFunction, type: string) {
+function renderType(t: TFunction, type: string) {
   if (type === "assigned") {
     return t("assigned to group");
   } else {
@@ -428,7 +433,7 @@ export function Interface(props: IExtendedInterfaceProps): JSX.Element {
   }>(null);
   const store = useStore();
   const gameId = useSelector(selectors.activeGameId);
-  const mods = useSelector((selState: types.IState) => selState.persistent.mods[gameId]);
+  const mods = useSelector((selState: IState) => selState.persistent.mods[gameId]);
   const userlist: ILOOTList = useSelector((selState: any) => selState.userlist);
 
   const state = store.getState();

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -85,6 +85,7 @@ import {
 } from "../../util/collectionInstallSessionSelectors";
 import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
 import { sessionWriteForDependency } from "../../util/collectionSessionWrite";
+import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import ConcurrencyLimiter from "../../util/ConcurrencyLimiter";
 import {
   DataInvalid,
@@ -837,8 +838,9 @@ class InstallManager {
       this.mActiveInstalls.delete(installKey);
     }
 
-    // Notify InstallDriver to update tracking status
-    api.events.emit("collection-mod-skipped", dep.reference);
+    // Mark the skipped member ignored directly against the active session (collections is core
+    // now, so no event round-trip through the InstallDriver is needed).
+    markCollectionMemberSkipped(api, { reference: dep.reference });
 
     // See if we can advance the phase
     this.maybeAdvancePhase(sourceModId, api);

--- a/src/renderer/src/extensions/mod_management/util/testModReference.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.ts
@@ -373,15 +373,22 @@ function testRef(
   return true;
 }
 
+/**
+ * The loose Nexus identifiers a reference can be matched against (a mod page + file ids/names),
+ * plus an optional caller-supplied fallback predicate. Shared so callers do not re-declare the
+ * shape inline.
+ */
+export interface IReferenceIdentifiers {
+  gameId: string;
+  modId?: number;
+  fileId?: number;
+  fileNames?: string[];
+  fileIds?: string[];
+  condition?: () => boolean;
+}
+
 export function testRefByIdentifiers(
-  identifiers: {
-    gameId: string;
-    modId?: number;
-    fileId?: number;
-    fileNames?: string[];
-    fileIds?: string[];
-    condition?: () => boolean;
-  },
+  identifiers: IReferenceIdentifiers,
   ref: IModReference,
 ): boolean {
   if (identifiers == null || typeof identifiers !== "object" || Array.isArray(identifiers)) {

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -36,6 +36,7 @@ import type { IModLookupResult } from "../../types/IModLookupResult";
 import type { IState } from "../../types/IState";
 import { getApplication } from "../../util/application";
 import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
+import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import {
   DataInvalid,
   HTTPError,
@@ -1782,7 +1783,9 @@ function onSkip(api: IExtensionApi, inputUrl: string) {
           fileNames: Array.from(fileNames),
           fileIds: Array.from(fileIdSet),
         };
-        api.events.emit("free-user-skipped-download", itemIdentifiers);
+        // collections is now core, so the skip site dispatches the ignore directly against the
+        // active install session rather than emitting an event for the InstallDriver to handle
+        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
         queueItem.rej(new UserCanceled(true));
       })
       .catch((err) => {

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -7,6 +7,15 @@
  * and accepts a partial override - the Test Data Builder pattern - so a test only
  * states the fields it cares about.
  *
+ * The data builders (makeMod, makeRule, makeReference, makeSession, ...) are deliberately PLAIN
+ * FUNCTIONS, not vitest fixtures (test.extend). They are stateless, deterministic, and allocate
+ * nothing that needs teardown, and their whole value is the partial-override args - wrapping them
+ * as fixtures would only add indirection and lose that ergonomics. Fixtures earn their keep for
+ * per-test setup/teardown + laziness, which here applies only to the STATEFUL harness below
+ * (makeApiHarness / makeDriverHarness register a fake game in a worker-global registry that must
+ * be cleared between tests); that lifecycle is wrapped by the harnessTest / driverTest fixtures,
+ * not by these builders.
+ *
  * Test-only: nothing in the production tree imports this module.
  */
 import { EventEmitter } from "events";

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -9,16 +9,35 @@
  *
  * Test-only: nothing in the production tree imports this module.
  */
-import type { IDownload } from "../extensions/download_management/types/IDownload";
-import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
+import { EventEmitter } from "events";
+
+import { batch } from "redux-act";
+
+import type InstallDriver from "../extensions/collections/util/InstallDriver";
+import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
+import { modsReducer } from "../extensions/mod_management/reducers/mods";
+import type {
+  IChoiceType,
+  IFileListItem,
+  IMod,
+  IModPatches,
+  IModReference,
+  IModRule,
+} from "../extensions/mod_management/types/IMod";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
-import type { IProfileMod } from "../extensions/profile_management/types/IProfile";
+import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
+import trackingReducer from "../reducers/collectionInstallTracking";
 import type {
   CollectionModStatus,
   ICollectionInstallSession,
   ICollectionInstallState,
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
+import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../types/IDialog";
+import type { IExtensionApi } from "../types/IExtensionContext";
+import type { IGame } from "../types/IGame";
+import type { IState } from "../types/IState";
+import local from "../util/local";
 
 export function makeReference(overrides: Partial<IModReference> = {}): IModReference {
   return { tag: "ref-tag", ...overrides };
@@ -125,4 +144,277 @@ export function modsByRule(
   return result;
 }
 
+export function makeInstallerChoices(overrides: Partial<IChoiceType> = {}): IChoiceType {
+  return { type: "fomod", options: [], ...overrides };
+}
+
+export function makePatches(overrides: IModPatches = {}): IModPatches {
+  return { "meshes/example.nif": "deadbeefdeadbeef", ...overrides };
+}
+
+export function makeFileListItem(overrides: Partial<IFileListItem> = {}): IFileListItem {
+  return { path: "textures/example.dds", md5: "abc123", ...overrides };
+}
+
+export function makeModInfo(overrides: Partial<IModInfo> = {}): IModInfo {
+  return { ...overrides };
+}
+
+/**
+ * The modInfo of a collection-archive download: the nexus `ids` the driver reads
+ * (nexusIdsFromDownloadId, the collectionId getter). No collectionSlug, so the driver's
+ * initCollectionInfo gets an undefined slug and getCollectionInfo short-circuits instead of
+ * hitting the network.
+ */
+export function makeCollectionModInfo(
+  overrides: { collectionId?: number; revisionId?: number; gameId?: string } = {},
+): IModInfo {
+  const { collectionId = 1, revisionId = 1, gameId = "skyrimse" } = overrides;
+  return makeModInfo({ nexus: { ids: { collectionId, revisionId, gameId } } });
+}
+
 export type { CollectionModStatus };
+
+/** A dispatched redux-act action as the harness sees it. */
+interface ITrackedAction {
+  type: string;
+  payload?: unknown;
+}
+
+const BATCH_TYPE: string = (batch as unknown as { getType: () => string }).getType();
+const sessionReducers = trackingReducer.reducers as Record<
+  string,
+  (state: ICollectionInstallState, payload: unknown) => ICollectionInstallState
+>;
+// the real mods reducer, applied to state.persistent.mods so the durable writes the driver
+// makes alongside the session (addModRule with `ignored`, setModAttribute install-spec stamps)
+// are observable by read-back, not just recordable as dispatched actions. keyed by gameId.
+type ModsSlice = Record<string, Record<string, IMod>>;
+const modsReducers = modsReducer.reducers as Record<
+  string,
+  (state: ModsSlice, payload: unknown) => ModsSlice
+>;
+
+/** The redux slices an InstallDriver test arranges, each a builder-style override. */
+export interface IDriverHarnessState {
+  // installed mods, keyed by gameId then modId (state.persistent.mods)
+  mods: Record<string, Record<string, IMod>>;
+  // downloads, keyed by download id (state.persistent.downloads.files)
+  downloads: Record<string, IDownload>;
+  // profiles, keyed by profile id (state.persistent.profiles)
+  profiles: Record<string, IProfile>;
+  // the install-tracking slice (state.session.collections)
+  session: ICollectionInstallState;
+}
+
+function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
+  const slices: IDriverHarnessState = {
+    mods: {},
+    downloads: {},
+    profiles: {},
+    session: trackingReducer.defaults,
+    ...overrides,
+  };
+  // a structurally-partial IState holding only the slices the driver reads; the single cast
+  // mirrors test-utils/sessionStore.asIState (a full IState is impractical to construct)
+  return {
+    persistent: {
+      mods: slices.mods,
+      downloads: { files: slices.downloads },
+      profiles: slices.profiles,
+      collections: { collections: {}, revisions: {} },
+    },
+    session: { collections: slices.session },
+    settings: {
+      downloads: { collectionsInstallWhileDownloading: false },
+      interface: { language: "en" },
+      gameMode: { discovered: {} },
+    },
+  } as unknown as IState;
+}
+
+/**
+ * Register a fake game in the process-`local` registries getGame() reads, so the driver's
+ * startImpl can resolve the installed game version (a global singleton, not redux, and not
+ * covered by the game-extension vortex-api mocks). vitest isolates these per test file, and
+ * registration is idempotent.
+ */
+function registerHarnessGame(gameId: string): void {
+  const gameReg = local<{
+    gameModeManager: unknown;
+    extensionGames: IGame[];
+    extensionStubs: unknown[];
+  }>("gamemode-management", {
+    gameModeManager: undefined,
+    extensionGames: [],
+    extensionStubs: [],
+  });
+  if (!gameReg.extensionGames.some((game) => game.id === gameId)) {
+    gameReg.extensionGames.push({
+      id: gameId,
+      name: gameId,
+      queryModPath: () => "mods",
+    } as unknown as IGame);
+  }
+
+  const gvReg = local<{
+    gameVersionManager: { getGameVersion: () => Promise<string> } | undefined;
+  }>("gameversion-manager", { gameVersionManager: undefined });
+  if (gvReg.gameVersionManager === undefined) {
+    gvReg.gameVersionManager = { getGameVersion: () => Promise.resolve("1.0.0") };
+  }
+}
+
+/**
+ * Clear the process-`local` registries registerHarnessGame populates. The registries live on
+ * the worker global, so without this a fake game (or version manager) registered by one test
+ * would persist and could mask a different test's expectation. Call from afterEach.
+ */
+export function resetHarnessRegistries(): void {
+  const gameReg = local<{
+    gameModeManager: unknown;
+    extensionGames: IGame[];
+    extensionStubs: unknown[];
+  }>("gamemode-management", {
+    gameModeManager: undefined,
+    extensionGames: [],
+    extensionStubs: [],
+  });
+  gameReg.extensionGames.length = 0;
+
+  const gvReg = local<{ gameVersionManager: unknown }>("gameversion-manager", {
+    gameVersionManager: undefined,
+  });
+  gvReg.gameVersionManager = undefined;
+}
+
+export interface IApiHarness {
+  api: IExtensionApi;
+  // every dispatched action, batched actions flattened, in order
+  dispatched: ITrackedAction[];
+  // emit a global event (runs any registered on/onAsync listeners synchronously)
+  emit: (event: string, ...args: unknown[]) => void;
+  // read the live fake state
+  getState: () => IState;
+  // mutate the state mid-test (to model churn between events)
+  setState: (mutate: (draft: IState) => void) => void;
+  // configure what the next showDialog call resolves to
+  setNextDialog: (result: IDialogResult) => void;
+  // showDialog calls, recorded in order
+  dialogCalls: Array<{ type: DialogType; title: string }>;
+}
+
+export interface IDriverHarness extends IApiHarness {
+  // the driver under test, constructed against the fake api
+  driver: InstallDriver;
+}
+
+/**
+ * A controllable fake IExtensionApi over a seeded, structurally-partial IState. This is the
+ * seam for code that reads state + dispatches actions + reacts to the global event bus.
+ *
+ * - `events` is a real EventEmitter, so `emit(...)` actually runs any `on`/`onAsync` listeners
+ *   (a vi.fn() stub could not).
+ * - `dispatch` applies the real install-tracking reducer to `state.session.collections` AND the
+ *   real mods reducer to `state.persistent.mods` (so both the session and durable writes are
+ *   observable by read-back), and records every action (so writes with no harness reducer are
+ *   still assertable). Batched actions are unwrapped.
+ * - the persistent / session slices are seeded from `overrides` (builder-style) and can be
+ *   mutated mid-test via `setState`.
+ */
+export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IApiHarness {
+  const state = makeDriverState(overrides);
+  const dispatched: ITrackedAction[] = [];
+
+  const apply = (action: ITrackedAction | null | undefined): void => {
+    if (action == null) {
+      return;
+    }
+    // redux-act batches several actions into one; unwrap so each is applied + recorded
+    if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
+      (action.payload as ITrackedAction[]).forEach(apply);
+      return;
+    }
+    dispatched.push(action);
+    const sessionReducer = sessionReducers[action.type];
+    if (sessionReducer !== undefined) {
+      state.session.collections = sessionReducer(state.session.collections, action.payload);
+    }
+    const modsReducerFn = modsReducers[action.type];
+    if (modsReducerFn !== undefined) {
+      state.persistent.mods = modsReducerFn(state.persistent.mods, action.payload);
+    }
+  };
+
+  const dispatch = (action: ITrackedAction) => {
+    apply(action);
+    return action;
+  };
+
+  const events = new EventEmitter();
+  events.setMaxListeners(0);
+
+  let nextDialog: IDialogResult = { action: "Continue", input: {} };
+  const dialogCalls: Array<{ type: DialogType; title: string }> = [];
+
+  const api = {
+    getState: () => state,
+    store: { getState: () => state, dispatch },
+    events,
+    // a driver registers will-install-mod via onAsync; route it onto the same bus so a
+    // plain emit() runs it (the returned promise is ignored, which is fine for assertions)
+    onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
+      events.on(event, cb);
+    },
+    onStateChange: () => undefined,
+    sendNotification: () => undefined,
+    dismissNotification: () => undefined,
+    showErrorNotification: () => undefined,
+    showDialog: (
+      type: DialogType,
+      title: string,
+      _content: IDialogContent,
+      _actions: DialogActions,
+    ) => {
+      dialogCalls.push({ type, title });
+      return Promise.resolve(nextDialog);
+    },
+    translate: (key: string) => key,
+    ext: { awaitProfileSwitch: () => Promise.resolve() },
+    emitAndAwait: () => Promise.resolve([]),
+  } as unknown as IExtensionApi;
+
+  return {
+    api,
+    dispatched,
+    emit: (event: string, ...args: unknown[]) => {
+      events.emit(event, ...args);
+    },
+    getState: () => state,
+    setState: (mutate: (draft: IState) => void) => {
+      mutate(state);
+    },
+    setNextDialog: (result: IDialogResult) => {
+      nextDialog = result;
+    },
+    dialogCalls,
+  };
+}
+
+/**
+ * Harness for InstallDriver orchestration tests. The driver is a singleton reacting to a
+ * GLOBAL event bus while mutating a SINGLE redux install session - the surface that
+ * misbehaves under churn (many member mods installing/updating/downgrading at once, events
+ * for non-member mods, several collections in a setup). Drives the REAL driver through the
+ * fake api (makeApiHarness) plus a fake game registered in the local() registry getGame reads.
+ */
+export function makeDriverHarness(
+  DriverCtor: new (api: IExtensionApi) => InstallDriver,
+  overrides: Partial<IDriverHarnessState> = {},
+  gameId = "skyrimse",
+): IDriverHarness {
+  registerHarnessGame(gameId);
+  const base = makeApiHarness(overrides);
+  const driver = new DriverCtor(base.api);
+  return { driver, ...base };
+}

--- a/src/renderer/src/test-utils/driverTest.ts
+++ b/src/renderer/src/test-utils/driverTest.ts
@@ -1,0 +1,25 @@
+import InstallDriver from "../extensions/collections/util/InstallDriver";
+import { type IDriverHarness, type IDriverHarnessState, makeDriverHarness } from "./builders";
+import { test as harnessTest } from "./harnessTest";
+
+export interface IDriverFixtures {
+  // build a harness around the REAL InstallDriver over the given seeded slices (registers a fake
+  // game in the local() registry; that registration is torn down by harnessTest's autoCleanup)
+  makeDriver: (overrides?: Partial<IDriverHarnessState>) => IDriverHarness;
+}
+
+/**
+ * Base test for InstallDriver suites. Extends the shared harnessTest with a `makeDriver` factory
+ * bound to the real InstallDriver, and inherits `makeApi` + the registry/mock teardown. This is a
+ * separate module from harnessTest on purpose: it imports the (slow) InstallDriver, so only driver
+ * suites pay that cost - api-only suites keep importing harnessTest directly.
+ */
+export const test = harnessTest.extend<IDriverFixtures>({
+  // `task` is destructured + ignored only to satisfy vitest's object-pattern requirement; this
+  // fixture depends on no other fixture
+  makeDriver: async ({ task: _task }, use) => {
+    await use((overrides?: Partial<IDriverHarnessState>) =>
+      makeDriverHarness(InstallDriver, overrides),
+    );
+  },
+});

--- a/src/renderer/src/test-utils/harnessTest.ts
+++ b/src/renderer/src/test-utils/harnessTest.ts
@@ -1,0 +1,39 @@
+import { test as base, vi } from "vitest";
+
+import {
+  type IApiHarness,
+  type IDriverHarnessState,
+  makeApiHarness,
+  resetHarnessRegistries,
+} from "./builders";
+
+export interface IHarnessFixtures {
+  // build an api-only harness over the given seeded slices (no driver, no game registration)
+  makeApi: (overrides?: Partial<IDriverHarnessState>) => IApiHarness;
+}
+
+/**
+ * Shared base test for harness-driven suites. An AUTOMATIC fixture clears the worker-global game
+ * registries (which makeDriverHarness populates) and mock state after every test - so a fake game
+ * registered by one test can never leak into the next, and it runs even for tests that build a
+ * harness directly (replacing a hand-written afterEach that such a test could bypass). Suites that
+ * need the real InstallDriver extend this with their own driver fixture, keeping the slow driver
+ * import out of api-only suites.
+ *
+ * The fixtures destructure the built-in `task` fixture (as the unused `_task`) only because
+ * vitest requires the fixture context to be an object-destructuring pattern; they depend on no
+ * other fixture.
+ */
+export const test = base.extend<IHarnessFixtures & { autoCleanup: void }>({
+  autoCleanup: [
+    async ({ task: _task }, use) => {
+      await use();
+      resetHarnessRegistries();
+      vi.clearAllMocks();
+    },
+    { auto: true },
+  ],
+  makeApi: async ({ task: _task }, use) => {
+    await use((overrides?: Partial<IDriverHarnessState>) => makeApiHarness(overrides));
+  },
+});

--- a/src/renderer/src/types/api.ts
+++ b/src/renderer/src/types/api.ts
@@ -56,7 +56,10 @@ export type {
 export type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
 export type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 export type { IDeploymentManifest } from "../extensions/mod_management/types/IDeploymentManifest";
-export type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+export type {
+  IModLookupInfo,
+  IReferenceIdentifiers,
+} from "../extensions/mod_management/util/testModReference";
 export type {
   IChoiceType,
   IFileListItem,

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -1,7 +1,7 @@
 /**
  * Planning + resolving writes to the collection install session. This is the WRITE side
  * of the session (the read side is collectionInstallSessionSelectors). It is internal to
- * the install flow - InstallManager (and the driver, for user skips) use it directly; it
+ * the install flow - InstallManager uses it directly for automatic lifecycle writes; it
  * is deliberately NOT re-exported through the public api barrels.
  */
 import type { IModReference } from "../extensions/mod_management/types/IMod";
@@ -27,12 +27,12 @@ export type CollectionSessionWrite =
 
 /**
  * Decide how an automatic install outcome should be written to a session mod, given that
- * mod's current status. This is the single source of the automatic write rules (the user
- * skip path, markRuleIgnored, deliberately bypasses it - see below):
+ * mod's current status. This is the single source of the automatic write rules (the skip
+ * path, markCollectionMemberSkipped, deliberately bypasses it - see below):
  *
  * - "ignored" is the user's final word: no automatic write overrides it. The user changes
- *   it by un-ignoring/resuming; markRuleIgnored sets it directly (bypassing this planner)
- *   precisely so an explicit skip CAN override a prior installed/in-progress state.
+ *   it by un-ignoring/resuming; markCollectionMemberSkipped sets it directly (bypassing this
+ *   planner) precisely so an explicit skip CAN override a prior installed/in-progress state.
  * - reaching "installed" wins over any in-progress or failed state (recorded via
  *   markModInstalled, which carries the modId) - but not over a user "ignored".
  * - a completed install ("installed") is not downgraded by a late/stray in-progress event.

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -6,11 +6,12 @@
  * ignored (transient status + durable rule flag). Production flakiness lived in the free-user
  * identifier matching, so the matching paths are all exercised here.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect } from "vitest";
 
 import type { IModRule } from "../extensions/mod_management/types/IMod";
 import {
-  makeApiHarness,
+  type IApiHarness,
+  type IDriverHarnessState,
   makeInstallState,
   makeMod,
   makeModInstallInfo,
@@ -18,6 +19,7 @@ import {
   makeRule,
   makeSession,
 } from "../test-utils/builders";
+import { test } from "../test-utils/harnessTest";
 import { modRuleId } from "./collectionInstallSession";
 import { getCollectionActiveSessionMod } from "./collectionInstallSessionSelectors";
 import { markCollectionMemberSkipped } from "./collectionSkip";
@@ -26,8 +28,8 @@ const GAME_ID = "skyrimse";
 const COLLECTION_ID = "col-1";
 const SESSION_ID = "sess-1";
 
-// seed an active session whose collection tracks the single given member rule
-function harnessWithRule(rule: IModRule) {
+// the harness slices for an active session whose collection tracks the single given member rule
+function ruleOverrides(rule: IModRule): Partial<IDriverHarnessState> {
   const collection = makeMod({ id: COLLECTION_ID, rules: [rule] });
   const session = makeSession({
     sessionId: SESSION_ID,
@@ -35,20 +37,18 @@ function harnessWithRule(rule: IModRule) {
     gameId: GAME_ID,
     mods: { [modRuleId(rule)]: makeModInstallInfo({ rule, status: "pending" }) },
   });
-  return makeApiHarness({
+  return {
     mods: { [GAME_ID]: { [COLLECTION_ID]: collection } },
     session: makeInstallState({ activeSession: session }),
-  });
+  };
 }
 
-type Harness = ReturnType<typeof harnessWithRule>;
-
-const statusOf = (h: Harness, rule: IModRule) =>
+const statusOf = (h: IApiHarness, rule: IModRule) =>
   getCollectionActiveSessionMod(h.getState(), modRuleId(rule))?.status;
 
 // the durable `ignored` flag lives on the collection mod's rule (not the session), so it
 // survives a restart; read it back through the real mods reducer the harness applies
-const durableIgnored = (h: Harness) =>
+const durableIgnored = (h: IApiHarness) =>
   h.getState().persistent.mods[GAME_ID][COLLECTION_ID].rules?.[0]?.ignored;
 
 const repoRule = (overrides: Partial<IModRule["reference"]> = {}): IModRule =>
@@ -62,9 +62,9 @@ const repoRule = (overrides: Partial<IModRule["reference"]> = {}): IModRule =>
   });
 
 describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
-  it("ignores the member whose reference matches the skipped dependency", () => {
+  test("ignores the member whose reference matches the skipped dependency", ({ makeApi }) => {
     const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       reference: makeReference({ tag: "mod-a" }),
@@ -75,9 +75,9 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(durableIgnored(h)).toBe(true);
   });
 
-  it("does nothing for a reference that is not a member", () => {
+  test("does nothing for a reference that is not a member", ({ makeApi }) => {
     const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       reference: makeReference({ tag: "not-a-member" }),
@@ -90,12 +90,12 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
 });
 
 describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
-  it("ignores a member matched by logical file name", () => {
+  test("ignores a member matched by logical file name", ({ makeApi }) => {
     const rule = makeRule({
       type: "requires",
       reference: makeReference({ tag: "mod-skip", logicalFileName: "Skip Me.7z" }),
     });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, fileNames: ["Skip Me.7z"] },
@@ -106,12 +106,12 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(durableIgnored(h)).toBe(true);
   });
 
-  it("does nothing when the file name matches no member", () => {
+  test("does nothing when the file name matches no member", ({ makeApi }) => {
     const rule = makeRule({
       type: "requires",
       reference: makeReference({ tag: "mod-skip", logicalFileName: "Skip Me.7z" }),
     });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, fileNames: ["Other Mod.7z"] },
@@ -121,9 +121,9 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(statusOf(h, rule)).toBe("pending");
   });
 
-  it("ignores a member on a definitive repo modId + fileId match", () => {
+  test("ignores a member on a definitive repo modId + fileId match", ({ makeApi }) => {
     const rule = repoRule();
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, modId: 42, fileIds: ["100"] },
@@ -133,9 +133,9 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(statusOf(h, rule)).toBe("ignored");
   });
 
-  it("does not ignore the same mod page but a different file", () => {
+  test("does not ignore the same mod page but a different file", ({ makeApi }) => {
     const rule = repoRule();
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, modId: 42, fileIds: ["999"] },
@@ -145,9 +145,9 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(statusOf(h, rule)).toBe("pending");
   });
 
-  it("does not ignore a different mod page", () => {
+  test("does not ignore a different mod page", ({ makeApi }) => {
     const rule = repoRule();
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, modId: 99 },
@@ -157,11 +157,13 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(statusOf(h, rule)).toBe("pending");
   });
 
-  it("ignores a fuzzy member by file name when the file id differs (update chain)", () => {
+  test("ignores a fuzzy member by file name when the file id differs (update chain)", ({
+    makeApi,
+  }) => {
     // fixed bug: testRefByIdentifiers returns false on the file-id mismatch, but the fuzzy
     // fallback matches by the skipped file name instead
     const rule = repoRule({ versionMatch: "1.0.0+prefer", logicalFileName: "Fuzzy Mod.7z" });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: {
@@ -176,10 +178,12 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
     expect(statusOf(h, rule)).toBe("ignored");
   });
 
-  it("ignores a fuzzy member matched by modId when the skip carries no file names", () => {
+  test("ignores a fuzzy member matched by modId when the skip carries no file names", ({
+    makeApi,
+  }) => {
     // fixed bug: the previous inline handler dereferenced fileNames before guarding it and threw
     const rule = repoRule({ versionMatch: "1.0.0+prefer" });
-    const h = harnessWithRule(rule);
+    const h = makeApi(ruleOverrides(rule));
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, modId: 42 },
@@ -191,8 +195,8 @@ describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
 });
 
 describe("markCollectionMemberSkipped - no active session", () => {
-  it("is a no-op when no collection install is active", () => {
-    const h = makeApiHarness();
+  test("is a no-op when no collection install is active", ({ makeApi }) => {
+    const h = makeApi();
 
     const matched = markCollectionMemberSkipped(h.api, {
       identifiers: { gameId: GAME_ID, fileNames: ["Anything.7z"] },

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Skip attribution for collection members. A member can be skipped two ways - automatically
+ * during install (InstallManager passes the dependency's mod reference) or by a free user
+ * declining a queued download (nexus_integration passes the loose Nexus identifiers) - and both
+ * resolve through markCollectionMemberSkipped: find the member in the active session and mark it
+ * ignored (transient status + durable rule flag). Production flakiness lived in the free-user
+ * identifier matching, so the matching paths are all exercised here.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IModRule } from "../extensions/mod_management/types/IMod";
+import {
+  makeApiHarness,
+  makeInstallState,
+  makeMod,
+  makeModInstallInfo,
+  makeReference,
+  makeRule,
+  makeSession,
+} from "../test-utils/builders";
+import { modRuleId } from "./collectionInstallSession";
+import { getCollectionActiveSessionMod } from "./collectionInstallSessionSelectors";
+import { markCollectionMemberSkipped } from "./collectionSkip";
+
+const GAME_ID = "skyrimse";
+const COLLECTION_ID = "col-1";
+const SESSION_ID = "sess-1";
+
+// seed an active session whose collection tracks the single given member rule
+function harnessWithRule(rule: IModRule) {
+  const collection = makeMod({ id: COLLECTION_ID, rules: [rule] });
+  const session = makeSession({
+    sessionId: SESSION_ID,
+    collectionId: COLLECTION_ID,
+    gameId: GAME_ID,
+    mods: { [modRuleId(rule)]: makeModInstallInfo({ rule, status: "pending" }) },
+  });
+  return makeApiHarness({
+    mods: { [GAME_ID]: { [COLLECTION_ID]: collection } },
+    session: makeInstallState({ activeSession: session }),
+  });
+}
+
+type Harness = ReturnType<typeof harnessWithRule>;
+
+const statusOf = (h: Harness, rule: IModRule) =>
+  getCollectionActiveSessionMod(h.getState(), modRuleId(rule))?.status;
+
+// the durable `ignored` flag lives on the collection mod's rule (not the session), so it
+// survives a restart; read it back through the real mods reducer the harness applies
+const durableIgnored = (h: Harness) =>
+  h.getState().persistent.mods[GAME_ID][COLLECTION_ID].rules?.[0]?.ignored;
+
+const repoRule = (overrides: Partial<IModRule["reference"]> = {}): IModRule =>
+  makeRule({
+    type: "requires",
+    reference: makeReference({
+      tag: "mod-repo",
+      repo: { repository: "nexus", modId: "42", fileId: "100" },
+      ...overrides,
+    }),
+  });
+
+describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
+  it("ignores the member whose reference matches the skipped dependency", () => {
+    const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "mod-a" }),
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+    expect(durableIgnored(h)).toBe(true);
+  });
+
+  it("does nothing for a reference that is not a member", () => {
+    const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "not-a-member" }),
+    });
+
+    expect(matched).toBe(false);
+    expect(statusOf(h, rule)).toBe("pending");
+    expect(durableIgnored(h)).toBeUndefined();
+  });
+});
+
+describe("markCollectionMemberSkipped - free-user skip (identifiers)", () => {
+  it("ignores a member matched by logical file name", () => {
+    const rule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-skip", logicalFileName: "Skip Me.7z" }),
+    });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, fileNames: ["Skip Me.7z"] },
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+    expect(durableIgnored(h)).toBe(true);
+  });
+
+  it("does nothing when the file name matches no member", () => {
+    const rule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-skip", logicalFileName: "Skip Me.7z" }),
+    });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, fileNames: ["Other Mod.7z"] },
+    });
+
+    expect(matched).toBe(false);
+    expect(statusOf(h, rule)).toBe("pending");
+  });
+
+  it("ignores a member on a definitive repo modId + fileId match", () => {
+    const rule = repoRule();
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, modId: 42, fileIds: ["100"] },
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+  });
+
+  it("does not ignore the same mod page but a different file", () => {
+    const rule = repoRule();
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, modId: 42, fileIds: ["999"] },
+    });
+
+    expect(matched).toBe(false);
+    expect(statusOf(h, rule)).toBe("pending");
+  });
+
+  it("does not ignore a different mod page", () => {
+    const rule = repoRule();
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, modId: 99 },
+    });
+
+    expect(matched).toBe(false);
+    expect(statusOf(h, rule)).toBe("pending");
+  });
+
+  it("ignores a fuzzy member by file name when the file id differs (update chain)", () => {
+    // fixed bug: testRefByIdentifiers returns false on the file-id mismatch, but the fuzzy
+    // fallback matches by the skipped file name instead
+    const rule = repoRule({ versionMatch: "1.0.0+prefer", logicalFileName: "Fuzzy Mod.7z" });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: {
+        gameId: GAME_ID,
+        modId: 42,
+        fileIds: ["999"],
+        fileNames: ["Fuzzy Mod.7z"],
+      },
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+  });
+
+  it("ignores a fuzzy member matched by modId when the skip carries no file names", () => {
+    // fixed bug: the previous inline handler dereferenced fileNames before guarding it and threw
+    const rule = repoRule({ versionMatch: "1.0.0+prefer" });
+    const h = harnessWithRule(rule);
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, modId: 42 },
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+  });
+});
+
+describe("markCollectionMemberSkipped - no active session", () => {
+  it("is a no-op when no collection install is active", () => {
+    const h = makeApiHarness();
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      identifiers: { gameId: GAME_ID, fileNames: ["Anything.7z"] },
+    });
+
+    expect(matched).toBe(false);
+  });
+});

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -1,0 +1,132 @@
+import { updateModStatus } from "../actions/collectionInstallTracking";
+import { addModRule } from "../extensions/mod_management/actions/mods";
+import type { IModReference } from "../extensions/mod_management/types/IMod";
+import { isFuzzyVersion } from "../extensions/mod_management/util/isFuzzyVersion";
+import {
+  testRefByIdentifiers,
+  type IReferenceIdentifiers,
+} from "../extensions/mod_management/util/testModReference";
+import { log } from "../logging";
+import type { IExtensionApi } from "../types/IExtensionContext";
+import { modRuleId } from "./collectionInstallSession";
+import { getCollectionActiveSession } from "./collectionInstallSessionSelectors";
+import { batchDispatch } from "./util";
+
+/**
+ * The identity of a download a free user skipped, as Nexus knows it: the mod page (modId), the
+ * skipped file (fileId) and the update-chain file ids / names around it. Any field may be
+ * absent depending on how the skip was reached. This is the reference-matching identifier shape
+ * (without the internal `condition` predicate testRefByIdentifiers accepts).
+ */
+export type ISkippedDownloadIdentifiers = Omit<IReferenceIdentifiers, "condition">;
+
+/**
+ * How a skipped collection member was identified. A premium/automatic skip (InstallManager)
+ * has the dependency's full mod reference; a free-user skip (nexus_integration) only has the
+ * loose Nexus identifiers of the file. Both resolve to the same outcome - mark the member
+ * ignored - so they share one entry point.
+ */
+export type ICollectionSkip =
+  | { reference: IModReference }
+  | { identifiers: ISkippedDownloadIdentifiers };
+
+const sanitizeFileName = (fileName: string): string =>
+  fileName.toLowerCase().replace(/[^a-z]+/gi, "");
+
+/**
+ * A fuzzy-version member can legitimately mismatch on file id (the "incorrect update chains"
+ * case), so testRefByIdentifiers' definitive file-id check is not enough on its own - it
+ * returns false on a file-id mismatch before any name comparison. This fallback matches such a
+ * member by file name instead, and (unlike the previous inline version) guards `fileNames` and
+ * the rule's `logicalFileName` before dereferencing them.
+ */
+function fuzzyChainMatch(identifiers: ISkippedDownloadIdentifiers, ref: IModReference): boolean {
+  if (ref.versionMatch == null || !isFuzzyVersion(ref.versionMatch)) {
+    return false;
+  }
+  if (identifiers.modId == null || ref.repo?.modId !== identifiers.modId.toString()) {
+    return false;
+  }
+  const { fileNames } = identifiers;
+  if (fileNames != null && fileNames.length > 0) {
+    if (ref.logicalFileName == null) {
+      return false;
+    }
+    const names = new Set(fileNames.map(sanitizeFileName));
+    return names.has(sanitizeFileName(ref.logicalFileName));
+  }
+  // same mod page, fuzzy version, no file names to disambiguate - good enough to match
+  return true;
+}
+
+/**
+ * Match the skipped dependency's reference against a collection rule. This mirrors the previous
+ * `collection-mod-skipped` handler exactly (tag is most reliable, then file hash, then logical
+ * file name) so the automatic/premium skip path is behaviourally unchanged.
+ */
+function matchesReference(reference: IModReference, ruleRef: IModReference): boolean {
+  if (reference.tag && ruleRef.tag === reference.tag) {
+    return true;
+  }
+  if (reference.fileMD5 && ruleRef.fileMD5 === reference.fileMD5) {
+    return true;
+  }
+  if (reference.logicalFileName && ruleRef.logicalFileName === reference.logicalFileName) {
+    return true;
+  }
+  return false;
+}
+
+function matchesSkip(skip: ICollectionSkip, ref: IModReference): boolean {
+  if ("reference" in skip) {
+    return matchesReference(skip.reference, ref);
+  }
+  return testRefByIdentifiers(skip.identifiers, ref) || fuzzyChainMatch(skip.identifiers, ref);
+}
+
+/**
+ * Mark the collection member that was skipped as ignored, directly against the active install
+ * session. This is the single entry point for both skip journeys (premium/automatic via
+ * InstallManager, free-user via nexus_integration) - they used to emit `collection-mod-skipped`
+ * / `free-user-skipped-download` for the InstallDriver to handle, an artifact of collections
+ * being a bundled extension. Now that collections is core, the skip site dispatches the decision
+ * itself instead of emitting and forgetting.
+ *
+ * Writes the transient session status AND the durable `ignored` flag on the rule together - the
+ * session is not persisted, so without the durable flag a mid-install restart would rehydrate a
+ * skipped (required) member as "pending" and the collection could never complete. This is an
+ * explicit decision to skip, so it intentionally overrides any terminal protection.
+ *
+ * Returns true if a member was matched and ignored.
+ */
+export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectionSkip): boolean {
+  const state = api.getState();
+  // getCollectionActiveSession guards state.session?.collections - collections is an extension
+  // reducer, so the slice can be absent (very early startup) where a raw deref would throw
+  const session = getCollectionActiveSession(state);
+  if (session === undefined) {
+    // not installing a collection - the skip is unrelated to collection tracking
+    return false;
+  }
+
+  const { gameId, collectionId, sessionId } = session;
+  const rules = (state.persistent.mods[gameId]?.[collectionId]?.rules ?? []).filter((rule) =>
+    ["requires", "recommends"].includes(rule.type),
+  );
+  // NOTE (LAZ-483 follow-up): find() returns the FIRST matching rule. This relies on collection
+  // members having distinct identities; if two members share the matched identifier (e.g. the
+  // same logicalFileName, or two fuzzy rules on one modId), the wrong member could be ignored.
+  // The previous mDependentMods.find had the same ambiguity, so this is not a new regression -
+  // but disambiguation (which member did the user actually skip?) needs investigation.
+  const rule = rules.find((iter) => matchesSkip(skip, iter.reference));
+  if (rule === undefined) {
+    log("error", "could not find collection rule for skipped download", { skip });
+    return false;
+  }
+
+  batchDispatch(api.store, [
+    updateModStatus(sessionId, modRuleId(rule), "ignored"),
+    addModRule(gameId, collectionId, { ...rule, ignored: true }),
+  ]);
+  return true;
+}


### PR DESCRIPTION
Collection members (mods and downloads) get skipped/ignored three ways: automatically during install (InstallManager), by a free user declining a queued download (nexus_integration), and manually from the collection page UI. The manual UI path already dispatches the decision directly (setRulesIgnored -> addModRule + resyncCollectionSessionRules) and is unchanged here. The other two used to emit a global event (collection-mod-skipped / free-user-skipped-download) for the InstallDriver to handle, an artifact of collections being a bundled extension. Now that collections is core, those two skip sites dispatch the decision directly too.

- Add util/collectionSkip.ts markCollectionMemberSkipped(api, {reference} | {identifiers}): one entry point that finds the skipped member in the active session and marks it ignored (session status + durable rule flag, the same dual-write the old markRuleIgnored did). InstallManager and nexus_integration call it directly; the driver's two skip listeners and markRuleIgnored are removed.
- Fix the free-user matching that the old inline handler got wrong: the fileNames dereference now happens after its guard (no longer throws when a skip carries no file names), and a fuzzy-version member matched by file name is no longer lost to testRefByIdentifiers' definitive file-id short-circuit. The automatic/premium reference match is unchanged (tag, then fileMD5, then logicalFileName).
- Split InstallDriver.onDidInstallDependencies into isInstallComplete (the completion decision) and finalizeInstalledCollection (the postprocessing side-effect), so the decision is unit-testable without the staging-path / fs infrastructure.
- Add a test harness (makeApiHarness / makeDriverHarness in test-utils/builders) that drives the real InstallDriver through a fake IExtensionApi, plus behaviour-grouped InstallDriver.test.ts and collectionSkip.test.ts (covering the previously-flaky free-user matching).
- Expose IReferenceIdentifiers as a public type and reuse it for both testRefByIdentifiers and the skip identifiers, and drop the now-unemitted collection-mod-skipped from EVENTS.md.

Edit: Also added shared vitest fixtures: harnessTest (makeApi + automatic registry/mock teardown,
so a fake game can't leak between tests) and driverTest (makeDriver, kept separate to keep the
slow driver import out of api-only suites). InstallDriver/collectionSkip tests build through
them; the data builders stay plain functions. [c9d6974e0d7212ab1895c8a3d6a3eb50530fd8fe](https://github.com/Nexus-Mods/Vortex/pull/23537/changes/c9d6974e0d7212ab1895c8a3d6a3eb50530fd8fe)

part of LAZ-483