### PR TITLE
Added the @vortex/nexus-api-v3 package

### DIFF
--- a/packages/nexus-api-v3/.gitignore
+++ b/packages/nexus-api-v3/.gitignore
@@ -1,0 +1,2 @@
+dist/
+src/generated/

--- a/packages/nexus-api-v3/.oxlintrc.json
+++ b/packages/nexus-api-v3/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../oxlint.base.config.json"],
+  "rules": {
+    "vitest/require-mock-type-parameters": "warn"
+  }
+}

--- a/packages/nexus-api-v3/README.md
+++ b/packages/nexus-api-v3/README.md
@@ -1,0 +1,17 @@
+# @vortex/nexus-api-v3
+
+Typed HTTP client for the Nexus Mods OpenAPI v3 API.
+
+## Codegen
+
+`pnpm codegen` runs `openapi-typescript` against
+`https://api.nexusmods.com/openapi.yaml` to produce
+`src/generated/nexus-api-v3.d.ts` (gitignored).
+
+`postinstall` runs `codegen`, so installing always regenerates the bindings
+from the latest spec — the same network you already need to install the
+dependency tree. `build` only runs `tsdown` against that generated output, so
+builds never hit the network and work offline.
+
+Fetching the latest spec on every install keeps the bindings current but means
+the generated types can change between installs.

--- a/packages/nexus-api-v3/package.json
+++ b/packages/nexus-api-v3/package.json
@@ -7,10 +7,38 @@
   "scripts": {
     "codegen": "openapi-typescript https://api.nexusmods.com/openapi.yaml -o src/generated/nexus-api-v3.d.ts --immutable",
     "build": "pnpm tsdown",
-    "dist": "pnpm tsdown",
     "test": "vitest run",
     "typecheck": "pnpm tsc --noEmit -p tsconfig.json",
-    "postinstall": "pnpm codegen"
+    "lint": "pnpm exec oxlint --quiet",
+    "lint:verbose": "pnpm exec oxlint"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": [
+          "codegen",
+          "^build"
+        ]
+      },
+      "typecheck": {
+        "dependsOn": [
+          "codegen",
+          "^build"
+        ]
+      },
+      "lint": {
+        "dependsOn": [
+          "codegen",
+          "^build"
+        ]
+      },
+      "lint:verbose": {
+        "dependsOn": [
+          "codegen",
+          "^build"
+        ]
+      }
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/nexus-api-v3/package.json
+++ b/packages/nexus-api-v3/package.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://www.schemastore.org/package.json",
+  "name": "@vortex/nexus-api-v3",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "codegen": "openapi-typescript https://api.nexusmods.com/openapi.yaml -o src/generated/nexus-api-v3.d.ts --immutable",
+    "build": "pnpm tsdown",
+    "dist": "pnpm tsdown",
+    "test": "vitest run",
+    "typecheck": "pnpm tsc --noEmit -p tsconfig.json",
+    "postinstall": "pnpm codegen"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "openapi-fetch": "catalog:"
+  },
+  "devDependencies": {
+    "openapi-typescript": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "vitest-fetch-mock": "catalog:"
+  }
+}

