### PR TITLE
collection completion tweaks + deterministic ref tags + free-user fixes (483 WIP)

### DIFF
--- a/src/renderer/src/extensions/collections/eventHandlers.ts
+++ b/src/renderer/src/extensions/collections/eventHandlers.ts
@@ -18,6 +18,7 @@ import getVortexPath from "../../util/getVortexPath";
 import * as selectors from "../../util/selectors";
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, sanitizeFilename, toPromise } from "../../util/util";
+import { REFERENCE_TAG_SCHEME } from "./util/deterministicReferenceTag";
 import type InstallDriver from "./util/InstallDriver";
 import { readCollection } from "./util/readCollection";
 import { collectionModToRule } from "./util/transformCollection";
@@ -122,7 +123,7 @@ async function collectionUpdate(
       const newCollectionData = await readCollection(api, path.join(tempDir, "collection.json"));
       const knownGames = selectors.knownGames(api.getState());
       const deterministic =
-        newCollectionData.collectionConfig?.referenceTagScheme === "deterministic";
+        newCollectionData.collectionConfig?.referenceTagScheme === REFERENCE_TAG_SCHEME;
       newRules = newCollectionData.mods.map((mod) =>
         collectionModToRule(knownGames, mod, deterministic),
       );

--- a/src/renderer/src/extensions/collections/eventHandlers.ts
+++ b/src/renderer/src/extensions/collections/eventHandlers.ts
@@ -121,7 +121,11 @@ async function collectionUpdate(
     try {
       const newCollectionData = await readCollection(api, path.join(tempDir, "collection.json"));
       const knownGames = selectors.knownGames(api.getState());
-      newRules = newCollectionData.mods.map((mod) => collectionModToRule(knownGames, mod));
+      const deterministic =
+        newCollectionData.collectionConfig?.referenceTagScheme === "deterministic";
+      newRules = newCollectionData.mods.map((mod) =>
+        collectionModToRule(knownGames, mod, deterministic),
+      );
     } catch (err) {
       await fs.removeAsync(tempDir).catch(() => undefined);
       throw err;

--- a/src/renderer/src/extensions/collections/makeInstall.ts
+++ b/src/renderer/src/extensions/collections/makeInstall.ts
@@ -92,7 +92,7 @@ export function makeInstall(api: IExtensionApi) {
         })),
         ...collection.mods.map((mod) => ({
           type: "rule" as any,
-          rule: collectionModToRule(knownGames, mod),
+          rule: collectionModToRule(knownGames, mod, config.referenceTagScheme === "deterministic"),
         })),
       ],
     });

--- a/src/renderer/src/extensions/collections/makeInstall.ts
+++ b/src/renderer/src/extensions/collections/makeInstall.ts
@@ -8,6 +8,7 @@ import { BUNDLED_PATH, MOD_TYPE } from "./constants";
 import type { ICollection } from "./types/ICollection";
 import type { ICollectionConfig } from "./types/ICollectionConfig";
 import { parseConfig } from "./util/collectionConfig";
+import { REFERENCE_TAG_SCHEME } from "./util/deterministicReferenceTag";
 import { readCollection } from "./util/readCollection";
 import { collectionModToRule } from "./util/transformCollection";
 
@@ -92,7 +93,11 @@ export function makeInstall(api: IExtensionApi) {
         })),
         ...collection.mods.map((mod) => ({
           type: "rule" as any,
-          rule: collectionModToRule(knownGames, mod, config.referenceTagScheme === "deterministic"),
+          rule: collectionModToRule(
+            knownGames,
+            mod,
+            config.referenceTagScheme === REFERENCE_TAG_SCHEME,
+          ),
         })),
       ],
     });

