### PR TITLE
Adds staging and version indicator to titlebar

### DIFF
--- a/src/renderer/src/views/components/Header/StagingIndicator.tsx
+++ b/src/renderer/src/views/components/Header/StagingIndicator.tsx
@@ -1,0 +1,14 @@
+import React, { type FC } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Pill } from "../../../ui/components/pill/Pill";
+
+export const StagingIndicator: FC = () => {
+  const { t } = useTranslation();
+
+  if (process.env.IS_VORTEX_PREVIEW !== "true") {
+    return null;
+  }
+
+  return <Pill pillType="success">{t("STAGING")}</Pill>;
+};

--- a/src/renderer/src/views/components/Header/VersionIndicator.tsx
+++ b/src/renderer/src/views/components/Header/VersionIndicator.tsx
@@ -1,0 +1,21 @@
+import React, { type FC } from "react";
+
+import { Typography } from "../../../ui/components/typography/Typography";
+import { getApplication } from "../../../util/application";
+
+export const VersionIndicator: FC = () => {
+  const version = getApplication().version;
+  const formattedVersion = `v${version}`;
+
+  return (
+    <Typography
+      appearance="weak"
+      brand="neutral-translucent"
+      className="text-translucent-weaker!"
+      data-testid="version-indicator"
+      typographyType="body-sm"
+    >
+      {formattedVersion}
+    </Typography>
+  );
+};

--- a/src/renderer/src/views/components/Header/index.tsx
+++ b/src/renderer/src/views/components/Header/index.tsx
@@ -16,6 +16,8 @@ import { IconButton } from "./IconButton";
 import { Notifications } from "./Notifications";
 import { PremiumIndicator } from "./PremiumIndicator";
 import { ProfileSection } from "./ProfileSection";
+import { StagingIndicator } from "./StagingIndicator";
+import { VersionIndicator } from "./VersionIndicator";
 import { WindowControls } from "./WindowControls";
 
 export const Header: FC = () => {
@@ -75,6 +77,8 @@ export const Header: FC = () => {
       </div>
 
       <div className="flex shrink-0 items-center gap-x-4" style={{ WebkitAppRegion: "no-drag" }}>
+        <StagingIndicator />
+        <VersionIndicator />
         <PremiumIndicator />
 
         <div className="flex gap-x-2">


### PR DESCRIPTION
A lost feature that is very useful when we receive screenshots from users to quickly identify what version is being run.

The staging pill is mainly for devs to not forget they are running against the `vortex-staging` repo (the `IS_VORTEX_PREVIEW` env var). Useful for checking releases and auto-update code before published on main repo.

<img width="1286" height="338" alt="image" src="https://github.com/user-attachments/assets/bb707ce0-8675-4a25-935c-26fa0268900d" />

<img width="1438" height="412" alt="image" src="https://github.com/user-attachments/assets/5e3152ee-e94b-43c5-9254-8c2e175b0c95" />

Laurence has OK'd this.