### PR TITLE
Use shell.openExternal instead of shell.openPath

### DIFF
--- a/src/main/src/open.ts
+++ b/src/main/src/open.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { shell } from "electron";
 
@@ -11,25 +12,23 @@ export function openUrl(url: URL): void {
   });
 }
 
-/** Opens the file using the default application for the file extension */
+/**
+ * Opens the file or folder using the default application for the file extension.
+ *
+ * Routes through a `file://` URL and `shell.openExternal` rather than
+ * `shell.openPath`. On native platforms both open the OS file manager for a
+ * directory, but under Wine `shell.openPath` triggers a Win32 `ShellExecute`
+ * "open" verb that Wine has no folder handler for, whereas `file://` URLs
+ * are routed by Wine to winebrowser → the host's xdg-open.
+ */
 export function openFile(filePath: string): void {
   const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
 
-  shell
-    .openPath(resolvedPath)
-    .then((errorMessage) => {
-      if (!errorMessage) return;
-      log("error", "failed to open file", {
-        filePath,
-        resolvedPath,
-        message: errorMessage,
-      });
-    })
-    .catch((err: unknown) => {
-      log("error", "failed to open file", {
-        filePath,
-        resolvedPath,
-        error: err,
-      });
+  shell.openExternal(pathToFileURL(resolvedPath).toString()).catch((err: unknown) => {
+    log("error", "failed to open file", {
+      filePath,
+      resolvedPath,
+      error: err,
     });
+  });
 }


### PR DESCRIPTION
Merging to master, so fix expected to land on v2.3

Fixes #23554
Closes [LAZ-621](https://linear.app/nexus-mods/issue/LAZ-621/open-folder-options-fail-on-wine)