--- a/src/renderer/src/extensions/collections/types/ICollectionConfig.ts
+++ b/src/renderer/src/extensions/collections/types/ICollectionConfig.ts
@@ -4,6 +4,17 @@ import type { ICollection } from "./ICollection";
 export interface ICollectionConfig {
   recommendNewProfile: boolean;
   excludePluginRules: boolean;
+  // Identifies how this collection's member referenceTags were generated. Deterministic tags can
+  // only be applied to collections authored AFTER that change (already-published collections keep
+  // their random shortid tags and can never be retrofitted), so the scheme must be recorded in the
+  // config NOW to tell the two apart at install time:
+  //   absent          -> legacy: random shortid tags, matched only by the stamped tag.
+  //   "deterministic" -> tags derived from file identity + installSpec (deterministicReferenceTag),
+  //                      stable across re-install/restart and recomputable/indexable by the matcher.
+  // Set ONLY by the authoring path (alongside actually generating deterministic tags); the config
+  // defaults must leave it absent so legacy collections that fall back to the defaults are not
+  // mislabelled.
+  referenceTagScheme?: "deterministic";
 }
 
 export interface IConfigGeneratorProps {

--- a/src/renderer/src/extensions/collections/types/ICollectionConfig.ts
+++ b/src/renderer/src/extensions/collections/types/ICollectionConfig.ts
@@ -4,17 +4,13 @@ import type { ICollection } from "./ICollection";
 export interface ICollectionConfig {
   recommendNewProfile: boolean;
   excludePluginRules: boolean;
-  // Identifies how this collection's member referenceTags were generated. Deterministic tags can
-  // only be applied to collections authored AFTER that change (already-published collections keep
-  // their random shortid tags and can never be retrofitted), so the scheme must be recorded in the
-  // config NOW to tell the two apart at install time:
-  //   absent          -> legacy: random shortid tags, matched only by the stamped tag.
-  //   "deterministic" -> tags derived from file identity + installSpec (deterministicReferenceTag),
-  //                      stable across re-install/restart and recomputable/indexable by the matcher.
-  // Set ONLY by the authoring path (alongside actually generating deterministic tags); the config
-  // defaults must leave it absent so legacy collections that fall back to the defaults are not
-  // mislabelled.
-  referenceTagScheme?: "deterministic";
+  // Identifies how this collection's member referenceTags were generated, so the install side knows
+  // how to match them:
+  //   absent -> random shortid tags, matched only by the stamped tag.
+  //   a version string (REFERENCE_TAG_SCHEME) -> tags derived from file identity + installSpec
+  //     (deterministicReferenceTag), stable across re-install/restart and recomputable by the matcher.
+  // Set only by the authoring path; the config defaults leave it absent.
+  referenceTagScheme?: string;
 }
 
 export interface IConfigGeneratorProps {

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -26,12 +26,14 @@ import {
   makeRule,
 } from "../../../test-utils/builders";
 import { test as driverTest } from "../../../test-utils/driverTest";
+import type { CollectionModStatus } from "../../../types/collections/ICollectionInstallSession";
 import { modRuleId } from "../../../util/collectionInstallSession";
 import type { IDownload } from "../../download_management/types/IDownload";
 import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import type { IProfile } from "../../profile_management/types/IProfile";
 import { MOD_TYPE } from "../constants";
 import { applyPatches } from "./binaryPatching";
+import { deterministicReferenceTag } from "./deterministicReferenceTag";
 
 // applyPatches is a single named collaborator that does binary file patching (fs). Stubbing it
 // at that boundary lets the member install-spec path run without touching disk while we still
@@ -53,22 +55,22 @@ interface ICollectionFixture {
 }
 
 // Compose a collection mod + its finished archive download from the shared builders, deriving
-// archiveId / installationPath / localPath from the id so each journey states only its member
-// rule. The download's modInfo omits collectionSlug, so initCollectionInfo short-circuits
+// archiveId / installationPath / localPath from the id. A real collection carries many member
+// rules, so buildCollectionFixture takes the full rule set and the churn journeys exercise that
+// scale. The download's modInfo omits collectionSlug, so initCollectionInfo short-circuits
 // instead of hitting the network.
-function makeCollectionFixture(opts: {
-  id: string;
-  rule: IModRule;
-  collectionId?: number;
-}): ICollectionFixture {
-  const { id, rule, collectionId = 1 } = opts;
+function buildCollectionFixture(
+  id: string,
+  rules: IModRule[],
+  collectionId = 1,
+): ICollectionFixture {
   const archiveId = `dl-${id}`;
   const collection = makeMod({
     id,
     type: MOD_TYPE,
     archiveId,
     installationPath: `mods/${id}`,
-    rules: [rule],
+    rules,
   });
   const download = makeDownload({
     id: archiveId,
@@ -77,6 +79,16 @@ function makeCollectionFixture(opts: {
     modInfo: makeCollectionModInfo({ collectionId, gameId: GAME_ID }),
   });
   return { collection, download };
+}
+
+// thin single-rule helper for the focused lifecycle/premium/completion tests that isolate one
+// member; the churn journeys below call buildCollectionFixture with a full member set instead.
+function makeCollectionFixture(opts: {
+  id: string;
+  rule: IModRule;
+  collectionId?: number;
+}): ICollectionFixture {
+  return buildCollectionFixture(opts.id, [opts.rule], opts.collectionId);
 }
 
 // extend the shared harness test with a driver fixture: build the harness for a collection
@@ -110,6 +122,17 @@ const installedMemberMod: IMod = makeMod({
   id: "installed-a",
   attributes: { referenceTag: "mod-a" },
 });
+
+// Drive the SESSION's per-member terminal status - the single source of truth that
+// isInstallComplete now reads (keyed by modRuleId, matching how start() builds the session).
+function setSessionStatus(h: IDriverHarness, rules: IModRule[], status: CollectionModStatus): void {
+  h.setState((draft) => {
+    const session = draft.session.collections.activeSession;
+    for (const rule of rules) {
+      session.mods[modRuleId(rule)].status = status;
+    }
+  });
+}
 
 describe("InstallDriver session lifecycle", () => {
   test("constructs in the prepare step", ({ makeDriver }) => {
@@ -158,6 +181,27 @@ describe("InstallDriver premium install journey", () => {
     expect(h.driver.installedMods.map((mod) => mod.id)).toContain(installedMemberMod.id);
   });
 
+  test("attributes a member matched by reference identity when it has no referenceTag (fallback)", async ({
+    startCollection,
+  }) => {
+    // a mod with no stamped referenceTag misses the O(1) tag index, so it must still be attributed
+    // via the reference/identifier fallback (here the rule's logicalFileName)
+    const lfnRule = makeRule({
+      type: "requires",
+      reference: makeReference({ logicalFileName: "ModA.zip" }),
+    });
+    const fixture = makeCollectionFixture({ id: "col-lfn", rule: lfnRule });
+    const h = await startCollection(fixture);
+    const installed = makeMod({ id: "installed-lfn", attributes: { logicalFileName: "ModA.zip" } });
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installed.id] = installed;
+    });
+
+    h.emit("did-install-mod", GAME_ID, fixture.download.id, installed.id);
+
+    expect(h.driver.installedMods.map((mod) => mod.id)).toContain(installed.id);
+  });
+
   test("is idempotent for a duplicate did-install-mod (counts the member once)", async ({
     startCollection,
   }) => {
@@ -178,8 +222,8 @@ describe("InstallDriver premium install journey", () => {
   test("applies the rule's install spec to a member mod when it finishes installing", async ({
     startCollection,
   }) => {
-    // a member with a description triggers the side-effect block: the rule's patches /
-    // installer choices / file list are applied + stamped onto the installed mod
+    // the member's reference carries a display name (reference.description), so the spec is
+    // stamped onto the installed mod AND applyPatches runs (it labels the mod by that name)
     const installerChoices = makeInstallerChoices();
     const patches = makePatches();
     const fileList = [makeFileListItem()];
@@ -218,6 +262,43 @@ describe("InstallDriver premium install journey", () => {
     expect(installed.attributes?.patches).toEqual(patches);
     expect(installed.attributes?.fileList).toEqual(fileList);
   });
+
+  test("stamps the install spec even when the member's reference has no display name", async ({
+    startCollection,
+  }) => {
+    // the spec stamping must NOT be gated on reference.description: a member whose reference has no
+    // display name still needs its spec stamped so findModByRef(+spec) can re-match it on a later
+    // pass. Only applyPatches (which uses the display name as the mod label) stays gated on it.
+    const installerChoices = makeInstallerChoices();
+    const patches = makePatches();
+    const fileList = [makeFileListItem()];
+    const rule: IModRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-nodesc" }), // no reference.description
+      installerChoices,
+      patches,
+      fileList,
+    });
+    const fixture = makeCollectionFixture({ id: "col-nodesc", rule, collectionId: 3 });
+    const installed = makeMod({
+      id: "installed-nodesc",
+      attributes: { referenceTag: "mod-nodesc" },
+    });
+
+    const h = await startCollection(fixture);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][installed.id] = installed;
+    });
+
+    h.emit("did-install-mod", GAME_ID, fixture.download.id, installed.id);
+
+    const stamped = h.getState().persistent.mods[GAME_ID][installed.id];
+    expect(stamped.attributes?.installerChoices).toEqual(installerChoices);
+    expect(stamped.attributes?.patches).toEqual(patches);
+    expect(stamped.attributes?.fileList).toEqual(fileList);
+    // no display name -> applyPatches (which labels by it) is skipped
+    expect(applyPatches).not.toHaveBeenCalled();
+  });
 });
 
 describe("InstallDriver churn (events from non-members / other collections)", () => {
@@ -254,30 +335,33 @@ describe("InstallDriver churn (events from non-members / other collections)", ()
 });
 
 describe("InstallDriver completion decision", () => {
-  // isInstallComplete is the completion DECISION, split out of onDidInstallDependencies so it
-  // is testable without the postprocessing side-effect (staging path / readCollection). The
-  // collection reaches review only when this returns true.
+  // isInstallComplete is the completion DECISION, split out of onDidInstallDependencies so it is
+  // testable without the postprocessing side-effect (staging path / readCollection). It reads the
+  // collection SESSION's per-member terminal status (the single source of truth) rather than
+  // re-deriving from persistent.mods, so a member counts as resolved once its session status is
+  // terminal: installed, failed, or ignored. The collection reaches review only when this is true.
 
-  test("reports complete once every required member is installed", async ({ startCollection }) => {
+  test("reports complete once every required member reaches a terminal status", async ({
+    startCollection,
+  }) => {
     const h = await startCollection(defaultFixture);
-    h.setState((draft) => {
-      draft.persistent.mods[GAME_ID][installedMemberMod.id] = installedMemberMod;
-    });
+    setSessionStatus(h, [memberRule], "installed");
 
     expect(h.driver.isInstallComplete(false)).toBe(true);
   });
 
-  test("reports incomplete while a required member is still missing", async ({
+  test("reports incomplete while a required member is still pending", async ({
     startCollection,
   }) => {
+    // freshly started: the member sits at a non-terminal status (pending), so not complete
     const h = await startCollection(defaultFixture);
 
     expect(h.driver.isInstallComplete(false)).toBe(false);
   });
 
   test("treats an ignored required member as resolved", async ({ startCollection }) => {
-    // a member that was skipped (durable ignored flag) must not block completion, even though
-    // it was never installed - otherwise a skipped required mod leaves the collection stuck
+    // a member skipped via the durable ignored flag reconstructs to session status "ignored",
+    // which is terminal - a skipped required mod must not leave the collection stuck
     const ignoredRule = makeRule({
       type: "requires",
       reference: makeReference({ tag: "mod-ign" }),
@@ -286,5 +370,253 @@ describe("InstallDriver completion decision", () => {
     const h = await startCollection(makeCollectionFixture({ id: "col-ign", rule: ignoredRule }));
 
     expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+
+  test("treats a failed required member as terminal so completion is not blocked", async ({
+    startCollection,
+  }) => {
+    // A failed required mod COUNTS toward completion rather than blocking it (no stuck-at-9X%).
+    // This is safe because InstallManager only writes "failed" after retries are exhausted: while
+    // retries remain it re-queues the install without writing "failed", so the member keeps a
+    // non-terminal status and still blocks. "failed" therefore means decided-not-pending, and is
+    // still revertible if the user manually retries (failed is unprotected -> flips back).
+    const h = await startCollection(defaultFixture);
+    setSessionStatus(h, [memberRule], "failed");
+
+    expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+});
+
+// Build `count` required members with stable tags (member-0 .. member-(count-1)) and the matching
+// installed mods. referenceTag is the identity the driver matches a finished install against, so
+// each rule/mod pair shares a tag; installed mods default to state "installed" (makeMod default).
+function makeMemberSet(count: number, prefix = "member"): { rules: IModRule[]; installed: IMod[] } {
+  const rules: IModRule[] = [];
+  const installed: IMod[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const tag = `${prefix}-${i}`;
+    rules.push(makeRule({ type: "requires", reference: makeReference({ tag }) }));
+    installed.push(makeMod({ id: `inst-${tag}`, attributes: { referenceTag: tag } }));
+  }
+  return { rules, installed };
+}
+
+// deterministic non-sequential ordering (front/back interleave) so a passing assertion can't be an
+// artifact of events arriving in member-declaration order
+function interleaved<T>(items: T[]): T[] {
+  const out: T[] = [];
+  let lo = 0;
+  let hi = items.length - 1;
+  while (lo <= hi) {
+    out.push(items[lo]);
+    if (lo !== hi) {
+      out.push(items[hi]);
+    }
+    lo += 1;
+    hi -= 1;
+  }
+  return out;
+}
+
+// Real collections run into the thousands of members; the churn/perf issues only surface at that
+// scale (the field reports were 2000-4000 mods). Default to 2000 and allow CI/local stress runs to
+// crank it higher via COLLECTION_CHURN_MEMBERS without editing the test.
+const MEMBER_COUNT = Number(process.env.COLLECTION_CHURN_MEMBERS) || 2000;
+const { rules: memberRules, installed: memberMods } = makeMemberSet(MEMBER_COUNT);
+const bigCollection = buildCollectionFixture("col-big", memberRules);
+
+// startBig builds on the startCollection fixture: start the big collection (no members in state
+// yet, so start() tracks every rule as pending), then seed the given member mods into persistent
+// state and hand back the started harness. Defaults to seeding all members.
+const churnTest = test.extend<{
+  startBig: (present?: IMod[]) => Promise<IDriverHarness>;
+}>({
+  startBig: async ({ startCollection }, use) => {
+    await use(async (present: IMod[] = memberMods) => {
+      const h = await startCollection(bigCollection);
+      h.setState((draft) => {
+        for (const mod of present) {
+          draft.persistent.mods[GAME_ID][mod.id] = mod;
+        }
+      });
+      return h;
+    });
+  },
+});
+
+describe("InstallDriver churn (large collection, concurrent member installs)", () => {
+  churnTest(
+    "counts every required member exactly once as installs finish out of order",
+    async ({ startBig }) => {
+      const h = await startBig();
+
+      for (const mod of interleaved(memberMods)) {
+        h.emit("did-install-mod", GAME_ID, bigCollection.download.id, mod.id);
+      }
+
+      expect(h.driver.installedMods).toHaveLength(MEMBER_COUNT);
+      expect(new Set(h.driver.installedMods.map((mod) => mod.id)).size).toBe(MEMBER_COUNT);
+    },
+  );
+
+  churnTest(
+    "duplicate did-install-mod events for members never double-count",
+    async ({ startBig }) => {
+      const h = await startBig();
+
+      for (const mod of memberMods) {
+        h.emit("did-install-mod", GAME_ID, bigCollection.download.id, mod.id);
+      }
+      // replay a scattered subset; repeated/out-of-order events are normal under 5-installer churn
+      for (const mod of [memberMods[0], memberMods[63], memberMods[MEMBER_COUNT - 1]]) {
+        h.emit("did-install-mod", GAME_ID, bigCollection.download.id, mod.id);
+      }
+
+      expect(h.driver.installedMods).toHaveLength(MEMBER_COUNT);
+    },
+  );
+
+  churnTest(
+    "isInstallComplete stays false until the final required member is terminal (at scale)",
+    async ({ startCollection }) => {
+      // completion reads the session, so this is O(members) even at 2000-4000. Mark all-but-last
+      // terminal, confirm still incomplete, then the last and confirm it flips.
+      const h = await startCollection(bigCollection);
+      setSessionStatus(h, memberRules.slice(0, MEMBER_COUNT - 1), "installed");
+      expect(h.driver.isInstallComplete(false)).toBe(false);
+
+      setSessionStatus(h, [memberRules[MEMBER_COUNT - 1]], "installed");
+      expect(h.driver.isInstallComplete(false)).toBe(true);
+    },
+  );
+});
+
+describe("InstallDriver churn (multiple collections in one setup)", () => {
+  // collection A is the active install; collection B is a different collection whose member mods
+  // also exist in state and fire install events on the same global bus. Only membership in the
+  // ACTIVE session's rules causes attribution - B's member must never be counted toward A.
+  const aMembers = makeMemberSet(2, "a");
+  const collectionA = buildCollectionFixture("col-a", aMembers.rules, 1);
+  const bMemberMod = makeMod({ id: "inst-b-0", attributes: { referenceTag: "b-0" } });
+
+  test("counts only the active collection's members under interleaved cross-collection events", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(collectionA);
+    h.setState((draft) => {
+      for (const mod of aMembers.installed) {
+        draft.persistent.mods[GAME_ID][mod.id] = mod;
+      }
+      draft.persistent.mods[GAME_ID][bMemberMod.id] = bMemberMod;
+    });
+
+    // interleave A and B install events; only A's two members belong to the active session
+    h.emit("did-install-mod", GAME_ID, collectionA.download.id, aMembers.installed[0].id);
+    h.emit("did-install-mod", GAME_ID, "dl-col-b", bMemberMod.id);
+    h.emit("did-install-mod", GAME_ID, collectionA.download.id, aMembers.installed[1].id);
+
+    expect(h.driver.installedMods.map((mod) => mod.id).sort()).toEqual(["inst-a-0", "inst-a-1"]);
+  });
+});
+
+describe("InstallDriver churn (out-of-order / pre-state events)", () => {
+  const members = makeMemberSet(3, "ooo");
+  const collection = buildCollectionFixture("col-ooo", members.rules);
+
+  test("a did-install-mod before the mod exists in state is a safe no-op, counted on re-emit", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(collection);
+    const target = members.installed[1];
+
+    // event arrives before the install record is written to persistent.mods
+    h.emit("did-install-mod", GAME_ID, collection.download.id, target.id);
+    expect(h.driver.installedMods).toHaveLength(0);
+
+    // the mod lands in state and the event is re-delivered: now counted, exactly once
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][target.id] = target;
+    });
+    h.emit("did-install-mod", GAME_ID, collection.download.id, target.id);
+    h.emit("did-install-mod", GAME_ID, collection.download.id, target.id);
+    expect(h.driver.installedMods.map((mod) => mod.id)).toEqual([target.id]);
+  });
+});
+
+describe("InstallDriver journey: re-attribution of an already-installed member", () => {
+  // Re-attributing an installed member to its rule on (re)start does NOT hinge on the referenceTag.
+  // The tag is a fast-path identity confirmation - ideal, and stable when deterministic - but a
+  // member is equally matched by its file identity (repo / fileMD5) plus its install spec
+  // (modMatchesInstallSpec). That fallback is what keeps the hundreds of thousands of existing
+  // random-tag collections re-attributable even though their tags drift on re-processing. The one
+  // hard requirement is that the install spec is actually present on the installed mod, which is
+  // why the driver now stamps it unconditionally (not only for members carrying a description).
+  const reference = makeReference({ fileMD5: "file-abc", tag: undefined });
+  const installSpec = { patches: makePatches() };
+  const tag = deterministicReferenceTag(reference, installSpec);
+  const rule = makeRule({ type: "requires", reference: { ...reference, tag }, ...installSpec });
+  const fixture = makeCollectionFixture({ id: "col-reattach", rule });
+
+  test("re-attributes via a matching referenceTag fast-path", async ({ makeDriver }) => {
+    const installed = makeMod({
+      id: "m-tag",
+      attributes: { referenceTag: tag, fileMD5: "file-abc", patches: makePatches() },
+    });
+    const h = makeDriver({
+      mods: {
+        [GAME_ID]: { [fixture.collection.id]: fixture.collection, [installed.id]: installed },
+      },
+      downloads: { [fixture.download.id]: fixture.download },
+      profiles: { [profile.id]: profile },
+    });
+
+    await h.driver.start(profile, fixture.collection);
+
+    expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+
+  test("re-attributes by fileMD5 + install spec even when the referenceTag has drifted", async ({
+    makeDriver,
+  }) => {
+    // installed earlier but now carrying a DIFFERENT (drifted/old random) tag; identity (fileMD5)
+    // plus the stamped spec still resolve it - the path that keeps legacy collections working
+    const installed = makeMod({
+      id: "m-drift",
+      attributes: { referenceTag: "old-random-tag", fileMD5: "file-abc", patches: makePatches() },
+    });
+    const h = makeDriver({
+      mods: {
+        [GAME_ID]: { [fixture.collection.id]: fixture.collection, [installed.id]: installed },
+      },
+      downloads: { [fixture.download.id]: fixture.download },
+      profiles: { [profile.id]: profile },
+    });
+
+    await h.driver.start(profile, fixture.collection);
+
+    expect(h.driver.isInstallComplete(false)).toBe(true);
+  });
+
+  test("does not re-attribute when the install spec was never stamped on the mod", async ({
+    makeDriver,
+  }) => {
+    // matching tag AND fileMD5, but no stamped spec -> modMatchesInstallSpec rejects it, so it
+    // reads as not-installed and would be re-pulled. The driver's unconditional spec stamping is
+    // exactly what prevents this for real installs.
+    const installed = makeMod({
+      id: "m-nospec",
+      attributes: { referenceTag: tag, fileMD5: "file-abc" },
+    });
+    const h = makeDriver({
+      mods: {
+        [GAME_ID]: { [fixture.collection.id]: fixture.collection, [installed.id]: installed },
+      },
+      downloads: { [fixture.download.id]: fixture.download },
+      profiles: { [profile.id]: profile },
+    });
+
+    await h.driver.start(profile, fixture.collection);
+
+    expect(h.driver.isInstallComplete(false)).toBe(false);
   });
 });

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -6,9 +6,15 @@ import Bluebird from "bluebird";
 
 import * as installActions from "../../../actions/collectionInstallTracking";
 import { log } from "../../../logging";
+import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import type { IState } from "../../../types/IState";
-import { generateCollectionSessionId, modRuleId } from "../../../util/collectionInstallSession";
+import {
+  generateCollectionSessionId,
+  isTerminalMemberStatus,
+  modRuleId,
+} from "../../../util/collectionInstallSession";
+import { getCollectionActiveSession } from "../../../util/collectionInstallSessionSelectors";
 import { reconstructSessionMods } from "../../../util/collectionSessionReconstruct";
 import Debouncer from "../../../util/Debouncer";
 import { getSafe, setSafe } from "../../../util/storeHelper";
@@ -65,6 +71,11 @@ class InstallDriver {
   private mUpdateHandlers: UpdateCB[] = [];
   private mInstalledMods: IMod[] = [];
   private mDependentMods: IModRule[] = [];
+  // referenceTag -> member rule, kept in sync with mDependentMods (see setDependentMods). Lets the
+  // did-install-mod handler resolve an installed mod to its rule in O(1) by its stamped
+  // referenceTag instead of scanning every member, which is what made attribution O(n^2) and froze
+  // the UI on 2000-4000 mod collections.
+  private mDependentByTag: Map<string, IModRule> = new Map();
   private mInstallingMod: string;
   private mInstallDone: boolean = false;
   private mCollectionInfo: nexusApi.ICollection;
@@ -100,6 +111,19 @@ class InstallDriver {
   }
   private get recommendedMods() {
     return this.mDependentMods.filter((m) => m.type === "recommends");
+  }
+
+  // single point that assigns the member rules, so the referenceTag index can never drift from
+  // mDependentMods. First rule wins on a duplicate tag.
+  private setDependentMods(rules: IModRule[]) {
+    this.mDependentMods = rules;
+    this.mDependentByTag = new Map();
+    for (const rule of rules) {
+      const tag = rule.reference.tag;
+      if (tag !== undefined && !this.mDependentByTag.has(tag)) {
+        this.mDependentByTag.set(tag, rule);
+      }
+    }
   }
 
   private completeInstallationTracking(success: boolean) {
@@ -159,10 +183,22 @@ class InstallDriver {
       const state: IState = api.store.getState();
       const mod = getSafe(state.persistent.mods, [gameId, modId], undefined);
       const downloads = state.persistent.downloads.files;
-      // verify the mod installed is actually one required by this collection
-      const dependent = this.mDependentMods.find((iter) => {
-        const nameSet = new Set<string>();
+
+      // verify the mod installed is actually one required by this collection. Fast path: an
+      // installed collection member is stamped with its rule's referenceTag, and testModReference
+      // treats an identical tag as authoritative, so a tag hit is a definitive O(1) match - this
+      // is what keeps attribution from being O(members) per event (the 2000-4000 mod freeze).
+      const taggedDependent =
+        mod?.attributes?.referenceTag !== undefined
+          ? this.mDependentByTag.get(mod.attributes.referenceTag)
+          : undefined;
+
+      // fallback for a mod with no (matching) referenceTag: match by reference / identifiers. The
+      // identifiers are independent of the rule, so build them once rather than per member.
+      let dependent = taggedDependent;
+      if (dependent === undefined) {
         const fileIdSet = new Set<string>();
+        const nameSet = new Set<string>();
         fileIdSet.add(mod?.attributes?.fileId?.toString());
         nameSet.add(downloads[archiveId]?.localPath);
         const identifiers = {
@@ -172,10 +208,12 @@ class InstallDriver {
           fileIds: Array.from(fileIdSet).filter((id) => id !== undefined),
           fileNames: Array.from(nameSet).filter((n) => n !== undefined),
         };
-        return (
-          testModReference(mod, iter.reference) || testRefByIdentifiers(identifiers, iter.reference)
+        dependent = this.mDependentMods.find(
+          (iter) =>
+            testModReference(mod, iter.reference) ||
+            testRefByIdentifiers(identifiers, iter.reference),
         );
-      });
+      }
 
       if (mod !== undefined && dependent !== undefined) {
         const isMarkedInstalled = this.mInstalledMods.find((m) => m.id === mod.id) !== undefined;
@@ -191,14 +229,33 @@ class InstallDriver {
         // the "installed" session status is now written by InstallManager directly
         // (the in-process write path); the driver keeps the patch/attribute side effects
 
+        const installSpec = ruleInstallSpec(dependent);
+
+        // Stamp the install spec (installerChoices/patches/fileList) onto the installed mod for
+        // every member, including those with no reference.description, so it can be re-matched to
+        // its rule on a later pass: reconstructSessionMods / findModByRef require a candidate to
+        // also match the spec (modMatchesInstallSpec), so a member whose spec was never stamped is
+        // judged "not installed" and gets re-pulled. (applyPatches below still needs the
+        // description, which it uses as the mod label.) The stamping is tag-scheme agnostic, so it
+        // keeps the hundreds of thousands of existing (random-tag) collections re-attributable too,
+        // not just new deterministic ones.
+        batchDispatch(api.store, [
+          setFileOverride(gameId, modId, dependent.extra?.fileOverrides),
+          setModAttribute(gameId, modId, "installerChoices", installSpec.installerChoices),
+          setModAttribute(gameId, modId, "patches", installSpec.patches),
+          setModAttribute(gameId, modId, "fileList", installSpec.fileList),
+        ]);
+
+        if (dependent.type === "requires") {
+          this.mProgressDebouncer.schedule();
+        }
+
+        // applyPatches writes the binary patches into the collection's staging path and uses the
+        // member's description as the mod label, so it (and only it) still needs both present.
         if (
           this.mCollection?.installationPath !== undefined &&
           dependent.reference.description !== undefined
         ) {
-          if (dependent.type === "requires") {
-            this.mProgressDebouncer.schedule();
-          }
-          const installSpec = ruleInstallSpec(dependent);
           applyPatches(
             api,
             this.mCollection,
@@ -207,12 +264,6 @@ class InstallDriver {
             modId,
             installSpec.patches,
           );
-          batchDispatch(api.store, [
-            setFileOverride(gameId, modId, dependent.extra?.fileOverrides),
-            setModAttribute(gameId, modId, "installerChoices", installSpec.installerChoices),
-            setModAttribute(gameId, modId, "patches", installSpec.patches),
-            setModAttribute(gameId, modId, "fileList", installSpec.fileList),
-          ]);
         }
       }
       this.triggerUpdate();
@@ -257,9 +308,11 @@ class InstallDriver {
           const required = (collection?.rules ?? []).filter((rule) =>
             ["requires", "recommends"].includes(rule.type),
           );
-          this.mDependentMods = required.filter(
-            (rule) =>
-              findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule)) === undefined,
+          this.setDependentMods(
+            required.filter(
+              (rule) =>
+                findModByRef(rule.reference, mods, undefined, ruleInstallSpec(rule)) === undefined,
+            ),
           );
         }
 
@@ -530,34 +583,31 @@ class InstallDriver {
   }
 
   /**
-   * Whether the active collection has nothing left to install: every required rule (and, on the
-   * recommendations pass, every recommended rule too) is either installed or explicitly ignored.
-   * This is the completion DECISION, deliberately separate from the postprocessing side-effect
-   * (finalizeInstalledCollection) so it can be unit-tested without the staging-path / fs
-   * infrastructure. The two passes differ as before: the required pass demands an installed
-   * state, the recommendations pass only that the mod is present.
+   * Whether the active collection has nothing left to install: every required member (and, on the
+   * recommendations pass, every recommended member too) has reached a terminal status - installed,
+   * failed, or ignored (see isTerminalMemberStatus). This is the completion DECISION, deliberately
+   * separate from the postprocessing side-effect (finalizeInstalledCollection) so it can be
+   * unit-tested without the staging-path / fs infrastructure.
    */
   public isInstallComplete(recommendations: boolean): boolean {
     if (this.mCollection === undefined || this.mGameId === undefined) {
       return false;
     }
-    const mods = this.mApi.getState().persistent.mods[this.mGameId] ?? {};
-    const rules = this.mCollection.rules ?? [];
-    if (!recommendations) {
-      const isInstalled = (rule: IModRule) => {
-        const mod = findModByRef(rule.reference, mods);
-        return mod != null && mod.state === "installed";
-      };
-      return !rules.some(
-        (rule) => rule.type === "requires" && rule.ignored !== true && !isInstalled(rule),
-      );
+    const session = getCollectionActiveSession(this.mApi.getState());
+    if (session === undefined || session.collectionId !== this.mCollection.id) {
+      // no active session for this collection - nothing we can assert as complete
+      return false;
     }
-    return !rules.some(
-      (rule) =>
-        ["requires", "recommends"].includes(rule.type) &&
-        rule.ignored !== true &&
-        findModByRef(rule.reference, mods) === undefined,
-    );
+    // The collection session is the single source of truth: it carries a terminal status per
+    // member rule (written by the single-writer install path), so completion is an O(members)
+    // scan. The required pass needs every required member terminal; the recommendations pass
+    // additionally needs every recommended member terminal.
+    const types: Array<ICollectionModInstallInfo["type"]> = recommendations
+      ? ["requires", "recommends"]
+      : ["requires"];
+    return Object.values(session.mods)
+      .filter((mod) => types.includes(mod.type))
+      .every((mod) => isTerminalMemberStatus(mod.status));
   }
 
   private async onDidInstallDependencies(gameId: string, modId: string, recommendations: boolean) {
@@ -698,7 +748,7 @@ class InstallDriver {
     this.mProfile = undefined;
     this.mGameId = undefined;
     this.mInstalledMods = [];
-    this.mDependentMods = [];
+    this.setDependentMods([]);
     this.mStep = "prepare";
     this.mOnStop?.();
   }
@@ -851,7 +901,7 @@ class InstallDriver {
       }
       return accum;
     }, []);
-    this.mDependentMods = dependencies;
+    this.setDependentMods(dependencies);
     // log('debug', 'dependent mods', JSON.stringify(dependencies));
 
     /* COLLECTIONS START ANALYTICS */
@@ -990,7 +1040,7 @@ class InstallDriver {
 
     this.completeInstallationTracking(true);
     this.mCollection = undefined;
-    this.mDependentMods = [];
+    this.setDependentMods([]);
     this.mInstallDone = true;
     this.triggerUpdate();
   };

--- a/src/renderer/src/extensions/collections/util/deterministicReferenceTag.test.ts
+++ b/src/renderer/src/extensions/collections/util/deterministicReferenceTag.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  makeExactRef,
+  makeFuzzyRef,
+  makePatches,
+  makeReference,
+} from "../../../test-utils/builders";
+import type { IModInstallSpec } from "../../mod_management/types/IMod";
+import { deterministicReferenceTag } from "./deterministicReferenceTag";
+
+describe("deterministicReferenceTag", () => {
+  test("is stable for the same file identity and install spec", () => {
+    // the core property: same inputs -> same tag, every time (no random shortid drift)
+    expect(deterministicReferenceTag(makeExactRef())).toBe(
+      deterministicReferenceTag(makeExactRef()),
+    );
+  });
+
+  test("ignores the reference's existing tag (derived from file identity, not the old tag)", () => {
+    // a re-installed mod that lost / changed its stamped tag still resolves to the same identity
+    expect(deterministicReferenceTag(makeExactRef({ tag: "random-1" }))).toBe(
+      deterministicReferenceTag(makeExactRef({ tag: "random-2" })),
+    );
+  });
+
+  test("for an exact rule, the identity is fileMD5 and repo modId / fileId are ignored", () => {
+    // an exact rule pins a file, so its identity is the content hash; two exact references with
+    // different repo ids but the same fileMD5 resolve to the same tag
+    const a = makeExactRef({
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "100", fileId: "5" },
+    });
+    const b = makeExactRef({
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "999", fileId: "7" },
+    });
+    expect(deterministicReferenceTag(a)).toBe(deterministicReferenceTag(b));
+  });
+
+  test("differs when the file hash (fileMD5) differs", () => {
+    expect(deterministicReferenceTag(makeExactRef({ fileMD5: "abc123" }))).not.toBe(
+      deterministicReferenceTag(makeExactRef({ fileMD5: "def456" })),
+    );
+  });
+
+  test("differs when the install spec differs (same file, different patches)", () => {
+    const specA: IModInstallSpec = { patches: makePatches() };
+    const specB: IModInstallSpec = {
+      patches: makePatches({ "meshes/other.nif": "cafebabecafebabe" }),
+    };
+    expect(deterministicReferenceTag(makeExactRef(), specA)).not.toBe(
+      deterministicReferenceTag(makeExactRef(), specB),
+    );
+  });
+
+  test("is independent of key order within the install spec (canonical serialization)", () => {
+    const a: IModInstallSpec = { patches: { "a.nif": "1", "b.nif": "2" } };
+    const b: IModInstallSpec = { patches: { "b.nif": "2", "a.nif": "1" } };
+    expect(deterministicReferenceTag(makeExactRef(), a)).toBe(
+      deterministicReferenceTag(makeExactRef(), b),
+    );
+  });
+
+  test("derives a stable, distinct tag for a bundle (no repo, content-hash fileMD5)", () => {
+    // bundles carry no repo; authoring sets fileMD5 to the bundled file's content hash so the tag
+    // is still deterministic and recomputable from the extracted file
+    const bundleA = makeReference({ fileMD5: "bundle-content-a" });
+    const bundleB = makeReference({ fileMD5: "bundle-content-b" });
+    expect(deterministicReferenceTag(bundleA)).toBe(
+      deterministicReferenceTag(makeReference({ fileMD5: "bundle-content-a" })),
+    );
+    expect(deterministicReferenceTag(bundleA)).not.toBe(deterministicReferenceTag(bundleB));
+  });
+
+  test("treats an empty install spec ({} / []) the same as an absent one", () => {
+    // some collections export empty objects/arrays for choices/patches/hashes where others omit
+    // them; both must hash identically or the same effective spec would drift to a different tag
+    const empty: IModInstallSpec = { patches: {}, fileList: [] };
+    expect(deterministicReferenceTag(makeExactRef(), empty)).toBe(
+      deterministicReferenceTag(makeExactRef()),
+    );
+  });
+
+  test("still yields a unique tag per file when the install spec is empty", () => {
+    // with an empty spec the tag falls back to fileMD5, which must still distinguish members
+    const empty: IModInstallSpec = { patches: {}, fileList: [] };
+    expect(deterministicReferenceTag(makeExactRef({ fileMD5: "file-x" }), empty)).not.toBe(
+      deterministicReferenceTag(makeExactRef({ fileMD5: "file-y" }), empty),
+    );
+  });
+
+  test("for a prefers/latest rule, the identity is repo.modId, not the (varying) fileMD5", () => {
+    // a fuzzy rule resolves to whatever version is newest/preferred, so its fileMD5 changes between
+    // versions; two fuzzy refs with the same mod page but different fileMD5 must yield the SAME tag
+    expect(deterministicReferenceTag(makeFuzzyRef({ fileMD5: "v1-md5" }))).toBe(
+      deterministicReferenceTag(makeFuzzyRef({ fileMD5: "v2-md5" })),
+    );
+  });
+
+  test("for a prefers/latest rule, differs when the mod page (repo.modId) differs", () => {
+    const modA = makeFuzzyRef({
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "100", fileId: "5" },
+    });
+    const modB = makeFuzzyRef({
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "200", fileId: "5" },
+    });
+    expect(deterministicReferenceTag(modA)).not.toBe(deterministicReferenceTag(modB));
+  });
+
+  test("for a prefers/latest rule, the same modId on a different repository or game does not collide", () => {
+    // modId is only unique within a repository+game, so the full repo triple is the identity
+    const nexus = makeFuzzyRef({
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "100", fileId: "5" },
+    });
+    const otherRepo = makeFuzzyRef({
+      repo: { repository: "other", gameId: "skyrimse", modId: "100", fileId: "5" },
+    });
+    const otherGame = makeFuzzyRef({
+      repo: { repository: "nexus", gameId: "fallout4", modId: "100", fileId: "5" },
+    });
+    expect(deterministicReferenceTag(nexus)).not.toBe(deterministicReferenceTag(otherRepo));
+    expect(deterministicReferenceTag(nexus)).not.toBe(deterministicReferenceTag(otherGame));
+  });
+
+  test("an exact and a fuzzy rule sharing an identity value do not collide", () => {
+    // exact hashes fileMD5, fuzzy hashes modId; the scheme is part of the hash so a coincidental
+    // shared string value can't produce the same tag
+    const exact = makeExactRef({
+      fileMD5: "shared",
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "shared", fileId: "5" },
+    });
+    const fuzzy = makeFuzzyRef({
+      fileMD5: "shared",
+      repo: { repository: "nexus", gameId: "skyrimse", modId: "shared", fileId: "5" },
+    });
+    expect(deterministicReferenceTag(exact)).not.toBe(deterministicReferenceTag(fuzzy));
+  });
+
+  test("returns undefined when the relevant identity is absent", () => {
+    // exact rule with no fileMD5, and a fuzzy rule with no repo.modId - nothing stable to hash
+    expect(deterministicReferenceTag(makeReference())).toBeUndefined();
+    expect(deterministicReferenceTag(makeFuzzyRef({ repo: undefined }))).toBeUndefined();
+  });
+});

--- a/src/renderer/src/extensions/collections/util/deterministicReferenceTag.ts
+++ b/src/renderer/src/extensions/collections/util/deterministicReferenceTag.ts
@@ -1,0 +1,86 @@
+import { checksum } from "../../../util/checksum";
+import type { IModInstallSpec, IModReference } from "../../mod_management/types/IMod";
+import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
+
+/**
+ * Derive a stable referenceTag for a collection member from its identity plus install spec,
+ * replacing the random shortid that can drift across re-install.
+ *
+ * The identity is UPDATE-POLICY aware. An "exact" rule pins a file, so its fileMD5 is the stable
+ * identity. A "prefers"/"latest" (fuzzy-version) rule resolves to whatever version is newest /
+ * preferred, so its fileMD5 changes between versions - the only identity that is stable across
+ * versions is the mod page, identified by the full repo triple (repository + gameId + modId), not
+ * modId alone (a modId is only unique within a repository+game). The install spec is folded in so two rules that share
+ * that identity but apply different patches / installer choices / file lists still get distinct
+ * tags. Returns undefined when the relevant identity is absent (nothing stable to hash); the
+ * caller then falls back to a random tag and re-attribution relies on the identity match.
+ *
+ * Only meaningful for collections authored with deterministic tags; legacy collections carry
+ * random tags and are matched by identity (gated on the collectionInfo referenceTagScheme).
+ */
+export function deterministicReferenceTag(
+  reference: IModReference,
+  installSpec?: IModInstallSpec,
+): string | undefined {
+  // exact -> fileMD5 (the pinned file's content hash, globally unique); fuzzy (prefers/latest) ->
+  // the mod PAGE (the resolved file and its md5 vary between versions). The page is the full repo
+  // triple, not modId alone, since a modId is only unique within a repository+game. Each
+  // install-spec part is normalised to null when absent OR empty ({}/[]): some collections export
+  // empty objects/arrays where others omit the field, and both must yield the same tag.
+  const fuzzy = isFuzzyVersion(reference.versionMatch);
+  const repo = reference.repo;
+  const coreIdentity = fuzzy
+    ? repo?.modId == null
+      ? undefined
+      : { repository: repo.repository, gameId: repo.gameId, modId: repo.modId }
+    : reference.fileMD5;
+  if (coreIdentity == null) {
+    return undefined;
+  }
+  const identity = {
+    // tag the scheme so an exact fileMD5 and a fuzzy modId that share a string value can't collide
+    scheme: fuzzy ? "modId" : "fileMD5",
+    coreIdentity,
+    installerChoices: nullIfEmpty(installSpec?.installerChoices),
+    patches: nullIfEmpty(installSpec?.patches),
+    fileList: nullIfEmpty(installSpec?.fileList),
+  };
+  return checksum(Buffer.from(stableStringify(identity)));
+}
+
+/**
+ * Collapse an absent, empty-object, or empty-array value to null so a serialized-empty install
+ * spec is treated identically to an omitted one. Non-empty values pass through unchanged.
+ */
+function nullIfEmpty<T>(value: T | undefined | null): T | null {
+  if (value == null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? null : value;
+  }
+  if (typeof value === "object" && Object.keys(value).length === 0) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * JSON.stringify with recursively sorted object keys, so structurally equal inputs serialize
+ * identically regardless of key insertion order (plain JSON.stringify is order-sensitive). Arrays
+ * keep their order (it is meaningful for fileList / patches).
+ */
+function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(
+      (key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`,
+    );
+  return `{${entries.join(",")}}`;
+}

--- a/src/renderer/src/extensions/collections/util/deterministicReferenceTag.ts
+++ b/src/renderer/src/extensions/collections/util/deterministicReferenceTag.ts
@@ -2,6 +2,11 @@ import { checksum } from "../../../util/checksum";
 import type { IModInstallSpec, IModReference } from "../../mod_management/types/IMod";
 import { isFuzzyVersion } from "../../mod_management/util/isFuzzyVersion";
 
+// Version of the deterministic referenceTag algorithm, recorded in a collection's config
+// (ICollectionConfig.referenceTagScheme). The install side only derives deterministic tags for a
+// collection whose recorded scheme matches this version.
+export const REFERENCE_TAG_SCHEME = "v1";
+
 /**
  * Derive a stable referenceTag for a collection member from its identity plus install spec,
  * replacing the random shortid that can drift across re-install.

--- a/src/renderer/src/extensions/collections/util/modToCollection.ts
+++ b/src/renderer/src/extensions/collections/util/modToCollection.ts
@@ -488,7 +488,9 @@ export async function modToCollection(
     modRules,
     ...extData,
     ...filteredGameSpecific,
-    collectionConfig: { ...collectionConfig },
+    // stamp the deterministic tag scheme so the install side knows it can derive stable member
+    // tags from file identity (see deterministicReferenceTag); absent on legacy collections
+    collectionConfig: { ...collectionConfig, referenceTagScheme: "deterministic" },
   };
 
   return res;

--- a/src/renderer/src/extensions/collections/util/modToCollection.ts
+++ b/src/renderer/src/extensions/collections/util/modToCollection.ts
@@ -36,6 +36,7 @@ import type {
 import { scanForDiffs } from "./binaryPatching";
 import { matchChecksums } from "./checksumMatcher";
 import { generateConfig } from "./collectionConfig";
+import { REFERENCE_TAG_SCHEME } from "./deterministicReferenceTag";
 import { ReplicateHashMismatchError } from "./errors";
 import type { IExtensionFeature } from "./extension";
 import { findExtensions } from "./extension";
@@ -489,8 +490,8 @@ export async function modToCollection(
     ...extData,
     ...filteredGameSpecific,
     // stamp the deterministic tag scheme so the install side knows it can derive stable member
-    // tags from file identity (see deterministicReferenceTag); absent on legacy collections
-    collectionConfig: { ...collectionConfig, referenceTagScheme: "deterministic" },
+    // tags from file identity (see deterministicReferenceTag)
+    collectionConfig: { ...collectionConfig, referenceTagScheme: REFERENCE_TAG_SCHEME },
   };
 
   return res;

--- a/src/renderer/src/extensions/collections/util/transformCollection.test.ts
+++ b/src/renderer/src/extensions/collections/util/transformCollection.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { makeCollectionMod } from "../../../test-utils/builders";
 import { rulePhase } from "../../mod_management/util/testModReference";
+import { deterministicReferenceTag } from "./deterministicReferenceTag";
 import {
   collectionModInstallSpec,
   collectionModToRule,
@@ -288,23 +290,6 @@ describe("makeBiDirRule", () => {
 
 describe("collectionModToRule", () => {
   const knownGames: any[] = [{ id: "skyrimse", domainName: "skyrimspecialedition" }];
-
-  const makeCollectionMod = (overrides: Record<string, any> = {}): any => ({
-    name: "Test Mod",
-    version: "1.2.3",
-    optional: false,
-    domainName: "skyrimspecialedition",
-    source: {
-      type: "nexus",
-      modId: 100,
-      fileId: 200,
-      md5: "abc",
-      fileSize: 1024,
-      logicalFilename: "TestMod",
-      updatePolicy: "exact",
-    },
-    ...overrides,
-  });
 
   it("creates a requires rule for a non-optional mod", () => {
     const result = collectionModToRule(knownGames, makeCollectionMod());
@@ -718,5 +703,64 @@ describe("makeTransferrable", () => {
 
     expect(result.fileList).toEqual([{ path: "file.esp" }]);
     expect(result.comment).toBe("load after this");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectionModToRule - deterministic referenceTag fallback
+// ---------------------------------------------------------------------------
+
+describe("collectionModToRule deterministic referenceTag", () => {
+  const knownGames: any[] = [{ id: "skyrimse", domainName: "skyrimspecialedition" }];
+
+  // the shared builder defaults to a tagless nexus member (no source.tag, has md5) - exactly the
+  // case that reaches the tag fallback (deterministic tag or random shortid). Bundles instead
+  // carry a stored source.tag and so never reach the fallback.
+  const withMd5 = (md5: string) =>
+    makeCollectionMod({ source: { ...makeCollectionMod().source, md5 } });
+
+  it("uses a random tag for a tagless member in legacy (non-deterministic) mode", () => {
+    const a = collectionModToRule(knownGames, makeCollectionMod());
+    const b = collectionModToRule(knownGames, makeCollectionMod());
+    expect(a.reference.tag).toBeDefined();
+    expect(a.reference.tag).not.toBe(b.reference.tag);
+  });
+
+  it("derives a stable tag from file identity + install spec in deterministic mode", () => {
+    const a = collectionModToRule(knownGames, makeCollectionMod(), true);
+    const b = collectionModToRule(knownGames, makeCollectionMod(), true);
+    expect(a.reference.tag).toBe(b.reference.tag);
+    // and it is exactly the deterministicReferenceTag of the reference + install spec
+    expect(a.reference.tag).toBe(
+      deterministicReferenceTag(a.reference, collectionModInstallSpec(makeCollectionMod())),
+    );
+  });
+
+  it("changes the deterministic tag when the file hash changes", () => {
+    const a = collectionModToRule(knownGames, withMd5("hash-a"), true);
+    const b = collectionModToRule(knownGames, withMd5("hash-b"), true);
+    expect(a.reference.tag).not.toBe(b.reference.tag);
+  });
+
+  it("keeps a stored tag regardless of mode (bundle members)", () => {
+    const stored = makeCollectionMod({
+      source: { ...makeCollectionMod().source, tag: "stored-tag" },
+    });
+    expect(collectionModToRule(knownGames, stored).reference.tag).toBe("stored-tag");
+    expect(collectionModToRule(knownGames, stored, true).reference.tag).toBe("stored-tag");
+  });
+
+  it("derives a stable modId-based tag for a fuzzy (latest) rule across differing file hashes", () => {
+    // a latest/prefer member floats across versions, so its tag must key on the mod page
+    // (repo.modId), not the version-specific fileMD5. Two resolutions of the same mod with
+    // different md5 must yield the SAME deterministic tag - and a real hash, not a random shortid.
+    const latest = (md5: string) =>
+      makeCollectionMod({ source: { ...makeCollectionMod().source, updatePolicy: "latest", md5 } });
+    const a = collectionModToRule(knownGames, latest("v1-md5"), true);
+    const b = collectionModToRule(knownGames, latest("v2-md5"), true);
+
+    expect(a.reference.tag).toBe(b.reference.tag);
+    // md5 hex (deterministic) is 32 chars; a shortid fallback would not match this
+    expect(a.reference.tag).toMatch(/^[0-9a-f]{32}$/);
   });
 });

--- a/src/renderer/src/extensions/collections/util/transformCollection.ts
+++ b/src/renderer/src/extensions/collections/util/transformCollection.ts
@@ -29,6 +29,7 @@ import type {
   ICollectionSourceInfo,
   SourceType,
 } from "../types/ICollection";
+import { deterministicReferenceTag } from "./deterministicReferenceTag";
 
 // the source types that carry a download hint (a URL/instructions to fetch the
 // mod), as opposed to "nexus"/"bundle" which are resolved differently
@@ -235,7 +236,11 @@ export function collectionModInstallSpec(mod: ICollectionMod): IModInstallSpec {
 /**
  * convert a mod entry from a collection into a mod rule
  */
-export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionMod): IModRule {
+export function collectionModToRule(
+  knownGames: IGameStored[],
+  mod: ICollectionMod,
+  deterministic = false,
+): IModRule {
   const downloadHint: IDownloadHint | undefined = isDownloadHintMode(mod.source.type)
     ? {
         url: mod.source.url,
@@ -267,6 +272,8 @@ export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionM
       ? mod.source.fileExpression
       : undefined;
 
+  const installSpec = collectionModInstallSpec(mod);
+
   const reference: IModReference = {
     description: mod.name,
     fileMD5: refMD5,
@@ -275,7 +282,6 @@ export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionM
     versionMatch,
     logicalFileName: mod.source.logicalFilename,
     fileExpression,
-    tag: mod.source.tag ?? shortid(),
   };
 
   if (["latest", "prefer"].includes(updatePolicy)) {
@@ -297,10 +303,21 @@ export function collectionModToRule(knownGames: IGameStored[], mod: ICollectionM
     };
   }
 
+  // Bundled members carry a tag stored at authoring; only tagless members (e.g. nexus) fall back
+  // here. For a deterministic collection, derive a stable tag from the member's identity + install
+  // spec so re-processing yields the same tag (no random drift, so an installed mod keeps matching
+  // its rule instead of being re-pulled). Computed AFTER the repo block on purpose: a fuzzy
+  // (prefers/latest) member's deterministic identity is repo.modId, which must be populated first.
+  // Legacy collections keep the random shortid, so mods already installed under an old random tag
+  // continue to match.
+  reference.tag =
+    mod.source.tag ??
+    (deterministic ? (deterministicReferenceTag(reference, installSpec) ?? shortid()) : shortid());
+
   const res: IModRule = {
     type: mod.optional ? "recommends" : "requires",
     reference,
-    ...collectionModInstallSpec(mod),
+    ...installSpec,
     downloadHint,
     phase: mod.phase ?? 0,
     extra: {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -74,7 +74,10 @@ import type { IExtensionApi, ThunkStore } from "../../types/IExtensionContext";
 import type { IProfile, IState } from "../../types/IState";
 import { getBatchContext, type IBatchContext } from "../../util/BatchContext";
 import calculateFolderSize from "../../util/calculateFolderSize";
-import { generateCollectionSessionId } from "../../util/collectionInstallSession";
+import {
+  generateCollectionSessionId,
+  isTerminalMemberStatus,
+} from "../../util/collectionInstallSession";
 import {
   getCollectionActiveSession,
   getCollectionInstallProgress,
@@ -84,7 +87,10 @@ import {
   isCollectionPhaseComplete,
 } from "../../util/collectionInstallSessionSelectors";
 import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
-import { sessionWriteForDependency } from "../../util/collectionSessionWrite";
+import {
+  planDependencyErrorRecovery,
+  sessionWriteForDependency,
+} from "../../util/collectionSessionWrite";
 import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import ConcurrencyLimiter from "../../util/ConcurrencyLimiter";
 import {
@@ -2542,35 +2548,55 @@ class InstallManager {
           const err = unknownToError(unknownError);
           this.mActiveInstalls.delete(installKey);
           const currentRetryCount = this.mDependencyRetryCount.get(installKey) || 0;
-          // A missing mDependencyInstalls entry means the install was torn down
-          // externally (cancel-dependency-install / clearQueued). Treat the
-          // late error as cancellation so it doesn't surface as a notification
-          // or trigger a retry for a download the user already canceled.
+          // A missing mDependencyInstalls entry means the whole install was torn down
+          // externally (cancel-dependency-install / clearQueued / pause). Treat the late
+          // error as cancellation so it doesn't surface as a notification.
           const installCanceled = !this.mDependencyInstalls[sourceModId];
           const isCanceled =
             installCanceled ||
             unknownError instanceof UserCanceled ||
             unknownError instanceof ProcessCanceled;
+          // An explicitly skipped member already carries the durable `ignored` flag (the skip
+          // site sets it before this rejection arrives). It is terminal: never requeue it (that
+          // would re-prompt the download a free user just skipped) and never re-mark it.
+          const ruleIgnored = isDependencyRuleIgnored(
+            api.getState(),
+            gameId,
+            sourceModId,
+            dep.reference,
+          );
           const hasRetriesLeft = currentRetryCount < InstallManager.MAX_DEPENDENCY_RETRIES;
-          if (!isCanceled && hasRetriesLeft) {
-            this.mPendingInstalls.set(installKey, dep); // Re-queue for potential retry
+          const recovery = planDependencyErrorRecovery({
+            installCanceled,
+            ruleIgnored,
+            isCanceled,
+            hasRetriesLeft,
+          });
+          if (recovery.action === "requeue") {
+            // A transient error OR a download cancelled as collateral while the install is still
+            // live. Requeue rather than abandoning the member non-terminal - a dangling member
+            // both blocks completion and gets re-prompted on the next install pass.
+            this.mPendingInstalls.set(installKey, dep);
             this.mDependencyRetryCount.set(installKey, currentRetryCount + 1);
-          } else if (!isCanceled) {
-            // Max retries exceeded, clean up and show error
-            this.mDependencyRetryCount.delete(installKey);
-            // record the terminal failure on the collection session so the install can
-            // still complete (a failed required mod is decided, not pending) and the UI
-            // shows it as failed rather than stuck
-            this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
-            this.showDependencyError(
-              api,
-              sourceModId,
-              "Failed to install dependency",
-              err,
-              renderModReference(dep.reference),
-            );
           } else {
             this.mDependencyRetryCount.delete(installKey);
+            if (recovery.action === "fail") {
+              // Retries exhausted: settle the member as failed (terminal) so the collection can
+              // still complete and the member is not re-prompted. writeCollectionSession no-ops
+              // over an already-terminal status, so this only settles a genuinely stuck member.
+              this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
+              if (recovery.showError) {
+                this.showDependencyError(
+                  api,
+                  sourceModId,
+                  "Failed to install dependency",
+                  err,
+                  renderModReference(dep.reference),
+                );
+              }
+            }
+            // action === "leave": whole-install pause/cancel (resume rebuilds) or an explicitly
+            // skipped member - nothing to recover.
           }
           // Don't rethrow to avoid crashing the concurrency limiter
         } finally {
@@ -3086,9 +3112,8 @@ class InstallManager {
       return 0;
     }
 
-    return Object.values(session.mods).filter((mod: any) =>
-      ["installed", "failed", "ignored"].includes(mod.status),
-    ).length;
+    return Object.values(session.mods).filter((mod: any) => isTerminalMemberStatus(mod.status))
+      .length;
   }
 
   // Helper to check if an archiveId has pending or active installations

--- a/src/renderer/src/extensions/nexus_integration/views/FreeUserDLDialog.tsx
+++ b/src/renderer/src/extensions/nexus_integration/views/FreeUserDLDialog.tsx
@@ -7,8 +7,10 @@ import { Button } from "react-bootstrap";
 import { useSelector } from "react-redux";
 
 import Modal from "../../../controls/Modal";
+import type { ICollectionInstallSession } from "../../../types/collections/ICollectionInstallSession";
 import type { IComponentContext } from "../../../types/IComponentContext";
 import type { IState } from "../../../types/IState";
+import { freeUserDownloadPosition } from "../../../util/collectionInstallSession";
 import { log } from "../../../util/log";
 import opn from "../../../util/opn";
 import { Campaign, Content, nexusModsURL, Section } from "../../../util/util";
@@ -99,7 +101,7 @@ function FreeUserDLDialog(props: IFreeUserDLDialogProps) {
     (state) => state.persistent["nexus"].userInfo,
   );
 
-  const collectionInstallSession = useSelector<IState, any>(
+  const collectionInstallSession = useSelector<IState, ICollectionInstallSession | undefined>(
     (state) => state.session?.["collections"]?.activeSession,
   );
   const context = React.useContext<IComponentContext>(MainContext);
@@ -127,14 +129,11 @@ function FreeUserDLDialog(props: IFreeUserDLDialogProps) {
   }, [show]);
 
   React.useEffect(() => {
-    if (collectionInstallSession?.downloadedCount != null) {
-      const position = collectionInstallSession.downloadedCount + 1;
-      const total = Math.max(
-        collectionInstallSession.totalRequired + collectionInstallSession.totalOptional,
-        1,
-      );
-      setPositionText(`${position}/${total}`);
+    if (collectionInstallSession?.mods == null) {
+      return;
     }
+    const { position, total } = freeUserDownloadPosition(collectionInstallSession);
+    setPositionText(`${position}/${total}`);
   }, [collectionInstallSession]);
 
   React.useEffect(() => {

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from "events";
 
 import { batch } from "redux-act";
 
+import type { ICollectionMod } from "../extensions/collections/types/ICollection";
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
 import { modsReducer } from "../extensions/mod_management/reducers/mods";
@@ -50,6 +51,22 @@ import local from "../util/local";
 
 export function makeReference(overrides: Partial<IModReference> = {}): IModReference {
   return { tag: "ref-tag", ...overrides };
+}
+
+// a repo-pinned EXACT reference (no fuzzy versionMatch): its stable identity is the pinned file's
+// fileMD5
+export function makeExactRef(overrides: Partial<IModReference> = {}): IModReference {
+  return makeReference({
+    repo: { repository: "nexus", gameId: "skyrimse", modId: "100", fileId: "5" },
+    fileMD5: "abc123",
+    ...overrides,
+  });
+}
+
+// a fuzzy-version (prefers/latest) reference: it resolves to a varying file across versions, so
+// its stable identity is the mod page (repo.modId) rather than the version-specific fileMD5
+export function makeFuzzyRef(overrides: Partial<IModReference> = {}): IModReference {
+  return makeExactRef({ versionMatch: "*", ...overrides });
 }
 
 export function makeRule(overrides: Partial<IModRule> = {}): IModRule {
@@ -180,6 +197,28 @@ export function makeCollectionModInfo(
 ): IModInfo {
   const { collectionId = 1, revisionId = 1, gameId = "skyrimse" } = overrides;
   return makeModInfo({ nexus: { ids: { collectionId, revisionId, gameId } } });
+}
+
+// A collection-manifest mod entry (ICollectionMod), as produced by authoring / read on install.
+// Defaults to a nexus-sourced member; override `source` wholesale (matching how the rule
+// transform reads mod.source) to model bundles, manual sources, missing ids, etc.
+export function makeCollectionMod(overrides: Partial<ICollectionMod> = {}): ICollectionMod {
+  return {
+    name: "Test Mod",
+    version: "1.2.3",
+    optional: false,
+    domainName: "skyrimspecialedition",
+    source: {
+      type: "nexus",
+      modId: 100,
+      fileId: 200,
+      md5: "abc",
+      fileSize: 1024,
+      logicalFilename: "TestMod",
+      updatePolicy: "exact",
+    },
+    ...overrides,
+  };
 }
 
 export type { CollectionModStatus };

--- a/src/renderer/src/util/collectionInstallSession.test.ts
+++ b/src/renderer/src/util/collectionInstallSession.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { makeDownload, makeMod, makeRule } from "../test-utils/builders";
-import { reconstructModStatus } from "./collectionInstallSession";
+import { makeDownload, makeMod, makeRule, makeSession, modsByRule } from "../test-utils/builders";
+import { freeUserDownloadPosition, reconstructModStatus } from "./collectionInstallSession";
 
 describe("reconstructModStatus", () => {
   it('rehydrates an ignored rule as the terminal "ignored" status so a skip survives a restart', () => {
@@ -54,5 +54,74 @@ describe("reconstructModStatus", () => {
 
   it('an untouched rule is "pending"', () => {
     expect(reconstructModStatus(makeRule(), undefined, undefined)).toBe("pending");
+  });
+});
+
+describe("freeUserDownloadPosition", () => {
+  it("counts resolved members + the current one against the total", () => {
+    const session = makeSession({
+      totalRequired: 4,
+      mods: modsByRule([
+        { ruleId: "r1", status: "downloaded" },
+        { ruleId: "r2", status: "installed" },
+        { ruleId: "r3", status: "downloading" }, // currently shown, not yet resolved
+        { ruleId: "r4", status: "pending" },
+      ]),
+    });
+    // two resolved (downloaded + installed) + 1 for the current download
+    expect(freeUserDownloadPosition(session)).toEqual({ position: 3, total: 4 });
+  });
+
+  it("advances on a skip (ignored counts as resolved)", () => {
+    const skipped = makeSession({
+      totalRequired: 3,
+      mods: modsByRule([
+        { ruleId: "r1", status: "ignored" },
+        { ruleId: "r2", status: "downloading" },
+        { ruleId: "r3", status: "pending" },
+      ]),
+    });
+    expect(freeUserDownloadPosition(skipped).position).toBe(2);
+  });
+
+  it("never overshoots the total once every download has been resolved (no 101/100)", () => {
+    const session = makeSession({
+      totalRequired: 2,
+      mods: modsByRule([
+        { ruleId: "r1", status: "installed" },
+        { ruleId: "r2", status: "downloaded" },
+      ]),
+    });
+    // resolved (2) + 1 would be 3/2; clamped to the total
+    expect(freeUserDownloadPosition(session)).toEqual({ position: 2, total: 2 });
+  });
+
+  it("reads 1/total at the very start when nothing has been resolved yet", () => {
+    const session = makeSession({
+      totalRequired: 3,
+      mods: modsByRule([
+        { ruleId: "r1", status: "downloading" },
+        { ruleId: "r2", status: "pending" },
+        { ruleId: "r3", status: "pending" },
+      ]),
+    });
+    expect(freeUserDownloadPosition(session)).toEqual({ position: 1, total: 3 });
+  });
+
+  it("counts both required and optional members in the total", () => {
+    const session = makeSession({
+      totalRequired: 2,
+      totalOptional: 1,
+      mods: modsByRule([
+        { ruleId: "r1", status: "installed", type: "requires" },
+        { ruleId: "r2", status: "pending", type: "requires" },
+        { ruleId: "r3", status: "pending", type: "recommends" },
+      ]),
+    });
+    expect(freeUserDownloadPosition(session)).toEqual({ position: 2, total: 3 });
+  });
+
+  it("clamps the total to at least 1 so an empty session never divides oddly", () => {
+    expect(freeUserDownloadPosition(makeSession())).toEqual({ position: 1, total: 1 });
   });
 });

--- a/src/renderer/src/util/collectionInstallSession.ts
+++ b/src/renderer/src/util/collectionInstallSession.ts
@@ -1,6 +1,38 @@
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
-import type { CollectionModStatus } from "../types/collections/ICollectionInstallSession";
+import type {
+  CollectionModStatus,
+  ICollectionInstallSession,
+} from "../types/collections/ICollectionInstallSession";
+
+/**
+ * The terminal member statuses: a member with one of these has a decided outcome and no longer
+ * blocks collection completion. "failed" is terminal because InstallManager writes it only after
+ * retries are exhausted (in-flight retries keep a non-terminal status, so they still block);
+ * "ignored" is an excluded member (a user skip or the durable ignored flag). "optional"
+ * (optional-not-selected) is intentionally NOT terminal. Shared so the driver's completion
+ * decision, the install-progress selector, and InstallManager's completion counter stay in sync.
+ */
+export function isTerminalMemberStatus(status: CollectionModStatus): boolean {
+  return status === "installed" || status === "failed" || status === "ignored";
+}
+
+/**
+ * Progress position for the free-user "download mod" dialog: the count of members whose download
+ * has been resolved (anything other than still-pending or in-flight `downloading`), plus one for
+ * the download currently shown, clamped to the total. Counting resolved members (so a skip
+ * advances the position) keeps it monotonic and inside 1..total.
+ */
+export function freeUserDownloadPosition(session: ICollectionInstallSession): {
+  position: number;
+  total: number;
+} {
+  const total = Math.max(session.totalRequired + session.totalOptional, 1);
+  const resolved = Object.values(session.mods).filter(
+    (mod) => mod.status !== "pending" && mod.status !== "downloading",
+  ).length;
+  return { position: Math.min(resolved + 1, total), total };
+}
 
 export function generateCollectionSessionId(collectionId: string, profileId: string): string {
   if (!profileId || !collectionId) {

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -13,6 +13,7 @@ import type {
   CollectionModStatus,
 } from "../types/collections/ICollectionInstallSession";
 import type { IDownload, IMod, IState } from "../types/IState";
+import { isTerminalMemberStatus } from "./collectionInstallSession";
 
 /**
  * Selectors for the installTracking reducer
@@ -279,8 +280,8 @@ export const getCollectionInstallProgress = createSelector(
         )
       : [];
     const installedRequired = requiredMods.filter((mod) => mod.status === "installed").length;
-    const completedRequired = requiredMods.filter(
-      (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "ignored",
+    const completedRequired = requiredMods.filter((mod) =>
+      isTerminalMemberStatus(mod.status),
     ).length;
 
     const installProgress =

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -16,7 +16,11 @@ import type {
   CollectionModStatus,
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
-import { planSessionWrite, sessionWriteForDependency } from "./collectionSessionWrite";
+import {
+  planDependencyErrorRecovery,
+  planSessionWrite,
+  sessionWriteForDependency,
+} from "./collectionSessionWrite";
 
 describe("planSessionWrite", () => {
   it("records reaching installed via markInstalled, over any in-progress or failed state", () => {
@@ -128,5 +132,51 @@ describe("sessionWriteForDependency", () => {
     expect(
       sessionWriteForDependency(state, refForTag("r1"), { type: "installed", modId: "mod-1" }),
     ).toBeNull();
+  });
+});
+
+describe("planDependencyErrorRecovery", () => {
+  const base = {
+    installCanceled: false,
+    ruleIgnored: false,
+    isCanceled: false,
+    hasRetriesLeft: true,
+  };
+
+  it("leaves an explicitly skipped member alone (never requeue - that would re-prompt the skip)", () => {
+    // even with retries available, an ignored member must not be resurrected
+    expect(planDependencyErrorRecovery({ ...base, ruleIgnored: true, isCanceled: true })).toEqual({
+      action: "leave",
+    });
+  });
+
+  it("leaves members alone when the whole install was cancelled (resume rebuilds them)", () => {
+    expect(
+      planDependencyErrorRecovery({ ...base, installCanceled: true, isCanceled: true }),
+    ).toEqual({ action: "leave" });
+  });
+
+  it("requeues a transient error while retries remain", () => {
+    expect(planDependencyErrorRecovery({ ...base })).toEqual({ action: "requeue" });
+  });
+
+  it("requeues a download cancelled as collateral (canceled, not skipped, retries left)", () => {
+    // the free-user skip cascade tears down sibling downloads; those are wanted mods, so retry
+    expect(
+      planDependencyErrorRecovery({ ...base, isCanceled: true, hasRetriesLeft: true }),
+    ).toEqual({ action: "requeue" });
+  });
+
+  it("settles a genuine failure as failed and surfaces the error once retries are exhausted", () => {
+    expect(planDependencyErrorRecovery({ ...base, hasRetriesLeft: false })).toEqual({
+      action: "fail",
+      showError: true,
+    });
+  });
+
+  it("settles a cancellation as failed WITHOUT surfacing an error (cancel is not a failure)", () => {
+    expect(
+      planDependencyErrorRecovery({ ...base, isCanceled: true, hasRetriesLeft: false }),
+    ).toEqual({ action: "fail", showError: false });
   });
 });

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -55,6 +55,40 @@ export function planSessionWrite(
   return { kind: "updateStatus", status: outcome.status };
 }
 
+/** What the dependency-install error handler should do with a member whose attempt threw. */
+export type DependencyErrorRecovery =
+  | { action: "leave" } // decided elsewhere (explicit skip) or whole install torn down: do nothing
+  | { action: "requeue" } // retryable: attempt again
+  | { action: "fail"; showError: boolean }; // terminal: settle as failed, report only a real error
+
+/**
+ * Decide how to recover a collection dependency whose install/download attempt threw. The sibling
+ * of planSessionWrite on the error path - pure, so the policy is testable apart from the install
+ * machinery:
+ * - an explicitly skipped member (ruleIgnored) or a whole-install cancel (installCanceled) is left
+ *   untouched - the skip is terminal and a cancelled install is rebuilt on resume; requeuing a
+ *   skipped member would re-prompt the very download a free user just skipped;
+ * - otherwise, while retries remain the member is requeued - a transient error or a download
+ *   cancelled as collateral (a sibling torn down during the free-user skip cascade) must not
+ *   abandon the member non-terminal, which would block completion and re-prompt next pass;
+ * - once retries are exhausted it is settled as failed (terminal) so the collection can still
+ *   complete, surfacing an error only for a genuine failure, never for a user cancellation.
+ */
+export function planDependencyErrorRecovery(input: {
+  installCanceled: boolean;
+  ruleIgnored: boolean;
+  isCanceled: boolean;
+  hasRetriesLeft: boolean;
+}): DependencyErrorRecovery {
+  if (input.installCanceled || input.ruleIgnored) {
+    return { action: "leave" };
+  }
+  if (input.hasRetriesLeft) {
+    return { action: "requeue" };
+  }
+  return { action: "fail", showError: !input.isCanceled };
+}
+
 /** A resolved session write: which session/rule to update and how. */
 export interface IResolvedSessionWrite {
   sessionId: string;


### PR DESCRIPTION
- isInstallComplete reads the session's per-member terminal status (O(members)), replacing the O(rules x mods) findModByRef derivation that froze 2000-4000 mod collections; isTerminalMemberStatus shared across driver/selector/InstallManager.
- deterministicReferenceTag: stable tags from identity + install spec (exact keys on fileMD5, fuzzy on the repo data), gated by a referenceTagScheme marker, shortid fallback for legacy collections. O(1) tag index for did-install attribution; install spec stamped on every member so it re-matches its rule.
- freeUserDownloadPosition fixes the dialog's 101/100 overshoot and skip stalls.
- planDependencyErrorRecovery: leave skips/whole-install cancels, requeue while retries remain, else mark failed so a member can't dangle and block completion.
- Churn suite (driver at 2000-4000 members) + unit tests + shared builders.

part of LAZ-483