### PR TITLE
surface failed members and settle stuck installs (LAZ-483 fixes)

### DIFF
--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -265,6 +265,27 @@ describe("buildCollectionItemRows", () => {
     expect(row.status).toBe("failed");
   });
 
+  it('lets a terminal download failure override a stale session "downloading"', () => {
+    // The live session keeps a failed member on "downloading"; the row must report "failed" so the
+    // status column's filter/sort agree with the "Download failed" label. Reality wins.
+    const rule = requiresRule({ reference: { tag: "ref-fail" } });
+    const download = makeDownload({ state: "failed", modInfo: { referenceTag: "ref-fail" } });
+    // keyed by rule id: the session snapshot is still the pre-failure "downloading"
+    const session: Record<string, ICollectionModInstallInfo> = {
+      [modRuleId(rule)]: { rule, status: "downloading", type: "requires" },
+    };
+
+    const rows = buildCollectionItemRows({
+      rules: [rule],
+      mods: {},
+      downloads: { dlFail: download },
+      modState: {},
+      sessionMods: session,
+    });
+
+    expect(rows[modRuleId(rule)].status).toBe("failed");
+  });
+
   it("reconstructs status from persistent state for rules outside the session", () => {
     const rule = requiresRule({ reference: { id: "mod-1" } });
     // a session entry for a different rule must not bleed into this row

--- a/src/renderer/src/extensions/collections/installSession/itemRows.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.ts
@@ -210,8 +210,13 @@ export function buildCollectionItemRows(
       indexes,
     );
 
-    // the session is the source of truth while it is tracking this mod
-    const status = sessionMods?.[id]?.status ?? persistentStatus;
+    // The session is the source of truth while it is tracking this mod, except for a terminal
+    // download failure: the live session keeps a failed member on "downloading", so reality
+    // (persistentStatus) wins to keep the status column's filter/sort in agreement with the
+    // "Download failed" label. persistentStatus is "failed" only when no installed mod exists and
+    // the download failed, so it cannot shadow a real install/installing state.
+    const sessionStatus = sessionMods?.[id]?.status;
+    const status = persistentStatus === "failed" ? "failed" : (sessionStatus ?? persistentStatus);
 
     const row = { ...data, status };
     // a row is `{ ...mod, ...modState, collectionRule, status }`; the immutable reducers reuse

--- a/src/renderer/src/extensions/collections/views/InstallDialog/InstallFinishedDialog.tsx
+++ b/src/renderer/src/extensions/collections/views/InstallDialog/InstallFinishedDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, Media, Panel } from "react-bootstrap";
+import { Button, Media } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
@@ -12,9 +12,13 @@ import type { IMod } from "../../../../extensions/mod_management/types/IMod";
 import { findModByRef } from "../../../../extensions/mod_management/util/findModByRef";
 import renderModName from "../../../../extensions/mod_management/util/modName";
 import { isOptionalRule } from "../../../../extensions/mod_management/util/testModReference";
-import { log } from "../../../../logging";
+import type { ICollectionModInstallInfo } from "../../../../types/collections/ICollectionInstallSession";
 import type { IExtensionApi } from "../../../../types/IExtensionContext";
 import type { IState } from "../../../../types/IState";
+import {
+  getFailedOptionalMods,
+  getFailedRequiredMods,
+} from "../../../../util/collectionInstallSessionSelectors";
 import { NAMESPACE } from "../../constants";
 import type InstallDriver from "../../util/InstallDriver";
 import CollectionThumbnail from "../CollectionTile";
@@ -79,6 +83,21 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
     forceUpdate((i) => i + 1);
   }, []);
 
