### PR TITLE
fixed instances where a failed download/install did not settle

### DIFF
--- a/src/renderer/src/extensions/mod_management/InstallManager.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.test.ts
@@ -30,6 +30,16 @@ interface IInstallManagerTestable {
   ensurePhaseState(sourceModId: string): void;
   maybeAdvancePhase(sourceModId: string, api: IExtensionApi): void;
   handleDownloadFailed(api: IExtensionApi, downloadId: string): void;
+  doInstallDependenciesPhase(
+    api: IExtensionApi,
+    dependencies: unknown[],
+    gameId: string,
+    sourceModId: string,
+    recommended: boolean,
+    doDownload: (dep: unknown) => Promise<{ updatedDep: unknown; downloadId: string }>,
+    abort: AbortController,
+    silent: boolean,
+  ): Promise<unknown[]>;
   markPhaseDownloadsFinished(sourceModId: string, phase: number, api: IExtensionApi): void;
   mInstallPhaseState: Map<
     string,
@@ -447,6 +457,28 @@ describe("collection download failure handling", () => {
     installManager.handleDownloadFailed(api, "dl-fail");
 
     // status leaves "downloading" so the row is no longer mis-bucketed under the Downloading filter
+    expect(dispatch).toHaveBeenCalledWith(updateModStatus("col-1_prof1", "rule-1", "failed"));
+  });
+
+  it("settles the member as failed when its download terminally fails in the install phase", async () => {
+    // The download is settled from the install phase using the dependency's own reference, so a
+    // failed download that can't be matched back by tag/md5 (e.g. resumed from another install,
+    // and md5-less because it never completed) still moves the member off "downloading".
+    const doDownload = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("Failed to open temp"), { code: "fs-error" }));
+
+    await installManager.doInstallDependenciesPhase(
+      api,
+      [{ reference: { tag: "member-tag" }, phase: 0, extra: {} }],
+      "skyrimse",
+      "col-1",
+      false,
+      doDownload,
+      new AbortController(),
+      true,
+    );
+
     expect(dispatch).toHaveBeenCalledWith(updateModStatus("col-1_prof1", "rule-1", "failed"));
   });
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -5617,6 +5617,13 @@ class InstallManager {
               this.dropUnfulfilled(api, dep, gameId, sourceModId, recommended);
               return undefined;
             }
+            // A terminal download/install failure settles the member as failed on the collection
+            // session. Keyed on the dependency's own reference, so it does not depend on matching the
+            // (possibly md5-less, tag-drifted) failed download back to a rule - which is how a failed
+            // download would otherwise be left stuck on "downloading". No-ops outside an active
+            // collection session and over an already-terminal status.
+            const settleMemberFailed = () =>
+              this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
             // don't cancel the whole process if one dependency fails to install
             if (innerErr instanceof ProcessCanceled) {
               if (
@@ -5627,6 +5634,7 @@ class InstallManager {
               ) {
                 return undefined;
               }
+              settleMemberFailed();
               const refName = renderModReference(dep.reference, undefined);
               const message =
                 innerErr.message +
@@ -5647,6 +5655,7 @@ class InstallManager {
               return undefined;
             }
             if (innerErr instanceof DownloadIsHTML) {
+              settleMemberFailed();
               const refName = renderModReference(dep.reference, undefined);
               const message =
                 "The direct download URL for this file is not valid or didn't lead to a file. " +
@@ -5665,6 +5674,7 @@ class InstallManager {
               return undefined;
             }
             if (innerErr instanceof NotFound) {
+              settleMemberFailed();
               const refName = renderModReference(dep.reference, undefined);
               this.showDependencyError(
                 api,
@@ -5687,6 +5697,7 @@ class InstallManager {
                 throw innerErr;
               }
             }
+            settleMemberFailed();
             const err = unknownToError(innerErr);
             const errCode = getErrorCode(err);
             const refName =


### PR DESCRIPTION
A terminal download/install failure in the dependency phase reported the error but never wrote a terminal status to the collection session, so the member stayed on "downloading"/"installing" and could block completion. Settle it as failed using the dependency's own reference, so it no longer depends on matching the (md5-less, tag-drifted) failed download back to a rule.

part of LAZ-483