### PR TITLE
fix: pass --repo to gh release download to avoid git repo requirement

### DIFF
--- a/.github/workflows/upload-release-to-r2.yml
+++ b/.github/workflows/upload-release-to-r2.yml
@@ -29,7 +29,7 @@ jobs:
           rm -rf awscliv2.zip aws
 
       - name: Download release asset
-        run: gh release download ${{ github.event.release.tag_name || inputs.tag }} --pattern "vortex-setup-*.exe"
+        run: gh release download ${{ github.event.release.tag_name || inputs.tag }} --pattern "vortex-setup-*.exe" --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `gh release download` fails when there is no git checkout on the runner — it needs `--repo` to identify the repository explicitly

Follow-up to #23600.

## Test plan

- [ ] Trigger via `workflow_dispatch` with a valid release tag and confirm the download succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)