### PR TITLE
adding /watch-log skill for log diagnosis

### DIFF
--- a/.claude/skills/watch-log/README.md
+++ b/.claude/skills/watch-log/README.md
@@ -1,0 +1,70 @@
+# `/watch-log` — Vortex log skill (overview & usage)
+
+A Claude Code skill for watching and investigating **Vortex log files**. It turns a
+noisy, multi-megabyte log into a short, session-scoped diagnosis: how the app
+terminated, what errors/warnings fired, whether persistence wrote cleanly, where an
+install/download/collection stalled, and which line of code emitted a given entry.
+
+It is **rotation-aware** (logs roll at ~11 MB into `vortex1.log`, `vortex2.log`, …) and
+**session-aware** (one file can hold several app runs; one run can span several files).
+
+## Install
+
+Unzip into your Claude Code skills directory so the folder lands at
+`.claude/skills/watch-log/` (either the repo's `.claude/` or your user-level
+`~/.claude/`). Restart/reload Claude Code and the `/watch-log` skill becomes available.
+
+## How it works (architecture)
+
+It is a **thin router**. `SKILL.md` reads a small core (`reference.md`) and then loads
+**only** the mode(s) and shared chunks a given request needs, keeping context small.
+
+```
+watch-log/
+  SKILL.md            router: picks the mode(s) from your request
+  reference.md        core facts: log format, dev/prod/rotation resolver, chunk index
+  modes/              one file per mode, loaded on demand
+  shared/             reusable chunks (sessions, lifecycle, persistence, …)
+  drift-check/        WIP, not wired into the router — ignore for evaluation
+```
+
+## The six modes
+
+| Mode                         | What it does                                                                                                                                                                                                                                                            | Trigger words                                                                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Live**                     | Streams matching log lines into chat in real time (no-timeout monitor).                                                                                                                                                                                                 | _watch / live / follow / tail / monitor_ (also the default)                                                         |
+| **Investigate**              | Session-scoped report: termination state (clean / killed-during-exit / hard-crash / in-progress), error & warning signatures, most error-prone session, regressions, re-installs, version downgrades.                                                                   | _investigate / analyze / report / crashes / errors / warnings / session_                                            |
+| **Persistence**              | Checks duckdb/`level_pivot` writes for failures, wedged (never-confirmed) writes, and slow writes.                                                                                                                                                                      | _persistence / duckdb / level_pivot / slow write / did it save_                                                     |
+| **Correlate**                | Takes a specific log line and finds the emitting call site, then walks the code bidirectionally (callers/callees) to a set depth.                                                                                                                                       | a pasted/quoted log line, or _correlate / why did this happen_                                                      |
+| **Trace**                    | Follows one download / mod install / collection / deployment top-to-bottom: phase timeline, durations, outcome, where it stalled.                                                                                                                                       | _trace / track / follow this install_, or a mod id / archive name / nxm url / collection name                       |
+| **Collection install audit** | Audits a whole collection install against the install-completion invariants (every member terminal, no requeue loop, phases advance, disk-full/failed-download/orphaned-archive paths settle, interrupted installs resume without data loss) and names which one broke. | _collection install audit / member stuck / requeue loop / did the collection finish / interrupted install / resume_ |
+
+More than one mode can run in a single request (e.g. "investigate this session and check
+its persistence").
+
+## Which log it reads
+
+By default it scans the **dev** log set (`%APPDATA%\@vortex\main\`). You can point it at
+**prod** (`%APPDATA%\Vortex\`) with the `prod` keyword, or at a **specific file path**.
+It always states which directory/file it chose and resolves the rolled-file set once.
+
+> Note: those default paths are specific to the Vortex dev workflow. On a different
+> setup, adjust the resolver in `reference.md`.
+
+## Example prompts
+
+- `/watch-log` — live-tail the dev log (default mode)
+- `/watch-log investigate` — report on the latest dev session (crashes, errors, warnings)
+- `/watch-log investigate prod, all sessions` — full prod history with cross-session signals
+- `/watch-log persistence` — did the last writes commit, or did any wedge / run slow?
+- `/watch-log trace "Skyrim Script Extender"` — follow that mod's install lifecycle
+- `/watch-log 483 — did the collection finish?` — collection install audit
+- paste a log line + `why did this happen?` — correlate it back to the emitting code
+
+## What it does _not_ do
+
+- It does not modify logs or app state — it is read-only analysis.
+- It is tuned to Vortex's log markers and collection-install invariants; it is not a
+  general-purpose log tool.
+- The `drift-check/` folder is an in-progress experiment and is not part of the routed
+  skill behaviour.

--- a/.claude/skills/watch-log/SKILL.md
+++ b/.claude/skills/watch-log/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: watch-log
+description: Watch or investigate a Vortex log file (rotation- and session-aware). A router over six modes loaded on demand — live tail, session/crash/error investigation, persistence (duckdb/level_pivot) integrity, log-line-to-code correlation, single download/install/collection/deploy trace, and a collection-install audit (also serves as the LAZ-483 regression check). Defaults to the dev log; can target prod or a specific file.
+when_to_use: When the user wants to watch/tail/follow a log live, or investigate/report on errors, crashes, warnings, persistence integrity, re-installs, version downgrades, a specific log entry, or a download/install/collection/deployment lifecycle in a Vortex log.
+user-invocable: true
+---
+
+# `/watch-log` (router)
+
+Watch or investigate a Vortex log file. The log is rotation-aware and session-aware:
+it rolls at ~11 MB into `vortex1.log`, `vortex2.log`, … so one run can span several
+files and one file can hold several runs. This skill is a **thin router**: it picks
+the mode(s) and loads only the files needed, keeping context small.
+
+## How to run
+
+1. **Always read `reference.md`** (the core) first — the universal log facts, the
+   dev/prod/rotation log-set resolver, and an index of the on-demand `shared/` chunks
+   (sessions, lifecycle, persistence, multi-file, edge-cases) that modes load as needed.
+2. **Pick the mode(s)** from `$ARGUMENTS` using the table below. **More than one mode
+   may be requested in a single invocation** (e.g. "investigate + persistence", or
+   "trace <mod> and correlate <error>").
+3. **For each selected mode, read its file** under `modes/` plus the `shared/` chunks
+   named in that mode's Prereq line, and follow it. Read `reference.md` and each chunk
+   at most once, even when running several modes.
+4. **Running several modes:** if they're independent (the common case), you may run
+   them concurrently — e.g. dispatch each mode to its own subagent (pass it
+   `reference.md` + the mode file + the resolved log target), then combine the
+   results into one report with a section per mode. If a mode depends on another's
+   output (rare), run them in order. Resolve the log set **once** (per `reference.md`)
+   and share the target across all selected modes.
+
+## Mode picker
+
+| Mode                         | Trigger (`$ARGUMENTS`)                                                                                                                                                          | File                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **Live**                     | default, or _watch / live / follow / tail / monitor_                                                                                                                            | `modes/live.md` (§A)               |
+| **Investigate**              | _investigate / analyze / report / crashes / errors / warnings / session / "what happened"_, or a date/session ref                                                               | `modes/investigate.md` (§B)        |
+| **Persistence**              | _persist / persistence / duckdb / level_pivot / slow write / did it save_                                                                                                       | `modes/persistence.md` (§C)        |
+| **Correlate**                | a pasted/quoted specific log line, or _correlate / why did this happen_                                                                                                         | `modes/correlate.md` (§D)          |
+| **Trace**                    | _trace / track / follow this install / download / collection / deployment_, or a mod id / archive name / nxm url / downloadId / collection name                                 | `modes/trace.md` (§E)              |
+| **Collection install audit** | _collection install audit / member stuck / requeue loop / did the collection finish / install completion / settled / interrupted install / resume / data loss on restart / 483_ | `modes/collection-install.md` (§F) |
+
+**Trace vs Collection install audit:** §E follows one entity and reports where it
+stalled; §F audits a whole collection install against the install-completion invariants
+(every member terminal, no requeue loop, phases advance, error paths settle) and names
+which invariant broke. Use §F to audit a whole install's health (this doubles as the
+LAZ-483 regression check), §E to chase one thread.
+
+If no mode is implied, default to **Live**. If a request clearly spans several
+(e.g. "give me the full picture of this session and its persistence"), select and
+run all that apply.

--- a/.claude/skills/watch-log/drift-check/README.md
+++ b/.claude/skills/watch-log/drift-check/README.md
@@ -1,0 +1,25 @@
+# watch-log drift-check
+
+Keeps the skill's log-message markers honest against the Vortex code.
+
+- **`markers.json`** - the markers (source literals) the skill greps for, grouped by
+  chunk/mode. This is the skill's code-dependency contract; edit it when you add or
+  rename a marker in a mode.
+- **`check.py`** - run it to:
+    1. **MISSING**: assert every manifest marker still exists in the source (catches a
+       renamed/removed log the skill would silently stop matching).
+    2. **UNCAPTURED**: list `warn`/`error` `log(...)` call sites in the code the skill
+       does not reference yet (candidates to surface when you need more data).
+
+```bash
+python .claude/skills/watch-log/drift-check/check.py          # full report
+python .claude/skills/watch-log/drift-check/check.py --quiet  # only problems
+```
+
+Exit code is non-zero if any marker is MISSING (so it can gate later if the skill is
+ever shared). Uses `git grep` (no extra deps); searches tracked + untracked files,
+excludes the skill itself, tests, and docs.
+
+**Caveat:** markers are matched as **source literals**. The emitted log line can differ
+(a logger wrapper may add a prefix, e.g. the collection logs). A clean drift-check still
+warrants a sanity check against a real `vortex.log` for the emitted format.

--- a/.claude/skills/watch-log/drift-check/check.py
+++ b/.claude/skills/watch-log/drift-check/check.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Drift-check for the watch-log skill.
+
+Verifies that every log-message marker the skill greps for still exists in the Vortex
+source (catches renamed/removed logs), and flags warn/error log call sites in the code
+that the skill does not yet reference (candidates to capture). Markers are SOURCE
+literals; the emitted log line can differ (a logger wrapper may add a prefix), so a
+clean run here still warrants a sanity check against a real log.
+
+Usage:  python check.py            # report
+        python check.py --quiet    # only print problems
+Exit code is non-zero if any marker is MISSING. Uses `git grep` (no extra deps).
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MANIFEST = HERE / "markers.json"
+
+
+def find_repo_root(start: Path) -> Path:
+    for p in [start, *start.parents]:
+        if (p / ".git").exists():
+            return p
+    return start.parents[3]  # .claude/skills/watch-log/drift-check -> repo root
+
+
+REPO = find_repo_root(HERE)
+
+# Inclusive root + excludes (skill text, tests, docs) so the skill's own marker text
+# and test-only logs don't count as matches. git pathspec needs an inclusive entry.
+PATHSPEC = [
+    ".",
+    ":(exclude,glob).claude/**",
+    ":(exclude,glob)**/*.test.*",
+    ":(exclude,glob)**/*.spec.*",
+    ":(exclude,glob)**/*.md",
+]
+
+
+def git_grep(extra_opts, pattern):
+    res = subprocess.run(
+        ["git", "grep", "-I", "--untracked", *extra_opts, "-e", pattern, "--", *PATHSPEC],
+        cwd=REPO, capture_output=True, text=True,
+    )
+    if res.returncode not in (0, 1):  # 1 = no matches (fine); other = error
+        sys.exit(f"git grep failed: {res.stderr.strip()}")
+    return res.stdout
+
+
+def marker_exists(marker: str) -> bool:
+    return bool(git_grep(["-l", "-F"], marker).strip())
+
+
+def load_manifest():
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    groups = {k: v for k, v in data.items() if not k.startswith("_")}
+    seen = {}
+    for group, markers in groups.items():
+        for m in markers:
+            seen.setdefault(m, group)
+    return groups, seen
+
+
+# matches a warn/error log call on one line and captures the message literal
+LOG_LINE = re.compile(r"""log\(\s*['"](?:warn|error)['"]\s*,\s*['"]([^'"]{4,})['"]""")
+
+
+def find_uncaptured(manifest_markers):
+    lines = git_grep(["-h", "-E"], r"log\([[:space:]]*['\"](warn|error)['\"]").splitlines()
+    literals = set()
+    for ln in lines:
+        m = LOG_LINE.search(ln)
+        if m:
+            literals.add(m.group(1).strip())
+
+    def captured(lit: str) -> bool:
+        return any(mk in lit or lit in mk for mk in manifest_markers)
+
+    return sorted(l for l in literals if not captured(l))
+
+
+def main():
+    quiet = "--quiet" in sys.argv
+    _, seen = load_manifest()
+
+    missing, ok = [], 0
+    for marker, group in seen.items():
+        if marker_exists(marker):
+            ok += 1
+        else:
+            missing.append((marker, group))
+
+    print(f"watch-log drift-check  (repo: {REPO})")
+    print(f"markers checked: {len(seen)}   present: {ok}   MISSING: {len(missing)}\n")
+
+    if missing:
+        print("== MISSING (referenced by skill, not found in code) ==")
+        for marker, group in sorted(missing, key=lambda x: x[1]):
+            print(f"  [{group}] {marker!r}")
+        print("  -> update the skill/manifest, or the log was renamed/removed.\n")
+    elif not quiet:
+        print("All markers present in code.\n")
+
+    uncaptured = find_uncaptured(list(seen.keys()))
+    if uncaptured and not quiet:
+        print(f"== UNCAPTURED warn/error logs ({len(uncaptured)}) - review, not all are skill-relevant ==")
+        for lit in uncaptured[:40]:
+            print(f"  {lit!r}")
+        if len(uncaptured) > 40:
+            print(f"  ... and {len(uncaptured) - 40} more")
+        print("  -> add to a mode/manifest if it is a signal the skill should surface.\n")
+
+    print("NOTE: markers are source literals; emitted lines may add a prefix. "
+          "Cross-check a real log when in doubt.")
+    sys.exit(1 if missing else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/watch-log/drift-check/markers.json
+++ b/.claude/skills/watch-log/drift-check/markers.json
@@ -1,0 +1,57 @@
+{
+  "_comment": "Log-message markers the watch-log skill depends on, as SOURCE literals (the text inside log('level','<message>',...) calls). The drift-check asserts each still exists in the Vortex code and flags warn/error logs the skill does not yet capture. NOTE: the emitted log line can differ from the source literal (a logger wrapper may add a prefix) - always cross-check a real log too. Matching is substring-based, so a short marker matches a longer literal that contains it.",
+  "core": ["Vortex Version", "startup instance", "Vortex closing", "clean application end"],
+  "sessions": ["Vortex Version", "startup instance", "Vortex closing", "clean application end"],
+  "lifecycle.download": [
+    "start download mod",
+    "starting download",
+    "download resolved",
+    "queuing download",
+    "download starting",
+    "download completed",
+    "download failed"
+  ],
+  "lifecycle.install": [
+    "start mod install",
+    "mod id for newly installed mod",
+    "installing to",
+    "extracting mod archive",
+    "invoking installer",
+    "finish mod install",
+    "Installation completed successfully"
+  ],
+  "lifecycle.collection": [
+    "starting install of collection",
+    "add collection rule",
+    "did install dependencies",
+    "postprocess collection"
+  ],
+  "lifecycle.deploy": ["deployment progress", "starting purge activity"],
+  "persistence": [
+    "Received persist:diff",
+    "level_pivot slow Write",
+    "level_pivot Write enter",
+    "level_pivot Write exit",
+    "Could not read persisted value",
+    "Could not write persisted value",
+    "Could not get persisted hives",
+    "DuckDBSingleton not initialized",
+    "Extension persistor removeItem failed"
+  ],
+  "collection-install.483": [
+    "Called callback for stuck installation",
+    "ignoring download failure",
+    "Found collection for failed download",
+    "reconciling orphaned archive before download",
+    "Failed to install dependency",
+    "Collection Download Failed",
+    "pause collection",
+    "resume collection",
+    "User logged out during collection install",
+    "Collection install stalled, attempting rescue",
+    "Collection install stalled after rescue attempt, resolving",
+    "Critical error in dependency installation",
+    "Error during scheduled phase deployment",
+    "Download not found when trying to resume"
+  ]
+}

--- a/.claude/skills/watch-log/modes/collection-install.md
+++ b/.claude/skills/watch-log/modes/collection-install.md
@@ -1,0 +1,152 @@
+# §F — Collection install audit
+
+Prereq: `reference.md` (core) + `shared/lifecycle.md` + `shared/sessions.md`. This mode
+extends §E (trace): §E threads one entity and reports where it stalled; §F audits a
+**whole collection install** against the install-completion invariants and names which
+one broke. Scope to one session (default latest, per §B); say which.
+
+A healthy collection install holds a set of invariants: collection state lives in the
+session SSOT (`state.session.collections`, written by `collectionSessionWrite` /
+`InstallManager`), every member reaches a terminal state, phases advance, and the error
+paths settle members instead of wedging them. This mode confirms that from the log and
+flags the specific failure modes so a problem surfaces as a **named check, not a
+mystery**. These invariants are the contract LAZ-483 established, so the same audit
+doubles as the **483 regression check** when you run it against a dev collection install.
+
+Confirm the message strings below still exist before relying on absence (grep the
+source named in each row); log text drifts.
+
+## Identify the collection
+
+From `$ARGUMENTS`: a collection name/id, or "the collection install". If none, grep the
+scoped log for `starting install of collection` and list candidates (with `collationId`
+and `totalMods`) for the user to pick. Thread members by `modId` / `referenceTag` /
+`collationId` and the `sourceModId` (= collection id) carried on the install logs.
+
+## Envelope (the collection-level lifecycle)
+
+- `starting install of collection {totalMods, missing}` (InstallDriver) — start anchor.
+- `did install dependencies {modId}` (InstallDriver) — dependencies phase done.
+- `add collection rule` (postprocessCollection) — rules applied.
+- `postprocess collection` (postprocessCollection) — terminal success anchor.
+- Pause/resume: `pause collection` / `resume collection` / `failed to pause collection`
+  / `User logged out during collection install, pausing` (collections/index.ts).
+- `already installing a collection` (InstallDriver) — a second install was refused.
+
+## Per-member lifecycle (each dependency)
+
+Generic install markers (`shared/lifecycle.md`, used by §E): `start mod install` → `installing to {modId,
+destinationPath}` → `extracting mod archive` → `invoking installer` → `finish mod
+install {outcome}` → `Installation completed successfully {installId, modId, duration}`.
+Collection hand-off: `Found collection for download` / `Found collection for failed
+download` (InstallManager). The SSOT status writes (`{type:"status", status:
+"downloaded"|"failed"|...}`) go to the session hive, not a log string — observe them via
+the install lifecycle logs above and, if needed, the `persist:diff {hive:"session"}`
+arrivals (§C markers).
+
+## Invariants to assert (and the bug signature if broken)
+
+| #   | invariant (what a healthy install holds)                                                          | broken signature in the log                                                                                                                                                                                                                                                                                               | source                                                 |
+| --- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 1   | every member reaches a terminal state (installed or failed)                                       | `Called callback for stuck installation` (a member wedged on "installing"); or the stall-rescue flow firing: `Collection install stalled, attempting rescue` followed by `Collection install stalled after rescue attempt, resolving` (the installer force-resolved a stalled phase, so members may be left non-terminal) | InstallManager                                         |
+| 2   | a failed download settles the member failed (and lets the phase advance)                          | `Found collection for failed download` with **no** following member-failed settle, or `Collection is not currently installing - ignoring download failure` firing while the collection _is_ installing                                                                                                                    | InstallManager `handleDownloadFailed`                  |
+| 3   | no requeue loop                                                                                   | the same `modId` runs `start mod install` more than `MAX_DEPENDENCY_RETRIES` (3) times                                                                                                                                                                                                                                    | InstallManager (`MAX_DEPENDENCY_RETRIES`)              |
+| 4   | disk-full ends the member terminally                                                              | extraction hits disk-full but the member neither completes nor logs a "Not enough disk space" terminal fail (failure mode: requeue → skip → stuck)                                                                                                                                                                        | InstallManager (`InsufficientDiskSpace`)               |
+| 5   | an orphaned archive (file on disk, no download record) is reconciled before re-download           | a dependency download stalls with no `reconciling orphaned archive before download {fileName, gameId}` when one was on disk                                                                                                                                                                                               | `reconcileOrphanedArchive.ts`                          |
+| 6   | the collection reaches postprocess                                                                | `starting install of collection` present but **no** `postprocess collection` / `did install dependencies` before session end (stuck phase); or `Error during scheduled phase deployment` (a phase failed to deploy, which can block advancing)                                                                            | InstallManager / InstallDriver / postprocessCollection |
+| 7   | pause/resume and logout are clean                                                                 | a `pause collection` / logout-pause with no matching `resume collection`, or `failed to pause collection`                                                                                                                                                                                                                 | collections/index.ts                                   |
+| 8   | progress stays sane                                                                               | a download/install progress value above 100 (the 101/100 `freeUserDownloadPosition` failure on the free-user path)                                                                                                                                                                                                        | InstallManager free-user path                          |
+| 9   | an interrupted install loses no progress, and a user-initiated resume preserves completed members | a member that logged `Installation completed successfully` pre-restart is re-installed post-restart (progress lost); or a `resume collection` that re-runs completed members or fails to continue. Note: resume is **user-initiated**, so a parked install with **no** `resume collection` is not a failure               | session SSOT (`state.session.collections`)             |
+
+### Stall, rescue, and critical-error signals
+
+The installer has a stall-detection safety net; surface these whenever present:
+
+- `Collection install stalled, attempting rescue {sourceModId}` (`[WARN]`) - a phase
+  stalled (first timeout); a rescue is underway. Not yet a failure, but a warning sign.
+- `Collection install stalled after rescue attempt, resolving {sourceModId}` (`[WARN]`)
+    - the rescue did not unblock it (second timeout) and the installer **force-resolved**
+      the phase. Members in that phase may be left non-terminal: pair with the per-member
+      roll-up to see which, and report it as a stall (relates to invariant 1/6).
+- `Critical error in dependency installation {downloadId, sourceModId}` (`[ERRO]`) - a
+  dependency install threw; confirm the member settled `failed` rather than wedging.
+- `Error during scheduled phase deployment {sourceModId}` (`[WARN]`) - a phase failed to
+  deploy (relates to invariant 6).
+- `Download not found when trying to resume {intendedId}` (`[WARN]`) - on resume an
+  intended member download was missing; relevant to invariant 9 (resume integrity).
+
+### Invariant 9 — interruption and resume (data-loss watch)
+
+This is the core promise of the session SSOT (the guarantee LAZ-483 established): an
+install interrupted by a restart/crash should resume from the session state without
+redoing or losing completed members. **Always surface an interruption** (it is a real
+signal), with this severity framing:
+
+- **Detect interruption:** a `starting install of collection` whose session ends (next
+  `Vortex Version` start anchor, or EOF with no `postprocess collection`) before the
+  collection reaches `postprocess collection`.
+- **Classify the boundary** using the termination classification from
+  `shared/sessions.md` / §B: **clean** (`Vortex closing` → `clean application end`), **killed-during-exit**
+  (`Vortex closing`, no clean end), **hard-crash** (no `Vortex closing`), or
+  **in-progress** (latest session, still running).
+- **Severity:**
+    - **prod** (`$APPDATA/Vortex/`): flag every interruption as a finding. A hard-crash
+      mid-install is a crash bug; a clean/killed exit mid-install is a resume-correctness
+      and data-loss concern to track.
+    - **dev** (`$APPDATA/@vortex/main/`): an interruption is **somewhat expected**
+      (developer restarts the rig), so report it but label it expected, **unless the
+      developer signals the restart was not intentional** (then treat it like prod, i.e. a
+      real finding, especially a hard-crash).
+- **Resume + lost-progress check:** in sessions after the boundary, look for
+  `resume collection` (collections/index.ts) or a fresh `starting install of collection`
+  for the same collection, and whether it reaches `postprocess collection`. Then compare
+  member `modId`s with `Installation completed successfully` **before** the boundary
+  against those re-running `start mod install` / completing **after** it:
+    - members re-installed that were already complete pre-restart = **progress lost / data
+      loss** (the SSOT did not preserve them) — flag regardless of dev/prod.
+    - completed members correctly skipped on resume = SSOT preserved progress (pass).
+    - **no `resume collection` attempted = parked, awaiting user resume — NOT a failure**
+      (resume is user-initiated). Report it as parked/incomplete, not stuck.
+
+**Prod monitoring.** On prod logs this invariant is the field signal for collection
+install reliability: per interrupted install, report the boundary class, whether the
+55-of-N style progress was preserved (no re-do) once resumed, and whether resume even
+succeeded. A hard-crash boundary, or any re-installed-completed-member (data loss), is a
+real finding to escalate; a clean exit with no resume attempt is benign.
+
+Also surface the diagnostic "ignore" logs that mean a download event found no owner:
+`No collection mod found for sourceModId`, `No active collection installation found`,
+`No matching rule found in collection for download`, `Collection mod not found in
+state`, `Skipping download failure - download not found`. A burst of these around a
+member is a strong hint that invariant 1 or 2 is about to break.
+
+## Steps
+
+1. Resolve the log set and scope to the session (per §B). Find the collection envelope.
+2. Build the **per-member roll-up**: for each member thread (`modId`), record its phase
+   reached, outcome (completed / failed / **stuck**), `duration` if completed, and
+   retry count (number of `start mod install` for that `modId`).
+3. Walk the invariant table; for each break, cite the member, the matching line(s), and
+   timestamps. Treat absence-of-terminal as **stuck** (invariant 1/6), not success.
+4. Report the envelope outcome (reached `postprocess collection`?) and any pause/resume
+   or logout transitions and whether they paired. If it did **not** reach postprocess,
+   run invariant 9: find the session boundary that ended it, classify it (clean /
+   killed-during-exit / hard-crash / in-progress), check later sessions for resume +
+   lost-progress, and apply the dev/prod severity framing.
+5. List interleaved `[ERRO]`/`[WARN]` whose payload references a member in its window.
+
+## Output shape
+
+- One-line verdict: collection completed / completed-with-failed-members / **stuck**,
+  with member counts (installed / failed / stuck of total).
+- Per-member table: `modId` · phase reached · outcome · duration · retries.
+- Invariant results: each of 1-9 as pass / **FAIL** (with the offending lines), or n/a
+  if the path wasn't exercised this session.
+- Envelope timeline (start → did install dependencies → add rule → postprocess) with Δs,
+  plus pause/resume/logout events.
+- **Interruption (invariant 9), if any:** the boundary classification (clean / killed /
+  hard-crash / in-progress), whether it resumed and reached postprocess, and the
+  lost-progress verdict (members re-done vs preserved). State dev-expected vs a real
+  finding per the severity framing; on prod always treat as a finding.
+- Anything anomalous (requeue loops, stuck members, orphaned-archive stalls, >100
+  progress, ignored-download bursts, data loss on resume).

--- a/.claude/skills/watch-log/modes/correlate.md
+++ b/.claude/skills/watch-log/modes/correlate.md
@@ -1,0 +1,38 @@
+# §D — Correlate a specific log entry to source
+
+Prereq: `reference.md` (core; the logging-call convention lives there).
+
+Input: a specific log line (quoted text and/or a timestamp). Depth is configurable
+(default **4**; accept a `--depth N` style arg). The static walk is **bidirectional**
+to depth N in **both** directions, and the time-window correlation looks **both
+before and after** the entry — the user wants to know both what led up to the entry
+and what happened next.
+
+1. **Locate the call site:** extract the literal message text from the line and grep
+   the codebase for it (`log('warn'|'error'|…, '<message>'`). Resolve the emitting
+   function. If several match, use the `[SOURCE]` (`MAIN`/`RENDERER`) and context to
+   disambiguate; list candidates if still ambiguous.
+2. **Walk backward (callers, up to depth N):** find callers of the emitting
+   function, then their callers, up to N levels. At each level note any **other**
+   `log(...)` statements reachable on the path **leading into** the target — the
+   breadcrumbs expected to fire _before_ the entry.
+3. **Walk forward (continuation + callees, up to depth N):** from the emitting call
+   site, follow what executes **after** the log statement — the rest of that
+   function, then the functions it calls, and their callees, up to N levels. Note
+   the `log(...)` statements reachable on that downstream path — the breadcrumbs
+   expected to fire _after_ the entry. Cover branches (success vs error/early-return)
+   so the "what should happen next" set includes the failure continuations, not just
+   the happy path.
+4. **Time-window correlation (both sides):** take the target entry's timestamp and
+   pull actual log lines in a window **before and after** it (default a few seconds
+   each side, widen if sparse). Present them as a **before / entry / after**
+   timeline, **highlight every `[WARN]` / `[ERRO]`** on both sides, and map lines to
+   the backward (step 2) and forward (step 3) log statements where possible. Flag
+   **expected-but-missing** forward breadcrumbs (a downstream log statement that
+   should have followed but didn't appear) — that gap pinpoints where the flow
+   diverged or wedged.
+5. **Output:** the resolved call site (`file:line`); the backward call-stack chain
+   and the forward continuation/callee chain, each with their log statements; and the
+   before/entry/after log timeline with warnings/errors highlighted and any
+   missing-after breadcrumbs called out — so the user sees both the static code path
+   (in and out) and what actually fired around the entry on both sides.

--- a/.claude/skills/watch-log/modes/investigate.md
+++ b/.claude/skills/watch-log/modes/investigate.md
@@ -1,0 +1,61 @@
+# §B — Investigate mode (session-scoped report)
+
+Prereq: `reference.md` (core) + `shared/sessions.md` + `shared/edge-cases.md`
+(+ `shared/multi-file.md` when handling multiple / foreign files).
+
+1. **Find the scoped session.** Default scope is the **latest** session, which lives
+   at the **tail of the current `vortex.log`**: scan `vortex.log` backward for the
+   last start anchor (`[INFO] [MAIN] Vortex Version`); that anchor → EOF is the
+   latest session. Only reach into `vortex1.log` (then `vortex2.log`, …) when the
+   start anchor is **not** in `vortex.log` (the session began before the last roll)
+   so the session is contiguous, or when the user wants older / all sessions — then
+   assemble files oldest→newest per Shared. Honor explicit scope: a session index, a
+   date/time, or "all sessions".
+2. **Record per session:** start ts, end ts, **duration**, which file(s) it spans,
+   the **termination state** (clean / killed-during-exit / hard-crash / in-progress,
+   per the 4-state classification in `shared/sessions.md`), the **app version** (the quoted
+   `Vortex Version` value), the **instanceId** (from the `startup instance` line),
+   and the **`[ERRO]` and `[WARN]` counts** (used for ranking in step 4).
+3. **Report for the scoped session:**
+    - Termination state (+ window timestamps & files), calling out a **hard crash**
+      prominently and noting killed-during-exit as the milder dev-stop signal.
+    - `[ERRO]` lines (grouped by normalized signature with counts).
+    - Warnings — `[WARN]` lines, split by source: `[WARN] [RENDERER]` (renderer/UI)
+      and `[WARN] [MAIN]`. Do NOT grep a bare `React` token — it false-matches words
+      like "Reactions"; rely on the `[WARN]` level token.
+    - No-level crash signatures (`Unhandled` / `uncaught` / `Traceback` / `FATAL`)
+      that may appear outside the structured logger.
+4. **Cross-session signals** (compute across the retained sessions, chronological):
+    - **Most error/warning-prone session:** rank the retained sessions by `[ERRO]` +
+      `[WARN]` count (show the top one with its window and counts). If the most prone
+      session is **not** the scoped/latest one, **highlight it prominently** and offer
+      to scope the report to it — it is often more relevant than the latest (e.g. when
+      the latest is a brief launch-and-quit and the real activity is in an earlier
+      session). Weight `[ERRO]` above `[WARN]`, and call out any session containing a
+      **hard crash** regardless of total count.
+    - **Regression / potentially-fixed** (the days-apart case): normalize each
+      error/warning into a signature (strip timestamps, paths, ids, numbers). A
+      signature present in older session(s) but **absent from the
+      latest** → highlight as **"potentially fixed — last seen `<ts>`, not in latest
+      session"**. A signature new in the latest session → flag as newly introduced.
+        - **Short-session caveat:** if the scoped/latest session is very short or barely
+          exercised (e.g. a sub-few-minute launch-and-quit, or its `[ERRO]`+`[WARN]`
+          count is a small fraction of the most-prone session's), **downgrade
+          "potentially fixed" to "not reproduced (session too short)"** — an absent
+          signature almost certainly means _not exercised this run_, not _fixed_. Say so
+          explicitly and point the user at the most-prone session for a real comparison.
+    - **Re-installs (prod only):** when the `instanceId` **changes** from one session
+      to the next, highlight it as a **re-install / fresh install** at that boundary
+      (prod instanceId is otherwise stable across restarts). **Skip this on dev** —
+      the dev instanceId churns per test run, so changes there are not re-installs.
+    - **Version downgrade:** track the app version per session. If a chronologically
+      later session runs a **lower** semver than an earlier one, highlight the
+      downgrade (`from <hi> down to <lo> at <ts>`). Surface this prominently when
+      **more than 2 distinct versions** appear across the retained sessions and the
+      sequence includes a downgrade. Plain forward upgrades are not flagged.
+5. **Reporting rule:** every report states which single session it covers and the
+   exact window; never silently mix sessions. Only widen when the user says "all" or
+   names a range — and then label each finding with its session. (Most-prone-session,
+   re-install, downgrade, and regression signals are inherently cross-session —
+   present them in a short "across sessions" addendum, distinct from the scoped
+   session report.)

--- a/.claude/skills/watch-log/modes/live.md
+++ b/.claude/skills/watch-log/modes/live.md
@@ -1,0 +1,35 @@
+# §A — Live mode (no-timeout watch)
+
+Prereq: `reference.md` (core) + `shared/edge-cases.md`.
+
+1. Target the **current** `vortex.log` (live == newest file), per the shared resolver.
+2. Build the filter. Default (all errors + warnings + no-level crash signatures):
+
+    ```
+    \[(ERRO|WARN)\]|Unhandled|uncaught|Traceback|FATAL
+    ```
+
+    `[(ERRO|WARN)]` catches every levelled error/warning; the rest catch raw crash
+    output printed outside the structured logger. Don't add a bare `React` token — it
+    false-matches "Reactions" etc.
+
+    If the user gave a pattern, OR-in the crash signatures so silence can't hide a
+    crash: `<user-pattern>|Unhandled|uncaught|FATAL`. State the final pattern back.
+
+3. Launch the **Monitor** tool:
+    - `persistent: true` (no timeout — this is the whole point; do NOT use a
+      `timeout_ms`-bounded watch or a one-shot `Bash run_in_background` here).
+    - `command:`
+      `tail -n 0 -F "<vortex.log>" | grep -E --line-buffered "<pattern>"`
+        - `-F` (capital) re-follows across the ~11 MB rollover (vortex.log is
+          recreated). `-n 0` starts from "now". `--line-buffered` flushes per line.
+    - `description:` specific, e.g. `errors/warnings in vortex dev log` (it shows on
+      every notification).
+4. Tell the user: matching lines now arrive as chat notifications as they're
+   written; the watch runs for the whole session; stop early with TaskStop. If it's
+   auto-stopped for volume, restart with a tighter filter. Lines written in the
+   brief roll gap land in `vortex1.log`; for gapless history use §B (investigate).
+5. **One-shot exception:** if the user only wants "tell me once when X appears / when
+   the run finishes", use `Bash` with `run_in_background` and an `until` loop
+   (`until grep -q "X" "<log>"; do sleep 0.5; done`) instead of a persistent
+   Monitor — that gives a single completion notification.

--- a/.claude/skills/watch-log/modes/persistence.md
+++ b/.claude/skills/watch-log/modes/persistence.md
@@ -1,0 +1,22 @@
+# §C — Persistence-integrity check (duckdb / level_pivot)
+
+Prereq: `reference.md` (core) + `shared/persistence.md`. Scope to one
+session (default latest, per §B / investigate.md). Confirm current message strings /
+threshold against `AGENTS-DEBUGGING.md` and `src/main/src/store/LevelPersist.ts`.
+
+1. **Activity:** count `Received persist:diff` (with hive + operationCount) over the
+   window to show persist load.
+2. **Slow writes:** collect `[WARN] [MAIN] level_pivot slow Write`; report the
+   count, the worst `elapsedMs`, and a breakdown by `method` (e.g. `bulkRemoveItem`).
+   Note the 250 ms `SLOW_WRITE_THRESHOLD_MS`.
+3. **Never-confirmed / wedged writes:** if `VORTEX_TRACE_DB_WRITES=1` was on, pair
+   `level_pivot Write enter` ↔ `Write exit` by order; any trailing `enter` with no
+   matching `exit` is a wedged / unconfirmed write — highlight it (classic shutdown
+   hang). If tracing was off, say so and fall back to: a persist burst immediately
+   followed by an error or by no further persist/shutdown progress.
+4. **Failures:** any `[ERRO] [MAIN]` on the persist / level_pivot / duckdb-singleton
+   path.
+5. **Verdict per session:** **clean** (writes present, none slow, no unmatched
+   enter, no error) vs **issues** (enumerate them). If the user asked about a
+   specific action/time, pair that `persist:diff` with the outcome in its immediate
+   window.

--- a/.claude/skills/watch-log/modes/trace.md
+++ b/.claude/skills/watch-log/modes/trace.md
@@ -1,0 +1,41 @@
+# §E — Trace a workflow lifecycle (top-to-bottom)
+
+Prereq: `reference.md` (core) + `shared/lifecycle.md` + `shared/sessions.md`.
+
+Trace one **download / install / collection / deployment** from its first to its last
+log entry. Scope to one session (default latest, per §B / investigate.md); say which.
+
+1. **Identify the entity and its thread key** from `$ARGUMENTS`:
+    - a **mod id / archive name** (e.g. `Atomic Lust-31853-2-7b-…`) → install thread,
+      key = `modId` / `archivePath`.
+    - an **nxm url** or **downloadId** / **collationId** → download thread.
+    - a **collection name / id** → collection thread (and its member installs).
+    - the word **deployment / deploy / purge** (optionally a game) → deploy thread.
+      If ambiguous, grep the chosen log for the term and list the candidate entities
+      (with their ids) for the user to pick.
+2. **Pull the ordered slice:** grep every line carrying the thread key (and the
+   related keys it fans out to — e.g. a download's nxm url → the resulting
+   `archivePath` → the install's `modId`), then sort by timestamp into a single
+   top-to-bottom timeline. Bridge stages by the shared field: nxm url/`downloadId`
+   (download) → `archivePath` (hand-off) → `modId` (install) → membership in the next
+   `deployment` summary.
+3. **Map to expected phases** (from the lifecycle markers in `shared/lifecycle.md`) and render
+   the timeline as **phase → timestamp → Δ since previous phase**, so slow steps are
+   visible (e.g. extract vs install vs deploy time). Compute total duration; for an
+   install prefer the logged `duration` from `Installation completed successfully`.
+4. **Outcome & gaps:** classify as **completed** (terminal success marker present —
+   `finish mod install {outcome:"success"}` / `Installation completed successfully` /
+   `download completed` / final `deployment {…}` / `postprocess collection`),
+   **failed** (an `[ERRO]` on the thread, or `outcome` != success), or **incomplete /
+   stuck** (a start phase with **no** terminal phase before session end — the last
+   phase reached pinpoints where it wedged, same expected-but-missing logic as §D).
+5. **Interleaved problems:** list any `[ERRO]`/`[WARN]` whose payload references the
+   thread key within the entity's time window (e.g. a `Buggy installer` error, a
+   `failed to parse esp`, a slow `level_pivot` write during the install).
+6. **For collections:** report the collection-level envelope (`starting install of
+collection {totalMods, missing}` → `postprocess collection`) and a **per-member
+   roll-up** (each member's modId, outcome, duration), flagging members that failed
+   or never reached a terminal phase. Note the `collationId` linking the members'
+   downloads.
+7. **Output:** the phase timeline with Δs, the outcome verdict, total/longest-step
+   timing, interleaved errors/warnings, and (collections) the per-member table.

--- a/.claude/skills/watch-log/reference.md
+++ b/.claude/skills/watch-log/reference.md
@@ -1,0 +1,70 @@
+# watch-log — core reference
+
+Always loaded by the router. The universal facts (how to find and read a Vortex log)
+plus an index of the on-demand chunks. Verified against real Vortex logs.
+
+## Reference facts
+
+**Log line format:** `TIMESTAMP [LEVEL] [SOURCE] message {json}`
+
+- Levels are 4-char tokens: `[DEBG] [INFO] [WARN] [ERRO]` — error is `[ERRO]`, NOT
+  `[ERROR]`.
+- Source is `[MAIN]` or `[RENDERER]`.
+
+**Directories:**
+
+- Dev (`@vortex/main`, the working build): `$APPDATA/@vortex/main/`
+- Prod: `$APPDATA/Vortex/`
+- Each dir also has a separate `network.log` (exclude it from log-set assembly).
+
+**Rotation & write order:** entries append in **iterative (chronological) order**, so
+the **tail of any file is its most recent activity** — the latest session lives at the
+bottom of the current `vortex.log`. Files roll at ~11 MB: `vortex.log` = current/newest;
+`vortex1.log` … `vortexN.log` = older, where **ascending number == older**. You only
+need older files when a session began before the last roll or the user wants history.
+
+## Resolve the log set (rotation-aware, dev/prod-aware)
+
+Determine the target, in priority order:
+
+1. **Explicit file path** in `$ARGUMENTS` → use it verbatim (single file; only pull in
+   rolled siblings if the user asks for history). If **multiple** files or files outside
+   a live log dir are given, also load `shared/multi-file.md`.
+2. **`prod` keyword** → the prod dir `$APPDATA/Vortex/`.
+3. **Default → DEV** dir `$APPDATA/@vortex/main/` (the working build; scan dev unless
+   told otherwise).
+
+State which dir/file was chosen. Quote all paths (`@vortex` and spaces). If the chosen
+dir has no `vortex.log`, say so and offer the other dir rather than silently switching.
+
+When you need rotation history (a session that spans a roll, or "all sessions"), build
+the oldest→newest ordered list for a dir in the Bash tool:
+
+```bash
+D="$APPDATA/@vortex/main"   # or "$APPDATA/Vortex", or the dir of an explicit path
+{ ls "$D"/vortex[0-9]*.log 2>/dev/null \
+    | sed -E 's/.*vortex([0-9]+)\.log/\1 &/' | sort -rn | cut -d' ' -f2- ; \
+  echo "$D/vortex.log" ; }
+```
+
+This prints numbered files by suffix descending (older first), then `vortex.log` last.
+`network.log` is excluded by the `vortex[0-9]*` / `vortex.log` globs.
+
+## On-demand chunks (load only what the selected mode needs)
+
+| chunk                   | holds                                                              | loaded by                         |
+| ----------------------- | ------------------------------------------------------------------ | --------------------------------- |
+| `shared/sessions.md`    | session boundary markers, 4-state termination, instanceId, scoping | §B, §E, §F                        |
+| `shared/lifecycle.md`   | download / install / collection / deploy markers + thread keys     | §E, §F                            |
+| `shared/persistence.md` | persist:diff / slow-write / wedged-write markers                   | §C                                |
+| `shared/multi-file.md`  | multiple / foreign-file handling (dedup, no cross-correlate)       | any mode given >1 / foreign files |
+| `shared/edge-cases.md`  | operational edge cases (app running, file-not-yet, firehose)       | §A, §B                            |
+
+Each mode file names its required chunks in its own "Prereq" line. Read this core once;
+load each chunk at most once even when running several modes.
+
+## Logging call convention (for code correlation)
+
+Source emits logs as `log('debug'|'info'|'warn'|'error', '<message>', {…})`. The literal
+`<message>` text in a log line is greppable in the codebase to find the emitting call
+site. (Primarily used by §D correlate.)

--- a/.claude/skills/watch-log/shared/edge-cases.md
+++ b/.claude/skills/watch-log/shared/edge-cases.md
@@ -1,0 +1,11 @@
+# Shared chunk — operational edge cases
+
+Load for modes that read a live/in-progress log: live (§A) and investigate (§B).
+(The "session start scrolled out of retained logs" case lives in `shared/sessions.md`.)
+
+- **App currently running:** the latest session has no end marker; that's "in progress",
+  not a crash. Say so.
+- **File doesn't exist yet** (app not started): `tail -F` still arms and emits once the
+  file appears; say so rather than erroring.
+- **Firehose request** (no filter): warn that high-volume monitors are auto-stopped;
+  suggest a filter, or §B / reading the saved monitor output file instead.

--- a/.claude/skills/watch-log/shared/lifecycle.md
+++ b/.claude/skills/watch-log/shared/lifecycle.md
@@ -1,0 +1,29 @@
+# Shared chunk — workflow lifecycle markers
+
+Load when a mode threads an entity through its lifecycle: trace (§E),
+collection-install (§F). Anchors plus the IDs that thread one entity top-to-bottom.
+
+- **Download:** `start download mod {urlStr}` → `starting download {encodedUrl, dest,
+collationId}` → `download resolved` → (MAIN) `queuing download {downloadId}` →
+  `download starting {downloadId}` → `download completed {downloadId}`. Thread on
+  **downloadId**, **collationId** (groups a collection's downloads), or the nxm url
+  (`nxm://<game>/mods/<modId>/files/<fileId>`). Failure: `[ERRO]` / `download failed`.
+- **Install (per mod):** `start mod install {id}` → `mod id for newly installed mod
+{archivePath, modId}` → `installing to {modId, destinationPath}` → `extracting mod
+archive` → `invoking installer {installer}` → `finish mod install {id, outcome}` →
+  `Installation completed successfully {installId, modId, duration}` → `Mod installed,
+scheduling debounced health check`. Thread on **modId** (= `id`, e.g.
+  `Atomic Lust-31853-2-7b-…`) / **archivePath** / **installId**. Dependencies:
+  `start/done installing dependencies {modId}`; recommendations similarly.
+- **Collection:** `starting install of collection {totalMods, missing}` (InstallDriver)
+  → member installs (each an install sequence above) + `add collection rule {…}` →
+  `did install dependencies {gameId, modId}` → `postprocess collection`
+  (postprocessCollection). All `[RENDERER]`, no `[collections]` prefix. For the
+  install-completion invariants (every member terminal, no requeue loop, phases advance,
+  error paths settle) and their bug signatures, see §F (`modes/collection-install.md`).
+- **Deploy:** `deployment progress {text, percent}` steps through `Loading deployment
+manifest` → `Running pre-deployment events` → `Checking for external changes` →
+  `Starting deployment` → `Sorting mods` → `Running post-deployment events`, then final
+  `deployment {added, removed, "source changed", modified}`. Purge:
+  `[mod-dependency-manager] starting purge activity` → `finished purge activity in N
+seconds`.

--- a/.claude/skills/watch-log/shared/multi-file.md
+++ b/.claude/skills/watch-log/shared/multi-file.md
@@ -1,0 +1,27 @@
+# Shared chunk — multiple / foreign log files
+
+Load when given more than one explicit file, or files outside a live log dir (e.g.
+browser-downloaded copies). The `vortexN.log` rotation ordering (see the resolver in
+`reference.md`) is trustworthy **only** for the actual dev/prod log dirs. Arbitrary
+copies — e.g. `vortex (2) (1).log`, `vortex1 (1) (1).log` — do **not** obey it: the
+numbers are copy markers, not rotation order, and different files may come from
+**different users, installs, or sessions**.
+
+When given multiple explicit files that are not a live log dir:
+
+- **Dedup first:** byte-identical copies are common (browser re-downloads). Run
+  `cmp -s a b` across the set and collapse duplicates — report each unique log once,
+  noting which paths are identical.
+- **Treat each file as an independent log** (its own sessions, version, instanceId,
+  timeline). Analyze and report per file.
+- **Do NOT cross-correlate across files** — no rotation reassembly, no
+  regression/potentially-fixed diff, no re-install/downgrade comparison **between**
+  files. Those signals assume one install's history; they are invalid across unrelated
+  copies.
+- Only relate files to each other if the user **explicitly says** they belong together
+  (e.g. "these three are the same user's rotation, oldest to newest"). Then treat them
+  as one ordered set in the stated order.
+- Cross-session signals are still valid **within** a single file (a file may contain
+  several sessions from the same install).
+- Use mtime / `Vortex Version` / instanceId per file only to **describe** it, never to
+  infer a relationship to another file.

--- a/.claude/skills/watch-log/shared/persistence.md
+++ b/.claude/skills/watch-log/shared/persistence.md
@@ -1,0 +1,22 @@
+# Shared chunk — persistence markers (duckdb / level_pivot)
+
+Load for the persistence mode (§C). See `AGENTS-DEBUGGING.md` and
+`src/main/src/store/LevelPersist.ts`. (For write-latency _attribution_ — the
+`VORTEX_TRACE_DB_WRITES=1` stage timing + `[lp-trace]` scan/commit markers — use the
+sibling `watch-persistence-trace` skill, not this chunk.)
+
+- **Persist call:** `[DEBG] [MAIN] Received persist:diff {"hive":…,"operationCount":N}`.
+- **Slow write (default):** `[WARN] [MAIN] level_pivot slow Write
+{"method":…,"alias":…,"count":N,"elapsedMs":NNN}` — fires when one write exceeds
+  `SLOW_WRITE_THRESHOLD_MS` (250 ms).
+- **Breadcrumb pairs** (only with `VORTEX_TRACE_DB_WRITES=1`): `level_pivot Write enter`
+  / `level_pivot Write exit`. A trailing `enter` with no matching `exit` = wedged /
+  never-confirmed write (shutdown hang).
+- **Failure (main, `mainPersistence.ts`):** `Could not read persisted value` /
+  `Could not write persisted value` / `Could not get persisted hives` (all `[WARN]`),
+  and `DuckDBSingleton not initialized, skipping query system` (`[WARN]`, query system
+  unavailable). Plus any `[ERRO] [MAIN]` from the persist / level_pivot / duckdb-singleton
+  path.
+- **Extension persistor failure (renderer, `ExtensionManager.ts`):**
+  `Extension persistor removeItem failed` (`[ERRO]`) — a per-extension hive write
+  failure (e.g. the `loadOrder` hive), distinct from the core `db` persistor.

--- a/.claude/skills/watch-log/shared/sessions.md
+++ b/.claude/skills/watch-log/shared/sessions.md
@@ -1,0 +1,48 @@
+# Shared chunk — sessions (boundaries, termination, scoping)
+
+Load when a mode reasons about sessions: investigate (§B), trace (§E),
+collection-install (§F). Holds the session facts; the per-mode procedure stays in the
+mode file.
+
+## Session boundary markers
+
+- **Start anchor:** `[INFO] [MAIN] Vortex Version "…"` (preceded by an
+  `[INFO] [MAIN] --------------------------` separator line). The quoted value is the
+  **app version** for that session.
+- `[DEBG] [MAIN] startup instance {"instanceId":"…"}` carries the **instanceId**.
+- **Shutdown markers:** `[INFO] [MAIN] Vortex closing` (exit initiated) →
+  `[INFO] [MAIN] clean application end` (exit completed).
+
+## Termination — a 4-state classification (don't collapse to clean-vs-crash)
+
+- **Clean** — `Vortex closing` followed by `clean application end`.
+- **Killed during exit** — `Vortex closing` present but **no** `clean application end`
+  before the next start / EOF. Typical of a dev stop, restart, or debugger-kill; common
+  in dev logs (which often never emit `clean application end`). Not a hard crash.
+- **Hard crash / abrupt** — **no** `Vortex closing` at all; the session just ends
+  mid-activity (or at the next start). This is the real crash signal.
+- **In progress** — latest session, no shutdown markers, app still running.
+
+Prod sessions normally reach `clean application end`; dev sessions frequently stop at
+`Vortex closing` — weight the signal accordingly per dir.
+
+## instanceId semantics
+
+From the `startup instance` line. Use the start/end markers (not instanceId) to delimit
+sessions. On **prod** it is stable across restarts of the same install, so a **change**
+between sessions means a **re-install / fresh install** — track and highlight it. On
+**dev** it churns (a new id can be minted per test run), so treat changes as noise.
+
+## Scoping to one session
+
+The latest session lives at the **tail of the current `vortex.log`**: scan backward for
+the last start anchor; that anchor → EOF is the latest session. Only reach into
+`vortex1.log` (then `vortex2.log`, …) when the start anchor is **not** in `vortex.log`
+(the session began before the last roll), so the session stays contiguous, or when the
+user wants older / all sessions (then assemble files oldest→newest, see the resolver in
+`reference.md`).
+
+## Edge case
+
+- **Session start scrolled out of retained logs** (oldest file begins mid-session):
+  note "session start not in retained logs; window is partial".


### PR DESCRIPTION
This is the result of a weekend experiment to debug existing logs, or monitor a dev log live. Was very helpful in diagnosing LAZ-483 issues that came up during development + QA testing.

It offers session-scoped diagnosis of termination state, errors/warnings, persistence writes, and download/mod/collection install traces, plus correlating a log line to its emitting call site.

(Will even tell you if the user downgraded/updated mid-session)

That being said - I thought I'd share in case anyone else is interested.

NGL - it's currently rough around the edges, and I'm hoping @Sewer56 could help optimize it if we do decide to keep it in the repo.