### PR TITLE
harden collection install against download and extraction failures

### DIFF
--- a/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionItemStatus.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionItemStatus.tsx
@@ -78,7 +78,7 @@ class CollectionItemStatus extends React.Component<ICollectionItemStatusProps, {
           <div className="collection-status-failed">
             <Icon name="warning" />
 
-            {t("Install failed")}
+            {t(download?.state === "failed" ? "Download failed" : "Install failed")}
           </div>
         );
       case "downloaded":

--- a/src/renderer/src/extensions/mod_management/InstallManager.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import { updateModStatus } from "../../actions/collectionInstallTracking";
+import {
+  makeDownload,
+  makeMod,
+  makeModInstallInfo,
+  makeRule,
+  makeSession,
+} from "../../test-utils/builders";
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
 import InstallManager from "./InstallManager";
+import { lookupFromDownload } from "./util/dependencies";
 
 // Mock dependencies
 vi.mock("./util/dependencies");
@@ -12,10 +21,15 @@ vi.mock("../../util/log", () => {
   return { default: log, log };
 });
 
+// TODO: prefer the shared api/harness fixtures (makeApiHarness and the test.extend fixtures in
+// test-utils) over the hand-built mockApi/mockState in this file; new tests should seed state with
+// the builders instead of adding more bespoke mocks.
+
 /** Subset of InstallManager internals exercised by these tests. */
 interface IInstallManagerTestable {
   ensurePhaseState(sourceModId: string): void;
   maybeAdvancePhase(sourceModId: string, api: IExtensionApi): void;
+  handleDownloadFailed(api: IExtensionApi, downloadId: string): void;
   markPhaseDownloadsFinished(sourceModId: string, phase: number, api: IExtensionApi): void;
   mInstallPhaseState: Map<
     string,
@@ -354,5 +368,85 @@ describe("Phased Installer", () => {
       expect(state.pendingByPhase.get(2)?.length).toBe(1);
       expect(state.pendingByPhase.get(3) ?? []).toEqual([]);
     });
+  });
+});
+
+describe("collection download failure handling", () => {
+  let installManager: IInstallManagerTestable;
+  let dispatch: ReturnType<typeof vi.fn>;
+  let state: Record<string, unknown>;
+  let api: IExtensionApi;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    state = {
+      persistent: {
+        profiles: { prof1: { id: "prof1", gameId: "skyrimse" } },
+        mods: { skyrimse: { "col-1": makeMod({ id: "col-1", rules: [] }) } },
+        downloads: {
+          files: {
+            "dl-fail": makeDownload({
+              id: "dl-fail",
+              state: "failed",
+              localPath: "member.zip",
+              modInfo: { referenceTag: "member-tag" },
+            }),
+          },
+        },
+      },
+      session: {
+        collections: {
+          activeSession: makeSession({
+            sessionId: "col-1_prof1",
+            collectionId: "col-1",
+            gameId: "skyrimse",
+            mods: {
+              "rule-1": makeModInstallInfo({
+                rule: makeRule({ reference: { tag: "member-tag" } }),
+                status: "downloading",
+              }),
+            },
+          }),
+        },
+      },
+      settings: {
+        downloads: { collectionsInstallWhileDownloading: false },
+        profiles: { activeProfileId: "prof1", nextProfileId: undefined, lastActiveProfile: {} },
+      },
+    };
+
+    api = {
+      getState: () => state as unknown as IState,
+      store: { getState: () => state as unknown as IState, dispatch },
+      events: { emit: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() },
+      onAsync: vi.fn(),
+      onStateChange: vi.fn(),
+      sendNotification: vi.fn(),
+      dismissNotification: vi.fn(),
+      showErrorNotification: vi.fn(),
+      translate: vi.fn((key: string) => key),
+      registerInstaller: vi.fn(),
+    } as unknown as IExtensionApi;
+
+    // findCollectionByDownload resolves the member from the download's lookup (referenceTag match)
+    vi.mocked(lookupFromDownload).mockReturnValue({
+      referenceTag: "member-tag",
+      fileName: "member.zip",
+    } as never);
+
+    installManager = new InstallManager(api, vi.fn()) as unknown as IInstallManagerTestable;
+    // mark the collection as actively installing so the failure is not ignored
+    installManager.ensurePhaseState("col-1");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("settles the member as failed when its download terminally fails", () => {
+    installManager.handleDownloadFailed(api, "dl-fail");
+
+    // status leaves "downloading" so the row is no longer mis-bucketed under the Downloading filter
+    expect(dispatch).toHaveBeenCalledWith(updateModStatus("col-1_prof1", "rule-1", "failed"));
   });
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -12,7 +12,7 @@ import {
   getErrorMessageOrDefault,
   unknownToError,
 } from "@vortex/shared";
-import { AlreadyDownloaded, DownloadIsHTML } from "@vortex/shared/errors";
+import { AlreadyDownloaded, DownloadIsHTML, InsufficientDiskSpace } from "@vortex/shared/errors";
 import * as _ from "lodash";
 import type { IHashResult, ILookupResult, IRule } from "modmeta-db";
 import Zip from "node-7z";
@@ -183,6 +183,7 @@ import { isFuzzyVersion } from "./util/isFuzzyVersion";
 import metaLookupMatch from "./util/metaLookupMatch";
 import modName, { renderModReference } from "./util/modName";
 import queryGameId from "./util/queryGameId";
+import { reconcileOrphanedArchive } from "./util/reconcileOrphanedArchive";
 import testModReference, {
   downloadToModRef,
   idOnlyRef,
@@ -777,8 +778,8 @@ class InstallManager {
       return;
     }
 
-    // Check if this download is part of a collection installation
-    const collectionInfo = findCollectionByDownload(state, download, downloadId);
+    // Check if this download is part of a collection installation.
+    const collectionInfo = findCollectionByDownload(state, download);
     if (!collectionInfo) {
       return;
     }
@@ -826,6 +827,13 @@ class InstallManager {
         },
       );
     }
+
+    // Settle the member as failed on the collection session. A terminally failed download is not
+    // requeued, so without this the member stays on "downloading" while rendering "Download failed"
+    // - bucketed under the Downloading filter and missed by the Failed filter. Mirrors how
+    // handleDownloadSkipped settles a skipped member, then lets the phase advance past it.
+    this.writeCollectionSession(matchingRule.reference, { type: "status", status: "failed" });
+    this.maybeAdvancePhase(collectionId, api);
   }
 
   private handleDownloadSkipped(api: IExtensionApi, sourceModId: string, dep: IDependency) {
@@ -1089,6 +1097,9 @@ class InstallManager {
           const critical = errors.find((err) => this.isCritical(err));
           if (critical !== undefined) {
             return Promise.reject(new ArchiveBrokenError(path.basename(archivePath), critical));
+          }
+          if (errors.some((err) => this.isDiskFull(err))) {
+            return Promise.reject(new InsufficientDiskSpace(path.parse(tempPath).root));
           }
           return this.queryContinue(api, errors, archivePath);
         } else {
@@ -1980,6 +1991,18 @@ class InstallManager {
                       },
                     );
                     promiseCallback?.(errObj, null);
+                  } else if (err instanceof InsufficientDiskSpace) {
+                    return prom.then(() => {
+                      if (installContext !== undefined) {
+                        installContext.reportError(
+                          "Not enough disk space",
+                          "There is not enough free space on the drive to install this mod. " +
+                            "Free up space and try again.",
+                          false,
+                        );
+                      }
+                      promiseCallback?.(err, null);
+                    });
                   } else {
                     return prom
                       .then(() => api.genMd5Hash(archivePath).catch(() => ({})))
@@ -2581,11 +2604,15 @@ class InstallManager {
             dep.reference,
           );
           const hasRetriesLeft = currentRetryCount < InstallManager.MAX_DEPENDENCY_RETRIES;
+          // A disk-full failure will not succeed on retry; settle it now so the member becomes
+          // terminally failed instead of cycling the retry budget while stuck on "installing".
+          const nonRetryable = unknownError instanceof InsufficientDiskSpace;
           const recovery = planDependencyErrorRecovery({
             installCanceled,
             ruleIgnored,
             isCanceled,
             hasRetriesLeft,
+            nonRetryable,
           });
           if (recovery.action === "requeue") {
             // A transient error OR a download cancelled as collateral while the install is still
@@ -3593,6 +3620,15 @@ class InstallManager {
     return patterns.some((pattern) => lowered.includes(pattern));
   }
 
+  // A disk-full extraction error is a genuine system failure, not archive damage: it must not be
+  // routed through the "archive damaged, continue?" prompt (whose Cancel yields a UserCanceled that
+  // leaves a collection member stuck non-terminal). Detected by message so it can be re-thrown as a
+  // real, ENOSPC-coded failure instead.
+  private isDiskFull(errorMessage: string): boolean {
+    const lowered = errorMessage.toLowerCase();
+    return lowered.includes("not enough space") || lowered.includes("enospc");
+  }
+
   private extractWithRetry(
     zip: Zip,
     archivePath: string,
@@ -3722,6 +3758,9 @@ class InstallManager {
           const critical = errors.find((err) => this.isCritical(err));
           if (critical !== undefined) {
             throw new ArchiveBrokenError(path.basename(archivePath), critical);
+          }
+          if (errors.some((err) => this.isDiskFull(err))) {
+            throw new InsufficientDiskSpace(path.parse(tempPath).root);
           }
           await this.queryContinue(api, errors, archivePath);
         }
@@ -5857,14 +5896,17 @@ class InstallManager {
       }
       return abort.signal.aborted
         ? Promise.reject(new UserCanceled(false))
-        : this.downloadDependencyAsync(
-            dep.reference,
-            api,
-            dep.lookupResults[0].value,
-            () => abort.signal.aborted,
-            dep.extra?.fileName,
-            parentCollectionId,
-          )
+        : reconcileOrphanedArchive(api, gameId, dep.extra?.fileName)
+            .then(() =>
+              this.downloadDependencyAsync(
+                dep.reference,
+                api,
+                dep.lookupResults[0].value,
+                () => abort.signal.aborted,
+                dep.extra?.fileName,
+                parentCollectionId,
+              ),
+            )
             .then((dlId) => {
               const idx = queuedDownloads.indexOf(dep.reference);
               queuedDownloads.splice(idx, 1);

--- a/src/renderer/src/extensions/mod_management/util/reconcileOrphanedArchive.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/reconcileOrphanedArchive.test.ts
@@ -1,0 +1,59 @@
+import { expect, vi } from "vitest";
+
+import { makeDownload } from "../../../test-utils/builders";
+import { test } from "../../../test-utils/harnessTest";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { reconcileOrphanedArchive } from "./reconcileOrphanedArchive";
+
+const { statMock } = vi.hoisted(() => ({ statMock: vi.fn() }));
+vi.mock("node:fs/promises", () => ({ default: { stat: statMock }, stat: statMock }));
+
+// record each refresh-downloads emission (by gameId) and answer its callback so the helper resolves
+function trackRefresh(api: IExtensionApi): string[] {
+  const calls: string[] = [];
+  api.events.on("refresh-downloads", (gameId: string, done: () => void) => {
+    calls.push(gameId);
+    done();
+  });
+  return calls;
+}
+
+test("reconcileOrphanedArchive is a no-op when no file name is given", async ({ makeApi }) => {
+  const { api } = makeApi();
+  const refreshed = trackRefresh(api);
+  await reconcileOrphanedArchive(api, "skyrimse", undefined);
+  await reconcileOrphanedArchive(api, "skyrimse", "");
+  expect(statMock).not.toHaveBeenCalled();
+  expect(refreshed).toHaveLength(0);
+});
+
+test("reconcileOrphanedArchive leaves the disk alone when a record already tracks the file", async ({
+  makeApi,
+}) => {
+  const { api } = makeApi({ downloads: { "dl-1": makeDownload({ localPath: "mod.zip" }) } });
+  const refreshed = trackRefresh(api);
+  await reconcileOrphanedArchive(api, "skyrimse", "mod.zip");
+  expect(statMock).not.toHaveBeenCalled();
+  expect(refreshed).toHaveLength(0);
+});
+
+test("reconcileOrphanedArchive does not refresh when the untracked file is absent from disk", async ({
+  makeApi,
+}) => {
+  statMock.mockRejectedValue(new Error("ENOENT"));
+  const { api } = makeApi();
+  const refreshed = trackRefresh(api);
+  await reconcileOrphanedArchive(api, "skyrimse", "mod.zip");
+  expect(statMock).toHaveBeenCalledOnce();
+  expect(refreshed).toHaveLength(0);
+});
+
+test("reconcileOrphanedArchive refreshes downloads for an untracked file present on disk", async ({
+  makeApi,
+}) => {
+  statMock.mockResolvedValue({} as never);
+  const { api } = makeApi({ downloads: { "dl-1": makeDownload({ localPath: "other.zip" }) } });
+  const refreshed = trackRefresh(api);
+  await reconcileOrphanedArchive(api, "skyrimse", "mod.zip");
+  expect(refreshed).toEqual(["skyrimse"]);
+});

--- a/src/renderer/src/extensions/mod_management/util/reconcileOrphanedArchive.ts
+++ b/src/renderer/src/extensions/mod_management/util/reconcileOrphanedArchive.ts
@@ -1,0 +1,43 @@
+import { stat } from "node:fs/promises";
+import * as path from "path";
+
+import { log } from "../../../logging";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { downloadPathForGame } from "../../../util/selectors";
+
+/**
+ * Guard against an orphaned archive: a file present in the game's download folder with no matching
+ * download record. A collection (re)install starts each dependency download with the redownload
+ * disposition "never", so the download adapter reuses the on-disk file's existing record; when that
+ * record is gone the lookup finds nothing and the download is left hanging. Rebuilding the records
+ * via refresh-downloads first lets the reuse path resolve. Resolves immediately when the file is
+ * absent or already tracked, so it is a no-op on the normal path.
+ */
+export async function reconcileOrphanedArchive(
+  api: IExtensionApi,
+  gameId: string,
+  fileName?: string,
+): Promise<void> {
+  if (fileName === undefined || fileName === "") {
+    return;
+  }
+  const state = api.getState();
+  const alreadyTracked = Object.values(state.persistent.downloads.files).some(
+    (dl) => dl.localPath === fileName,
+  );
+  if (alreadyTracked) {
+    return;
+  }
+  const dlPath = downloadPathForGame(state, gameId);
+  const onDisk = await stat(path.join(dlPath, fileName)).then(
+    () => true,
+    () => false,
+  );
+  if (!onDisk) {
+    return;
+  }
+  log("info", "reconciling orphaned archive before download", { fileName, gameId });
+  await new Promise<void>((resolve) => {
+    api.events.emit("refresh-downloads", gameId, () => resolve());
+  });
+}

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -341,7 +341,8 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
     },
     session: { collections: slices.session },
     settings: {
-      downloads: { collectionsInstallWhileDownloading: false },
+      // download path pattern so downloadPathForGame resolves a concrete per-game folder
+      downloads: { collectionsInstallWhileDownloading: false, path: "{USERDATA}\\downloads" },
       interface: { language: "en" },
       gameMode: { discovered: {} },
     },

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -179,4 +179,17 @@ describe("planDependencyErrorRecovery", () => {
       planDependencyErrorRecovery({ ...base, isCanceled: true, hasRetriesLeft: false }),
     ).toEqual({ action: "fail", showError: false });
   });
+
+  it("fails a non-retryable error immediately even with retries left (e.g. disk full)", () => {
+    // a disk-full cannot succeed on retry, so settle now instead of burning the retry budget
+    expect(
+      planDependencyErrorRecovery({ ...base, nonRetryable: true, hasRetriesLeft: true }),
+    ).toEqual({ action: "fail", showError: true });
+  });
+
+  it("still leaves a non-retryable error alone when the member is skipped or the install cancelled", () => {
+    expect(planDependencyErrorRecovery({ ...base, nonRetryable: true, ruleIgnored: true })).toEqual(
+      { action: "leave" },
+    );
+  });
 });

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -68,6 +68,8 @@ export type DependencyErrorRecovery =
  * - an explicitly skipped member (ruleIgnored) or a whole-install cancel (installCanceled) is left
  *   untouched - the skip is terminal and a cancelled install is rebuilt on resume; requeuing a
  *   skipped member would re-prompt the very download a free user just skipped;
+ * - a non-retryable failure (e.g. the disk is full) is settled as failed immediately - retrying
+ *   cannot succeed, so burning the retry budget only leaves the member non-terminal for longer;
  * - otherwise, while retries remain the member is requeued - a transient error or a download
  *   cancelled as collateral (a sibling torn down during the free-user skip cascade) must not
  *   abandon the member non-terminal, which would block completion and re-prompt next pass;
@@ -79,11 +81,12 @@ export function planDependencyErrorRecovery(input: {
   ruleIgnored: boolean;
   isCanceled: boolean;
   hasRetriesLeft: boolean;
+  nonRetryable?: boolean;
 }): DependencyErrorRecovery {
   if (input.installCanceled || input.ruleIgnored) {
     return { action: "leave" };
   }
-  if (input.hasRetriesLeft) {
+  if (!input.nonRetryable && input.hasRetriesLeft) {
     return { action: "requeue" };
   }
   return { action: "fail", showError: !input.isCanceled };

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,9 +1,55 @@
 // NOTE(erri120): yes, the library is called "jest-dom" but it works for vitest as well with this import:
 // https://www.npmjs.com/package/@testing-library/jest-dom#with-vitest
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import type { VortexPaths } from "@vortex/shared/ipc";
+import { beforeAll, vi } from "vitest";
 
-// Many modules access window.api.log during import, so provide a default stub.
+import { ApplicationData } from "./src/applicationData";
+
+// Every path keyed off a single absolute test root so getVortexPath-backed selectors
+// (downloadPathForGame, etc.) resolve real strings instead of throwing in tests.
+const TEST_ROOT = "C:\\vortex-test";
+const testPaths: VortexPaths = {
+  base: TEST_ROOT,
+  base_unpacked: TEST_ROOT,
+  assets: `${TEST_ROOT}\\assets`,
+  assets_unpacked: `${TEST_ROOT}\\assets`,
+  modules: `${TEST_ROOT}\\modules`,
+  modules_unpacked: `${TEST_ROOT}\\modules`,
+  bundledPlugins: `${TEST_ROOT}\\plugins`,
+  locales: `${TEST_ROOT}\\locales`,
+  package: `${TEST_ROOT}\\package`,
+  package_unpacked: `${TEST_ROOT}\\package`,
+  application: TEST_ROOT,
+  userData: `${TEST_ROOT}\\userData`,
+  appData: `${TEST_ROOT}\\appData`,
+  localAppData: `${TEST_ROOT}\\localAppData`,
+  temp: `${TEST_ROOT}\\temp`,
+  home: `${TEST_ROOT}\\home`,
+  documents: `${TEST_ROOT}\\documents`,
+  exe: `${TEST_ROOT}\\vortex.exe`,
+  desktop: `${TEST_ROOT}\\desktop`,
+};
+
+// Many modules access window.api.* during import, so provide a default stub.
 if (typeof window !== "undefined" && !(window as any).api) {
-  (window as any).api = { log: vi.fn() };
+  (window as any).api = {
+    log: vi.fn(),
+    app: {
+      getName: () => Promise.resolve("vortex"),
+      getVersion: () => Promise.resolve("0.0.0-test"),
+      getVortexPaths: () => Promise.resolve(testPaths),
+    },
+    window: { getId: () => Promise.resolve(0) },
+  };
 }
+
+// Initialize once per (isolated) test file so getVortexPath returns the stub paths above.
+// The instance getter throws until initialized; use that to init exactly once.
+beforeAll(async () => {
+  try {
+    void ApplicationData.instance;
+  } catch {
+    await ApplicationData.init();
+  }
+});


### PR DESCRIPTION
Reconcile orphaned archives before a dependency download: collection downloads use the redownload "never" disposition, so a present archive with no matching download record made the adapter's reuse lookup hang. Reconcile via refresh-downloads first so a record exists.

Fail the member terminally on a disk-full extraction: ENOSPC is thrown as InsufficientDiskSpace rather than routed through the "archive damaged, continue?" prompt (whose cancel left the member stuck on "installing"), surfaced with a clear "not enough disk space" message and marked non-retryable.

Settle the member as failed when its download fails: handleDownloadFailed resolves the member from the active session instead of mis-using the download id as a mod id, so the row leaves "downloading" and matches the Failed filter.

Initialize ApplicationData in the renderer test setup and seed the download path in the api fixture so getVortexPath-backed selectors resolve.

part of LAZ-483