### PR TITLE
Extract feature flag IPC code into FlagService

### DIFF
--- a/src/renderer/src/FlagService.test.ts
+++ b/src/renderer/src/FlagService.test.ts
@@ -1,0 +1,205 @@
+import type { FeatureFlag } from "@vortex/shared/flags";
+import type { FeatureFlagsApi } from "@vortex/shared/preload";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FlagService } from "./FlagService";
+
+// -- window.api mock ---------------------------------------------------------
+
+const mockOnSynchronize = vi.fn<FeatureFlagsApi["onSynchronize"]>();
+const mockIpcUnsubscribe = vi.fn<() => void>();
+const mockReportMetrics = vi.fn<FeatureFlagsApi["reportMetrics"]>();
+
+function push(flags: FeatureFlag[]) {
+  const callback = mockOnSynchronize.mock.calls[0][0];
+  callback(flags);
+}
+
+// -- Setup / teardown --------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockIpcUnsubscribe.mockReset();
+  mockOnSynchronize.mockReset();
+  mockReportMetrics.mockReset();
+  mockOnSynchronize.mockReturnValue(mockIpcUnsubscribe);
+  (window as any).api = {
+    featureFlags: { onSynchronize: mockOnSynchronize, reportMetrics: mockReportMetrics },
+  };
+  FlagService.init();
+});
+
+afterEach(() => {
+  FlagService.destroyIfInitialized();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// -- Lifecycle ---------------------------------------------------------------
+
+describe("lifecycle", () => {
+  it("throws if init() is called twice without destroy", () => {
+    expect(() => FlagService.init()).toThrow("already initialized");
+  });
+
+  it("allows re-init after destroy", () => {
+    FlagService.instance.destroy();
+    expect(() => FlagService.init()).not.toThrow();
+  });
+
+  it("destroyIfInitialized is a no-op when not initialized", () => {
+    FlagService.instance.destroy();
+    expect(() => FlagService.destroyIfInitialized()).not.toThrow();
+  });
+
+  it("instance getter throws when not initialized", () => {
+    FlagService.instance.destroy();
+    expect(() => FlagService.instance).toThrow("not initialized");
+  });
+
+  it("subscribes to onSynchronize on init", () => {
+    expect(mockOnSynchronize).toHaveBeenCalledOnce();
+  });
+
+  it("unsubscribes from IPC on destroy", () => {
+    FlagService.instance.destroy();
+    expect(mockIpcUnsubscribe).toHaveBeenCalledOnce();
+  });
+});
+
+// -- Flag reads --------------------------------------------------------------
+
+describe("flags and getFlag", () => {
+  it("flags is empty before first push", () => {
+    expect(FlagService.instance.flags.size).toBe(0);
+  });
+
+  it("flags reflects pushed flags", () => {
+    push([{ name: "vortex-test-flag" }]);
+    expect(FlagService.instance.flags.size).toBe(1);
+    expect(FlagService.instance.flags.get("vortex-test-flag")).toBeDefined();
+  });
+
+  it("getFlag returns undefined before first push", () => {
+    expect(FlagService.instance.getFlag("vortex-test-flag")).toBeUndefined();
+  });
+
+  it("getFlag returns the flag after it is pushed", () => {
+    const flag: FeatureFlag = { name: "vortex-test-flag", variant: { name: "variant-1", data: 1 } };
+    push([flag]);
+    expect(FlagService.instance.getFlag("vortex-test-flag")).toEqual(flag);
+  });
+
+  it("getFlag returns undefined when flag is absent from the latest push", () => {
+    push([{ name: "vortex-test-flag" }]);
+    expect(FlagService.instance.getFlag("vortex-test-flag")).toBeDefined();
+    push([]);
+    expect(FlagService.instance.getFlag("vortex-test-flag")).toBeUndefined();
+  });
+});
+
+// -- Subscriptions -----------------------------------------------------------
+
+describe("subscribe", () => {
+  it("fires callback when flags are pushed", () => {
+    const cb = vi.fn();
+    FlagService.instance.subscribe(cb);
+    push([{ name: "vortex-test-flag" }]);
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("fires callback on each subsequent push", () => {
+    const cb = vi.fn();
+    FlagService.instance.subscribe(cb);
+    push([{ name: "vortex-test-flag" }]);
+    push([]);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it("unsubscribe stops the callback from firing", () => {
+    const cb = vi.fn();
+    const unsubscribe = FlagService.instance.subscribe(cb);
+    unsubscribe();
+    push([{ name: "vortex-test-flag" }]);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+// -- Metrics -----------------------------------------------------------------
+
+describe("metrics", () => {
+  it("does not call reportMetrics when nothing has been evaluated", () => {
+    FlagService.instance.destroy();
+    expect(mockReportMetrics).not.toHaveBeenCalled();
+  });
+
+  it("reports a yes count for an enabled flag", () => {
+    push([{ name: "vortex-test-flag" }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+    FlagService.instance.destroy();
+
+    expect(mockReportMetrics).toHaveBeenCalledOnce();
+    const bucket = mockReportMetrics.mock.calls[0][0];
+    expect(bucket.toggles["vortex-test-flag"].yes).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports a no count for an absent flag", () => {
+    FlagService.instance.getFlag("vortex-test-flag");
+    FlagService.instance.destroy();
+
+    expect(mockReportMetrics).toHaveBeenCalledOnce();
+    const bucket = mockReportMetrics.mock.calls[0][0];
+    expect(bucket.toggles["vortex-test-flag"].no).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports variant counts when a flag has a variant", () => {
+    push([{ name: "vortex-test-flag", variant: { name: "variant-1", data: 99 } }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+    FlagService.instance.destroy();
+
+    const bucket = mockReportMetrics.mock.calls[0][0];
+    expect(bucket.toggles["vortex-test-flag"].variants?.["variant-1"]).toBeGreaterThanOrEqual(1);
+  });
+
+  it("omits variants from the bucket entry when none were seen", () => {
+    push([{ name: "vortex-test-flag" }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+    FlagService.instance.destroy();
+
+    const bucket = mockReportMetrics.mock.calls[0][0];
+    expect(bucket.toggles["vortex-test-flag"].variants).toBeUndefined();
+  });
+
+  it("flushes automatically after 60 seconds", () => {
+    push([{ name: "vortex-test-flag" }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+
+    expect(mockReportMetrics).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(60_000);
+    expect(mockReportMetrics).toHaveBeenCalledOnce();
+  });
+
+  it("resets counts after a flush so the next empty bucket does not report", () => {
+    push([{ name: "vortex-test-flag" }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+
+    vi.advanceTimersByTime(60_000);
+    expect(mockReportMetrics).toHaveBeenCalledTimes(1);
+
+    // No new evaluations — second interval should not flush
+    vi.advanceTimersByTime(60_000);
+    expect(mockReportMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes on destroy and does not double-report at the next interval", () => {
+    push([{ name: "vortex-test-flag" }]);
+    FlagService.instance.getFlag("vortex-test-flag");
+
+    FlagService.instance.destroy();
+    expect(mockReportMetrics).toHaveBeenCalledOnce();
+
+    // Interval was cleared, so no second call
+    vi.advanceTimersByTime(60_000);
+    expect(mockReportMetrics).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/src/FlagService.ts
+++ b/src/renderer/src/FlagService.ts
@@ -1,0 +1,135 @@
+import type { FeatureFlag, KnownFlagName } from "@vortex/shared/flags";
+import type { FlagMetricsBucket } from "@vortex/shared/ipc";
+
+const METRICS_INTERVAL_MS = 60_000;
+
+type EvalEntry = { yes: number; no: number; variants: Record<string, number> };
+type EvalCounts = Record<string, EvalEntry>;
+type FlagByName<N extends KnownFlagName> = Extract<FeatureFlag, { name: N }>;
+
+/**
+ * Renderer-side singleton that owns the feature flag lifecycle:
+ * - Subscribes to flag pushes from main via window.api.featureFlags.onSynchronize
+ * - Tracks evaluation metrics for every getFlag call
+ * - Periodically flushes metrics to main via window.api.featureFlags.reportMetrics
+ *
+ * Initialize once near app startup with FlagService.init(), destroy on quit
+ * with FlagService.instance.destroy(). destroy() resets the instance so
+ * re-initialization is possible (useful in tests).
+ */
+export class FlagService {
+  #flags: ReadonlyMap<KnownFlagName, FeatureFlag> = new Map();
+  #evalCounts: EvalCounts = {};
+  #bucketStart: number;
+  #subscribers: Set<() => void> = new Set();
+  #unsubscribeIpc: () => void;
+  #intervalId: ReturnType<typeof setInterval>;
+
+  static #instance: FlagService | null = null;
+
+  private constructor() {
+    this.#bucketStart = Date.now();
+
+    this.#unsubscribeIpc = window.api.featureFlags.onSynchronize((updated) => {
+      this.#flags = new Map(updated.map((f) => [f.name, f]));
+      for (const cb of this.#subscribers) {
+        cb();
+      }
+    });
+
+    this.#intervalId = setInterval(() => this.#flush(), METRICS_INTERVAL_MS);
+  }
+
+  /** Initialize the singleton. Throws if already initialized without a prior destroy(). */
+  static init(): FlagService {
+    if (this.#instance !== null) {
+      throw new Error("FlagService is already initialized!");
+    }
+    this.#instance = new FlagService();
+    return this.#instance;
+  }
+
+  /** Returns the initialized instance. Throws if init() has not been called. */
+  static get instance(): FlagService {
+    if (this.#instance !== null) {
+      return this.#instance;
+    }
+    throw new Error("FlagService is not initialized. Call FlagService.init() first.");
+  }
+
+  /** Destroys the instance if one exists. No-op if not yet initialized. Safe to call from beforeunload. */
+  static destroyIfInitialized(): void {
+    this.#instance?.destroy();
+  }
+
+  /**
+   * Unsubscribes from IPC, clears the flush interval, and flushes any
+   * remaining metrics. Resets the singleton so init() can be called again.
+   */
+  destroy(): void {
+    this.#unsubscribeIpc();
+    clearInterval(this.#intervalId);
+    this.#flush();
+    FlagService.#instance = null;
+  }
+
+  /**
+   * Returns the current flag map. Primarily for React context providers that
+   * need to expose the full map to consumers.
+   */
+  get flags(): ReadonlyMap<KnownFlagName, FeatureFlag> {
+    return this.#flags;
+  }
+
+  /**
+   * Returns the flag for the given name if it is enabled, or undefined if it
+   * is absent. Records a yes/no evaluation count (and variant count) for
+   * metrics reporting regardless of where the call originates.
+   */
+  getFlag<N extends KnownFlagName>(name: N): FlagByName<N> | undefined {
+    const flag = this.#flags.get(name) as FlagByName<N> | undefined;
+    const entry = (this.#evalCounts[name] ??= { yes: 0, no: 0, variants: {} });
+    if (flag !== undefined) {
+      entry.yes++;
+      if (flag.variant) {
+        entry.variants[flag.variant.name] = (entry.variants[flag.variant.name] ?? 0) + 1;
+      }
+    } else {
+      entry.no++;
+    }
+    return flag;
+  }
+
+  /**
+   * Subscribes to flag map changes. The callback is invoked synchronously
+   * inside the onSynchronize handler each time main pushes updated flags.
+   * Returns an unsubscribe function.
+   */
+  subscribe(callback: () => void): () => void {
+    this.#subscribers.add(callback);
+    return () => {
+      this.#subscribers.delete(callback);
+    };
+  }
+
+  #flush(): void {
+    const counts = this.#evalCounts;
+    const start = this.#bucketStart;
+    const stop = Date.now();
+
+    this.#evalCounts = {};
+    this.#bucketStart = stop;
+
+    if (Object.keys(counts).length === 0) return;
+
+    const toggles: FlagMetricsBucket["toggles"] = {};
+    for (const [name, entry] of Object.entries(counts)) {
+      toggles[name] = {
+        yes: entry.yes,
+        no: entry.no,
+        ...(Object.keys(entry.variants).length > 0 && { variants: entry.variants }),
+      };
+    }
+    window.api.featureFlags.reportMetrics({ start, stop, toggles });
+  }
+}

--- a/src/renderer/src/contexts/FlagsContext.test.tsx
+++ b/src/renderer/src/contexts/FlagsContext.test.tsx
@@ -1,48 +1,78 @@
 import { act, render, screen } from "@testing-library/react";
-import type { FeatureFlag } from "@vortex/shared/flags";
-import type { FeatureFlagsApi } from "@vortex/shared/preload";
+import type { FeatureFlag, KnownFlagName } from "@vortex/shared/flags";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FlagsProvider, useFlag, useFlagsContext } from "./FlagsContext";
 
-const mockOnSynchronize = vi.fn<FeatureFlagsApi["onSynchronize"]>();
-const mockUnsubscribe = vi.fn<() => void>();
-const mockReportMetrics = vi.fn<FeatureFlagsApi["reportMetrics"]>();
+const state = vi.hoisted(() => ({
+  flags: new Map() as ReadonlyMap<KnownFlagName, FeatureFlag>,
+  subscribeCallback: null as (() => void) | null,
+}));
+
+const mockUnsubscribe = vi.hoisted(() => vi.fn<() => void>());
+const mockSubscribe = vi.hoisted(() => vi.fn<(cb: () => void) => () => void>());
+const mockGetFlag = vi.hoisted(() => vi.fn<(name: KnownFlagName) => FeatureFlag | undefined>());
+
+vi.mock("../FlagService", () => ({
+  FlagService: {
+    instance: {
+      get flags() {
+        return state.flags;
+      },
+      subscribe: mockSubscribe,
+      getFlag: mockGetFlag,
+    },
+  },
+}));
+
+// -- Helpers -----------------------------------------------------------------
+
+function push(flags: FeatureFlag[]) {
+  state.flags = new Map(flags.map((f) => [f.name, f]));
+  mockGetFlag.mockImplementation((name) => state.flags.get(name));
+  act(() => {
+    state.subscribeCallback?.();
+  });
+}
+
+// -- Setup / teardown --------------------------------------------------------
 
 beforeEach(() => {
-  mockUnsubscribe.mockClear();
-  mockOnSynchronize.mockClear();
-  mockReportMetrics.mockClear();
-  mockOnSynchronize.mockReturnValue(mockUnsubscribe);
-  (window as any).api = {
-    log: vi.fn(),
-    featureFlags: { onSynchronize: mockOnSynchronize, reportMetrics: mockReportMetrics },
-  };
+  state.flags = new Map();
+  state.subscribeCallback = null;
+
+  mockUnsubscribe.mockReset();
+  mockSubscribe.mockReset();
+  mockGetFlag.mockReset();
+
+  mockUnsubscribe.mockImplementation(() => {
+    state.subscribeCallback = null;
+  });
+  mockSubscribe.mockImplementation((cb) => {
+    state.subscribeCallback = cb;
+    return mockUnsubscribe;
+  });
+  mockGetFlag.mockImplementation((name) => state.flags.get(name));
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function push(flags: FeatureFlag[]) {
-  const callback = mockOnSynchronize.mock.calls[0][0];
-  act(() => {
-    callback(flags);
-  });
-}
+// -- Tests -------------------------------------------------------------------
 
 describe("FlagsProvider", () => {
-  it("subscribes to onSynchronize on mount", () => {
+  it("subscribes to FlagService on mount", () => {
     render(
       <FlagsProvider>
         <span />
       </FlagsProvider>,
     );
-    expect(mockOnSynchronize).toHaveBeenCalledOnce();
+    expect(mockSubscribe).toHaveBeenCalledOnce();
   });
 
-  it("unsubscribes on unmount", () => {
+  it("unsubscribes from FlagService on unmount", () => {
     const { unmount } = render(
       <FlagsProvider>
         <span />
@@ -155,7 +185,6 @@ describe("useFlag", () => {
       const flag = useFlag("vortex-test-flag");
       return <span data-testid="val">{flag ? "on" : "off"}</span>;
     }
-
     render(
       <FlagsProvider>
         <Indicator />
@@ -187,161 +216,5 @@ describe("getFlag", () => {
     push([flag]);
     expect(got?.name).toBe("vortex-test-flag");
     expect(got?.variant).toEqual({ name: "variant-2", data: 7 });
-  });
-});
-
-describe("metrics", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("does not call reportMetrics when nothing has been evaluated", () => {
-    const { unmount } = render(
-      <FlagsProvider>
-        <span />
-      </FlagsProvider>,
-    );
-    unmount();
-    expect(mockReportMetrics).not.toHaveBeenCalled();
-  });
-
-  it("reports a yes count for an enabled flag", () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    const { unmount } = render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag" }]);
-    // Spy re-renders after the push, so getFlag is called once more with the flag present
-    unmount();
-
-    expect(mockReportMetrics).toHaveBeenCalledOnce();
-    const bucket = mockReportMetrics.mock.calls[0][0];
-    expect(bucket.toggles["vortex-test-flag"].yes).toBeGreaterThanOrEqual(1);
-  });
-
-  it("reports a no count for an absent flag", () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    const { unmount } = render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    // flags map stays empty — every getFlag call is a "no"
-    unmount();
-
-    expect(mockReportMetrics).toHaveBeenCalledOnce();
-    const bucket = mockReportMetrics.mock.calls[0][0];
-    expect(bucket.toggles["vortex-test-flag"].no).toBeGreaterThanOrEqual(1);
-  });
-
-  it("reports variant counts when a flag has a variant", () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    const { unmount } = render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag", variant: { name: "variant-1", data: 99 } }]);
-    unmount();
-
-    const bucket = mockReportMetrics.mock.calls[0][0];
-    expect(bucket.toggles["vortex-test-flag"].variants?.["variant-1"]).toBeGreaterThanOrEqual(1);
-  });
-
-  it("omits variants from the bucket entry when none were seen", () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    const { unmount } = render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag" }]);
-    unmount();
-
-    const bucket = mockReportMetrics.mock.calls[0][0];
-    expect(bucket.toggles["vortex-test-flag"].variants).toBeUndefined();
-  });
-
-  it("flushes automatically after 60 seconds", async () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag" }]);
-
-    expect(mockReportMetrics).not.toHaveBeenCalled();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
-    expect(mockReportMetrics).toHaveBeenCalledOnce();
-  });
-
-  it("resets counts after a flush so the next empty bucket does not report", async () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag" }]);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
-    expect(mockReportMetrics).toHaveBeenCalledTimes(1);
-
-    // No new evaluations — second interval should not flush
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
-    expect(mockReportMetrics).toHaveBeenCalledTimes(1);
-  });
-
-  it("flushes on unmount and does not double-report at the next interval", () => {
-    function Spy() {
-      useFlag("vortex-test-flag");
-      return null;
-    }
-    const { unmount } = render(
-      <FlagsProvider>
-        <Spy />
-      </FlagsProvider>,
-    );
-    push([{ name: "vortex-test-flag" }]);
-
-    unmount();
-    expect(mockReportMetrics).toHaveBeenCalledOnce();
-
-    // Counts were cleared on unmount, so no second call
-    act(() => {
-      vi.advanceTimersByTime(60_000);
-    });
-    expect(mockReportMetrics).toHaveBeenCalledOnce();
   });
 });

--- a/src/renderer/src/contexts/FlagsContext.tsx
+++ b/src/renderer/src/contexts/FlagsContext.tsx
@@ -1,5 +1,4 @@
 import type { FeatureFlag, KnownFlagName } from "@vortex/shared/flags";
-import type { FlagMetricsBucket } from "@vortex/shared/ipc";
 import React, {
   createContext,
   type FC,
@@ -8,14 +7,10 @@ import React, {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
-const METRICS_INTERVAL_MS = 60_000;
-
-type EvalEntry = { yes: number; no: number; variants: Record<string, number> };
-type EvalCounts = Record<string, EvalEntry>;
+import { FlagService } from "../FlagService";
 
 type FlagByName<N extends KnownFlagName> = Extract<FeatureFlag, { name: N }>;
 
@@ -36,59 +31,22 @@ export interface IFlagsProviderProps {
 }
 
 export const FlagsProvider: FC<IFlagsProviderProps> = ({ children }) => {
-  const [flags, setFlags] = useState<ReadonlyMap<KnownFlagName, FeatureFlag>>(() => new Map());
-  const evalRef = useRef<EvalCounts>({});
-  const bucketStartRef = useRef<number>(Date.now());
+  const [flags, setFlags] = useState<ReadonlyMap<KnownFlagName, FeatureFlag>>(
+    () => FlagService.instance.flags,
+  );
 
   useEffect(() => {
-    return window.api.featureFlags.onSynchronize((updated) => {
-      setFlags(new Map(updated.map((f) => [f.name, f])));
+    return FlagService.instance.subscribe(() => {
+      setFlags(FlagService.instance.flags);
     });
   }, []);
 
-  const flush = useCallback((): void => {
-    const counts = evalRef.current;
-    const start = bucketStartRef.current;
-    const stop = Date.now();
-
-    evalRef.current = {};
-    bucketStartRef.current = stop;
-
-    if (Object.keys(counts).length === 0) return;
-
-    const toggles: FlagMetricsBucket["toggles"] = {};
-    for (const [name, entry] of Object.entries(counts)) {
-      toggles[name] = {
-        yes: entry.yes,
-        no: entry.no,
-        ...(Object.keys(entry.variants).length > 0 && { variants: entry.variants }),
-      };
-    }
-    window.api.featureFlags.reportMetrics({ start, stop, toggles });
-  }, []);
-
-  useEffect(() => {
-    const timer = setInterval(flush, METRICS_INTERVAL_MS);
-    return () => {
-      clearInterval(timer);
-      flush();
-    };
-  }, [flush]);
-
   const getFlag = useCallback(
-    <N extends KnownFlagName>(name: N): FlagByName<N> | undefined => {
-      const flag = flags.get(name) as FlagByName<N> | undefined;
-      const entry = (evalRef.current[name] ??= { yes: 0, no: 0, variants: {} });
-      if (flag !== undefined) {
-        entry.yes++;
-        if (flag.variant) {
-          entry.variants[flag.variant.name] = (entry.variants[flag.variant.name] ?? 0) + 1;
-        }
-      } else {
-        entry.no++;
-      }
-      return flag;
-    },
+    <N extends KnownFlagName>(name: N): FlagByName<N> | undefined =>
+      FlagService.instance.getFlag(name),
+    // flags is listed so getFlag referential identity changes when flags do,
+    // ensuring consumers that memoize on getFlag re-evaluate after a push.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
     [flags],
   );
 

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -121,6 +121,7 @@ import { ApplicationData } from "./applicationData";
 import { FlagsProvider } from "./contexts/FlagsContext";
 import ExtensionManager from "./ExtensionManager";
 import { ExtensionContext } from "./ExtensionProvider";
+import { FlagService } from "./FlagService";
 import { log } from "./logging";
 import { initApplicationMenu } from "./menu";
 import reducer, { buildReducerTree, Decision, sanitizeHydrationState } from "./reducers/index";
@@ -191,6 +192,7 @@ const middleware = [
 // final writes are lost and affected mods reload missing fields (GH#23363).
 window.addEventListener("beforeunload", () => {
   flushPendingDiffsSync();
+  FlagService.destroyIfInitialized();
 });
 
 function sanityCheckCB(err: StateError) {
@@ -455,6 +457,7 @@ async function initGlobals(): Promise<void> {
   // Initialize application data asynchronously from main process cache
   // This replaces synchronous IPC calls that were in the preload script
   await ApplicationData.init();
+  FlagService.init();
   readStartupSettings();
 }
 


### PR DESCRIPTION
Allows you to use feature flags from anywhere in the renderer, not just within a React tree.