### PR TITLE
Disable CET compatibility in dotnetprobe

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,11 +261,11 @@ catalogs:
       specifier: 2.8.0
       version: 2.8.0
     '@nexusmods/fomod-installer-ipc':
-      specifier: 0.13.1
-      version: 0.13.1
-    '@nexusmods/fomod-installer-native':
       specifier: 0.13.2
       version: 0.13.2
+    '@nexusmods/fomod-installer-native':
+      specifier: 0.13.3
+      version: 0.13.3
     '@nexusmods/nexus-api':
       specifier: git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
       version: 1.7.0
@@ -4240,10 +4240,10 @@ importers:
         version: link:../../packages/adaptor-api
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.2
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.13.2
+        version: 0.13.3
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
@@ -4753,10 +4753,10 @@ importers:
         version: 2.8.0
       '@nexusmods/fomod-installer-ipc':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.2
       '@nexusmods/fomod-installer-native':
         specifier: 'catalog:'
-        version: 0.13.2
+        version: 0.13.3
       '@nexusmods/nexus-api':
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe
@@ -6357,12 +6357,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nexusmods/fomod-installer-ipc@0.13.1':
-    resolution: {integrity: sha512-Q3tZIMWjMV0J8wJAe2qPCMQQJP+MlI7fn60UFtRYcO8igdaevQvI0OPprH8bJyFOe3WMDyrpyyQiD9vTjwPqww==}
+  '@nexusmods/fomod-installer-ipc@0.13.2':
+    resolution: {integrity: sha512-0I6HBu5s9EBQlcEvm3v+YbYMBKrNWjQ/wL8OwOEFAJLAIvpvbIPdquSde4HyQheB69lUpodOryBQuLtPQMm+0g==}
     engines: {node: '>=22'}
 
-  '@nexusmods/fomod-installer-native@0.13.2':
-    resolution: {integrity: sha512-5yRkKEQ8vtbmHYk4z5Mk3H3zoEc5SfZw79r4VFvlaSm73U9f5xYmnyoP0Locn7GXkYjuYa2FNyPmMUtXebZVjA==}
+  '@nexusmods/fomod-installer-native@0.13.3':
+    resolution: {integrity: sha512-Xb05QlkzIy2Ge1Y8N4SheTeOWAKNtsCYZBJO9BUKG7BA3pjwzzmTXjr3Ikn2Fr7UsX5uLMYMa4JhSbgkszUZUA==}
     engines: {node: '>=22'}
 
   '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/99a97cd1359527dbf5c46c93723d1846538badfe':
@@ -13999,9 +13999,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nexusmods/fomod-installer-ipc@0.13.1': {}
+  '@nexusmods/fomod-installer-ipc@0.13.2': {}
 
-  '@nexusmods/fomod-installer-native@0.13.2':
+  '@nexusmods/fomod-installer-native@0.13.3':
     dependencies:
       node-gyp-build: 4.8.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,8 +49,8 @@ catalog:
   "@mdi/js": 7.4.47
   "@microsoft/api-extractor": 7.58.7
   "@msgpack/msgpack": 2.8.0
-  "@nexusmods/fomod-installer-ipc": 0.13.1
-  "@nexusmods/fomod-installer-native": 0.13.2
+  "@nexusmods/fomod-installer-ipc": 0.13.2
+  "@nexusmods/fomod-installer-native": 0.13.3
   "@nexusmods/nexus-api": git+https://github.com/Nexus-Mods/node-nexus-api#99a97cd1359527dbf5c46c93723d1846538badfe
   "@opentelemetry/api": 1.9.1
   "@opentelemetry/context-async-hooks": 2.6.1

--- a/tools/dotnetprobe/dotnetprobe.csproj
+++ b/tools/dotnetprobe/dotnetprobe.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Authors>Nexus Mods</Authors>
     <Description>Probes for the .NET Desktop Runtime</Description>
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Some .NET runtimes (including 9) enable CET by default which can be problematic because it requires a very specific setup to work, which is not guaranteed on all systems(like mine). Setting compat to false allows everyone to run it without a problem.

This should also fix these issues:
#20915
#20780

Kind regards,

nerfnet