### PR TITLE
consolidate collection pause/resume onto the canonical handlers

### DIFF
--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -65,6 +65,7 @@ import sessionReducer from "./reducers/session";
 import settingsReducer from "./reducers/settings";
 import { testSupported } from "./testSupported";
 import initTools from "./tools";
+import type { CollectionPauseTrigger } from "./types/CollectionPauseTrigger";
 import type { ICollection } from "./types/ICollection";
 import type { IExtendedInterfaceProps } from "./types/IExtendedInterfaceProps";
 import { cloneCollection } from "./util/cloneCollection";
@@ -347,6 +348,7 @@ async function pauseCollection(
   gameId: string,
   modId: string,
   silent?: boolean,
+  trigger?: CollectionPauseTrigger,
 ) {
   const state = api.getState();
   const mods = state.persistent.mods[gameId];
@@ -356,6 +358,10 @@ async function pauseCollection(
   if (collection === undefined) {
     return;
   }
+
+  // Log here, the single chokepoint, so every pause path (UI button, logout, game
+  // switch, removal) is recorded; trigger says which one.
+  log("info", "pause collection", { gameId, modId, trigger });
 
   (collection?.rules ?? []).forEach((rule) => {
     const dlId = findDownloadByRef(rule.reference, downloads);
@@ -445,7 +451,7 @@ async function removeCollection(
 
   modsBeingRemoved.add(makeModKey(gameId, modId));
 
-  await pauseCollection(api, gameId, modId, true);
+  await pauseCollection(api, gameId, modId, true, "remove");
 
   let progress = 0;
   const notiId = shortid();
@@ -1275,7 +1281,7 @@ function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
         log("info", "User logged out during collection install, pausing", {
           modId,
         });
-        pauseCollection(api, gameId, modId, true)
+        pauseCollection(api, gameId, modId, true, "logout")
           .then(() => {
             api.sendNotification({
               type: "warning",
@@ -1564,13 +1570,31 @@ function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
 
   api.events.on("resume-collection", (gameId: string, modId: string) => {
     const state = api.getState();
+
+    // Collections need Nexus auth; block resume when logged out. This is the single
+    // chokepoint now that the UI routes through here.
+    const userInfo = state.persistent["nexus"]?.userInfo;
+    if (userInfo == null) {
+      void api.showDialog(
+        "info",
+        "Not logged in",
+        { text: "You have to be logged in with Nexus Mods to install collections." },
+        [{ label: "Continue" }],
+      );
+      return;
+    }
+
+    const mod = state.persistent.mods[gameId]?.[modId];
+    if (mod === undefined) {
+      return;
+    }
+
     const profileId = selectors.lastActiveProfileForGame(state, gameId);
     const profile = state.persistent.profiles[profileId];
-    const mod = state.persistent.mods[gameId]?.[modId];
     log("info", "resume collection", {
       gameId,
       modId,
-      archiveId: mod?.archiveId,
+      archiveId: mod.archiveId,
     });
     driver.start(profile, mod);
   });
@@ -1578,16 +1602,18 @@ function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
   // Keeps the full cleanup path (driver, notification, queued downloads,
   // InstallManager cancel) owned by this extension instead of forcing
   // external callers to chain the pieces.
-  api.events.on("pause-collection", (gameId: string, modId: string) => {
-    log("info", "pause collection", { gameId, modId });
-    pauseCollection(api, gameId, modId, true).catch((err: unknown) => {
-      log("error", "failed to pause collection", {
-        gameId,
-        modId,
-        error: getErrorMessageOrDefault(err),
+  api.events.on(
+    "pause-collection",
+    (gameId: string, modId: string, trigger?: CollectionPauseTrigger) => {
+      pauseCollection(api, gameId, modId, true, trigger).catch((err: unknown) => {
+        log("error", "failed to pause collection", {
+          gameId,
+          modId,
+          error: getErrorMessageOrDefault(err),
+        });
       });
-    });
-  });
+    },
+  );
 
   api.onStateChange(["persistent", "collections", "collections"], (prev, cur) => {
     // tslint:disable-next-line:no-shadowed-variable
@@ -1637,7 +1663,13 @@ function once(api: IExtensionApi, collectionsCB: () => ICallbackMap) {
 
   const onGameModeChange = (gameMode: string) => {
     if (driver.profile?.gameId && driver.profile.gameId !== gameMode) {
-      pauseCollection(api, driver.profile?.gameId, driver.collection?.id, false);
+      void pauseCollection(
+        api,
+        driver.profile?.gameId,
+        driver.collection?.id,
+        false,
+        "gamemode-changed",
+      );
     }
 
     updateOwnCollectionsCB(gameMode);

--- a/src/renderer/src/extensions/collections/types/CollectionPauseTrigger.ts
+++ b/src/renderer/src/extensions/collections/types/CollectionPauseTrigger.ts
@@ -1,0 +1,9 @@
+// What initiated a collection install pause, recorded on the "pause collection" log so a
+// log audit can tell an intentional user pause from an incidental one (game switch,
+// logout, removal, free-user download cancel).
+export type CollectionPauseTrigger =
+  | "user"
+  | "logout"
+  | "remove"
+  | "gamemode-changed"
+  | "free-user-cancel";

--- a/src/renderer/src/extensions/collections/views/CollectionList/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionList/index.tsx
@@ -16,7 +16,6 @@ import * as tooltip from "../../../../controls/TooltipControls";
 import type { IDownload } from "../../../../extensions/download_management/types/IDownload";
 import type { IGameStored } from "../../../../extensions/gamemode_management/types/IGameStored";
 import type { IMod, IModRule } from "../../../../extensions/mod_management/types/IMod";
-import { findDownloadByRef } from "../../../../extensions/mod_management/util/dependencies";
 import { findModByRef } from "../../../../extensions/mod_management/util/findModByRef";
 import renderModName from "../../../../extensions/mod_management/util/modName";
 import type { IProfile } from "../../../../extensions/profile_management/types/IProfile";
@@ -31,7 +30,7 @@ import { toPromise } from "../../../../util/util";
 import MainPage from "../../../../views/MainPage";
 import { updateSuccessRate } from "../../actions/persistent";
 import { doExportToAPI } from "../../collectionExport";
-import { INSTALLING_NOTIFICATION_ID, MOD_TYPE, NAMESPACE, TOS_URL } from "../../constants";
+import { MOD_TYPE, NAMESPACE } from "../../constants";
 import type { IExtensionFeature } from "../../util/extension";
 import { findExtensions } from "../../util/extension";
 import type InstallDriver from "../../util/InstallDriver";
@@ -302,35 +301,25 @@ class CollectionsMainPage extends ComponentEx<ICollectionsMainPageProps, ICompon
     this.showPage("edit", modId);
   };
 
-  private pause = async (modId: string, silent?: boolean) => {
-    const { downloads, mods } = this.props;
+  private pause = (modId: string) => {
+    const { mods, profile } = this.props;
 
-    const collection = mods[modId];
-    if (collection === undefined) {
+    if (mods[modId] === undefined) {
       return;
     }
 
-    (collection?.rules ?? []).forEach((rule) => {
-      const dlId = findDownloadByRef(rule.reference, downloads);
-      if (dlId !== undefined) {
-        this.context.api.events.emit("pause-download", dlId);
-      }
+    // Route through the canonical pause-collection handler so the pause is logged once
+    // at its chokepoint and shares one cleanup path (driver reset, in-progress-only
+    // download pause) instead of a divergent copy here.
+    this.context.api.events.emit("pause-collection", profile.gameId, modId, "user");
+
+    this.context.api.sendNotification({
+      id: "collection-pausing",
+      type: "success",
+      title: "Collection pausing",
+      message: "Already queued mod installations will still finish",
+      displayMS: 3000,
     });
-    const { api } = this.context;
-    await api.emitAndAwait("cancel-dependency-install", modId);
-
-    this.props.driver.cancel();
-
-    api.dismissNotification(INSTALLING_NOTIFICATION_ID + modId);
-    if (silent !== true) {
-      api.sendNotification({
-        id: "collection-pausing",
-        type: "success",
-        title: "Collection pausing",
-        message: "Already queued mod installations will still finish",
-        displayMS: 3000,
-      });
-    }
   };
 
   private async removeWorkshop(modId: string) {
@@ -530,26 +519,15 @@ class CollectionsMainPage extends ComponentEx<ICollectionsMainPageProps, ICompon
       });
   };
 
-  private resume = async (modId: string) => {
-    const { driver, mods, profile, userInfo } = this.props;
-
-    if (mods[modId] === undefined) {
+  private resume = (modId: string) => {
+    const { profile } = this.props;
+    if (profile === undefined) {
       return;
     }
 
-    if (userInfo === null || userInfo === undefined) {
-      const { api } = this.context;
-      api.showDialog(
-        "info",
-        "Not logged in",
-        {
-          text: "You have to be logged in with Nexus Mods to install collections.",
-        },
-        [{ label: "Continue" }],
-      );
-    } else if (mods[modId] !== undefined) {
-      driver.start(profile, mods[modId]);
-    }
+    // Route through the canonical resume-collection handler, which owns the not-logged-in
+    // guard, logging, and the start path.
+    this.context.api.events.emit("resume-collection", profile.gameId, modId);
   };
 }
 

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -1826,7 +1826,7 @@ function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
     // reset the driver, dismiss the install notification.
     const session = getCollectionActiveSession(api.getState());
     if (session?.collectionId && session.gameId) {
-      api.events.emit("pause-collection", session.gameId, session.collectionId);
+      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
     }
     return true;
   } else {


### PR DESCRIPTION
The UI Pause/Resume buttons reimplemented the pause/start logic instead of going through the pause-collection/resume-collection handlers, so a manual pause was never logged (only the per-download "pausing download" lines) and the resume handler was dead code.

Route both UI buttons through the canonical events and make those the single chokepoints:
- pauseCollection logs "pause collection" itself, so every path (UI, logout, game switch, removal, free-user cancel) is recorded, tagged with a typed CollectionPauseTrigger.
- the resume-collection handler now owns the not-logged-in guard and the mod-exists guard; the UI just emits.

The UI pause keeps the canonical in-progress-only download-pause guard, which avoids the download manager throwing on already-finished downloads.

Nice to have for LAZ 483.