### PR TITLE
Report crashes when consent is still not available

### DIFF
--- a/docs/error-reporting/telemetry-otel.md
+++ b/docs/error-reporting/telemetry-otel.md
@@ -99,6 +99,72 @@ Main process watches for changes via `persist:diff` IPC in `src/main/telemetry/i
 
 Stable across machines; version-scoped so different releases produce different fingerprints.
 
+## Privacy Sanitisation (allow-list)
+
+**File**: `src/shared/src/telemetry/sanitizer.ts`
+
+Error traces can be exported **without analytics consent** (LAZ-638), with
+consent selecting the **sanitisation mode** per export rather than gating it.
+
+Unconsented export is behind a switch — `isUnconsentedReportingEnabled()` in
+`telemetry/state.ts`, **disabled, used for development only**.
+
+`SanitizingSpanExporter` wraps the OTLP exporter and is the single enforcement
+boundary — both the main-process ring buffer (`telemetry/setup.ts`) and the
+crash reporter (`errorReporting.ts`) export through it, so main spans,
+renderer-forwarded spans and crash reports are all covered regardless of how
+their attributes were set upstream. It is constructed with an `isConsented`
+predicate (wired to `isTelemetryEnabled`); omitting it defaults to **strict**.
+
+### Strict mode (no consent) — deny-by-default
+
+Only allow-listed attributes survive; everything else is dropped. Attributes
+added anywhere in the codebase are excluded until consciously added to the
+allow-list. Per span it:
+
+- **Drops** any span attribute not in the allow-list — including local names and
+  paths such as `context.value`, `mod.baseName`, `mod.modId`, `mod.archiveId`,
+  `mod.installerChoices`, `extension.archive`, `deployment.modPath`, and the
+  `*.transfer.from`/`to` path attributes.
+- **Buckets** counts (`context.mod_count`, `context.active_downloads`,
+  `deployment.modCount`, `mod.fileCount`) into ranges (`0-50`, `51-100`, …) so an
+  exact count can't fingerprint a user.
+- **Reduces** span events to `exception` only, keeping just the standard OTel
+  exception fields (`exception.type`/`message`/`stacktrace`/`escaped`).
+
+Only **public** Nexus identifiers pass from the mod-install span
+(`mod.numericModId`, `mod.fileId`); the internal `mod.modId` (derived from the
+local archive name) is dropped.
+
+The allow-list was cross-checked against ~2 months of collected traces
+(ClickStack `vortex.otel_traces`): every attribute key the app actually emits is
+either allowed (e.g. `error.isCommunityExtension`, `componentStack`) or
+deliberately dropped (`download.fileName`, `download.url`, `context.value`,
+`*.transfer.*`, `mod.baseName`/`installerChoices`/`archiveId`, `extension.archive`).
+
+### Baseline mode (consent given) — richer payload
+
+All span attributes and events are kept and exact counts are included. This is
+where the consented payload can carry local mod names and (per APP-425) a user
+id for cross-session correlation.
+
+### Always-on (both modes)
+
+- String values run through `sanitizeFramePath` (strips install prefixes, redacts
+  the OS username — including multi-word Windows account names) then well-known
+  folders are tokenised (`C:\Program Files` → `programfiles:/`). Username/path
+  redaction is baseline GDPR minimisation and is never gated on consent.
+- The **resource** is always reduced to its allow-list (process metadata only —
+  `service.*`, `process.*`, `os.*`, `host.arch`, `deployment.environment`); never
+  hostnames or usernames.
+
+The crash reporter receives consent explicitly: `createErrorReport` (renderer)
+captures it into `crashinfo.json` while the state is available, and the report
+subprocess reads it back. In-process main callers forward `isTelemetryEnabled()`.
+When consent is unknown (early crash before state exists, or a malformed report
+file) it defaults to `false` → strict, the safe floor for the most sensitive
+payload.
+
 ## Attributes Reference
 
 ### Resource (every span)

--- a/src/main/src/errorHandling.ts
+++ b/src/main/src/errorHandling.ts
@@ -9,6 +9,7 @@ import {
   isErrorReportingDisabled,
 } from "./errorReporting";
 import { log } from "./logging";
+import { isTelemetryEnabled } from "./telemetry/state";
 
 /** Terminates the applpication on an error */
 export function terminate(error: Error): void {
@@ -32,7 +33,13 @@ export async function terminateAsync(error: Error): Promise<void> {
       getErrorMessage(error) + "\n\n" + (error.stack ?? ""),
     );
     if (allowReport) {
-      await reportCrash("Crash", errorToReportableError(error)).catch(() => {
+      await reportCrash(
+        "Crash",
+        errorToReportableError(error),
+        undefined,
+        undefined,
+        isTelemetryEnabled(),
+      ).catch(() => {
         /* best-effort */
       });
     }
@@ -85,7 +92,13 @@ async function showTerminateError(
 
   const response = buttons[result.response];
   if (response === BUTTON_REPORT) {
-    await reportCrash("Crash", errorToReportableError(error));
+    await reportCrash(
+      "Crash",
+      errorToReportableError(error),
+      undefined,
+      undefined,
+      isTelemetryEnabled(),
+    );
     return false;
   }
 

--- a/src/main/src/errorReporting.ts
+++ b/src/main/src/errorReporting.ts
@@ -4,7 +4,7 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BasicTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { sanitizeFramePath } from "@vortex/shared";
 import type { ReportableError } from "@vortex/shared/errors";
-import { recordErrorOnSpan } from "@vortex/shared/telemetry";
+import { recordErrorOnSpan, SanitizingSpanExporter } from "@vortex/shared/telemetry";
 import { app } from "electron";
 
 import { createVortexResource } from "./telemetry/resources";
@@ -36,12 +36,13 @@ interface ICrashInfo {
   error: ReportableError;
   context?: Record<string, string>;
   reportProcess?: string;
+  consentGiven?: boolean;
 }
 
 export async function sendReportFile(filePath: string): Promise<void> {
   const contents = await readFile(filePath, "utf8");
   const json: ICrashInfo = JSON.parse(contents) as ICrashInfo;
-  await reportCrash(json.type, json.error, json.context, json.reportProcess);
+  await reportCrash(json.type, json.error, json.context, json.reportProcess, json.consentGiven);
 }
 
 /**
@@ -53,13 +54,17 @@ export async function reportCrash(
   error: ReportableError,
   context?: Record<string, string>,
   sourceProcess?: string,
+  consentGiven = false,
 ): Promise<void> {
   const resource = createVortexResource("report");
 
-  const exporter = new OTLPTraceExporter({
-    url: `${COLLECTOR_URL}/v1/traces`,
-    headers: OTLP_HEADERS,
-  });
+  const exporter = new SanitizingSpanExporter(
+    new OTLPTraceExporter({
+      url: `${COLLECTOR_URL}/v1/traces`,
+      headers: OTLP_HEADERS,
+    }),
+    () => consentGiven,
+  );
 
   const provider = new BasicTracerProvider({
     resource,

--- a/src/main/src/telemetry/setup.ts
+++ b/src/main/src/telemetry/setup.ts
@@ -2,11 +2,12 @@ import { context, trace } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { SanitizingSpanExporter } from "@vortex/shared/telemetry";
 
 import { log } from "../logging";
 import { createVortexResource } from "./resources";
 import { RingBufferSpanProcessor, type RingBufferOptions } from "./RingBufferSpanProcessor";
-import { isTelemetryEnabled, setProcessor } from "./state";
+import { isTelemetryEnabled, isUnconsentedReportingEnabled, setProcessor } from "./state";
 
 export const COLLECTOR_URL =
   process.env.VORTEX_COLLECTOR_URL ?? "https://vortex-collector.nexusmods.com";
@@ -20,15 +21,18 @@ export const OTLP_HEADERS: Record<string, string> = {};
 export const createMainTelemetryProvider = (options?: RingBufferOptions): void => {
   const resource = createVortexResource("main");
 
-  const exporter = new OTLPTraceExporter({
-    url: `${COLLECTOR_URL}/v1/traces`,
-    headers: OTLP_HEADERS,
-  });
+  const exporter = new SanitizingSpanExporter(
+    new OTLPTraceExporter({
+      url: `${COLLECTOR_URL}/v1/traces`,
+      headers: OTLP_HEADERS,
+    }),
+    isTelemetryEnabled,
+  );
 
   const processor = new RingBufferSpanProcessor({
     ...options,
     onExportSpans: (spans) => {
-      if (!isTelemetryEnabled()) return;
+      if (!isTelemetryEnabled() && !isUnconsentedReportingEnabled()) return;
       exporter.export(spans, (result) => {
         if (result.error) {
           const { message, code } = result.error as Error & {

--- a/src/main/src/telemetry/state.ts
+++ b/src/main/src/telemetry/state.ts
@@ -21,3 +21,18 @@ export const setTelemetryEnabled = (enabled: boolean): void => {
 export const isTelemetryEnabled = (): boolean => {
   return telemetryExportEnabled;
 };
+
+/**
+ * Whether error traces may be exported when the user has NOT consented to
+ * analytics. When enabled, unconsented exports still go through the
+ * strict allow-list sanitiser. For dev environments.
+ */
+let unconsentedReportingEnabled = false;
+
+export const setUnconsentedReportingEnabled = (enabled: boolean): void => {
+  unconsentedReportingEnabled = enabled;
+};
+
+export const isUnconsentedReportingEnabled = (): boolean => {
+  return unconsentedReportingEnabled;
+};

--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -50,6 +50,7 @@ export function createErrorReport(
 ) {
   const userData = getVortexPath("userData");
   const reportPath = path.join(userData, "crashinfo.json");
+  const consentGiven = state !== undefined && isTelemetryEnabled(state);
   fs.writeFileSync(
     reportPath,
     JSON.stringify({
@@ -59,9 +60,10 @@ export function createErrorReport(
       reportProcess: process.type,
       sourceProcess,
       userData,
+      consentGiven,
     }),
   );
-  if (state !== undefined && isTelemetryEnabled(state)) {
+  if (consentGiven) {
     spawnSelf(["--report", reportPath]);
   }
 }

--- a/src/shared/src/api/telemetry.ts
+++ b/src/shared/src/api/telemetry.ts
@@ -1,4 +1,14 @@
 export { SHARED_TELEMETRY_ATTRIBUTES } from "../telemetry/attributes";
+export {
+  bucketCount,
+  BUCKETED_ATTRIBUTES,
+  RESOURCE_ATTRIBUTE_ALLOWLIST,
+  sanitizeResourceAttributes,
+  sanitizeSpan,
+  sanitizeSpanAttributes,
+  SanitizingSpanExporter,
+  SPAN_ATTRIBUTE_ALLOWLIST,
+} from "../telemetry/sanitizer";
 export { recordErrorOnSpan } from "../telemetry/spans";
 export { deserializeSpan, serializeSpan } from "../telemetry/types";
 export type { SerializedSpan } from "../telemetry/types";

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -196,6 +196,44 @@ describe("sanitizeFramePath", () => {
       expect(sanitizeFramePath(input)).toBe(`C:/Users/<USER>/a.txt and C:/Users/<USER>/b.txt`);
     });
 
+    // Username-in-path redaction across OS styles, for both single-word and
+    // multi-word (space-containing) Windows account names. Real telemetry showed
+    // "C:/Users/<USER> Sparshott/..." leaking the surname when the segment was
+    // only redacted up to the first space.
+    it.each([
+      // [description, input, expected]
+      [
+        "Windows backslash, no space",
+        `C:\\Users\\bob\\AppData\\foo.pak`,
+        `C:/Users/<USER>/AppData/foo.pak`,
+      ],
+      [
+        "Windows backslash, with space",
+        `C:\\Users\\John S. Junior\\AppData\\foo.pak`,
+        `C:/Users/<USER>/AppData/foo.pak`,
+      ],
+      [
+        "Windows forward slash, no space",
+        `C:/Users/bob/AppData/foo.pak`,
+        `C:/Users/<USER>/AppData/foo.pak`,
+      ],
+      [
+        "Windows forward slash, with space",
+        `C:/Users/Jane Doe/AppData/foo.pak`,
+        `C:/Users/<USER>/AppData/foo.pak`,
+      ],
+      ["macOS, no space", `/Users/bob/Library/foo.plist`, `/Users/<USER>/Library/foo.plist`],
+      ["macOS, with space", `/Users/Jane Doe/Library/foo.plist`, `/Users/<USER>/Library/foo.plist`],
+      ["Linux, no space", `/home/bob/.config/x`, `/home/<USER>/.config/x`],
+      ["Linux, with space", `/home/jane doe/.config/x`, `/home/<USER>/.config/x`],
+    ])("redacts the username segment (%s)", (_desc, input, expected) => {
+      expect(sanitizeFramePath(input)).toBe(expected);
+    });
+
+    it("redacts a multi-word username at the end of a quoted path", () => {
+      expect(sanitizeFramePath(`open 'C:/Users/Jane Doe'`)).toBe(`open 'C:/Users/<USER>'`);
+    });
+
     it("is idempotent — running twice gives the same result", () => {
       const input = `C:\\Users\\user\\file.txt and /home/user/other.txt`;
       const once = sanitizeFramePath(input);

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -164,9 +164,11 @@ const INSTALL_PATH_RE = new RegExp(String.raw`(?:${WIN}|${UNIX})${SEGS}(?=${ANCH
 
 /** Matches the username segment of a user-home path (`/Users/<name>` or
  * `/home/<name>`). Run after backslash normalization so only forward slashes
- * need to be considered. The username character class excludes `<` so that
- * already-redacted `<USER>` is not matched again (idempotence). */
-const USER_HOME_RE = /(\/(?:Users|home)\/)([^/\s'"<>:|?*]+)/gi;
+ * need to be considered. The segment runs up to the next `/`, so it captures
+ * multi-word Windows account names (`John S. Junior`) — spaces are allowed, but
+ * other whitespace (tab/newline) and quotes/`<>` bound it so free text and an
+ * already-redacted `<USER>` aren't consumed (the latter keeps it idempotent). */
+const USER_HOME_RE = /(\/(?:Users|home)\/)([^/\t\r\n'"<>:|?*]+)/gi;
 
 /** Strips the trailing `:column` from a `:line:col` position, keeping `:line`.
  *  V8 reports the call-site column for each frame, which differs per invocation

--- a/src/shared/src/telemetry/sanitizer.test.ts
+++ b/src/shared/src/telemetry/sanitizer.test.ts
@@ -1,0 +1,233 @@
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  bucketCount,
+  sanitizeResourceAttributes,
+  sanitizeSpan,
+  sanitizeSpanAttributes,
+  SanitizingSpanExporter,
+} from "./sanitizer";
+
+describe("bucketCount", () => {
+  it("matches the ranges", () => {
+    expect(bucketCount(0)).toBe("0-50");
+    expect(bucketCount(50)).toBe("0-50");
+    expect(bucketCount(51)).toBe("51-100");
+    expect(bucketCount(100)).toBe("51-100");
+    expect(bucketCount(101)).toBe("101-150");
+    expect(bucketCount(73)).toBe("51-100");
+  });
+
+  it("accepts numeric strings (setErrorContext stores counts as strings)", () => {
+    expect(bucketCount("73")).toBe("51-100");
+  });
+
+  it("returns 'unknown' for non-numeric or negative input", () => {
+    expect(bucketCount("nope")).toBe("unknown");
+    expect(bucketCount(-1)).toBe("unknown");
+  });
+});
+
+describe("sanitizeSpanAttributes (baseline / consent given)", () => {
+  it("keeps non-allow-listed keys but still redacts string values", () => {
+    const result = sanitizeSpanAttributes(
+      {
+        "context.value": "ENOENT 'C:\\Users\\bob\\mod.pak'",
+        "mod.baseName": "Animate Dead++.pak",
+        "deployment.method": "hardlink",
+      },
+      false,
+    );
+    expect(result).toEqual({
+      "context.value": "ENOENT 'C:/Users/<USER>/mod.pak'",
+      "mod.baseName": "Animate Dead++.pak",
+      "deployment.method": "hardlink",
+    });
+  });
+
+  it("keeps exact counts (no bucketing) when consented", () => {
+    const result = sanitizeSpanAttributes(
+      { "context.mod_count": "73", "mod.fileCount": 10 },
+      false,
+    );
+    expect(result).toEqual({ "context.mod_count": "73", "mod.fileCount": 10 });
+  });
+});
+
+describe("sanitizeSpanAttributes (strict / no consent)", () => {
+  it("drops attributes that are not allow-listed", () => {
+    const result = sanitizeSpanAttributes({
+      "context.value": "Animate Dead++.pak",
+      "mod.baseName": "Animate Dead++.pak",
+      "mod.modId": "Animate Dead++-1234-1-0",
+      "mod.installerChoices": '{"plugin":"My Choice"}',
+      "extension.archive": "MyExtension.7z",
+      "deployment.modPath": "C:/Users/bob/AppData/Roaming/Vortex/skyrim/mods",
+      "downloads.transfer.from": "C:/Users/bob/Downloads",
+    });
+    expect(result).toEqual({});
+  });
+
+  it("keeps allow-listed attributes and public Nexus ids", () => {
+    const result = sanitizeSpanAttributes({
+      "error.fingerprint": "deadbeef",
+      "error.isCommunityExtension": true,
+      componentStack: "\n    in Foo\n    in Bar",
+      "mod.numericModId": "1234",
+      "mod.fileId": "5678",
+      "deployment.method": "hardlink",
+      "context.gamemode": "Skyrim Special Edition",
+    });
+    expect(result).toEqual({
+      "error.fingerprint": "deadbeef",
+      "error.isCommunityExtension": true,
+      componentStack: "\n    in Foo\n    in Bar",
+      "mod.numericModId": "1234",
+      "mod.fileId": "5678",
+      "deployment.method": "hardlink",
+      "context.gamemode": "Skyrim Special Edition",
+    });
+  });
+
+  it("buckets count attributes (numbers and numeric strings)", () => {
+    const result = sanitizeSpanAttributes({
+      "context.mod_count": "73",
+      "deployment.modCount": 120,
+      "mod.fileCount": 10,
+    });
+    expect(result).toEqual({
+      "context.mod_count": "51-100",
+      "deployment.modCount": "101-150",
+      "mod.fileCount": "0-50",
+    });
+  });
+
+  it("redacts the OS username and tokenises well-known paths in string values", () => {
+    const result = sanitizeSpanAttributes({
+      "error.message": "ENOENT: 'C:\\Program Files\\Steam\\steamapps\\foo.esp'",
+      "error.title": "open '/home/alice/game/mod.esp'",
+    });
+    expect(result["error.message"]).toBe("ENOENT: 'programfiles://Steam/steamapps/foo.esp'");
+    expect(result["error.title"]).toContain("/home/<USER>/");
+  });
+});
+
+describe("sanitizeResourceAttributes", () => {
+  it("keeps known resource attributes and drops anything else", () => {
+    const result = sanitizeResourceAttributes({
+      "service.name": "vortex",
+      "service.version": "2.3.0",
+      "os.type": "Windows_NT",
+      "telemetry.sdk.name": "opentelemetry",
+      "host.name": "BOBS-GAMING-PC",
+      "process.command_line": "C:/Users/bob/Vortex.exe",
+    });
+    expect(result).toEqual({
+      "service.name": "vortex",
+      "service.version": "2.3.0",
+      "os.type": "Windows_NT",
+      "telemetry.sdk.name": "opentelemetry",
+    });
+  });
+});
+
+const fakeSpan = (overrides: Partial<ReadableSpan> = {}): ReadableSpan =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  ({
+    name: "mod.install",
+    kind: 0,
+    spanContext: () => ({ traceId: "t", spanId: "s", traceFlags: 1 }),
+    parentSpanContext: undefined,
+    startTime: [0, 0],
+    endTime: [0, 0],
+    status: { code: 2, message: "failed at C:\\Program Files\\Vortex\\app.asar\\x.js:1:2" },
+    attributes: { "mod.baseName": "secret.pak", "mod.numericModId": "42" },
+    links: [],
+    events: [
+      {
+        name: "exception",
+        time: [0, 0],
+        attributes: {
+          "exception.type": "Error",
+          "exception.message": "boom in C:\\Users\\bob\\mod.pak",
+          "exception.secret": "leak",
+        },
+      },
+      { name: "log", time: [0, 0], attributes: { detail: "noise" } },
+    ],
+    duration: [0, 0],
+    ended: true,
+    resource: { attributes: { "service.name": "vortex", "host.name": "BOBS-PC" } },
+    instrumentationScope: { name: "vortex" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ...overrides,
+  }) as unknown as ReadableSpan;
+
+describe("sanitizeSpan", () => {
+  it("filters attributes, resource, status message and events", () => {
+    const out = sanitizeSpan(fakeSpan());
+
+    expect(out.attributes).toEqual({ "mod.numericModId": "42" });
+    expect(out.resource.attributes).toEqual({ "service.name": "vortex" });
+    expect(out.status.message).toBe("failed at app.asar/x.js:1:2");
+
+    // Only the exception event survives, reduced to allow-listed fields.
+    expect(out.events).toHaveLength(1);
+    const event = out.events[0];
+    expect(event?.name).toBe("exception");
+    expect(event?.attributes).toEqual({
+      "exception.type": "Error",
+      "exception.message": "boom in C:/Users/<USER>/mod.pak",
+    });
+  });
+
+  it("preserves span identity and timing", () => {
+    const span = fakeSpan();
+    const out = sanitizeSpan(span);
+    expect(out.spanContext()).toEqual(span.spanContext());
+    expect(out.name).toBe(span.name);
+    expect(out.startTime).toBe(span.startTime);
+  });
+
+  it("keeps all attributes/events (string-redacted) and the resource allow-list when not strict", () => {
+    const out = sanitizeSpan(fakeSpan(), false);
+    // local mod name kept (consent), resource still allow-listed.
+    expect(out.attributes).toEqual({ "mod.baseName": "secret.pak", "mod.numericModId": "42" });
+    expect(out.resource.attributes).toEqual({ "service.name": "vortex" });
+    // non-exception event retained, string values still redacted.
+    expect(out.events).toHaveLength(2);
+    const exception = out.events.find((e) => e.name === "exception");
+    expect(exception?.attributes?.["exception.message"]).toBe("boom in C:/Users/<USER>/mod.pak");
+  });
+});
+
+describe("SanitizingSpanExporter", () => {
+  it("strict-sanitises before delegating when consent is absent (default)", () => {
+    const inner = { export: vi.fn(), shutdown: vi.fn(), forceFlush: vi.fn() };
+    const exporter = new SanitizingSpanExporter(inner);
+    const cb = vi.fn();
+
+    exporter.export([fakeSpan()], cb);
+
+    expect(inner.export).toHaveBeenCalledTimes(1);
+    const [forwarded, forwardedCb] = inner.export.mock.calls[0] ?? [];
+    expect(forwardedCb).toBe(cb);
+    expect(forwarded?.[0]?.attributes).toEqual({ "mod.numericModId": "42" });
+  });
+
+  it("keeps the richer payload when consent is given", () => {
+    const inner = { export: vi.fn(), shutdown: vi.fn(), forceFlush: vi.fn() };
+    const exporter = new SanitizingSpanExporter(inner, () => true);
+
+    exporter.export([fakeSpan()], vi.fn());
+
+    const forwarded = inner.export.mock.calls[0]?.[0];
+    expect(forwarded?.[0]?.attributes).toEqual({
+      "mod.baseName": "secret.pak",
+      "mod.numericModId": "42",
+    });
+  });
+});

--- a/src/shared/src/telemetry/sanitizer.ts
+++ b/src/shared/src/telemetry/sanitizer.ts
@@ -1,0 +1,266 @@
+import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { ReadableSpan, SpanExporter, TimedEvent } from "@opentelemetry/sdk-trace-base";
+
+import { sanitizeFramePath } from "../errors";
+
+/**
+ * Privacy sanitiser for OpenTelemetry spans.
+ *
+ * Error traces are exported even without explicit user consent, so the payload
+ * must be free of anything that could identify a user or their machine. The
+ * sanitiser runs at the export boundary (see {@link SanitizingSpanExporter}), so
+ * it covers main-process spans, renderer-forwarded spans and the crash reporter
+ * alike, regardless of how their attributes were set upstream.
+ *
+ * It has two modes, chosen per export by consent:
+ *
+ *   - **strict** (no consent) — deny-by-default: only explicitly allow-listed
+ *     attributes survive, everything else is dropped; counts are bucketed; span
+ *     events are reduced to the standard `exception` fields. New attributes
+ *     added anywhere in the codebase are excluded until consciously added here.
+ *   - **baseline** (consent given) — the richer payload: all attributes and
+ *     events are kept, exact counts included.
+ *
+ * Both modes always run string values through {@link sanitizeFramePath} (strips
+ * install prefixes, redacts the OS username) and tokenise well-known folders
+ * (C:\Program Files → programfiles:/). Username/path redaction is baseline GDPR
+ * minimisation and is never gated on consent. The resource is always reduced to
+ * its allow-list (process metadata only — never hostnames or usernames),
+ * regardless of consent.
+ */
+
+/** Resource attributes permitted to leave the process. Everything the
+ *  Vortex resource sets (see telemetry/resources.ts) and nothing host- or
+ *  user-identifying (hostnames, usernames). */
+export const RESOURCE_ATTRIBUTE_ALLOWLIST: ReadonlySet<string> = new Set([
+  "service.name",
+  "service.version",
+  "process.type",
+  "process.pid",
+  "deployment.environment",
+  "os.type",
+  "os.version",
+  "host.arch",
+  // Auto-added by the OTel SDK; non-identifying metadata.
+  "telemetry.sdk.name",
+  "telemetry.sdk.version",
+  "telemetry.sdk.language",
+]);
+
+/** Span attributes permitted to leave the process verbatim (after string
+ *  sanitisation). Keys not listed here — and not in {@link BUCKETED_ATTRIBUTES}
+ *  — are dropped. */
+export const SPAN_ATTRIBUTE_ALLOWLIST: ReadonlySet<string> = new Set([
+  // Fault classification
+  "error.fingerprint",
+  "error.title",
+  "error.code",
+  "error.message",
+  "error.isCommunityExtension",
+  "componentStack",
+  "crash.type",
+  "crash.sourceProcess",
+  // Ambient context (setErrorContext) — active game, extension + deployment context
+  "context.gamemode",
+  "context.extension_type",
+  "context.extension_version",
+  "context.deployment_method",
+  "context.update_channel",
+  // Deployment context
+  "deployment.gameId",
+  "deployment.typeId",
+  "deployment.method",
+  "deployment.isUnmanaging",
+  "deployment.manual",
+  // Profile context (opaque ids + active game)
+  "profile.from",
+  "profile.to",
+  "profile.gameId",
+  // Extension context
+  "extension.name",
+  "extension.type",
+  // Mod install context — public Nexus ids only, never local names/paths/choices
+  "mod.installGameId",
+  "mod.installerId",
+  "mod.modType",
+  "mod.numericModId",
+  "mod.fileId",
+  "mod.hasPatches",
+  "mod.hasFileList",
+]);
+
+/** Numeric attributes that must be reported as a coarse range rather than an
+ *  exact value, so the count can't become a fingerprint. Values may arrive as
+ *  numbers or numeric strings. */
+export const BUCKETED_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "context.mod_count",
+  "context.active_downloads",
+  "deployment.modCount",
+  "mod.fileCount",
+]);
+
+/** Attributes allowed on `exception` span events (recordException output). */
+const EXCEPTION_EVENT_ATTRIBUTE_ALLOWLIST: ReadonlySet<string> = new Set([
+  "exception.type",
+  "exception.message",
+  "exception.stacktrace",
+  "exception.escaped",
+]);
+
+const BUCKET_SIZE = 50;
+
+/**
+ * Reduce an exact count to a coarse range so it can't fingerprint a user.
+ */
+export const bucketCount = (value: number | string): string => {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n < 0) return "unknown";
+  const floored = Math.floor(n);
+  if (floored <= BUCKET_SIZE) return `0-${BUCKET_SIZE}`;
+  const upper = Math.ceil(floored / BUCKET_SIZE) * BUCKET_SIZE;
+  return `${upper - BUCKET_SIZE + 1}-${upper}`;
+};
+
+/** Well-known Windows folders, tokenised so the path stays diagnostic without
+ *  revealing the drive layout. Applied after backslashes are normalised to
+ *  forward slashes by {@link sanitizeFramePath}. Longest match first. */
+const KNOWN_PATH_TOKENS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/[A-Za-z]:\/Program Files \(x86\)/gi, "programfiles86:/"],
+  [/[A-Za-z]:\/Program Files/gi, "programfiles:/"],
+  [/[A-Za-z]:\/ProgramData/gi, "programdata:/"],
+];
+
+const tokenizeWellKnownPaths = (text: string): string =>
+  KNOWN_PATH_TOKENS.reduce((acc, [re, token]) => acc.replace(re, token), text);
+
+/** Strip install prefixes + OS username, then tokenise well-known folders. */
+const sanitizeText = (text: string): string => tokenizeWellKnownPaths(sanitizeFramePath(text));
+
+const sanitizeValue = (value: AttributeValue): AttributeValue =>
+  typeof value === "string" ? sanitizeText(value) : value;
+
+/**
+ * Process span attributes. In `strict` mode (no consent) only allow-listed keys
+ * survive and counts are bucketed; otherwise all keys are kept. String values
+ * are always sanitised regardless of mode.
+ */
+export const sanitizeSpanAttributes = (attributes: Attributes, strict = true): Attributes => {
+  const out: Attributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) continue;
+    if (strict && BUCKETED_ATTRIBUTES.has(key)) {
+      out[key] = bucketCount(typeof value === "number" ? value : String(value));
+    } else if (!strict || SPAN_ATTRIBUTE_ALLOWLIST.has(key)) {
+      out[key] = sanitizeValue(value);
+    }
+    // strict + not allow-listed: dropped
+  }
+  return out;
+};
+
+/** Apply the resource allow-list: drop unknown keys, sanitise text. */
+export const sanitizeResourceAttributes = (attributes: Attributes): Attributes => {
+  const out: Attributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) continue;
+    if (RESOURCE_ATTRIBUTE_ALLOWLIST.has(key)) {
+      out[key] = sanitizeValue(value);
+    }
+  }
+  return out;
+};
+
+/**
+ * Process span events. In `strict` mode (no consent) only `exception` events
+ * survive, reduced to the standard allow-listed fields; otherwise all events are
+ * kept. Event attribute string values are always sanitised.
+ */
+const sanitizeEvents = (events: readonly TimedEvent[], strict: boolean): TimedEvent[] =>
+  events
+    .filter((event) => !strict || event.name === "exception")
+    .map((event) => {
+      const attributes: Attributes = {};
+      for (const [key, value] of Object.entries(event.attributes ?? {})) {
+        if (value === undefined) continue;
+        if (!strict || EXCEPTION_EVENT_ATTRIBUTE_ALLOWLIST.has(key)) {
+          attributes[key] = sanitizeValue(value);
+        }
+      }
+      return { name: event.name, time: event.time, attributes };
+    });
+
+/**
+ * Produce a privacy-sanitised copy of a span. The original is never mutated.
+ * Span/parent context, timing and instrumentation scope are preserved as-is;
+ * only attributes, resource, status message, events and link attributes are
+ * filtered. Mirrors the hand-built ReadableSpan shape used by deserializeSpan.
+ *
+ * `strict` (default) enforces the no-consent allow-list; pass `false` once
+ * consent is established to keep the richer payload (string redaction stays on).
+ */
+export const sanitizeSpan = (span: ReadableSpan, strict = true): ReadableSpan => {
+  const ctx = span.spanContext();
+  return {
+    name: span.name,
+    kind: span.kind,
+    spanContext: () => ctx,
+    parentSpanContext: span.parentSpanContext,
+    startTime: span.startTime,
+    endTime: span.endTime,
+    status:
+      span.status.message !== undefined
+        ? { code: span.status.code, message: sanitizeText(span.status.message) }
+        : span.status,
+    attributes: sanitizeSpanAttributes(span.attributes, strict),
+    links: span.links.map((link) => ({
+      context: link.context,
+      attributes: link.attributes ? sanitizeSpanAttributes(link.attributes, strict) : undefined,
+    })),
+    events: sanitizeEvents(span.events, strict),
+    duration: span.duration,
+    ended: span.ended,
+    resource: resourceFromAttributes(sanitizeResourceAttributes(span.resource.attributes)),
+    instrumentationScope: span.instrumentationScope,
+    droppedAttributesCount: span.droppedAttributesCount,
+    droppedEventsCount: span.droppedEventsCount,
+    droppedLinksCount: span.droppedLinksCount,
+  };
+};
+
+/**
+ * A SpanExporter decorator that privacy-sanitises every span before handing it
+ * to the wrapped exporter. This is the single enforcement boundary for
+ * both the main-process ring buffer and the crash reporter wrap their
+ * OTLP exporter with this, so no span reaches the collector un-sanitised.
+ *
+ * `isConsented` selects the sanitisation mode per export: strict (allow-list)
+ * when the user has not consented to analytics, baseline (richer payload, string
+ * redaction only) when they have. Omitting it defaults to strict — the safe
+ * choice for contexts that can't read consent state (e.g. the crash subprocess).
+ */
+export class SanitizingSpanExporter implements SpanExporter {
+  readonly #inner: SpanExporter;
+  readonly #isConsented: () => boolean;
+
+  constructor(inner: SpanExporter, isConsented: () => boolean = () => false) {
+    this.#inner = inner;
+    this.#isConsented = isConsented;
+  }
+
+  export(spans: ReadableSpan[], resultCallback: Parameters<SpanExporter["export"]>[1]): void {
+    const strict = !this.#isConsented();
+    this.#inner.export(
+      spans.map((span) => sanitizeSpan(span, strict)),
+      resultCallback,
+    );
+  }
+
+  shutdown(): Promise<void> {
+    return this.#inner.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    return this.#inner.forceFlush?.() ?? Promise.resolve();
+  }
+}


### PR DESCRIPTION
We have a major gap where if Vortex crashed before we can access the state, where we can see whether analytics is enabled - the error will not be reported.
This is a huge issue, since we are losing critical errors that a user would need to report manually to be resolved.

Closes LAZ-638