### PR TITLE
resolve a collection member by identity when the tag/md5 index misses

### DIFF
--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi } from "vitest";
 import { makeDownload, makeMod, makeRule } from "../../../test-utils/builders";
 import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import { modRuleId } from "../../../util/collectionInstallSession";
+import { reconstructSessionMods } from "../../../util/collectionSessionReconstruct";
 import type { IMod, IModAttributes, IModRule } from "../../mod_management/types/IMod";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 import { buildCollectionItemRows } from "./itemRows";
@@ -149,6 +150,32 @@ describe("buildCollectionItemRows", () => {
 
     expect(row.id).toBe("m1");
     expect(row.status).toBe("installed");
+  });
+
+  it("resolves a fuzzy member installed under another collection's tag, matching the session", () => {
+    // Two collections include the same member. Collection 1 installed it, so the mod on disk carries
+    // collection 1's referenceTag. Collection 2's rule carries a different tag and, being a
+    // fuzzy/latest member, has no fileMD5 - so the tag index misses and there is no hash fallback.
+    // The session resolves the member by identity (reconstructSessionMods -> findModByRef) and sees
+    // it installed, which is what drives completion; the table must agree, not show it "pending".
+    const rule = requiresRule({ reference: { tag: "tag-col2", logicalFileName: "MCM" } });
+    const mods = {
+      "inst-mcm": installedMod("inst-mcm", { referenceTag: "tag-col1", logicalFileName: "MCM" }),
+    };
+
+    // the session (identity-aware) sees the member installed - so completion treats it as resolved
+    const sessionMods = reconstructSessionMods({ rules: [rule], mods, downloads: {} });
+    expect(sessionMods[modRuleId(rule)].status).toBe("installed");
+
+    // the table must resolve the same installed mod rather than falling back to "pending"
+    const rows = buildCollectionItemRows({
+      rules: [rule],
+      mods,
+      downloads: {},
+      modState: {},
+      sessionMods: {},
+    });
+    expect(rows[modRuleId(rule)].status).toBe("installed");
   });
 
   it("resolves a tagged rule's download via the referenceTag index", () => {

--- a/src/renderer/src/extensions/collections/installSession/itemRows.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.ts
@@ -91,14 +91,17 @@ function persistentRow(
   // mod and its download carry the rule's referenceTag (authoritative), and an installed mod is also
   // keyed by content hash (fileMD5) so a member whose tag drifted, or that was matched by hash rather
   // than tag, is still recognised - a hash match is the same file, so there are no false positives.
-  // Only a rule carrying neither identity needs the full scan.
   const { tag, fileMD5 } = rule.reference;
 
   let mod = tag !== undefined ? indexes.modByTag.get(tag) : undefined;
   if (mod === undefined && fileMD5 !== undefined) {
     mod = indexes.modByMd5.get(fileMD5);
   }
-  if (mod === undefined && tag === undefined && fileMD5 === undefined) {
+  // Neither the tag nor the hash index resolved the mod (e.g. a fuzzy/latest member whose tag
+  // drifted across collections and has no fileMD5). Fall back to findModByRef - the same identity
+  // match reconstructSessionMods uses - so the table agrees with the session rather than showing an
+  // installed member as "pending".
+  if (mod === undefined) {
     mod = findModByRef(rule.reference, mods);
   }
   if (mod !== undefined) {


### PR DESCRIPTION
persistentRow gated the identity fallback on the rule having neither a tag nor a fileMD5, so a member whose tag/md5 lookup missed (fuzzy, or installed under another collection's tag) was rendered "pending" though installed. Drop the gate and fall back whenever the index misses, matching the session's match.

part of LAZ-483