### PR TITLE
remove the re-sync button for collections

### DIFF
--- a/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionProgress.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/CollectionProgress.tsx
@@ -48,10 +48,6 @@ export interface ICollectionProgressProps {
   onCancel: () => void;
   onPause: () => void;
   onResume: () => void;
-  onResync: () => void;
-  // disabled while an install or deployment is in flight, so a manual resync can't race
-  // InstallManager's own writes
-  resyncDisabled: boolean;
 }
 
 interface ICompState {
@@ -84,8 +80,6 @@ class CollectionProgress extends ComponentEx<ICollectionProgressProps, ICompStat
       onCancel,
       onPause,
       onResume,
-      onResync,
-      resyncDisabled,
     } = this.props;
 
     const group = (mod: ICollectionItemRow, download?: IDownload): string => {
@@ -172,21 +166,6 @@ class CollectionProgress extends ComponentEx<ICollectionProgressProps, ICompStat
                       onClick={onPause}
                     />
                   ) : null}
-
-                  <tooltip.IconButton
-                    className="btn-embed btn-refresh"
-                    icon="refresh"
-                    disabled={resyncDisabled}
-                    tooltip={
-                      resyncDisabled
-                        ? t("Available once the current install and deployment have finished")
-                        : t(
-                            "Refresh the install status from disk if it looks out of date, " +
-                              "e.g. after manually removing or re-downloading a mod",
-                          )
-                    }
-                    onClick={onResync}
-                  />
 
                   <tooltip.IconButton
                     className="btn-embed btn-cancel"

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
@@ -31,7 +31,7 @@ import type { IOverlay, IState } from "../../../../types/IState";
 import type { ITableAttribute } from "../../../../types/ITableAttribute";
 import { getCollectionActiveSession } from "../../../../util/collectionInstallSessionSelectors";
 import {
-  resyncCollectionSessionFromReality,
+  // resyncCollectionSessionFromReality, // re-enable with the commented-out resync action
   resyncCollectionSessionRules,
 } from "../../../../util/collectionSessionReconstruct";
 import { ProcessCanceled, UserCanceled } from "../../../../util/CustomErrors";
@@ -563,7 +563,7 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
     }
 
     // a collection install (this one or another) is in flight; gates Resume ("installing
-    // something else") and disables Resync so a manual resync can't race InstallManager
+    // something else")
     const installInFlight = driver.collection !== undefined && !driver.installDone;
 
     const selection =
@@ -654,7 +654,6 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
               downloads={downloads}
               mods={itemRows}
               profile={profile}
-              resyncDisabled={installInFlight || (activity.mods ?? []).length > 0}
               showPremiumAd={this.props.showPremiumAd}
               t={t}
               totalSize={totalSize}
@@ -667,7 +666,6 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
                     ? null // installing something else
                     : this.resume
               }
-              onResync={this.resync}
             />
           </FlexLayout.Fixed>
         )}
@@ -705,6 +703,10 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
     this.props.onResume(this.props.collection.id);
   };
 
+  /*
+   * Re-sync action removed from the UI (button gone): only valid with no active
+   * collection session, and start/resume already refreshes from local state.
+   * Kept commented for easy re-enable.
   private resync = () => {
     const { t } = this.props;
     const changed = resyncCollectionSessionFromReality(this.context.api);
@@ -719,6 +721,7 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
       displayMS: 4000,
     });
   };
+  */
 
   private setEnabled = (enable: boolean) => {
     const { collection, profile } = this.props;


### PR DESCRIPTION
The re-sync button is only meaningful when there is no active collection session, and starting or resuming a collection already refreshes the session from local state, so the button has no valid use in the install view.

Remove the button and its onResync/resyncDisabled props. The resync handler and its import are commented out rather than deleted so it can be re-enabled in the future after I have a think of whether this is even needed.

QA are not testing re-sync - current implementation is pointless anyway, so this has to go before `laz-483-integration` is merged.