+  // Open the collection's Mods tab filtered to the failed members. Navigate, clear any existing
+  // filter, then set the status column ("collection_status") filter to "Failed" (a multi-select
+  // OptionsFilter, so the value is an array).
+  const viewFailed = React.useCallback(async () => {
+    if (driver.collection !== undefined) {
+      api.events.emit("view-collection", driver.collection.id, "mods");
+      api.store.dispatch(actions.setAttributeFilter("collection-mods", undefined, undefined));
+      api.store.dispatch(
+        actions.setAttributeFilter("collection-mods", "collection_status", ["Failed"]),
+      );
+      await driver.continue();
+    }
+    forceUpdate((i) => i + 1);
+  }, [driver]);
+
   const clone = React.useCallback(async () => {
     if (driver.collection === undefined) {
       return;
@@ -108,6 +127,20 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
 
   const finalizing = driver.postprocessing;
 
+  // Required members that settled as failed (e.g. a download that failed after a network drop). When
+  // any required member failed the collection isn't fully installed, so the dialog switches to an
+  // "incomplete" variant: reworded copy, a "View failed mods" action, and the optional-mods / clone
+  // actions suppressed - there's no point offering to add optional mods on top of a broken required
+  // set.
+  const failedRequired = useSelector<IState, ICollectionModInstallInfo[]>(getFailedRequiredMods);
+  const hasFailures = failedRequired.length > 0;
+
+  // Optional members the user SELECTED that then failed. A failed optional annotates the result but
+  // does not make the collection "incomplete" (that is driven by failedRequired), so it never
+  // reworks the title or trims the actions.
+  const failedOptional = useSelector<IState, ICollectionModInstallInfo[]>(getFailedOptionalMods);
+  const failedCount = failedRequired.length + failedOptional.length;
+
   return (
     <Modal
       id="install-finished-dialog"
@@ -115,7 +148,11 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
       onHide={nop}
     >
       <Modal.Header>
-        <Modal.Title>{t("Collection installation complete")}</Modal.Title>
+        <Modal.Title>
+          {hasFailures
+            ? t("Collection installation incomplete")
+            : t("Collection installation complete")}
+        </Modal.Title>
       </Modal.Header>
 
       <Modal.Body>
@@ -129,6 +166,7 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
               details={true}
               gameId={driver.profile?.gameId}
               imageTime={42}
+              incomplete={hasFailures}
               t={t}
             />
           </Media.Left>
@@ -140,7 +178,7 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
 
             {driver.collection?.attributes?.shortDescription ?? t("No description")}
 
-            {ownCollection && optionals.length > 0 ? (
+            {!hasFailures && ownCollection && optionals.length > 0 ? (
               <div>
                 <YouCuratedTag t={t} />
 
@@ -150,7 +188,21 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
           </Media.Right>
         </div>
 
-        {optionals.length > 0 ? (
+        {hasFailures ? (
+          <div className="collection-finished-failures">
+            <div className="collection-finished-optionals-text">
+              {t("{{count}} mod could not be installed", { count: failedCount, ns: NAMESPACE })}
+            </div>
+
+            <p>
+              {t(
+                "Some required mods failed to install (for example after a network interruption), " +
+                  "so the collection is not fully installed. Review the failed mods to retry them.",
+                { ns: NAMESPACE },
+              )}
+            </p>
+          </div>
+        ) : optionals.length > 0 ? (
           <div className="collection-finished-optionals">
             <div className="collection-finished-optionals-text">
               {t("{{numOptionals}} optional mods available", {
@@ -192,6 +244,17 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
           </div>
         ) : null}
 
+        {!hasFailures && failedOptional.length > 0 ? (
+          <div className="collection-finished-failures">
+            <div className="collection-finished-optionals-text">
+              {t("{{count}} optional mod could not be installed", {
+                count: failedOptional.length,
+                ns: NAMESPACE,
+              })}
+            </div>
+          </div>
+        ) : null}
+
         {finalizing ? (
           <div
             className="collection-finished-finalizing"
@@ -209,8 +272,24 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
         ) : null}
       </Modal.Body>
 
-      {optionals.length > 0 ? (
+      {hasFailures ? (
         <Modal.Footer>
+          <Button disabled={finalizing} onClick={viewFailed}>
+            {t("View failed mods")}
+          </Button>
+
+          <Button disabled={finalizing} onClick={skip}>
+            {t("Close")}
+          </Button>
+        </Modal.Footer>
+      ) : optionals.length > 0 ? (
+        <Modal.Footer>
+          {failedOptional.length > 0 ? (
+            <Button disabled={finalizing} onClick={viewFailed}>
+              {t("View failed mods")}
+            </Button>
+          ) : null}
+
           <Button disabled={finalizing} onClick={skip}>
             {t("No Thanks")}
           </Button>
@@ -225,6 +304,12 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
         </Modal.Footer>
       ) : (
         <Modal.Footer>
+          {failedOptional.length > 0 ? (
+            <Button disabled={finalizing} onClick={viewFailed}>
+              {t("View failed mods")}
+            </Button>
+          ) : null}
+
           <Button disabled={finalizing} onClick={skip}>
             {t("Done")}
           </Button>

--- a/src/renderer/src/extensions/mod_management/InstallManager.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.test.ts
@@ -10,11 +10,13 @@ import {
 } from "../../test-utils/builders";
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
+import { resyncCollectionSessionRules } from "../../util/collectionSessionReconstruct";
 import InstallManager from "./InstallManager";
 import { lookupFromDownload } from "./util/dependencies";
 
 // Mock dependencies
 vi.mock("./util/dependencies");
+vi.mock("../../util/collectionSessionReconstruct");
 vi.mock("../../util/api");
 vi.mock("../../util/log", () => {
   const log = vi.fn();
@@ -30,6 +32,7 @@ interface IInstallManagerTestable {
   ensurePhaseState(sourceModId: string): void;
   maybeAdvancePhase(sourceModId: string, api: IExtensionApi): void;
   handleDownloadFailed(api: IExtensionApi, downloadId: string): void;
+  cleanupPendingInstalls(sourceModId: string, hard?: boolean): void;
   doInstallDependenciesPhase(
     api: IExtensionApi,
     dependencies: unknown[],
@@ -480,5 +483,61 @@ describe("collection download failure handling", () => {
     );
 
     expect(dispatch).toHaveBeenCalledWith(updateModStatus("col-1_prof1", "rule-1", "failed"));
+  });
+});
+
+describe("cleanupPendingInstalls session resync", () => {
+  let installManager: IInstallManagerTestable;
+  let state: Record<string, unknown>;
+  let api: IExtensionApi;
+
+  const memberRule = makeRule({ type: "requires", reference: { tag: "m1" } });
+
+  beforeEach(() => {
+    vi.mocked(resyncCollectionSessionRules).mockClear();
+    state = {
+      persistent: {
+        mods: { skyrimse: { "col-1": makeMod({ id: "col-1", rules: [memberRule] }) } },
+        downloads: { files: {} },
+      },
+      session: {
+        collections: {
+          activeSession: makeSession({
+            sessionId: "col-1_prof1",
+            collectionId: "col-1",
+            gameId: "skyrimse",
+            mods: {
+              requires_m1: makeModInstallInfo({ rule: memberRule, status: "installing" }),
+            },
+          }),
+        },
+      },
+    };
+    api = {
+      getState: () => state as unknown as IState,
+      store: { getState: () => state as unknown as IState, dispatch: vi.fn() },
+      events: { emit: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() },
+      onAsync: vi.fn(),
+      onStateChange: vi.fn(),
+      sendNotification: vi.fn(),
+      dismissNotification: vi.fn(),
+      showErrorNotification: vi.fn(),
+      translate: vi.fn((key: string) => key),
+      registerInstaller: vi.fn(),
+    } as unknown as IExtensionApi;
+    installManager = new InstallManager(api, vi.fn()) as unknown as IInstallManagerTestable;
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("re-derives the collection session from reality when tearing down its active install", () => {
+    // a member left mid-"installing" on pause/cancel/stall must not keep the stale status
+    installManager.cleanupPendingInstalls("col-1", true);
+    expect(resyncCollectionSessionRules).toHaveBeenCalledWith(api, [memberRule]);
+  });
+
+  it("does not resync when the torn-down mod is not the active collection", () => {
+    installManager.cleanupPendingInstalls("some-other-mod", true);
+    expect(resyncCollectionSessionRules).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -86,6 +86,7 @@ import {
   getCollectionStatusBreakdown,
   isCollectionPhaseComplete,
 } from "../../util/collectionInstallSessionSelectors";
+import { resyncCollectionSessionRules } from "../../util/collectionSessionReconstruct";
 import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
 import {
   planDependencyErrorRecovery,
@@ -2315,6 +2316,22 @@ class InstallManager {
       this.mDependencyPipelineLimit.clearQueue();
       this.mInstallPhaseState.delete(sourceModId);
     }
+
+    // Re-derive the collection session from reality. This teardown runs on pause/cancel/stall; a
+    // member that was mid-install keeps a stale "installing" status otherwise (the per-dependency
+    // error path leaves a torn-down install untouched, expecting resume to rebuild it - but a pause
+    // never rebuilds, so the mods tab shows a phantom "installing"). Resyncing drops such a member
+    // back to its real status (downloaded / pending), so it reads as resumable rather than stuck.
+    const state = this.mApi.getState();
+    const session = getCollectionActiveSession(state);
+    if (session?.collectionId === sourceModId) {
+      const rules = (state.persistent.mods[session.gameId]?.[sourceModId]?.rules ?? []).filter(
+        isDependencyRule,
+      );
+      if (rules.length > 0) {
+        resyncCollectionSessionRules(this.mApi, rules);
+      }
+    }
   }
 
   /**
@@ -2606,7 +2623,15 @@ class InstallManager {
           const hasRetriesLeft = currentRetryCount < InstallManager.MAX_DEPENDENCY_RETRIES;
           // A disk-full failure will not succeed on retry; settle it now so the member becomes
           // terminally failed instead of cycling the retry budget while stuck on "installing".
-          const nonRetryable = unknownError instanceof InsufficientDiskSpace;
+          // Likewise a ProcessCanceled from the install itself - Vortex rejects an install that
+          // produced no instructions (empty archive / invalid installer output, e.g. an unreadable
+          // manifest) with ProcessCanceled - is deterministic: retrying reruns the same failing
+          // install, and a requeue never re-drives it, so the member sits stuck on "installing" and
+          // stalls the collection. Settle it failed. A whole-install teardown is excluded here
+          // (installCanceled -> "leave", handled first in planDependencyErrorRecovery).
+          const nonRetryable =
+            unknownError instanceof InsufficientDiskSpace ||
+            (unknownError instanceof ProcessCanceled && !installCanceled);
           const recovery = planDependencyErrorRecovery({
             installCanceled,
             ruleIgnored,

--- a/src/renderer/src/util/collectionInstallSession.test.ts
+++ b/src/renderer/src/util/collectionInstallSession.test.ts
@@ -41,6 +41,14 @@ describe("reconstructModStatus", () => {
     );
   });
 
+  it('a failed download with no mod is "failed", not "downloading"', () => {
+    // a failed download (e.g. a network drop) is a terminal failure, not an in-progress download, so
+    // it reconstructs to "failed" - what the Mods-tab "Failed" filter and "View failed mods" key on.
+    expect(reconstructModStatus(makeRule(), undefined, makeDownload({ state: "failed" }))).toBe(
+      "failed",
+    );
+  });
+
   it('a bundled rule with no mod or download is "downloaded"', () => {
     // bundled mods ship inside the collection archive, so there is no separate download
     expect(

--- a/src/renderer/src/util/collectionInstallSession.ts
+++ b/src/renderer/src/util/collectionInstallSession.ts
@@ -89,6 +89,11 @@ export function reconstructModStatus(
     return mod.state ?? "installed";
   }
   if (download !== undefined) {
+    // a failed download is a terminal failure, not activity: report it as "failed" so the row and
+    // the Mods-tab "Failed" filter treat it as such rather than an in-progress download.
+    if (download.state === "failed") {
+      return "failed";
+    }
     return download.state === "finished" ? "downloaded" : "downloading";
   }
   // bundled mods ship inside the collection archive, so they count as downloaded

--- a/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
@@ -23,6 +23,7 @@ import {
   getCollectionModByReference,
   getCollectionPhaseProgress,
   getCollectionStatusBreakdown,
+  getFailedOptionalMods,
 } from "./collectionInstallSessionSelectors";
 
 interface Entry {
@@ -106,6 +107,18 @@ describe("getCollectionStatusBreakdown", () => {
     expect(breakdown.optional.installed).toBe(1);
     expect(breakdown.total.installed).toBe(2);
     expect(breakdown.total.downloading).toBe(1);
+  });
+});
+
+describe("getFailedOptionalMods", () => {
+  it("returns only optional members with a failed status", () => {
+    const state = stateWith([
+      { ruleId: "r1", type: "requires", status: "failed" },
+      { ruleId: "o1", type: "recommends", status: "failed" },
+      { ruleId: "o2", type: "recommends", status: "ignored" },
+      { ruleId: "o3", type: "recommends", status: "installed" },
+    ]);
+    expect(getFailedOptionalMods(state).map((m) => m.rule.reference.tag)).toEqual(["o1"]);
   });
 });
 

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -192,6 +192,30 @@ export const getCollectionRequiredMods = (state: IState): ICollectionModInstallI
 };
 
 /**
+ * Required members of the active session that settled as failed (terminal "failed"). Used by the
+ * install-finished dialog to reword the prompt and trim its actions when the collection completed
+ * WITH failures rather than cleanly - a failed required member means the collection isn't really
+ * "installed", so we don't offer to install the optional mods on top of a broken required set.
+ * @returns Array of failed required mods
+ */
+export const getFailedRequiredMods = (state: IState): ICollectionModInstallInfo[] => {
+  const mods = getCollectionActiveSessionMods(state);
+  return Object.values(mods).filter((mod) => isRequiredRule(mod) && mod.status === "failed");
+};
+
+/**
+ * Optional members of the active session that settled as failed. A default-skipped optional is
+ * "ignored", never "failed", so this lists only optionals the user SELECTED and that then failed to
+ * install. Surfaced additively in the install-finished dialog - a failed optional annotates the
+ * result but does not make the collection "incomplete" the way a failed required member does.
+ * @returns Array of failed optional mods
+ */
+export const getFailedOptionalMods = (state: IState): ICollectionModInstallInfo[] => {
+  const mods = getCollectionActiveSessionMods(state);
+  return Object.values(mods).filter((mod) => isOptionalRule(mod) && mod.status === "failed");
+};
+
+/**
  * Get all optional/recommended mods from the active session
  * @returns Array of optional mods
  */


### PR DESCRIPTION
- Install-finished dialog: mark the collection incomplete when a required member failed (reworded title, Incomplete pill, "View failed mods" action; hide optional/clone actions). Add getFailedRequiredMods / getFailedOptionalMods.
- Report a failed download as "failed" (reconstructModStatus + itemRows precedence over the session status) so it counts and appears under the "Failed" filter.
- InstallManager: resync the session from reality in cleanupPendingInstalls on pause/cancel/stall; treat a no-instructions ProcessCanceled as non-retryable so the member settles failed.

part of LAZ-483

Note: Yes the `InstallManager` tests are disgusting - I'm going to work on that iteratively once we decide to refactor `InstallManager`. Treat them as placeholders.