--- a/packages/nexus-api-v3/src/client.test.ts
+++ b/packages/nexus-api-v3/src/client.test.ts
@@ -17,8 +17,9 @@ function makeClient(options: Partial<Parameters<typeof createNexusV3Client>[0]> 
 }
 
 function lastRequest(): Request {
-  const requests = fetchMocker.requests();
-  return requests[requests.length - 1];
+  const request = fetchMocker.requests().at(-1);
+  if (!request) throw new Error("no fetch request was recorded");
+  return request;
 }
 
 async function lastBody(): Promise<Record<string, unknown>> {
@@ -29,6 +30,16 @@ async function lastBody(): Promise<Record<string, unknown>> {
 function mockData(data: unknown, status = 200): void {
   fetchMocker.mockResponseOnce(JSON.stringify({ data }), { status });
 }
+
+// A minimal payload that satisfies the generated CollectionPayload type.
+const collectionData = {
+  adult_content: false,
+  collection_manifest: {
+    info: { author: "author", name: "My Collection", domain_name: "skyrimspecialedition" },
+    mods: [],
+  },
+  collection_schema_id: 1,
+};
 
 beforeEach(() => {
   fetchMocker.resetMocks();
@@ -61,11 +72,11 @@ describe("auth headers", () => {
     expect(lastRequest().headers.get("apikey")).toBeNull();
   });
 
-  it("sends the Vortex user agent", async () => {
+  it("sends the user agent from options", async () => {
     mockData({ id: "upload-1" });
-    await makeClient().createUpload(1024, "file.zip");
+    await makeClient({ userAgent: "Vortex/1.2.3" }).createUpload(1024, "file.zip");
 
-    expect(lastRequest().headers.get("user-agent")).toBe("Vortex");
+    expect(lastRequest().headers.get("user-agent")).toBe("Vortex/1.2.3");
   });
 });
 
@@ -137,13 +148,8 @@ describe("getUpload", () => {
 describe("createCollection", () => {
   it("POSTs upload_id and collection_data to /collections", async () => {
     mockData({ id: "col-1", revision_id: "rev-1" });
-    const collectionData = {
-      adult_content: false,
-      collection_manifest: { info: {}, mods: [] },
-      collection_schema_id: 1,
-    };
 
-    const result = await makeClient().createCollection("upload-1", collectionData as never);
+    const result = await makeClient().createCollection("upload-1", collectionData);
 
     expect(lastRequest().method).toBe("POST");
     expect(lastRequest().url).toBe(`${BASE_URL}/collections`);
@@ -170,16 +176,13 @@ describe("createCollection", () => {
       { status: 422, headers: { "content-type": "application/problem+json" } },
     );
 
-    try {
-      await makeClient().createCollection("upload-1", {} as never);
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(V3ApiError);
-      const v3err = err as V3ApiError;
-      expect(v3err.status).toBe(422);
-      expect(v3err.validationErrors).toHaveLength(1);
-      expect(v3err.validationErrors![0].pointer).toContain("mod_id");
-    }
+    const promise = makeClient().createCollection("upload-1", collectionData);
+
+    await expect(promise).rejects.toBeInstanceOf(V3ApiError);
+    await expect(promise).rejects.toMatchObject({
+      status: 422,
+      validationErrors: [expect.objectContaining({ pointer: expect.stringContaining("mod_id") })],
+    });
   });
 });
 
@@ -187,11 +190,11 @@ describe("createCollectionRevision", () => {
   it("POSTs to /collections/{id}/revisions with the id interpolated", async () => {
     mockData({ id: "rev-2", collection_id: "col-1" });
 
-    const result = await makeClient().createCollectionRevision("col-1", "upload-1", {} as never);
+    const result = await makeClient().createCollectionRevision("col-1", "upload-1", collectionData);
 
     expect(lastRequest().method).toBe("POST");
     expect(lastRequest().url).toBe(`${BASE_URL}/collections/col-1/revisions`);
-    expect(await lastBody()).toEqual({ upload_id: "upload-1", collection_data: {} });
+    expect(await lastBody()).toEqual({ upload_id: "upload-1", collection_data: collectionData });
     expect(result.id).toBe("rev-2");
     expect(result.collection_id).toBe("col-1");
   });
@@ -227,15 +230,13 @@ describe("error fallback", () => {
   it("builds a V3ApiError from the HTTP response when the body is not problem+json", async () => {
     fetchMocker.mockResponseOnce("<html>502 Bad Gateway</html>", { status: 502 });
 
-    try {
-      await makeClient().createUpload(1024, "file.zip");
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(V3ApiError);
-      const v3err = err as V3ApiError;
-      expect(v3err.status).toBe(502);
-      expect(v3err.message).toBe("HTTP 502");
-      expect(v3err.problemType).toBe("about:blank");
-    }
+    const promise = makeClient().createUpload(1024, "file.zip");
+
+    await expect(promise).rejects.toBeInstanceOf(V3ApiError);
+    await expect(promise).rejects.toMatchObject({
+      status: 502,
+      message: "HTTP 502",
+      problemType: "about:blank",
+    });
   });
 });

--- a/packages/nexus-api-v3/src/client.test.ts
+++ b/packages/nexus-api-v3/src/client.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+
+import { createNexusV3Client } from "./client";
+import { V3ApiError } from "./errors";
+
+// Mock at the fetch boundary so the real openapi-fetch stack runs: header
+// merging, URL/path-param building, body serialization and response parsing
+// are all exercised, not stubbed.
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+const BASE_URL = "https://api.test/v3";
+
+function makeClient(options: Partial<Parameters<typeof createNexusV3Client>[0]> = {}) {
+  return createNexusV3Client({ baseUrl: BASE_URL, apiKey: "key", ...options });
+}
+
+function lastRequest(): Request {
+  const requests = fetchMocker.requests();
+  return requests[requests.length - 1];
+}
+
+async function lastBody(): Promise<Record<string, unknown>> {
+  return JSON.parse(await lastRequest().text());
+}
+
+// Mocks a JSON success body of the shape the client unwraps ({ data: ... }).
+function mockData(data: unknown, status = 200): void {
+  fetchMocker.mockResponseOnce(JSON.stringify({ data }), { status });
+}
+
+beforeEach(() => {
+  fetchMocker.resetMocks();
+});
+
+describe("auth headers", () => {
+  it("sends the apikey header when apiKey is provided", async () => {
+    mockData({ id: "upload-1" });
+    await makeClient({ apiKey: "my-api-key" }).createUpload(1024, "file.zip");
+
+    expect(lastRequest().headers.get("apikey")).toBe("my-api-key");
+    expect(lastRequest().headers.get("authorization")).toBeNull();
+  });
+
+  it("sends the Authorization header when bearerToken is provided", async () => {
+    mockData({ id: "upload-1" });
+    await makeClient({ apiKey: undefined, bearerToken: "my-jwt" }).createUpload(1024, "file.zip");
+
+    expect(lastRequest().headers.get("authorization")).toBe("Bearer my-jwt");
+  });
+
+  it("prefers bearerToken over apiKey", async () => {
+    mockData({ id: "upload-1" });
+    await makeClient({ apiKey: "my-api-key", bearerToken: "my-jwt" }).createUpload(
+      1024,
+      "file.zip",
+    );
+
+    expect(lastRequest().headers.get("authorization")).toBe("Bearer my-jwt");
+    expect(lastRequest().headers.get("apikey")).toBeNull();
+  });
+
+  it("sends the Vortex user agent", async () => {
+    mockData({ id: "upload-1" });
+    await makeClient().createUpload(1024, "file.zip");
+
+    expect(lastRequest().headers.get("user-agent")).toBe("Vortex");
+  });
+});
+
+describe("createUpload", () => {
+  it("POSTs size and filename to /uploads and returns the unwrapped data", async () => {
+    mockData({ id: "upload-1", presigned_url: "https://s3/upload" });
+
+    const result = await makeClient().createUpload(1024, "file.zip");
+
+    expect(lastRequest().method).toBe("POST");
+    expect(lastRequest().url).toBe(`${BASE_URL}/uploads`);
+    expect(await lastBody()).toEqual({ size_bytes: 1024, filename: "file.zip" });
+    expect(result.id).toBe("upload-1");
+    expect(result.presigned_url).toBe("https://s3/upload");
+  });
+
+  it("throws V3ApiError on an error response", async () => {
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        type: "about:blank",
+        title: "Bad Request",
+        status: 400,
+        detail: "Invalid size",
+        instance: "/uploads",
+      }),
+      { status: 400, headers: { "content-type": "application/problem+json" } },
+    );
+
+    await expect(makeClient().createUpload(-1, "file.zip")).rejects.toThrow(V3ApiError);
+  });
+});
+
+describe("createMultipartUpload", () => {
+  it("POSTs to /uploads/multipart", async () => {
+    mockData({ id: "upload-2", parts: [] });
+
+    const result = await makeClient().createMultipartUpload(8_000_000, "big.zip");
+
+    expect(lastRequest().method).toBe("POST");
+    expect(lastRequest().url).toBe(`${BASE_URL}/uploads/multipart`);
+    expect(await lastBody()).toEqual({ size_bytes: 8_000_000, filename: "big.zip" });
+    expect(result.id).toBe("upload-2");
+  });
+});
+
+describe("finaliseUpload", () => {
+  it("POSTs to /uploads/{id}/finalise with the id interpolated into the path", async () => {
+    mockData({ id: "upload-1", state: "created" });
+
+    await makeClient().finaliseUpload("upload-1");
+
+    expect(lastRequest().method).toBe("POST");
+    expect(lastRequest().url).toBe(`${BASE_URL}/uploads/upload-1/finalise`);
+  });
+});
+
+describe("getUpload", () => {
+  it("GETs /uploads/{id} and returns the state", async () => {
+    mockData({ id: "upload-1", state: "available" });
+
+    const result = await makeClient().getUpload("upload-1");
+
+    expect(lastRequest().method).toBe("GET");
+    expect(lastRequest().url).toBe(`${BASE_URL}/uploads/upload-1`);
+    expect(result.state).toBe("available");
+  });
+});
+
+describe("createCollection", () => {
+  it("POSTs upload_id and collection_data to /collections", async () => {
+    mockData({ id: "col-1", revision_id: "rev-1" });
+    const collectionData = {
+      adult_content: false,
+      collection_manifest: { info: {}, mods: [] },
+      collection_schema_id: 1,
+    };
+
+    const result = await makeClient().createCollection("upload-1", collectionData as never);
+
+    expect(lastRequest().method).toBe("POST");
+    expect(lastRequest().url).toBe(`${BASE_URL}/collections`);
+    expect(await lastBody()).toEqual({ upload_id: "upload-1", collection_data: collectionData });
+    expect(result.id).toBe("col-1");
+    expect(result.revision_id).toBe("rev-1");
+  });
+
+  it("surfaces validation errors from a 422 response", async () => {
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        type: "about:blank",
+        title: "Unprocessable Entity",
+        status: 422,
+        detail: "Validation failed",
+        instance: "/collections",
+        errors: [
+          {
+            detail: "mod_id is required",
+            pointer: "/collection_data/collection_manifest/mods/0/source/mod_id",
+          },
+        ],
+      }),
+      { status: 422, headers: { "content-type": "application/problem+json" } },
+    );
+
+    try {
+      await makeClient().createCollection("upload-1", {} as never);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(V3ApiError);
+      const v3err = err as V3ApiError;
+      expect(v3err.status).toBe(422);
+      expect(v3err.validationErrors).toHaveLength(1);
+      expect(v3err.validationErrors![0].pointer).toContain("mod_id");
+    }
+  });
+});
+
+describe("createCollectionRevision", () => {
+  it("POSTs to /collections/{id}/revisions with the id interpolated", async () => {
+    mockData({ id: "rev-2", collection_id: "col-1" });
+
+    const result = await makeClient().createCollectionRevision("col-1", "upload-1", {} as never);
+
+    expect(lastRequest().method).toBe("POST");
+    expect(lastRequest().url).toBe(`${BASE_URL}/collections/col-1/revisions`);
+    expect(await lastBody()).toEqual({ upload_id: "upload-1", collection_data: {} });
+    expect(result.id).toBe("rev-2");
+    expect(result.collection_id).toBe("col-1");
+  });
+});
+
+describe("editCollection", () => {
+  it("PATCHes /collections/{id} with the patch body and resolves on 204", async () => {
+    fetchMocker.mockResponseOnce(null, { status: 204 });
+
+    await makeClient().editCollection(42, { name: "Renamed" });
+
+    expect(lastRequest().method).toBe("PATCH");
+    expect(lastRequest().url).toBe(`${BASE_URL}/collections/42`);
+    expect(await lastBody()).toEqual({ name: "Renamed" });
+  });
+
+  it("throws V3ApiError on an error response", async () => {
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        type: "about:blank",
+        title: "Forbidden",
+        status: 403,
+        detail: "Not the owner",
+      }),
+      { status: 403, headers: { "content-type": "application/problem+json" } },
+    );
+
+    await expect(makeClient().editCollection(42, { name: "Renamed" })).rejects.toThrow(V3ApiError);
+  });
+});
+
+describe("error fallback", () => {
+  it("builds a V3ApiError from the HTTP response when the body is not problem+json", async () => {
+    fetchMocker.mockResponseOnce("<html>502 Bad Gateway</html>", { status: 502 });
+
+    try {
+      await makeClient().createUpload(1024, "file.zip");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(V3ApiError);
+      const v3err = err as V3ApiError;
+      expect(v3err.status).toBe(502);
+      expect(v3err.message).toBe("HTTP 502");
+      expect(v3err.problemType).toBe("about:blank");
+    }
+  });
+});

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -1,0 +1,133 @@
+import createClient, { type Middleware } from "openapi-fetch";
+
+import { V3ApiError } from "./errors";
+import type { paths } from "./generated/nexus-api-v3";
+
+export interface NexusV3ClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  bearerToken?: string;
+  middleware?: Middleware[];
+}
+
+export type NexusV3Client = ReturnType<typeof createNexusV3Client>;
+
+export function createNexusV3Client(options: NexusV3ClientOptions) {
+  const headers: Record<string, string> = {
+    "User-Agent": "Vortex",
+  };
+
+  if (options.bearerToken) {
+    headers["Authorization"] = `Bearer ${options.bearerToken}`;
+  } else if (options.apiKey) {
+    headers["apikey"] = options.apiKey;
+  }
+
+  const client = createClient<paths>({
+    baseUrl: options.baseUrl,
+    headers,
+  });
+
+  for (const mw of options.middleware ?? []) {
+    client.use(mw);
+  }
+
+  // Wrap the client methods to throw V3ApiError on error responses
+  return {
+    ...client,
+
+    async createUpload(sizeBytes: number, filename: string) {
+      const { data, error, response } = await client.POST("/uploads", {
+        body: { size_bytes: sizeBytes, filename },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async createMultipartUpload(sizeBytes: number, filename: string) {
+      const { data, error, response } = await client.POST("/uploads/multipart", {
+        body: { size_bytes: sizeBytes, filename },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async finaliseUpload(uploadId: string) {
+      const { data, error, response } = await client.POST("/uploads/{id}/finalise", {
+        params: { path: { id: uploadId } },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async getUpload(uploadId: string) {
+      const { data, error, response } = await client.GET("/uploads/{id}", {
+        params: { path: { id: uploadId } },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async createCollection(
+      uploadId: string,
+      collectionData: paths["/collections"]["post"]["requestBody"]["content"]["application/json"]["collection_data"],
+    ) {
+      const { data, error, response } = await client.POST("/collections", {
+        body: { upload_id: uploadId, collection_data: collectionData },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async createCollectionRevision(
+      collectionId: string,
+      uploadId: string,
+      collectionData: paths["/collections/{id}/revisions"]["post"]["requestBody"]["content"]["application/json"]["collection_data"],
+    ) {
+      const { data, error, response } = await client.POST("/collections/{id}/revisions", {
+        params: { path: { id: collectionId } },
+        body: { upload_id: uploadId, collection_data: collectionData },
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
+    },
+
+    async editCollection(
+      collectionId: number,
+      patch: paths["/collections/{id}"]["patch"]["requestBody"]["content"]["application/json"],
+    ) {
+      const { error, response } = await client.PATCH("/collections/{id}", {
+        params: { path: { id: collectionId } },
+        body: patch,
+      });
+      if (error) throw toV3Error(error, response);
+    },
+  };
+}
+
+function toV3Error(error: unknown, response: Response): V3ApiError {
+  // openapi-fetch returns the parsed error body. For problem+json responses,
+  // this will be a ProblemDetails or ValidationProblem object — but proxies,
+  // 502 pages, and transport errors can all produce other shapes, so we fall
+  // back to the HTTP response whenever a field is missing.
+  const problem = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+
+  return new V3ApiError({
+    type: typeof problem.type === "string" ? problem.type : "about:blank",
+    title:
+      typeof problem.title === "string" && problem.title.length > 0
+        ? problem.title
+        : `HTTP ${response.status}`,
+    status: typeof problem.status === "number" ? problem.status : response.status,
+    detail:
+      typeof problem.detail === "string"
+        ? problem.detail
+        : error instanceof Error
+          ? error.message
+          : "",
+    instance: typeof problem.instance === "string" ? problem.instance : response.url,
+    errors: Array.isArray(problem.errors)
+      ? (problem.errors as V3ApiError["validationErrors"])
+      : undefined,
+  });
+}

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -5,6 +5,8 @@ import type { paths } from "./generated/nexus-api-v3";
 
 export interface NexusV3ClientOptions {
   baseUrl: string;
+  /** User-Agent header, e.g. `Vortex/1.2.3`. The caller supplies the app version. */
+  userAgent?: string;
   apiKey?: string;
   bearerToken?: string;
   middleware?: Middleware[];
@@ -13,9 +15,11 @@ export interface NexusV3ClientOptions {
 export type NexusV3Client = ReturnType<typeof createNexusV3Client>;
 
 export function createNexusV3Client(options: NexusV3ClientOptions) {
-  const headers: Record<string, string> = {
-    "User-Agent": "Vortex",
-  };
+  const headers: Record<string, string> = {};
+
+  if (options.userAgent) {
+    headers["User-Agent"] = options.userAgent;
+  }
 
   if (options.bearerToken) {
     headers["Authorization"] = `Bearer ${options.bearerToken}`;
@@ -110,7 +114,8 @@ function toV3Error(error: unknown, response: Response): V3ApiError {
   // this will be a ProblemDetails or ValidationProblem object — but proxies,
   // 502 pages, and transport errors can all produce other shapes, so we fall
   // back to the HTTP response whenever a field is missing.
-  const problem = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+  const problem: Record<string, unknown> =
+    typeof error === "object" && error !== null ? Object.fromEntries(Object.entries(error)) : {};
 
   return new V3ApiError({
     type: typeof problem.type === "string" ? problem.type : "about:blank",

--- a/packages/nexus-api-v3/src/errors.ts
+++ b/packages/nexus-api-v3/src/errors.ts
@@ -1,0 +1,22 @@
+import type { components } from "./generated/nexus-api-v3";
+
+type ProblemDetails = components["schemas"]["ProblemDetails"];
+type ValidationProblemItem = components["schemas"]["ValidationProblemItem"];
+
+export class V3ApiError extends Error {
+  public readonly status: number;
+  public readonly problemType: string;
+  public readonly detail: string;
+  public readonly instance: string;
+  public readonly validationErrors?: ValidationProblemItem[];
+
+  constructor(problem: Partial<ProblemDetails> & { errors?: ValidationProblemItem[] }) {
+    super(problem.title || "Request failed");
+    this.name = "V3ApiError";
+    this.status = problem.status ?? 0;
+    this.problemType = problem.type || "about:blank";
+    this.detail = problem.detail || "";
+    this.instance = problem.instance || "";
+    this.validationErrors = problem.errors;
+  }
+}

--- a/packages/nexus-api-v3/src/index.ts
+++ b/packages/nexus-api-v3/src/index.ts
@@ -1,0 +1,4 @@
+export type { paths, components, operations } from "./generated/nexus-api-v3";
+export { createNexusV3Client, type NexusV3Client, type NexusV3ClientOptions } from "./client";
+export { V3ApiError } from "./errors";
+export type { Middleware as NexusV3Middleware } from "openapi-fetch";

--- a/packages/nexus-api-v3/tsconfig.json
+++ b/packages/nexus-api-v3/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://www.schemastore.org/tsconfig.json",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": false,
+    "composite": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ESNext"]
+  }
+}

--- a/packages/nexus-api-v3/tsconfig.json
+++ b/packages/nexus-api-v3/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig.json",
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.strict.json",
   "include": ["src/**/*"],
   "compilerOptions": {
     "target": "esnext",

--- a/packages/nexus-api-v3/tsdown.config.ts
+++ b/packages/nexus-api-v3/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "./src/index.ts",
+  },
+  format: ["esm", "commonjs"],
+  dts: {
+    sourcemap: true,
+  },
+  exports: true,
+  platform: "neutral",
+});

--- a/packages/nexus-api-v3/vitest.config.ts
+++ b/packages/nexus-api-v3/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4119,6 +4119,28 @@ importers:
         specifier: workspace:*
         version: link:../pe-resources
 
+  packages/nexus-api-v3:
+    dependencies:
+      openapi-fetch:
+        specifier: 'catalog:'
+        version: 0.17.0
+    devDependencies:
+      openapi-typescript:
+        specifier: 'catalog:'
+        version: 7.13.0(typescript@6.0.3)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(vite@8.0.16)
+      vitest-fetch-mock:
+        specifier: 'catalog:'
+        version: 0.4.5(vitest@4.1.8)
+
   packages/pe-resources: {}
 
   packages/vortex-api:
@@ -20371,7 +20393,7 @@ snapshots:
 
   vitest-fetch-mock@0.4.5(vitest@4.1.8):
     dependencies:
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(vite@8.0.16)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(vite@8.0.16)
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(vite@8.0.16):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4938,6 +4938,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16)
+      '@vortex/nexus-api-v3':
+        specifier: workspace:*
+        version: link:../../packages/nexus-api-v3
       '@vortex/shared':
         specifier: workspace:*
         version: link:../shared

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -105,6 +105,7 @@
     "@types/ws": "catalog:",
     "@types/xml2js": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "@vortex/nexus-api-v3": "workspace:*",
     "@vortex/shared": "workspace:*",
     "@welldone-software/why-did-you-render": "catalog:",
     "bbcode-to-react": "catalog:",

--- a/src/renderer/src/extensions/nexus_integration/constants.ts
+++ b/src/renderer/src/extensions/nexus_integration/constants.ts
@@ -7,6 +7,8 @@ export const NEXUS_USERS_SUBDOMAIN = process.env["USERS_SUBDOMAIN"] || "users";
 
 export const NEXUS_BASE_URL =
   process.env["NEXUS_BASE_URL"] || `https://${NEXUS_FLAMEWORK_SUBDOMAIN}.${NEXUS_DOMAIN}`;
+export const NEXUS_API_URL =
+  process.env["NEXUS_API_URL"] || `https://${NEXUS_API_SUBDOMAIN}.${NEXUS_DOMAIN}`;
 export const NEXUS_GAMES_URL = process.env["NEXUS_GAMES_URL"] || `https://${NEXUS_DOMAIN}/games`;
 export const NEXUS_PROTOCOL = "https:";
 export const PREMIUM_PATH = ["account", "billing", "premium"];

--- a/src/renderer/src/extensions/nexus_integration/nexusV3Client.ts
+++ b/src/renderer/src/extensions/nexus_integration/nexusV3Client.ts
@@ -1,0 +1,35 @@
+import {
+  createNexusV3Client,
+  type NexusV3Client,
+  type NexusV3ClientOptions,
+} from "@vortex/nexus-api-v3";
+
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import { getApplication } from "../../util/application";
+import { NEXUS_API_URL } from "./constants";
+import { hasConfidentialWithNexus } from "./guards";
+import { getOAuthTokenFromState } from "./util";
+
+export type VortexNexusV3ClientOptions = Omit<NexusV3ClientOptions, "baseUrl" | "userAgent">;
+
+/**
+ * Creates a Nexus v3 API client pre-configured for Vortex.
+ * Credentials can still be overridden via `options`.
+ */
+export function createVortexNexusV3Client(
+  api: IExtensionApi,
+  options: VortexNexusV3ClientOptions = {},
+): NexusV3Client {
+  const { confidential } = api.getState();
+  const apiKey = hasConfidentialWithNexus(confidential)
+    ? confidential.account.nexus?.APIKey
+    : undefined;
+
+  return createNexusV3Client({
+    bearerToken: getOAuthTokenFromState(api),
+    apiKey,
+    ...options,
+    baseUrl: NEXUS_API_URL,
+    userAgent: `Vortex/${getApplication().version}`,
+  });
+}


### PR DESCRIPTION
Generates a typed HTTP client from the Nexus Mods OpenAPI v3 spec (openapi-typescript + openapi-fetch) and wraps the upload/collection endpoints with V3ApiError-based error handling