### PR TITLE
BG3: resolve to Public profile and correct modsettings format

### DIFF
--- a/extensions/games/game-baldursgate3/package.json
+++ b/extensions/games/game-baldursgate3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-baldursgate3",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "Support for Baldur's Gate 3",
   "author": "Black Tree Gaming Ltd.",
   "license": "GPL-3.0",

--- a/extensions/games/game-baldursgate3/src/index.tsx
+++ b/extensions/games/game-baldursgate3/src/index.tsx
@@ -72,6 +72,7 @@ import {
   profilesPath,
   convertV6toV7,
   convertToV8,
+  fileExists,
 } from "./util";
 
 const STOP_PATTERNS = ["[^/]*\\.pak$"];
@@ -207,19 +208,28 @@ async function onGameModeActivated(api: types.IExtensionApi, gameId: string) {
     await migrate(api);
     const bg3ProfileId = await getActivePlayerProfile(api);
     const gameSettingsPath: string = path.join(profilesPath(), bg3ProfileId, "modsettings.lsx");
-    let nodes = await getNodes(gameSettingsPath);
-    const { modsNode, modsOrderNode } = nodes;
-    if (modsNode.children === undefined || (modsNode.children[0] as any) === "") {
-      modsNode.children = [{ node: [] }];
-    }
+    // The game generates modsettings.lsx on first run for the active player
+    // profile. If it's absent (game never launched on this profile, or the
+    // profile resolved to the "global" fallback) there is nothing to read or
+    // convert yet, so skip rather than surfacing "Failed to migrate" on every
+    // startup. The load-order export path guides the user to run the game once.
+    if (!(await fileExists(gameSettingsPath))) {
+      logDebug("modsettings.lsx not found, skipping load order migration", gameSettingsPath);
+    } else {
+      const nodes = await getNodes(gameSettingsPath);
+      const { modsNode, modsOrderNode } = nodes;
+      if (modsNode.children === undefined || (modsNode.children[0] as any) === "") {
+        modsNode.children = [{ node: [] }];
+      }
 
-    const format = await getDefaultModSettingsFormat(api);
-    if (modsOrderNode === undefined && ["v7", "v8"].includes(format)) {
-      const convFunc = format === "v7" ? convertV6toV7 : convertToV8;
-      const data = await fs.readFileAsync(gameSettingsPath, { encoding: "utf8" });
-      const newData = await convFunc(data);
-      await fs.removeAsync(gameSettingsPath).catch((err) => Promise.resolve());
-      await fs.writeFileAsync(gameSettingsPath, newData, { encoding: "utf8" });
+      const format = await getDefaultModSettingsFormat(api);
+      if (modsOrderNode === undefined && ["v7", "v8"].includes(format)) {
+        const convFunc = format === "v7" ? convertV6toV7 : convertToV8;
+        const data = await fs.readFileAsync(gameSettingsPath, { encoding: "utf8" });
+        const newData = await convFunc(data);
+        await fs.removeAsync(gameSettingsPath).catch((err) => Promise.resolve());
+        await fs.writeFileAsync(gameSettingsPath, newData, { encoding: "utf8" });
+      }
     }
   } catch (err) {
     api.showErrorNotification("Failed to migrate", err, {

--- a/extensions/games/game-baldursgate3/src/loadOrder.ts
+++ b/extensions/games/game-baldursgate3/src/loadOrder.ts
@@ -13,6 +13,7 @@ import { GAME_ID, LO_FILE_NAME, NOTIF_IMPORT_ACTIVITY } from "./common";
 import { DivineAborted, DivineExecMissing, DivinePakInvalid } from "./divineCore";
 import { BG3Pak, IModNode, IModSettings, IProps, IRootNode } from "./types";
 import {
+  fileExists,
   findNode,
   forceRefresh,
   getActivePlayerProfile,
@@ -232,6 +233,13 @@ export async function importModSettingsGame(api: types.IExtensionApi): Promise<b
   const gameSettingsPath: string = path.join(profilesPath(), bg3ProfileId, "modsettings.lsx");
 
   logDebug("importModSettingsGame gameSettingsPath=", gameSettingsPath);
+
+  // The game writes modsettings.lsx on first run; if it isn't there yet there's
+  // nothing to import, so skip instead of surfacing a "Failed to import" error.
+  if (!(await fileExists(gameSettingsPath))) {
+    logDebug("importModSettingsGame: modsettings.lsx not found, skipping", gameSettingsPath);
+    return;
+  }
 
   processLsxFile(api, gameSettingsPath);
 }

--- a/extensions/games/game-baldursgate3/src/util.ts
+++ b/extensions/games/game-baldursgate3/src/util.ts
@@ -2,6 +2,7 @@
 import * as path from "path";
 
 import { actions, fs, types, selectors, log, util } from "@nexusmods/vortex-api";
+import { getFileVersion } from "exe-version";
 import * as semver from "semver";
 import { generate as shortid } from "shortid";
 import walk from "turbowalk";
@@ -45,6 +46,15 @@ export function profilesPath() {
   return path.join(documentsPath(), "PlayerProfiles");
 }
 
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.statAsync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function globalProfilePath(api: types.IExtensionApi) {
   const bg3ProfileId = await getActivePlayerProfile(api);
   return path.join(documentsPath(), bg3ProfileId);
@@ -64,13 +74,30 @@ export const getPlayerProfiles = (() => {
   return () => cached;
 })();
 
+// The game's user-facing product version (read via getOwnGameVersion) coerces
+// to 4.1.1 for the public release. Only pre-release/early-access builds below
+// that used per-player-profile modsettings; the public release stores them in
+// the shared "Public" profile. So anything < 4.1.1 keeps the legacy profile
+// path, the public release uses "Public".
 export function gameSupportsProfile(gameVersion: string) {
-  return semver.lt(semver.coerce(gameVersion), "4.1.206");
+  return semver.lt(semver.coerce(gameVersion), "4.1.1");
 }
 
 export async function getOwnGameVersion(state: types.IState): Promise<string> {
   const discovery = selectors.discoveryByGame(state, GAME_ID);
   return await util.getGame(GAME_ID).getInstalledVersion(discovery);
+}
+
+// Patch-tier detection (v6/v7/v8) needs the numeric FileVersion, which is the
+// reliably monotonic patch number (e.g. 4.72.9.685). The reported game version
+// (getOwnGameVersion) is the user-facing product version (4.1.1.x), which no
+// longer tracks the patch, so read the FileVersion straight off the executable.
+export async function getOwnGameFileVersion(state: types.IState): Promise<string> {
+  const discovery = selectors.discoveryByGame(state, GAME_ID);
+  if (!discovery?.path) {
+    return "";
+  }
+  return getFileVersion(path.join(discovery.path, "bin", "bg3.exe"));
 }
 
 export async function getActivePlayerProfile(api: types.IExtensionApi): Promise<string> {
@@ -187,7 +214,7 @@ export async function getDefaultModSettingsFormat(api: types.IExtensionApi): Pro
   _FORMAT = "v8";
   try {
     const state = api.getState();
-    const gameVersion = await getOwnGameVersion(state);
+    const gameVersion = await getOwnGameFileVersion(state);
     const coerced = gameVersion ? semver.coerce(gameVersion) : PATCH_8;
     if (semver.gte(coerced, PATCH_8)) {
       _FORMAT = "v8";


### PR DESCRIPTION
The switch to productVersion (4.1.1.x) for the reported game version left the profile and modsettings-format checks comparing against FileVersion-scale thresholds. On current BG3 they resolved to the non-existent "global" profile and "pre-v6" format, so startup failed with "Failed to migrate" and the load order couldn't be deployed.

- gameSupportsProfile: lower threshold 4.1.206 -> 4.1.1 (still productVersion);
  `>=4.1.1` uses the shared "Public" profile, pre-release builds keep the legacy
  per-profile path.
- Add getOwnGameFileVersion and use the numeric FileVersion for v6/v7/v8 tier detection in getDefaultModSettingsFormat; the reported/displayed version stays productVersion.
- Add a fileExists helper and skip migration/import when modsettings.lsx is absent (game not yet run) instead of surfacing an error.

closes LAZ-651
closes #23470