### PR TITLE
Add tri-state Switch component (LAZ-614)

### DIFF
--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -13,6 +13,7 @@ import { CollectionTileDemo } from "@/ui/components/collectiontile/CollectionTil
 import { DropdownDemo } from "@/ui/components/dropdown/DropdownDemo";
 import { InputDemo } from "@/ui/components/form/input/InputDemo";
 import { SelectDemo } from "@/ui/components/form/select/SelectDemo";
+import { SwitchDemo } from "@/ui/components/form/switch/Switch.demo";
 import { IconDemo } from "@/ui/components/icon/IconDemo";
 import { ImageDemo } from "@/ui/components/image/ImageDemo";
 import { ListingDemo } from "@/ui/components/listing/ListingDemo";
@@ -130,6 +131,8 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
                     <TabButton name="Input" />
 
                     <TabButton name="Select" />
+
+                    <TabButton name="Switch" />
                   </TabBar>
 
                   <div className="mt-6">
@@ -139,6 +142,10 @@ export const DesignSystemPage = ({ api }: { api: IExtensionApi }) => {
 
                     <TabPanel name="Select">
                       <SelectDemo />
+                    </TabPanel>
+
+                    <TabPanel name="Switch">
+                      <SwitchDemo />
                     </TabPanel>
                   </div>
                 </TabProvider>

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -12,9 +12,11 @@ ui/
 │   ├── collectiontile/  - Collection card with image, metadata, and actions
 │   ├── dropdown/        - Dropdown menu (Headless UI Menu)
 │   ├── form/            - Form components
+│   │   ├── checkbox/    - Checkbox input
 │   │   ├── formfield/   - Form field wrapper with labels and validation
 │   │   ├── input/       - Text input with validation
-│   │   └── select/      - Select dropdown with custom styling
+│   │   ├── select/      - Select dropdown with custom styling
+│   │   └── switch/      - Tri-state toggle switch (off / on / semi-on)
 │   ├── icon/            - Icon rendering (MDI + Nexus custom icons)
 │   ├── image/           - Image wrapper with aspect ratios and fallback (+ adult-aware variant)
 │   ├── listbox/         - Listbox select (Headless UI Listbox)
@@ -287,6 +289,29 @@ import { FormFieldWrap } from "../../ui/components/form/formfield/FormField";
   <Input id="last" label="Last Name" type="text" required />
 </FormFieldWrap>
 ```
+
+### Switch
+
+A tri-state toggle switch (xs) — `off`, `on`, and a programmatic `semi-on` ("mixed") state. Built on a visually-hidden native `<input type="checkbox">`; setting `indeterminate` renders `semi-on` and reports `aria-checked="mixed"`. Clicking only ever flips on/off — `semi-on` is set by the consumer (e.g. a master control whose children are partially on). It's controlled-visual (appearance follows the `checked`/`indeterminate` props, like `Checkbox`).
+
+```tsx
+import { Switch } from "../../ui/components/form/switch/Switch";
+
+// Controlled on/off
+<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} aria-label="Enable" />
+
+// Semi-on (mixed) — e.g. a "select all" with some children on
+<Switch
+  checked={allOn}
+  indeterminate={someOn && !allOn}
+  onChange={(e) => setAll(e.target.checked)}
+  aria-label="All settings"
+/>
+```
+
+**Props:** native `<input>` attributes (minus `type`) plus `indeterminate?: boolean`.
+
+> **Porting note:** when `@headlessui/react` reaches v2 (after the React upgrade), reimplement on top of HeadlessUI's `<Switch>`. The `nxm-switch` classes live on the track/thumb so they can move straight across. HeadlessUI's Switch is binary, so the tri-state stays the wrapper's responsibility (`data-state` + `indeterminate`/`aria-checked="mixed"`).
 
 ### Dropdown
 

--- a/src/renderer/src/ui/components/form/switch/Switch.demo.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.demo.tsx
@@ -1,0 +1,126 @@
+/**
+ * SwitchDemo Component
+ * Demonstrates the tri-state Switch: off / on / semi-on, an interactive
+ * controlled example, and a "select all" master switch that derives its semi-on
+ * (mixed) state from its children.
+ */
+
+import React, { useState } from "react";
+
+import { Typography } from "../../typography/Typography";
+import { Switch } from "./Switch";
+
+const CHILD_LABELS = ["Auto-update", "Notifications", "Telemetry"];
+
+export const SwitchDemo = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [children, setChildren] = useState<boolean[]>([true, false, false]);
+
+  const allOn = children.every(Boolean);
+  const noneOn = !children.some(Boolean);
+
+  const setChild = (index: number, value: boolean) =>
+    setChildren((current) => current.map((on, i) => (i === index ? value : on)));
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-sm bg-surface-mid p-4">
+        <Typography as="h3" typographyType="heading-xs">
+          Switch
+        </Typography>
+
+        <Typography appearance="subdued">
+          A tri-state switch: off, on, and a programmatic semi-on (reported to assistive tech as
+          aria-checked=&quot;mixed&quot;). Clicking only flips between on and off — semi-on is set
+          by a pre-existing state, such as a master control whose children are partially enabled.
+        </Typography>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h4" typographyType="heading-xs">
+          States
+        </Typography>
+
+        <div className="grid w-max grid-cols-[auto_auto_auto] items-center gap-x-8 gap-y-3">
+          <span />
+          <Typography appearance="subdued" typographyType="body-sm">
+            Enabled
+          </Typography>
+          <Typography appearance="subdued" typographyType="body-sm">
+            Disabled
+          </Typography>
+
+          <Typography appearance="subdued" typographyType="body-sm">
+            Off
+          </Typography>
+          <Switch aria-label="Off, enabled" checked={false} onChange={() => undefined} />
+          <Switch aria-label="Off, disabled" checked={false} disabled={true} />
+
+          <Typography appearance="subdued" typographyType="body-sm">
+            On
+          </Typography>
+          <Switch aria-label="On, enabled" checked={true} onChange={() => undefined} />
+          <Switch aria-label="On, disabled" checked={true} disabled={true} />
+
+          <Typography appearance="subdued" typographyType="body-sm">
+            Semi-on
+          </Typography>
+          <Switch aria-label="Semi-on, enabled" indeterminate={true} onChange={() => undefined} />
+          <Switch aria-label="Semi-on, disabled" disabled={true} indeterminate={true} />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h4" typographyType="heading-xs">
+          Interactive
+        </Typography>
+
+        <div className="flex w-max items-center gap-3">
+          <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+
+          <Typography as="span" typographyType="body-sm">
+            {enabled ? "Enabled" : "Disabled"}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Typography as="h4" typographyType="heading-xs">
+          Semi-on from children (&quot;select all&quot;)
+        </Typography>
+
+        <Typography appearance="subdued" typographyType="body-sm">
+          The master switch is semi-on when some — but not all — children are on. Clicking it turns
+          everything on, or off when already fully on.
+        </Typography>
+
+        <div className="flex w-max items-center gap-3">
+          <Switch
+            checked={allOn}
+            indeterminate={!allOn && !noneOn}
+            onChange={(e) => setChildren(children.map(() => e.target.checked))}
+          />
+
+          <Typography as="span" typographyType="body-sm">
+            All settings
+          </Typography>
+        </div>
+
+        <div className="ml-6 space-y-2">
+          {CHILD_LABELS.map((label, index) => (
+            <div className="flex w-max items-center gap-3" key={label}>
+              <Switch
+                checked={children[index]}
+                onChange={(e) => setChild(index, e.target.checked)}
+              />
+
+              <Typography as="span" typographyType="body-sm">
+                {label}
+              </Typography>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/ui/components/form/switch/Switch.test.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { Switch } from "./Switch";
+
+afterEach(() => {
+  cleanup();
+});
+
+const getSwitch = () => screen.getByRole("checkbox");
+
+describe("Switch", () => {
+  it("renders an unchecked checkbox by default", () => {
+    render(<Switch aria-label="Setting" />);
+    expect(getSwitch()).not.toBeChecked();
+  });
+
+  it("reflects the checked prop", () => {
+    render(<Switch aria-label="Setting" checked={true} onChange={() => undefined} />);
+    expect(getSwitch()).toBeChecked();
+  });
+
+  it("reports semi-on as partially checked (aria mixed)", () => {
+    render(<Switch aria-label="Setting" indeterminate={true} onChange={() => undefined} />);
+    expect(getSwitch()).toBePartiallyChecked();
+  });
+
+  it("marks the track with the matching data-state", () => {
+    const { rerender } = render(<Switch aria-label="Setting" checked={false} />);
+    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "off");
+
+    rerender(<Switch aria-label="Setting" checked={true} />);
+    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "on");
+
+    rerender(<Switch aria-label="Setting" indeterminate={true} />);
+    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "semi-on");
+  });
+
+  it("calls onChange when clicked", async () => {
+    const onChange = vi.fn();
+    render(<Switch aria-label="Setting" checked={false} onChange={onChange} />);
+
+    await userEvent.click(getSwitch());
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onChange when disabled", async () => {
+    const onChange = vi.fn();
+    render(<Switch aria-label="Setting" checked={false} disabled={true} onChange={onChange} />);
+
+    await userEvent.click(getSwitch());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/ui/components/form/switch/Switch.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef, type InputHTMLAttributes } from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+/**
+ * Switch — a tri-state switch: `off`, `on`, and `semi-on` (a "mixed" state set
+ * programmatically, e.g. a master control whose children are partially on).
+ * Clicking only ever flips between on and off; semi-on is never reached by user
+ * interaction.
+ *
+ * Implementation: a visually-hidden native `<input type="checkbox">` drives the
+ * state and accessibility. Setting `indeterminate` makes the browser report
+ * `aria-checked="mixed"` — that is the `semi-on` state. The visible track/thumb
+ * are styled spans whose appearance is keyed off `data-state` on the track.
+ *
+ * PORTING NOTE: once `@headlessui/react` is upgraded to v2 (after the React
+ * upgrade), reimplement this on top of HeadlessUI's `<Switch>`. The `nxm-switch`
+ * classes live on the track/thumb specifically so they can move straight onto
+ * the Switch's elements. HeadlessUI's Switch is binary, so the tri-state must be
+ * preserved here in the wrapper — keep driving `data-state` (and the native
+ * `indeterminate`/`aria-checked="mixed"`) for the `semi-on` state.
+ */
+export type ISwitchProps = Omit<InputHTMLAttributes<HTMLInputElement>, "type"> & {
+  /** Renders the "semi-on" state and reports `aria-checked="mixed"`. */
+  indeterminate?: boolean;
+};
+
+export const Switch = ({
+  checked,
+  className,
+  disabled,
+  indeterminate,
+  ...inputProps
+}: ISwitchProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // `indeterminate` is a DOM property, not an attribute, so it must be set
+  // imperatively. This also drives the `:indeterminate` pseudo-class and makes
+  // the accessibility tree report `aria-checked="mixed"`.
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = !!indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <label
+      className={joinClasses(["nxm-switch", className], {
+        "nxm-switch-disabled": disabled,
+      })}
+      data-state={indeterminate ? "semi-on" : checked ? "on" : "off"}
+    >
+      <input
+        checked={checked}
+        className="nxm-switch-input"
+        disabled={disabled}
+        ref={inputRef}
+        type="checkbox"
+        {...inputProps}
+      />
+
+      <span className="nxm-switch-thumb" />
+    </label>
+  );
+};

--- a/src/renderer/src/ui/components/table/Table.demo.tsx
+++ b/src/renderer/src/ui/components/table/Table.demo.tsx
@@ -7,13 +7,14 @@
 import {
   mdiCheckCircle,
   mdiCloudDownload,
-  mdiDelete,
+  mdiDotsVertical,
   mdiThumbUp,
   mdiThumbUpOutline,
 } from "@mdi/js";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import { Button } from "../button/Button";
+import { Switch } from "../form/switch/Switch";
 import { Icon } from "../icon/Icon";
 import { Typography } from "../typography/Typography";
 import { Table } from "./Table";
@@ -31,6 +32,7 @@ interface IDemoMod {
   downloads: number;
   updated: string;
   endorsed: boolean;
+  installed: boolean;
 }
 
 const CATEGORIES = ["Animation", "Armour", "Audio", "Gameplay", "Patches", "UI", "Weapons"];
@@ -53,6 +55,7 @@ const buildMods = (count: number): IDemoMod[] =>
     downloads: (index * 1373) % 100000,
     updated: `${MONTHS[index % MONTHS.length]} 2026`,
     endorsed: index % 3 === 0,
+    installed: (index * 7) % 9 > 2,
   }));
 
 // Stand-in for widths a user previously dragged and we restored from
@@ -64,6 +67,34 @@ const PRESET_COLUMN_WIDTHS: Record<string, number> = {
   version: 160,
   category: 220,
   endorsed: 160,
+};
+
+const ActionsCell = ({ mod }: { mod: IDemoMod }) => {
+  const [enabled, setEnabled] = useState(mod.status === "Enabled");
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      {mod.installed ? (
+        <Switch
+          aria-label={`${enabled ? "Disable" : "Enable"} ${mod.name}`}
+          checked={enabled}
+          onChange={(event) => setEnabled(event.target.checked)}
+        />
+      ) : (
+        <Button appearance="moderate" brand="primary" size="xs">
+          Install
+        </Button>
+      )}
+
+      <Button
+        appearance="weak"
+        aria-label={`More actions for ${mod.name}`}
+        brand="neutral"
+        leftIconPath={mdiDotsVertical}
+        size="xs"
+      />
+    </div>
+  );
 };
 
 export const TableDemo = () => {
@@ -202,11 +233,7 @@ export const TableDemo = () => {
         width: "140px",
         hideable: false,
         resizable: false,
-        cell: () => (
-          <Button appearance="moderate" brand="neutral" leftIconPath={mdiDelete} size="xs">
-            Remove
-          </Button>
-        ),
+        cell: (row) => <ActionsCell mod={row} />,
       },
     ],
     [],
@@ -239,7 +266,7 @@ export const TableDemo = () => {
         onColumnWidthsChange={(widths) => {
           // A consumer would persist this map (e.g. per table id); here we just
           // log it so the design-system demo stays self-contained.
-          // eslint-disable-next-line no-console
+
           console.log("[TableDemo] column widths changed:", widths);
         }}
       />

--- a/src/stylesheets/ui/form/index.css
+++ b/src/stylesheets/ui/form/index.css
@@ -1,2 +1,3 @@
 @import "./checkbox.css";
 @import "./input.css";
+@import "./switch.css";

--- a/src/stylesheets/ui/form/switch.css
+++ b/src/stylesheets/ui/form/switch.css
@@ -1,0 +1,135 @@
+@layer components {
+    .nxm-switch {
+        flex-shrink: 0;
+        cursor: pointer;
+        position: relative;
+        display: inline-flex;
+
+        border-radius: 9999px;
+        width: calc(var(--spacing) * 8);
+        height: calc(var(--spacing) * 4);
+
+        border: 2px solid var(--color-translucent-subdued);
+        background-color: transparent;
+
+        transition-property: background-color, border-color, outline-color;
+        transition-duration: var(--default-transition-duration);
+        transition-timing-function: var(--default-transition-timing-function);
+
+        /* override bootstrap styles */
+        &,
+        .nxm-switch-input {
+            margin: 0;
+        }
+
+        &[data-state="on"],
+        &[data-state="semi-on"] {
+            border-color: transparent;
+            background-color: var(--color-translucent-strong);
+        }
+
+        &:has(.nxm-switch-input:focus-visible) {
+            outline: 2px solid var(--color-focus-subdued);
+            outline-offset: 2px;
+        }
+
+        .nxm-switch-input {
+            opacity: 0;
+            position: absolute;
+            pointer-events: none;
+        }
+
+        .nxm-switch-thumb {
+            top: 50%;
+            position: absolute;
+            box-sizing: border-box;
+            left: calc(var(--spacing) * 0.5);
+
+            border-radius: 9999px;
+            width: calc(var(--spacing) * 2);
+            height: calc(var(--spacing) * 2);
+
+            border: 2px solid transparent;
+            transform: translate(0, -50%);
+            background-color: var(--color-translucent-subdued);
+
+            transition-property: transform, width, height, border-color, background-color;
+            transition-duration: var(--default-transition-duration);
+            transition-timing-function: var(--default-transition-timing-function);
+
+            &::before {
+                top: 50%;
+                left: 50%;
+                content: "";
+                position: absolute;
+
+                border-radius: 9999px;
+                width: calc(var(--spacing) * 6);
+                height: calc(var(--spacing) * 6);
+
+                pointer-events: none;
+                background-color: transparent;
+                transform: translate(-50%, -50%);
+
+                transition-property: background-color;
+                transition-duration: var(--default-transition-duration);
+                transition-timing-function: var(--default-transition-timing-function);
+            }
+        }
+
+        &[data-state="on"] .nxm-switch-thumb,
+        &[data-state="semi-on"] .nxm-switch-thumb {
+            width: calc(var(--spacing) * 3);
+            height: calc(var(--spacing) * 3);
+            transform: translate(calc(var(--spacing) * 3.5), -50%);
+        }
+
+        &[data-state="on"] .nxm-switch-thumb {
+            background-color: var(--color-surface-mid);
+        }
+
+        &[data-state="semi-on"] .nxm-switch-thumb {
+            background-color: transparent;
+            border-color: var(--color-surface-mid);
+        }
+
+        &:not(.nxm-switch-disabled) {
+            &:hover .nxm-switch-thumb::before {
+                background-color: var(--color-translucent-50);
+            }
+
+            &:active .nxm-switch-thumb::before {
+                background-color: var(--color-translucent-100);
+            }
+        }
+
+        .nxm-switch-input:focus-visible ~ .nxm-switch-thumb::before {
+            background-color: var(--color-translucent-100);
+        }
+
+        &.nxm-switch-disabled {
+            cursor: not-allowed;
+
+            &[data-state="off"] {
+                border-color: var(--color-translucent-50);
+
+                .nxm-switch-thumb {
+                    background-color: var(--color-translucent-200);
+                }
+            }
+
+            &[data-state="on"],
+            &[data-state="semi-on"] {
+                background-color: var(--color-translucent-100);
+            }
+
+            &[data-state="on"] .nxm-switch-thumb {
+                background-color: var(--color-surface-low);
+            }
+
+            &[data-state="semi-on"] .nxm-switch-thumb {
+                border-color: var(--color-surface-low);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a design-system switch (form/switch/Switch.tsx) matching the Figma "Toggles" design.

- Tri-state: off / on / semi-on. Built on a visually-hidden native checkbox — setting indeterminate renders the semi-on ring and reports aria-checked="mixed". Clicking only ever flips on/off; semi-on is set programmatically (e.g. a "select all" whose children are partially on).
- Styling (nxm-switch) keyed off a data-state attribute, with the Material-style state-layer halo and the standard keyboard focus ring (:focus-visible → --color-focus-subdued, matching buttons/inputs).
- Portability: the nxm-switch classes live on the track/thumb so they can move onto a HeadlessUI <Switch> once the package is upgraded to v2 (post React upgrade); the tri-state stays the wrapper's responsibility.
- Includes a demo on the design-system page (Form → Switch), unit tests, and README docs.