### PR TITLE
Added an error origin tracker to avoid error re-serialization

### DIFF
--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -1,4 +1,4 @@
-import { rehydrateSerializedError, serializeError, setErrorOriginTracker } from "@vortex/shared";
+import { type ErrorOriginTracker, rehydrateSerializedError, serializeError } from "@vortex/shared";
 import type {
   AppInitMetadata,
   RendererChannels,
@@ -28,17 +28,18 @@ const betterIpcRenderer = {
 };
 
 // Pass renderer-owned errors by reference across the IPC round-trip: a callback
-// error serialized here is stashed live and handed straight back when its
-// proxied copy returns — preserving identity, prototype and the real throw-site
-// stack. Bounded, so a one-way error that never returns is evicted rather than
-// retained; an evicted ref just falls back to generic-Error hydration. The
-// renderer and preload share one V8 context (contextIsolation is off for the
-// main window), so the stashed object is the same one the callback threw. The
-// "renderer" namespace keeps these refs distinct from any tracker main installs.
+// error serialized here (rendererCallback) is stashed live and handed straight
+// back when its proxied copy returns (rendererInvoke) — preserving identity,
+// prototype and the real throw-site stack. Bounded, so a one-way error that
+// never returns is evicted rather than retained; an evicted ref just falls back
+// to generic-Error hydration. The renderer and preload share one V8 context
+// (contextIsolation is off for the main window), so the stashed object is the
+// same one the callback threw. The "renderer" namespace keeps these refs
+// distinct from any tracker main owns.
 const ORIGIN_STASH_MAX = 512;
 const originStash = new Map<string, Error>();
 let originSeq = 0;
-setErrorOriginTracker({
+const errorOriginTracker: ErrorOriginTracker = {
   namespace: "renderer",
   capture: (err: Error): string => {
     const id = `${originSeq++}`;
@@ -54,7 +55,7 @@ setErrorOriginTracker({
     if (err !== undefined) originStash.delete(id);
     return err;
   },
-});
+};
 
 try {
   expose("versions", {
@@ -309,7 +310,7 @@ async function rendererInvoke<C extends keyof InvokeChannels>(
   if (isWireResult(reply)) {
     const result = reply as Result;
     if (result.ok) return result.value;
-    throw rehydrateSerializedError(result.error as unknown as SerializedError);
+    throw rehydrateSerializedError(result.error as unknown as SerializedError, errorOriginTracker);
   }
   return reply as AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>;
 }
@@ -375,7 +376,7 @@ function rendererCallback<C extends keyof CallbackChannels>(
       .catch((err: unknown) => {
         ipcRenderer.send(`callback:${channel}`, collationId, {
           ok: false,
-          error: serializeError(err),
+          error: serializeError(err, errorOriginTracker),
         });
       });
   };

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -1,4 +1,4 @@
-import { rehydrateSerializedError, serializeError } from "@vortex/shared";
+import { rehydrateSerializedError, serializeError, setErrorOriginTracker } from "@vortex/shared";
 import type {
   AppInitMetadata,
   RendererChannels,
@@ -26,6 +26,35 @@ const betterIpcRenderer = {
   off: rendererOff,
   callback: rendererCallback,
 };
+
+// Pass renderer-owned errors by reference across the IPC round-trip: a callback
+// error serialized here is stashed live and handed straight back when its
+// proxied copy returns — preserving identity, prototype and the real throw-site
+// stack. Bounded, so a one-way error that never returns is evicted rather than
+// retained; an evicted ref just falls back to generic-Error hydration. The
+// renderer and preload share one V8 context (contextIsolation is off for the
+// main window), so the stashed object is the same one the callback threw. The
+// "renderer" namespace keeps these refs distinct from any tracker main installs.
+const ORIGIN_STASH_MAX = 512;
+const originStash = new Map<string, Error>();
+let originSeq = 0;
+setErrorOriginTracker({
+  namespace: "renderer",
+  capture: (err: Error): string => {
+    const id = `${originSeq++}`;
+    originStash.set(id, err);
+    if (originStash.size > ORIGIN_STASH_MAX) {
+      const oldest = originStash.keys().next().value;
+      if (oldest !== undefined) originStash.delete(oldest);
+    }
+    return id;
+  },
+  resolve: (id: string): Error | undefined => {
+    const err = originStash.get(id);
+    if (err !== undefined) originStash.delete(id);
+    return err;
+  },
+});
 
 try {
   expose("versions", {

--- a/src/shared/src/error-serialization.test.ts
+++ b/src/shared/src/error-serialization.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
+  type ErrorOriginTracker,
   rehydrateSerializedError,
   serializeError,
-  setErrorOriginTracker,
 } from "./error-serialization";
 import { DownloadError, ProcessCanceled } from "./types/errors";
 
 // A round-trip mirrors what crosses the IPC boundary: serialize on one side,
-// hand the plain object to the other, rehydrate there.
-const roundTrip = (err: unknown): Error => rehydrateSerializedError(serializeError(err));
+// hand the plain object to the other, rehydrate there. An optional tracker is
+// threaded through both ends, the way a caller (preload) owns and passes it.
+const roundTrip = (err: unknown, tracker?: ErrorOriginTracker): Error =>
+  rehydrateSerializedError(serializeError(err, tracker), tracker);
 
 describe("serializeError / rehydrateSerializedError", () => {
   it("preserves name and message", () => {
@@ -81,14 +83,13 @@ describe("serializeError / rehydrateSerializedError", () => {
 });
 
 describe("by-reference origin tracker", () => {
-  afterEach(() => setErrorOriginTracker(undefined));
-
-  // Mimic the renderer's preload stash: hand back the same live object on return.
-  const installStash = () => {
+  // Mimic the renderer's preload tracker: a namespaced stash that hands back the
+  // same live object on return. Owned by the caller and passed in — no globals.
+  const makeTracker = (namespace = "test"): ErrorOriginTracker => {
     const stash = new Map<string, Error>();
     let seq = 0;
-    setErrorOriginTracker({
-      namespace: "test",
+    return {
+      namespace,
       capture: (err) => {
         const id = `${seq++}`;
         stash.set(id, err);
@@ -99,87 +100,67 @@ describe("by-reference origin tracker", () => {
         if (err !== undefined) stash.delete(id);
         return err;
       },
-    });
-    return stash;
+    };
   };
 
   it("returns the original object (identity + prototype + stack) on round-trip", () => {
-    installStash();
+    const tracker = makeTracker();
     const original = new ProcessCanceled("Wrong user id");
-    const out = roundTrip(original);
+    const out = roundTrip(original, tracker);
     expect(out).toBe(original); // same reference, not a copy
     expect(out.stack).toBe(original.stack); // real throw-site stack preserved
   });
 
   it("resolves the original even when relayed through a context that re-serializes it", () => {
-    const stash = new Map<string, Error>();
-    const tracker = {
-      namespace: "test",
-      capture: (err: Error) => {
-        stash.set("k", err);
-        return "k";
-      },
-      resolve: (id: string) => stash.get(id),
-    };
+    const tracker = makeTracker();
     const original = new ProcessCanceled("Wrong user id");
 
     // renderer: capture + tag the wire form (namespaced)
-    setErrorOriginTracker(tracker);
-    const onWire = serializeError(original);
-    expect(onWire.data?.["__originRef"]).toBe("test:k");
+    const onWire = serializeError(original, tracker);
+    expect(onWire.data?.["__originRef"]).toBe("test:0");
 
     // main (no tracker): hydrate then re-serialize — the ref must ride through
-    setErrorOriginTracker(undefined);
     const relayed = serializeError(rehydrateSerializedError(onWire));
-    expect(relayed.data?.["__originRef"]).toBe("test:k");
+    expect(relayed.data?.["__originRef"]).toBe("test:0");
 
     // renderer regains ownership and gets the original back
-    setErrorOriginTracker(tracker);
-    expect(rehydrateSerializedError(relayed)).toBe(original);
+    expect(rehydrateSerializedError(relayed, tracker)).toBe(original);
   });
 
   it("resolves the original carried on a wrapped error's cause chain", () => {
-    installStash();
+    const tracker = makeTracker();
     const original = new ProcessCanceled("Wrong user id");
     // Wire shape of a wrapper (e.g. main's "Resolver failed") whose cause is the
     // captured original — mirrors main wrapping a relayed renderer callback error.
-    const wire = { message: "Resolver failed", cause: serializeError(original) };
-    expect(rehydrateSerializedError(wire).cause as Error).toBe(original);
+    const wire = { message: "Resolver failed", cause: serializeError(original, tracker) };
+    expect(rehydrateSerializedError(wire, tracker).cause as Error).toBe(original);
   });
 
   it("ignores a ref minted under a different namespace (no cross-context mis-resolve)", () => {
     // Context A captures and tags the wire under its namespace.
-    const stashA = new Map<string, Error>();
-    setErrorOriginTracker({
-      namespace: "main",
-      capture: (err) => {
-        stashA.set("0", err);
-        return "0";
-      },
-      resolve: (id) => stashA.get(id),
-    });
+    const trackerA = makeTracker("main");
     const original = new ProcessCanceled("from main");
-    const onWire = serializeError(original);
+    const onWire = serializeError(original, trackerA);
     expect(onWire.data?.["__originRef"]).toBe("main:0");
 
     // Context B has a colliding local id "0" but a different namespace — it must
     // NOT resolve A's ref, and must fall back to hydration instead.
     const stashB = new Map<string, Error>([["0", new Error("unrelated B error")]]);
-    setErrorOriginTracker({
+    const trackerB: ErrorOriginTracker = {
       namespace: "renderer",
       capture: () => undefined,
       resolve: (id) => stashB.get(id),
-    });
-    const out = rehydrateSerializedError(onWire);
+    };
+    const out = rehydrateSerializedError(onWire, trackerB);
     expect(out).not.toBe(original);
     expect(out).not.toBe(stashB.get("0"));
     expect(out.name).toBe("ProcessCanceled");
   });
 
-  it("falls back to a generic Error when the ref isn't owned here (evicted / foreign context)", () => {
-    const onWire = serializeError(new ProcessCanceled("gone")); // captured by no tracker
-    // No tracker installed on this side → plain Error carrying the name, which
-    // name-based checks (isErrorOfType) still match.
+  it("falls back to a generic Error when no tracker is passed (foreign context)", () => {
+    const onWire = serializeError(new ProcessCanceled("gone"));
+    // No tracker on this side → plain Error carrying the name, which name-based
+    // checks (isErrorOfType) still match.
     const out = rehydrateSerializedError(onWire);
     expect(out).not.toBeInstanceOf(ProcessCanceled);
     expect(out.name).toBe("ProcessCanceled");

--- a/src/shared/src/error-serialization.test.ts
+++ b/src/shared/src/error-serialization.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { serializeError, rehydrateSerializedError } from "./error-serialization";
-import { DownloadError } from "./types/errors";
+import {
+  rehydrateSerializedError,
+  serializeError,
+  setErrorOriginTracker,
+} from "./error-serialization";
+import { DownloadError, ProcessCanceled } from "./types/errors";
 
 // A round-trip mirrors what crosses the IPC boundary: serialize on one side,
 // hand the plain object to the other, rehydrate there.
@@ -62,7 +66,7 @@ describe("serializeError / rehydrateSerializedError", () => {
     expect(roundTrip("just a string").message).toBe("just a string");
   });
 
-  it("round-trips a DownloadError generically (name + payload, no concrete prototype)", () => {
+  it("round-trips a DownloadError generically (name + code + payload, no concrete prototype)", () => {
     const out = roundTrip(
       new DownloadError(
         { code: "network-bad-status", url: new URL("https://cdn.example/file"), statusCode: 503 },
@@ -73,5 +77,112 @@ describe("serializeError / rehydrateSerializedError", () => {
     expect(out.name).toBe("DownloadError");
     expect((out as Error & { code?: string }).code).toBe("network-bad-status");
     expect((out as Error & { payload?: { statusCode: number } }).payload?.statusCode).toBe(503);
+  });
+});
+
+describe("by-reference origin tracker", () => {
+  afterEach(() => setErrorOriginTracker(undefined));
+
+  // Mimic the renderer's preload stash: hand back the same live object on return.
+  const installStash = () => {
+    const stash = new Map<string, Error>();
+    let seq = 0;
+    setErrorOriginTracker({
+      namespace: "test",
+      capture: (err) => {
+        const id = `${seq++}`;
+        stash.set(id, err);
+        return id;
+      },
+      resolve: (id) => {
+        const err = stash.get(id);
+        if (err !== undefined) stash.delete(id);
+        return err;
+      },
+    });
+    return stash;
+  };
+
+  it("returns the original object (identity + prototype + stack) on round-trip", () => {
+    installStash();
+    const original = new ProcessCanceled("Wrong user id");
+    const out = roundTrip(original);
+    expect(out).toBe(original); // same reference, not a copy
+    expect(out.stack).toBe(original.stack); // real throw-site stack preserved
+  });
+
+  it("resolves the original even when relayed through a context that re-serializes it", () => {
+    const stash = new Map<string, Error>();
+    const tracker = {
+      namespace: "test",
+      capture: (err: Error) => {
+        stash.set("k", err);
+        return "k";
+      },
+      resolve: (id: string) => stash.get(id),
+    };
+    const original = new ProcessCanceled("Wrong user id");
+
+    // renderer: capture + tag the wire form (namespaced)
+    setErrorOriginTracker(tracker);
+    const onWire = serializeError(original);
+    expect(onWire.data?.["__originRef"]).toBe("test:k");
+
+    // main (no tracker): hydrate then re-serialize — the ref must ride through
+    setErrorOriginTracker(undefined);
+    const relayed = serializeError(rehydrateSerializedError(onWire));
+    expect(relayed.data?.["__originRef"]).toBe("test:k");
+
+    // renderer regains ownership and gets the original back
+    setErrorOriginTracker(tracker);
+    expect(rehydrateSerializedError(relayed)).toBe(original);
+  });
+
+  it("resolves the original carried on a wrapped error's cause chain", () => {
+    installStash();
+    const original = new ProcessCanceled("Wrong user id");
+    // Wire shape of a wrapper (e.g. main's "Resolver failed") whose cause is the
+    // captured original — mirrors main wrapping a relayed renderer callback error.
+    const wire = { message: "Resolver failed", cause: serializeError(original) };
+    expect(rehydrateSerializedError(wire).cause as Error).toBe(original);
+  });
+
+  it("ignores a ref minted under a different namespace (no cross-context mis-resolve)", () => {
+    // Context A captures and tags the wire under its namespace.
+    const stashA = new Map<string, Error>();
+    setErrorOriginTracker({
+      namespace: "main",
+      capture: (err) => {
+        stashA.set("0", err);
+        return "0";
+      },
+      resolve: (id) => stashA.get(id),
+    });
+    const original = new ProcessCanceled("from main");
+    const onWire = serializeError(original);
+    expect(onWire.data?.["__originRef"]).toBe("main:0");
+
+    // Context B has a colliding local id "0" but a different namespace — it must
+    // NOT resolve A's ref, and must fall back to hydration instead.
+    const stashB = new Map<string, Error>([["0", new Error("unrelated B error")]]);
+    setErrorOriginTracker({
+      namespace: "renderer",
+      capture: () => undefined,
+      resolve: (id) => stashB.get(id),
+    });
+    const out = rehydrateSerializedError(onWire);
+    expect(out).not.toBe(original);
+    expect(out).not.toBe(stashB.get("0"));
+    expect(out.name).toBe("ProcessCanceled");
+  });
+
+  it("falls back to a generic Error when the ref isn't owned here (evicted / foreign context)", () => {
+    const onWire = serializeError(new ProcessCanceled("gone")); // captured by no tracker
+    // No tracker installed on this side → plain Error carrying the name, which
+    // name-based checks (isErrorOfType) still match.
+    const out = rehydrateSerializedError(onWire);
+    expect(out).not.toBeInstanceOf(ProcessCanceled);
+    expect(out.name).toBe("ProcessCanceled");
+    expect(out.message).toBe("gone");
   });
 });

--- a/src/shared/src/error-serialization.ts
+++ b/src/shared/src/error-serialization.ts
@@ -5,10 +5,11 @@
 // can branch on `err.name` (e.g. via isErrorOfType) rather than `instanceof`.
 //
 // When a context owns the live error (the renderer, for a callback error that
-// round-trips back to it), an optional ErrorOriginTracker passes it by
-// reference instead — the original object is handed back verbatim, preserving
-// identity, prototype and the real throw-site stack. This is the only path that
-// recovers the concrete type across the wire; everything else is a plain Error.
+// round-trips back to it), the caller can pass an ErrorOriginTracker to both
+// functions to carry the error by reference instead — the original object is
+// handed back verbatim, preserving identity, prototype and the real throw-site
+// stack. This is the only path that recovers the concrete type across the wire;
+// everything else is a plain Error.
 //
 // `cause` chains are serialized recursively up to MAX_CAUSE_DEPTH levels.
 // Deeper chains (and non-Error causes) are truncated silently to avoid runaway
@@ -18,37 +19,31 @@ import { getErrorMessage } from "./errors";
 import type { SerializedError } from "./types/ipc";
 
 /**
- * Optional hook a context installs to pass errors it owns by reference instead
- * of by value. The classic case: the renderer makes an IPC call, main invokes a
+ * Caller-owned hook to carry errors a context owns by reference instead of by
+ * value. The classic case: the renderer makes an IPC call, main invokes a
  * renderer callback, that callback throws, and main proxies the error back to
  * the renderer. The thrown error never actually left the renderer's heap, so
- * instead of reconstructing a lossy copy we stash the live object on
- * serialization (`capture`) and hand the original straight back when it returns
+ * instead of reconstructing a lossy copy the caller stashes the live object when
+ * serializing (`capture`) and hands the original straight back when it returns
  * (`resolve`) — preserving identity, prototype and the real throw-site stack.
  *
- * Each context (renderer, main) may install its own tracker for the round-trips
- * it owns; a tracker only ever resolves errors it captured. `namespace` keeps
- * two installed trackers from colliding: refs are tagged with it on the wire,
- * and a ref carrying a different namespace is ignored and falls back to generic
- * `Error` hydration. A context that installs nothing always hydrates.
+ * The tracker (and its stash) live in the caller, not here — pass it to
+ * {@link serializeError} / {@link rehydrateSerializedError}. Each context
+ * (renderer, main) owns its own; a tracker only ever resolves errors it
+ * captured. `namespace` keeps two trackers from colliding: refs are tagged with
+ * it on the wire, and a ref carrying a different namespace is ignored and falls
+ * back to generic `Error` hydration. Calls that pass no tracker always hydrate.
  */
 export interface ErrorOriginTracker {
   /**
-   * Distinct id for the installing context (e.g. "renderer", "main"). Namespaces
-   * ref tokens so two trackers can't mis-resolve each other's errors.
+   * Distinct id for the owning context (e.g. "renderer", "main"). Namespaces ref
+   * tokens so two trackers can't mis-resolve each other's errors.
    */
   readonly namespace: string;
   /** Stash a live error and return a context-local id, or undefined to opt out. */
   capture(err: Error): string | undefined;
   /** Return the original for a context-local id (namespace already stripped), if still held. */
   resolve(id: string): Error | undefined;
-}
-
-let originTracker: ErrorOriginTracker | undefined;
-
-/** Install (or clear, with `undefined`) the by-reference tracker for this context. */
-export function setErrorOriginTracker(tracker: ErrorOriginTracker | undefined): void {
-  originTracker = tracker;
 }
 
 // Key under which the by-reference token rides in `data`. Living in `data`
@@ -104,8 +99,11 @@ export function serializeCause(value: unknown, depth: number): SerializedError |
   return nested === undefined ? fields : { ...fields, cause: nested };
 }
 
-/** Serialize any thrown value into its wire representation. */
-export function serializeError(err: unknown): SerializedError {
+/**
+ * Serialize any thrown value into its wire representation. Pass `tracker` to
+ * carry an error this context owns by reference (see {@link ErrorOriginTracker}).
+ */
+export function serializeError(err: unknown, tracker?: ErrorOriginTracker): SerializedError {
   if (!(err instanceof Error)) {
     return { message: getErrorMessage(err) ?? "" };
   }
@@ -113,35 +111,45 @@ export function serializeError(err: unknown): SerializedError {
   const cause = serializeCause((err as Error & { cause?: unknown }).cause, MAX_CAUSE_DEPTH);
   const result: SerializedError = cause === undefined ? fields : { ...fields, cause };
 
-  // If this context owns the live error, stash it and tag the wire form (with
-  // this tracker's namespace) so the original can be handed back if it returns
-  // here (see ErrorOriginTracker).
-  if (originTracker !== undefined) {
-    const id = originTracker.capture(err);
+  // If a tracker is given, stash the live error and tag the wire form (with the
+  // tracker's namespace) so the original can be handed back if it returns here.
+  if (tracker !== undefined) {
+    const id = tracker.capture(err);
     if (id !== undefined) {
-      result.data = { ...result.data, [ORIGIN_REF_KEY]: `${originTracker.namespace}:${id}` };
+      result.data = { ...result.data, [ORIGIN_REF_KEY]: `${tracker.namespace}:${id}` };
     }
   }
 
   return result;
 }
 
-export function rehydrateSerializedError(serialized: SerializedError): Error {
-  // By-reference fast path: if this context still holds the original, return it as-is.
-  // Avoids using the generic Error constructor and losing identity, prototype and the real throw-site stack.
+/**
+ * Rehydrate a serialized error. Pass the same `tracker` used to serialize to
+ * recover an error this context owns by reference instead of reconstructing it.
+ */
+export function rehydrateSerializedError(
+  serialized: SerializedError,
+  tracker?: ErrorOriginTracker,
+): Error {
+  // By-reference fast path: if the tracker still holds the original, return it
+  // as-is — avoids the generic Error constructor and keeps identity, prototype
+  // and the real throw-site stack.
   const ref = serialized.data?.[ORIGIN_REF_KEY];
-  if (typeof ref === "string" && originTracker !== undefined) {
-    // Only resolve refs this context minted; another context's namespace (or an
+  if (typeof ref === "string" && tracker !== undefined) {
+    // Only resolve refs this tracker minted; another context's namespace (or an
     // evicted ref) falls through to plain-Error hydration below.
-    const prefix = `${originTracker.namespace}:`;
+    const prefix = `${tracker.namespace}:`;
     if (ref.startsWith(prefix)) {
-      const original = originTracker.resolve(ref.slice(prefix.length));
+      const original = tracker.resolve(ref.slice(prefix.length));
       if (original !== undefined) return original;
     }
   }
 
   const err = new Error(serialized.message, {
-    cause: serialized.cause !== undefined ? rehydrateSerializedError(serialized.cause) : undefined,
+    cause:
+      serialized.cause !== undefined
+        ? rehydrateSerializedError(serialized.cause, tracker)
+        : undefined,
   });
   if (serialized.name !== undefined) err.name = serialized.name;
   if (serialized.code !== undefined) {

--- a/src/shared/src/error-serialization.ts
+++ b/src/shared/src/error-serialization.ts
@@ -1,9 +1,14 @@
 // Generic Error <-> wire serializer shared across the IPC boundaries (the
-// adaptor RPC transport and the renderer<->main callback channels). The
-// serializer is agnostic to the error classes it carries: the sender serializes
-// `name`, `code`, and any extra own enumerable properties; the receiver
-// rehydrates a generic `Error` with those fields copied back, so callers can
-// branch on `err.name` and reconstruct their concrete error type.
+// adaptor RPC transport and the renderer<->main callback channels). The sender
+// serializes `name`, `code`, and any extra own enumerable properties; the
+// receiver rebuilds a generic `Error` with those fields copied back, so callers
+// can branch on `err.name` (e.g. via isErrorOfType) rather than `instanceof`.
+//
+// When a context owns the live error (the renderer, for a callback error that
+// round-trips back to it), an optional ErrorOriginTracker passes it by
+// reference instead — the original object is handed back verbatim, preserving
+// identity, prototype and the real throw-site stack. This is the only path that
+// recovers the concrete type across the wire; everything else is a plain Error.
 //
 // `cause` chains are serialized recursively up to MAX_CAUSE_DEPTH levels.
 // Deeper chains (and non-Error causes) are truncated silently to avoid runaway
@@ -11,6 +16,47 @@
 
 import { getErrorMessage } from "./errors";
 import type { SerializedError } from "./types/ipc";
+
+/**
+ * Optional hook a context installs to pass errors it owns by reference instead
+ * of by value. The classic case: the renderer makes an IPC call, main invokes a
+ * renderer callback, that callback throws, and main proxies the error back to
+ * the renderer. The thrown error never actually left the renderer's heap, so
+ * instead of reconstructing a lossy copy we stash the live object on
+ * serialization (`capture`) and hand the original straight back when it returns
+ * (`resolve`) — preserving identity, prototype and the real throw-site stack.
+ *
+ * Each context (renderer, main) may install its own tracker for the round-trips
+ * it owns; a tracker only ever resolves errors it captured. `namespace` keeps
+ * two installed trackers from colliding: refs are tagged with it on the wire,
+ * and a ref carrying a different namespace is ignored and falls back to generic
+ * `Error` hydration. A context that installs nothing always hydrates.
+ */
+export interface ErrorOriginTracker {
+  /**
+   * Distinct id for the installing context (e.g. "renderer", "main"). Namespaces
+   * ref tokens so two trackers can't mis-resolve each other's errors.
+   */
+  readonly namespace: string;
+  /** Stash a live error and return a context-local id, or undefined to opt out. */
+  capture(err: Error): string | undefined;
+  /** Return the original for a context-local id (namespace already stripped), if still held. */
+  resolve(id: string): Error | undefined;
+}
+
+let originTracker: ErrorOriginTracker | undefined;
+
+/** Install (or clear, with `undefined`) the by-reference tracker for this context. */
+export function setErrorOriginTracker(tracker: ErrorOriginTracker | undefined): void {
+  originTracker = tracker;
+}
+
+// Key under which the by-reference token rides in `data`. Living in `data`
+// (rather than a dedicated SerializedError field) means it survives a context
+// that rehydrates and re-serializes the error in transit (e.g. main relaying a
+// renderer callback error back), since `data` is copied onto the error and
+// re-extracted as an own property.
+const ORIGIN_REF_KEY = "__originRef";
 
 /** Own-property keys that are part of the standard Error surface. */
 const STANDARD_ERROR_KEYS = new Set<string>(["name", "message", "stack", "cause", "code"]);
@@ -20,12 +66,12 @@ export const MAX_CAUSE_DEPTH = 3;
 
 export function extractErrorFields(err: Error): Omit<SerializedError, "cause"> {
   const result: Omit<SerializedError, "cause"> = { message: err.message };
-  // Type identity only exists on the live error and is lost the moment it crosses
-  // the wire (the receiver always mints a plain `Error`). Prefer the explicit
-  // `name` when the author set one; otherwise fall back to the runtime class name
-  // (`constructor.name`) so subclasses that never assign `this.name` — and would
-  // otherwise serialize as a nameless "Error" — keep their type for downstream
-  // consumers (e.g. error fingerprinting that branches on `name`).
+  // Type identity is lost on the wire (the receiver mints a plain `Error`), so
+  // `name` is the only type signal downstream consumers have — both callers
+  // branching via isErrorOfType and error fingerprinting. Prefer the explicit
+  // `name` when the author set one; otherwise fall back to the runtime class
+  // name (`constructor.name`) so subclasses that never assign `this.name` — and
+  // would otherwise serialize as a nameless "Error" — keep their type.
   if (err.name && err.name !== "Error") {
     result.name = err.name;
   } else {
@@ -65,10 +111,35 @@ export function serializeError(err: unknown): SerializedError {
   }
   const fields = extractErrorFields(err);
   const cause = serializeCause((err as Error & { cause?: unknown }).cause, MAX_CAUSE_DEPTH);
-  return cause === undefined ? fields : { ...fields, cause };
+  const result: SerializedError = cause === undefined ? fields : { ...fields, cause };
+
+  // If this context owns the live error, stash it and tag the wire form (with
+  // this tracker's namespace) so the original can be handed back if it returns
+  // here (see ErrorOriginTracker).
+  if (originTracker !== undefined) {
+    const id = originTracker.capture(err);
+    if (id !== undefined) {
+      result.data = { ...result.data, [ORIGIN_REF_KEY]: `${originTracker.namespace}:${id}` };
+    }
+  }
+
+  return result;
 }
 
 export function rehydrateSerializedError(serialized: SerializedError): Error {
+  // By-reference fast path: if this context still holds the original, return it as-is.
+  // Avoids using the generic Error constructor and losing identity, prototype and the real throw-site stack.
+  const ref = serialized.data?.[ORIGIN_REF_KEY];
+  if (typeof ref === "string" && originTracker !== undefined) {
+    // Only resolve refs this context minted; another context's namespace (or an
+    // evicted ref) falls through to plain-Error hydration below.
+    const prefix = `${originTracker.namespace}:`;
+    if (ref.startsWith(prefix)) {
+      const original = originTracker.resolve(ref.slice(prefix.length));
+      if (original !== undefined) return original;
+    }
+  }
+
   const err = new Error(serialized.message, {
     cause: serialized.cause !== undefined ? rehydrateSerializedError(serialized.cause) : undefined,
   });


### PR DESCRIPTION
Each process (main/renderer) can now use a error origin tracker system.
Only renderer enables it for now.
> When `renderer` calls `main` and `main` calls `renderer` (callback), if the callback throws and error, it will be saved in the error origin tracker. Once it passes back to `main` and `renderer`, we will use the original error instead of the serialized one, saving the type information