### PR TITLE
Bundle openapi deps in V3 package

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -27,6 +27,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @tailwindcss/cli | 4.3.0 |
 | @types/bluebird | 3.5.20 |
 | @types/uuid | 3.4.13 |
+| @vortex/nexus-api-v3 | link:../../packages/nexus-api-v3 |
 | bbcode-to-react | 0.2.11 |
 | big.js | 5.2.2 |
 | bluebird | 3.7.2 |

--- a/packages/nexus-api-v3/package.json
+++ b/packages/nexus-api-v3/package.json
@@ -50,14 +50,16 @@
     },
     "./package.json": "./package.json"
   },
-  "dependencies": {
-    "openapi-fetch": "catalog:"
-  },
   "devDependencies": {
+    "openapi-fetch": "catalog:",
     "openapi-typescript": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-fetch-mock": "catalog:"
+  },
+  "inlinedDependencies": {
+    "openapi-fetch": "0.17.0",
+    "openapi-typescript-helpers": "0.1.0"
   }
 }

--- a/packages/nexus-api-v3/tsdown.config.ts
+++ b/packages/nexus-api-v3/tsdown.config.ts
@@ -4,10 +4,13 @@ export default defineConfig({
   entry: {
     index: "./src/index.ts",
   },
-  format: ["esm", "commonjs"],
+  format: ["esm", "cjs"],
   dts: {
     sourcemap: true,
   },
   exports: true,
   platform: "neutral",
+  deps: {
+    onlyBundle: ["openapi-typescript-helpers", "openapi-fetch"],
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4120,11 +4120,10 @@ importers:
         version: link:../pe-resources
 
   packages/nexus-api-v3:
-    dependencies:
+    devDependencies:
       openapi-fetch:
         specifier: 'catalog:'
         version: 0.17.0
-    devDependencies:
       openapi-typescript:
         specifier: 'catalog:'
         version: 7.13.0(typescript@6.0.3)
@@ -4299,6 +4298,9 @@ importers:
       '@types/uuid':
         specifier: 'catalog:'
         version: 3.4.13
+      '@vortex/nexus-api-v3':
+        specifier: workspace:*
+        version: link:../../packages/nexus-api-v3
       bbcode-to-react:
         specifier: 'catalog:'
         version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@16.14.0)

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -229,6 +229,7 @@
     "@tailwindcss/cli": "catalog:",
     "@types/bluebird": "catalog:",
     "@types/uuid": "catalog:",
+    "@vortex/nexus-api-v3": "workspace:*",
     "bbcode-to-react": "catalog:",
     "big.js": "catalog:",
     "bluebird": "catalog:",


### PR DESCRIPTION
Both `openapi-fetch` and `openapi-typescript-helpers` can easily be bundled by tsdown to avoid import errors. Also adds `@vortex/nexus-api-v3` as a dependency to the main project so it can be imported with `nodeIntegration` from the renderer.