### PR TITLE
Use Nexus tile art on the Games page

### DIFF
--- a/docs/game-art-assets.md
+++ b/docs/game-art-assets.md
@@ -1,0 +1,167 @@
+# Game Art Assets in Vortex
+
+This document explains where game art (logos, tiles, thumbnails) comes from, how Vortex chooses which image to show on each surface, and the conventions game extensions should follow. It reflects the state after the Games page was migrated to the Nexus **tile** artwork.
+
+---
+
+## Table of Contents
+
+1. [The art sources](#the-art-sources)
+2. [The two Nexus image URLs](#the-two-nexus-image-urls)
+3. [Where art is used, and the precedence per surface](#where-art-is-used-and-the-precedence-per-surface)
+4. [How the numeric Nexus id is resolved](#how-the-numeric-nexus-id-is-resolved)
+5. [Caching and offline behaviour](#caching-and-offline-behaviour)
+6. [Extension authoring guidance](#extension-authoring-guidance)
+7. [Key files](#key-files)
+
+---
+
+## The art sources
+
+For any game, up to five distinct image sources can be in play. Which ones are available depends on whether the game's support extension is installed and whether the game maps to a Nexus game id.
+
+| Source                         | Origin                                            | Shape / size           | Availability                                                    |
+| ------------------------------ | ------------------------------------------------- | ---------------------- | --------------------------------------------------------------- |
+| **Nexus `tile.jpg`**           | Nexus CDN                                         | 2:3 portrait, 400×600  | remote; needs a numeric Nexus id                                |
+| **Nexus `thumbnail.jpg`**      | Nexus CDN                                         | 1:1 square, 80×80      | remote; needs a numeric Nexus id                                |
+| **Local logo** (`gameart.jpg`) | game extension folder (`extensionPath` + `logo`)  | authored per extension | local file; only when the extension is installed                |
+| **`imageURL`**                 | game support extension **manifest** (`ext.image`) | author-supplied        | remote; used for **uninstalled** extensions (no local logo yet) |
+| **Custom `icon.png`**          | `{userData}/{gameId}/icon.png`                    | user-provided          | local file; only if the user set a custom icon                  |
+
+Notes:
+
+- The **local logo** is the reliability floor: it ships inside the extension, works offline, and covers non-Nexus/community games that have no numeric id.
+- **`imageURL`** exists because an _uninstalled_ extension has no folder on disk (`extensionPath` is undefined), so the only art available is the preview URL carried in its manifest metadata.
+- The **custom `icon.png`** is written when a user sets a custom game/tool icon via the Starter (Tools) dashlet; it is also used for OS shortcut icons, so it must remain a real local file.
+
+---
+
+## The two Nexus image URLs
+
+Both are built the same way — resolve the game's numeric Nexus id, then request a named rendition from the Nexus image CDN. Only the filename differs:
+
+```
+https://images.nexusmods.com/images/games/v2/{numericId}/tile.jpg       // 2:3 portrait, 400×600
+https://images.nexusmods.com/images/games/v2/{numericId}/thumbnail.jpg  // 1:1 square, 80×80
+```
+
+- **`tile.jpg`** matches the game tiles on the Nexus Mods website. Used on the **Games page**.
+- **`thumbnail.jpg`** is a small square icon. Used in the **Spine** sidebar (modern layout).
+
+Neither is bundled by Vortex; both are fetched from Nexus at runtime.
+
+The `tile.jpg` URL is built by the shared helper `gameTileImageURL()`
+(`src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts`), which returns `undefined`
+when no numeric id resolves (e.g. non-Nexus games).
+
+---
+
+## Where art is used, and the precedence per surface
+
+Art is chosen by a **priority order** per surface — the first available source wins.
+
+| Surface                                                    | UI mode      | Priority order                                               | Nexus art?                |
+| ---------------------------------------------------------- | ------------ | ------------------------------------------------------------ | ------------------------- |
+| **Games page** — `GameThumbnail` (grid) / `GameRow` (list) | both         | `tile.jpg` → local logo → `imageURL`                         | ✅ tile                   |
+| **Dashboard** — Recently Managed dashlet                   | both         | _(reuses `GameThumbnail`)_                                   | ✅ tile                   |
+| **Spine** sidebar — `GameButton`                           | modern only  | local logo → `imageURL` → `thumbnail.jpg` (cached, upgrades) | ✅ thumbnail              |
+| **QuickLauncher** — active-game widget in the toolbar      | classic only | custom `icon.png` → local logo                               | ❌ local only             |
+| **Profiles** — `ProfileItem`                               | both         | user profile image → local logo                              | ❌ local only             |
+| **OS shortcuts** — `StarterInfo`                           | n/a          | custom `icon.png` → local logo                               | ❌ must stay a local file |
+| **Extension browser** — `BrowseExtensions`                 | both         | manifest `ext.image` directly                                | manifest image            |
+
+Key consequences:
+
+- On the **Games page**, a Nexus game (once the games list has loaded) always shows `tile.jpg`. The local logo / `imageURL` only appear for **non-Nexus games**, or briefly at startup/offline before the list resolves.
+- **`imageURL`** is therefore mostly bypassed on the Games page (reached only by uninstalled extensions of non-Nexus games). It remains fully used in the **Spine** and the **extension browser**.
+- **QuickLauncher, Profiles, and OS shortcuts** never use Nexus art — they resolve a local file (custom icon or packaged logo). They benefit automatically as extensions ship 2:3 art.
+- `GameThumbnail` is shared by the Games page **and** the Recently Managed dashlet, so any change to it affects both.
+
+---
+
+## How the numeric Nexus id is resolved
+
+The Nexus image URLs need a **numeric** game id, but games are identified internally by a domain string. Resolution:
+
+1. `nexusGameId(game)` (`src/renderer/src/extensions/nexus_integration/util/convertGameId.ts`) →
+   the Nexus **domain name** (honours `game.details.nexusPageId` and a few hard-coded aliases such as
+   `skyrimse` → `skyrimspecialedition`).
+2. Look the domain up in the cached Nexus games list `nexusGames()`
+   (`src/renderer/src/extensions/nexus_integration/util.ts`, sourced from `games.json`) to get the numeric `id`.
+
+If the games list has not loaded yet, or the game has no matching entry, no Nexus URL is produced and the
+surface falls back to local art.
+
+---
+
+## Caching and offline behaviour
+
+There are two very different caching stories:
+
+- **Games page (`<Image>` / raw remote URL):** relies on Chromium's normal **HTTP cache** in the default
+  Electron session (persists across launches; nothing clears it at startup). A returning, online user is
+  typically served tiles from cache; the first sighting of a tile is a network fetch. There is **no
+  application-level cache and no runtime fallback**: if a tile fails (offline with a cold cache, or 404),
+  the design-system `Image` component shows its broken-image icon.
+- **Spine sidebar:** has a deliberate **application cache** at `{userData}/icon_cache/` with a 3-day TTL
+  (`src/renderer/src/views/components/Spine/utils.ts`). It shows the local logo instantly, background-downloads
+  the Nexus `thumbnail.jpg`, caches it to disk, and upgrades in place — so it degrades gracefully offline.
+
+---
+
+## Extension authoring guidance
+
+- Game extensions declare their local art via the `logo` field (conventionally `logo: "gameart.jpg"`, with the
+  file shipped alongside the extension). See the `logo` doc comment in `src/renderer/src/types/ITool.ts`.
+- **New extensions should author `gameart.jpg` at 2:3 (400×600)** so the local fallback matches the Nexus tile
+  shape on the Games page. Existing 16:9 assets keep working — they are cover-cropped in the 2:3 box — and can
+  convert over time; there is no bulk migration.
+- Keep the background transparent and avoid embedding the game name (Vortex renders the name as text near the art).
+
+### Known, accepted downside
+
+A game that still ships a **16:9 `gameart.jpg`** _and_ whose local logo is actually shown on the Games page
+(i.e. a non-Nexus game, or startup/offline) will be cover-cropped in the 2:3 tile (top/bottom clipped). This is
+accepted; it self-resolves as extensions adopt 2:3 art.
+
+---
+
+## The design-system `Image` component
+
+The Games-page tiles render through the shared `Image` component
+(`src/renderer/src/ui/components/image/Image.tsx`), using `imageType="game"` (a 2:3 aspect box backed by the
+`--aspect-game: 2 / 3` theme token in `src/stylesheets/ui/theme/generic.css`). The component provides the
+design-spec inner border and the broken-image fallback for free.
+
+Because `Image` uses an **aspect-ratio box**, the tile needs a resolved width _or_ height from its container:
+
+- **Games page grid** (`.game-group`) supplies width via `grid-template-columns`; the tile fills its column.
+- **Recently Managed dashlet** places the tile in a short flex row, so `gamepicker.scss` gives `.game-thumbnail`
+  a default width, and `dashlet.scss` overrides it there with a fixed **height** (width follows the ratio) so it
+  fits the dashlet. If a new surface embeds `GameThumbnail`, ensure it constrains either width or height.
+
+The tile overlays (name gradient, active-mod count, "Community" tag, hover menu, info button) render inside the
+`Image` component's `children` slot and are lifted above the image with `z-index: 2` (below the component's
+`z-5` border, which is `pointer-events-none` so buttons stay clickable).
+
+---
+
+## Key files
+
+| Concern                         | File                                                                                                |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Tile URL helper (`tile.jpg`)    | `src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts`                            |
+| Domain → numeric id             | `src/renderer/src/extensions/nexus_integration/util/convertGameId.ts`, `.../util.ts` (`nexusGames`) |
+| Games page grid tile            | `src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx`                           |
+| Games page list row             | `src/renderer/src/extensions/gamemode_management/views/GameRow.tsx`                                 |
+| Games page container            | `src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx`                              |
+| Recently Managed dashlet        | `src/renderer/src/extensions/gamemode_management/views/RecentlyManagedDashlet.tsx`                  |
+| Spine sidebar art + cache       | `src/renderer/src/views/components/Spine/utils.ts`, `GameButton.tsx`                                |
+| QuickLauncher (classic)         | `src/renderer/src/views/QuickLauncher.tsx`, `src/renderer/src/util/StarterInfo.ts`                  |
+| Profiles                        | `src/renderer/src/extensions/profile_management/views/ProfileItem.tsx`                              |
+| Extension browser               | `src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx`                                |
+| `Image` component + `game` type | `src/renderer/src/ui/components/image/Image.tsx`                                                    |
+| Aspect token                    | `src/stylesheets/ui/theme/generic.css` (`--aspect-game`)                                            |
+| Games page styling              | `src/stylesheets/vortex/gamepicker.scss`                                                            |
+| Dashlet tile sizing             | `src/stylesheets/vortex/dashlet.scss`                                                               |
+| `logo` field contract           | `src/renderer/src/types/ITool.ts`                                                                   |

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -118,6 +118,7 @@
             "dependentTasksOutputFiles": "**/dist/**"
           },
           "{projectRoot}/copy-assets.mjs",
+          "{workspaceRoot}/src/stylesheets/**/*.scss",
           "{workspaceRoot}/src/renderer/src/index.html",
           "{workspaceRoot}/src/renderer/src/splash.html",
           "{workspaceRoot}/src/queries/",

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -84,6 +84,10 @@ interface IComponentState {
   currentFilterValue: string;
   expandManaged: boolean;
   expandUnmanaged: boolean;
+  // How many tiles per list to actually render. Grows a chunk per frame so the
+  // (potentially hundreds of) tiles mount incrementally instead of blocking the
+  // main thread in one synchronous pass.
+  renderLimit: number;
 }
 
 function nop() {
@@ -99,11 +103,16 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
   // "PAYDAY 2" vs "Payday 2" or "Resident Evil: Village" vs "Resident Evil Village" are 100 similar
   // "Final Fantasy 7 Remake" vs "Final Fantasy VII Remake" are 91 similar
   public static SIMILARITY_RATIO: number = 90;
+  // Tiles revealed per frame while streaming in the list.
+  private static RENDER_CHUNK = 60;
   declare public context: IComponentContext;
 
   private buttons: IActionDefinition[];
   private mRef: HTMLElement;
   private mScrollRef: HTMLElement;
+  private mGrowRAF: number;
+  // Largest list length the current render needs to fully reveal; drives the grow loop.
+  private mDisplayedCount = 0;
 
   private nexusGameById = memoizeOne((gameList: IGameListEntry[]) =>
     gameList.reduce<{ [id: string]: IGameListEntry }>((prev, entry) => {
@@ -129,6 +138,7 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
       currentFilterValue: "",
       expandManaged: true,
       expandUnmanaged: true,
+      renderLimit: GamePicker.RENDER_CHUNK,
     });
 
     this.buttons = [
@@ -142,6 +152,33 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
       },
     ];
   }
+
+  public componentDidMount() {
+    this.scheduleGrow();
+  }
+
+  public componentDidUpdate() {
+    this.scheduleGrow();
+  }
+
+  public componentWillUnmount() {
+    if (this.mGrowRAF !== undefined) {
+      cancelAnimationFrame(this.mGrowRAF);
+    }
+  }
+
+  // Reveal another chunk of tiles on the next frame until the whole list is
+  // rendered. renderLimit only grows, so it self-heals when more games arrive
+  // and never needs resetting (a smaller filtered list is fully shown at once).
+  private scheduleGrow = () => {
+    if (this.mGrowRAF !== undefined || this.state.renderLimit >= this.mDisplayedCount) {
+      return;
+    }
+    this.mGrowRAF = requestAnimationFrame(() => {
+      this.mGrowRAF = undefined;
+      this.nextState.renderLimit = this.state.renderLimit + GamePicker.RENDER_CHUNK;
+    });
+  };
 
   public render(): JSX.Element {
     const {
@@ -240,6 +277,9 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
     const filteredUnmanaged = unmanagedGameList
       .filter((game) => this.applyGameFilter(game))
       .sort(this.sortBy(sortUnmanaged));
+
+    // Drive the incremental grow loop (see scheduleGrow) off the largest list.
+    this.mDisplayedCount = Math.max(filteredManaged.length, filteredUnmanaged.length);
 
     const titleManaged = t("Managed ({{filterCount}})", {
       replace: {
@@ -549,11 +589,14 @@ class GamePicker extends ComponentEx<IProps, IComponentState> {
       }
     }
 
+    // Only render up to renderLimit tiles; the rest stream in over later frames.
+    const shown = games.slice(0, this.state.renderLimit);
+
     switch (pickerLayout) {
       case "list":
-        return this.renderGamesList(games, type, gameMode);
+        return this.renderGamesList(shown, type, gameMode);
       case "small":
-        return this.renderGamesSmall(games, type, gameMode);
+        return this.renderGamesSmall(shown, type, gameMode);
       default:
         throw new Error("invalid picker layout " + pickerLayout);
     }

--- a/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
@@ -11,8 +11,7 @@ import { ComponentEx } from "../../../controls/ComponentEx";
 import IconBar from "../../../controls/IconBar";
 import OverlayTrigger from "../../../controls/OverlayTrigger";
 import { IconButton } from "../../../controls/TooltipControls";
-import { nexusGames } from "../../../extensions/nexus_integration/util";
-import { nexusGameId } from "../../../extensions/nexus_integration/util/convertGameId";
+import { gameTileImageURL } from "../../../extensions/nexus_integration/util/gameTileImageURL";
 import type { IActionDefinition } from "../../../types/IActionDefinition";
 import opn from "../../../util/opn";
 import type { IMod } from "../../mod_management/types/IMod";
@@ -49,19 +48,14 @@ class GameRow extends ComponentEx<IProps, {}> {
       return null;
     }
 
-    let logoPath: string | undefined =
-      game.extensionPath !== undefined && game.logo !== undefined
-        ? path.join(game.extensionPath, game.logo)
-        : game.imageURL;
-
-    // For adaptor-registered games (no local logo), resolve a Nexus thumbnail
+    // Prefer the Nexus "tile" art so it matches the website. Fall back to a
+    // local extension logo / imageURL when no Nexus tile can be resolved.
+    let logoPath: string | undefined = gameTileImageURL(game);
     if (logoPath == null) {
-      const domain = nexusGameId(game);
-      const numericId =
-        domain != null ? nexusGames().find((g) => g.domain_name === domain)?.id : undefined;
-      if (numericId !== undefined) {
-        logoPath = `https://images.nexusmods.com/images/games/v2/${numericId}/thumbnail.jpg`;
-      }
+      logoPath =
+        game.extensionPath !== undefined && game.logo !== undefined
+          ? path.join(game.extensionPath, game.logo)
+          : game.imageURL;
     }
 
     const location =

--- a/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
@@ -7,6 +7,8 @@ import * as React from "react";
 import { ListGroupItem, Media, Popover } from "react-bootstrap";
 import { Provider } from "react-redux";
 
+import { Image } from "@/ui/components/image/Image";
+
 import { ComponentEx } from "../../../controls/ComponentEx";
 import IconBar from "../../../controls/IconBar";
 import OverlayTrigger from "../../../controls/OverlayTrigger";
@@ -114,9 +116,12 @@ class GameRow extends ComponentEx<IProps, {}> {
         <Media>
           <Media.Left>
             <div className="game-thumbnail-container-list">
-              <img
-                className="game-thumbnail-img-list"
+              <Image
+                className="w-12"
+                imageType="game"
+                fit="cover"
                 src={imgurl}
+                alt={game.name}
                 loading="lazy"
                 decoding="async"
               />

--- a/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -7,6 +7,8 @@ import * as React from "react";
 import { Button, Panel, Popover } from "react-bootstrap";
 import { Provider } from "react-redux";
 
+import { Image } from "@/ui/components/image/Image";
+
 import { connect, PureComponentEx } from "../../../controls/ComponentEx";
 import Icon from "../../../controls/Icon";
 import IconBar from "../../../controls/IconBar";
@@ -103,35 +105,44 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
     return (
       <Panel className={classes.join(" ")} bsStyle={active ? "primary" : "default"}>
         <Panel.Body className="game-thumbnail-body">
-          <img className={"thumbnail-img"} src={imgurl} loading="lazy" decoding="async" />
-          <div className="bottom">
-            <div className="name">{game.name}</div>
-            {modCount !== undefined ? (
-              <div className="active-mods">
-                <Icon name="mods" />
-                <span>{t("{{ count }} active mod", { count: modCount })}</span>
-              </div>
+          <Image
+            className="w-full"
+            imageType="game"
+            fit="cover"
+            src={imgurl}
+            alt={game.name}
+            loading="lazy"
+            decoding="async"
+          >
+            <div className="bottom">
+              <div className="name">{game.name}</div>
+              {modCount !== undefined ? (
+                <div className="active-mods">
+                  <Icon name="mods" />
+                  <span>{t("{{ count }} active mod", { count: modCount })}</span>
+                </div>
+              ) : null}
+            </div>
+            <div className="hover-menu">
+              {type === "launcher" ? this.renderLaunch() : this.renderMenu()}
+            </div>
+            {type !== "launcher" ? (
+              game.contributed ? (
+                <div
+                  className="game-thumbnail-tags"
+                  title={
+                    game.contributed
+                      ? t("Contributed by {{name}}", {
+                          replace: { name: game.contributed },
+                        })
+                      : null
+                  }
+                >
+                  {game.contributed ? "Community" : null}
+                </div>
+              ) : null
             ) : null}
-          </div>
-          <div className="hover-menu">
-            {type === "launcher" ? this.renderLaunch() : this.renderMenu()}
-          </div>
-          {type !== "launcher" ? (
-            game.contributed ? (
-              <div
-                className="game-thumbnail-tags"
-                title={
-                  game.contributed
-                    ? t("Contributed by {{name}}", {
-                        replace: { name: game.contributed },
-                      })
-                    : null
-                }
-              >
-                {game.contributed ? "Community" : null}
-              </div>
-            ) : null
-          ) : null}
+          </Image>
         </Panel.Body>
       </Panel>
     );

--- a/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -12,8 +12,7 @@ import Icon from "../../../controls/Icon";
 import IconBar from "../../../controls/IconBar";
 import OverlayTrigger from "../../../controls/OverlayTrigger";
 import { IconButton } from "../../../controls/TooltipControls";
-import { nexusGames } from "../../../extensions/nexus_integration/util";
-import { nexusGameId } from "../../../extensions/nexus_integration/util/convertGameId";
+import { gameTileImageURL } from "../../../extensions/nexus_integration/util/gameTileImageURL";
 import type { IActionDefinition } from "../../../types/api";
 import type { IMod, IProfile, IState } from "../../../types/IState";
 import { getSafe } from "../../../util/storeHelper";
@@ -59,19 +58,14 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
       return null;
     }
 
-    let logoPath: string | undefined =
-      game.extensionPath !== undefined && game.logo !== undefined
-        ? path.join(game.extensionPath, game.logo)
-        : game.imageURL;
-
-    // For adaptor-registered games (no local logo), resolve a Nexus thumbnail
+    // Prefer the Nexus "tile" art so it matches the website. Fall back to a
+    // local extension logo / imageURL when no Nexus tile can be resolved.
+    let logoPath: string | undefined = gameTileImageURL(game);
     if (logoPath == null) {
-      const domain = nexusGameId(game);
-      const numericId =
-        domain != null ? nexusGames().find((g) => g.domain_name === domain)?.id : undefined;
-      if (numericId !== undefined) {
-        logoPath = `https://images.nexusmods.com/images/games/v2/${numericId}/thumbnail.jpg`;
-      }
+      logoPath =
+        game.extensionPath !== undefined && game.logo !== undefined
+          ? path.join(game.extensionPath, game.logo)
+          : game.imageURL;
     }
 
     // Mod count should only be shown for Managed and Discovered games as

--- a/src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts
@@ -1,0 +1,17 @@
+import type { IGameStored } from "../../gamemode_management/types/IGameStored";
+import { nexusGames } from "../util";
+import { nexusGameId } from "./convertGameId";
+
+/**
+ * Resolve the Nexus "tile" art URL (2:3 portrait) for a game, matching the
+ * artwork used on the Nexus Mods website. Returns undefined if no numeric
+ * Nexus game id can be resolved (e.g. for non-Nexus/community games).
+ */
+export function gameTileImageURL(game: IGameStored): string | undefined {
+  const domain = nexusGameId(game);
+  const numericId =
+    domain != null ? nexusGames().find((g) => g.domain_name === domain)?.id : undefined;
+  return numericId !== undefined
+    ? `https://images.nexusmods.com/images/games/v2/${numericId}/tile.jpg`
+    : undefined;
+}

--- a/src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/gameTileImageURL.ts
@@ -1,6 +1,22 @@
+import type { IGameListEntry } from "@nexusmods/nexus-api";
+
 import type { IGameStored } from "../../gamemode_management/types/IGameStored";
 import { nexusGames } from "../util";
 import { nexusGameId } from "./convertGameId";
+
+// Index the games list into a domain->id map for O(1) lookups (the Games page
+// resolves this once per tile per render). Rebuilt only when the list is replaced.
+let cachedList: IGameListEntry[] | undefined;
+let domainToId = new Map<string, number>();
+
+function nexusIdForDomain(domain: string): number | undefined {
+  const list = nexusGames();
+  if (list !== cachedList) {
+    cachedList = list;
+    domainToId = new Map(list.map((g) => [g.domain_name, g.id]));
+  }
+  return domainToId.get(domain);
+}
 
 /**
  * Resolve the Nexus "tile" art URL (2:3 portrait) for a game, matching the
@@ -9,8 +25,7 @@ import { nexusGameId } from "./convertGameId";
  */
 export function gameTileImageURL(game: IGameStored): string | undefined {
   const domain = nexusGameId(game);
-  const numericId =
-    domain != null ? nexusGames().find((g) => g.domain_name === domain)?.id : undefined;
+  const numericId = domain != null ? nexusIdForDomain(domain) : undefined;
   return numericId !== undefined
     ? `https://images.nexusmods.com/images/games/v2/${numericId}/tile.jpg`
     : undefined;

--- a/src/renderer/src/types/ITool.ts
+++ b/src/renderer/src/types/ITool.ts
@@ -45,7 +45,9 @@ export interface ITool {
    *  - Preferably the logo should *not* contain the game name because Vortex will display
    *    the name as text near the logo. This way the name can be localised.
    *  - Background should be transparent. The logo will be resized preserving aspect
-   *    ratio, the canvas has a 3:4 (portrait) ratio.
+   *    ratio, the canvas has a 2:3 (portrait) ratio (400x600). This image also serves
+   *    as the offline fallback for the game tile on the Games page (which otherwise
+   *    uses the Nexus tile.jpg), so authoring it at 2:3 avoids an awkward crop.
    *
    * @type {string}
    */

--- a/src/renderer/src/ui/components/image/Image.demo.tsx
+++ b/src/renderer/src/ui/components/image/Image.demo.tsx
@@ -26,6 +26,13 @@ const imageTypes: {
     incorrectSrc: "https://picsum.photos/seed/collection/500/280",
   },
   {
+    imageType: "game",
+    ratio: "2 / 3 (portrait)",
+    className: "w-40",
+    correctSrc: "https://picsum.photos/seed/game/400/600",
+    incorrectSrc: "https://picsum.photos/seed/game/500/280",
+  },
+  {
     imageType: "mod",
     ratio: "16 / 9 (landscape)",
     className: "w-56",

--- a/src/renderer/src/ui/components/image/Image.test.tsx
+++ b/src/renderer/src/ui/components/image/Image.test.tsx
@@ -68,6 +68,11 @@ describe("Image", () => {
       expect(getContainer()).toHaveClass("aspect-collection");
     });
 
+    it('applies the aspect class for imageType="game"', () => {
+      renderComponent({ imageType: "game" });
+      expect(getContainer()).toHaveClass("aspect-game");
+    });
+
     it("merges className on the container and imageClassName on the img", () => {
       renderComponent({ className: "my-container", imageClassName: "my-img" });
       expect(getContainer()).toHaveClass("my-container");

--- a/src/renderer/src/ui/components/image/Image.tsx
+++ b/src/renderer/src/ui/components/image/Image.tsx
@@ -12,12 +12,13 @@ export interface IImageProps extends Omit<
   className?: string;
   fit?: "cover" | "contain";
   imageClassName?: string;
-  imageType?: "collection" | "mod" | "other";
+  imageType?: "collection" | "game" | "mod" | "other";
   isBlurred?: boolean;
 }
 
 const imageTypeMap: Record<NonNullable<IImageProps["imageType"]>, string> = {
   collection: "aspect-collection",
+  game: "aspect-game",
   mod: "aspect-mod",
   other: "",
 };

--- a/src/stylesheets/ui/theme/generic.css
+++ b/src/stylesheets/ui/theme/generic.css
@@ -9,6 +9,7 @@
     --z-index-toast: 1090;
 
     --aspect-collection: 4 / 5;
+    --aspect-game: 2 / 3;
     --aspect-mod: 16 / 9;
 
     --shadow-sm:

--- a/src/stylesheets/vortex/dashlet.scss
+++ b/src/stylesheets/vortex/dashlet.scss
@@ -399,6 +399,24 @@
     }
 }
 
+// The Recently Managed dashlet places GameThumbnail in a short flex row. Size
+// the tile by a fixed height (width follows the 2:3 aspect ratio) so it fits
+// the dashlet instead of overflowing from the default fixed width. The Image
+// wrapper is the direct child of .game-thumbnail-body; make the chain fill the
+// height so the aspect box derives its width from it.
+.dashlet-recently-managed .list-recently-managed .game-thumbnail {
+    width: auto;
+    height: 120px;
+
+    .game-thumbnail-body {
+        height: 100%;
+
+        > * {
+            height: 100%;
+        }
+    }
+}
+
 .dashlet-announcement {
     .placeholder {
         flex: 1 1 0;

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-$thumbnail-width: 180px;
+$thumbnail-width: 160px;
 
 #gamepicker-layout {
     text-align: right;
@@ -52,6 +52,15 @@ $thumbnail-width: 180px;
 .game-thumbnail-body {
     @extend .panel-body;
     padding: 0;
+
+    // Overlays live inside the design-system Image wrapper, whose <img> sits at
+    // z-1; lift them above it (but below the wrapper's z-5 border overlay).
+    .bottom,
+    .hover-menu,
+    .game-thumbnail-tags,
+    .game-thumbnail-info {
+        z-index: 2;
+    }
 
     .bottom {
         position: absolute;
@@ -117,24 +126,6 @@ $thumbnail-width: 180px;
             margin-left: 4px;
         }
     }
-
-    .thumbnail-img {
-        width: 100%;
-        aspect-ratio: 2 / 3;
-        object-fit: cover;
-    }
-}
-
-@media (max-width: 1280px) {
-    // .game-thumbnail-body .thumbnail-img {
-    //   max-width: 128px;
-    // }
-}
-
-.game-thumbnail-img-list {
-    width: 48px;
-    aspect-ratio: 2 / 3;
-    object-fit: cover;
 }
 
 .game-thumbnail-container-list {

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-$thumbnail-width: 256px;
+$thumbnail-width: 180px;
 
 #gamepicker-layout {
     text-align: right;
@@ -119,10 +119,8 @@ $thumbnail-width: 256px;
     }
 
     .thumbnail-img {
-        max-width: 256px;
-        max-height: 144px;
-        min-height: 144px;
         width: 100%;
+        aspect-ratio: 2 / 3;
         object-fit: cover;
     }
 }
@@ -134,8 +132,9 @@ $thumbnail-width: 256px;
 }
 
 .game-thumbnail-img-list {
-    max-width: 150px;
-    max-height: 70px;
+    width: 48px;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
 }
 
 .game-thumbnail-container-list {

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -12,6 +12,8 @@ $thumbnail-width: 160px;
 
     > .game-thumbnail {
         margin: $half-gutter !important;
+        // fill the grid column (overrides the default width below)
+        width: auto;
     }
 }
 
@@ -31,6 +33,10 @@ $thumbnail-width: 160px;
     position: relative;
     height: auto;
     border: 0;
+    // Default width so the aspect-ratio Image box can resolve its height when
+    // the tile isn't in the Games-page grid (e.g. dashboard dashlets, which
+    // place it in a plain flex row). The .game-group grid overrides this.
+    width: 160px;
 
     box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.35);
 

--- a/src/stylesheets/vortex/gamepicker.scss
+++ b/src/stylesheets/vortex/gamepicker.scss
@@ -33,11 +33,6 @@ $thumbnail-width: 160px;
     border: 0;
 
     box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.35);
-    transition: $thumbnail-transition-duration ease-out;
-
-    &:hover {
-        transform: scale($thumbnail-zoom-scale);
-    }
 
     &panel-primary {
         border-color: $border-color;


### PR DESCRIPTION
Switches the Games page to the Nexus tile.jpg portrait artwork (2:3) so Vortex matches the website, and migrates the tiles to the design-system Image component.

- Prefer Nexus tile.jpg → local logo → imageURL in GameThumbnail / GameRow (new shared gameTileImageURL() helper).
- Add a game image type (2:3) to the Image component + --aspect-game theme token; render tiles via Image (inner border + broken-image fallback for free).
- Tiles are 2:3 portrait, no hover-zoom; overlays (name, mod count, Community tag, hover menu) preserved.
- Fix the Recently Managed dashlet (shares GameThumbnail) so the aspect-ratio tile sizes correctly in its row.
- Document the logo contract as 2:3 / 400×600 (ITool.ts) and add docs/game-art-assets.md mapping every art surface.
- Build tweak: add SCSS sources to the copy-assets Nx cache inputs so stylesheet edits rebuild reliably.

### Notes

- Affects both classic and modern layouts (the Games page component is shared).
- imageURL (extension manifest art) is now only reached on the Games page for non-Nexus uninstalled extensions; unchanged elsewhere (Spine, extension browser).
- Existing 16:9 gameart.jpg assets still work (cover-cropped); new extensions should ship 2:3 art — no bulk migration.
- Games-page tiles use the browser HTTP cache only (no runtime fallback); the Spine keeps its own disk cache. Accepted per discussion.

### Testing
Games page (grid + list) and the Recently Managed dashlet in both layouts: tiles show tile.jpg at 2:3 with overlays intact; broken/offline tiles show the fallback icon; non-Nexus games fall back to the local logo.