### PR TITLE
guard plugin warnings against a cleared plugin list

### DIFF
--- a/extensions/gamebryo-plugin-management/src/reducers/plugins.test.ts
+++ b/extensions/gamebryo-plugin-management/src/reducers/plugins.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+
+import * as actions from "../actions/plugins";
+import { pluginsReducer } from "./plugins";
+
+// invoke a single case of the reducer spec by the action it handles
+function reduce(state: unknown, action: { type: string; payload: unknown }) {
+  return pluginsReducer.reducers[action.type](state, action.payload);
+}
+
+const initial = () => ({ ...pluginsReducer.defaults });
+
+describe("pluginsReducer", () => {
+  describe("setPluginList", () => {
+    test("stores the provided plugin map", () => {
+      const plugins = { "a.esp": { name: "a.esp", enabled: true } };
+
+      const next = reduce(initial(), actions.setPluginList(plugins as any));
+
+      expect(next.pluginList).toEqual(plugins);
+    });
+
+    test("replaces any existing plugin list", () => {
+      const state = { ...initial(), pluginList: { "old.esp": { name: "old.esp" } } };
+
+      const next = reduce(state, actions.setPluginList({ "new.esp": { name: "new.esp" } } as any));
+
+      expect(next.pluginList).toEqual({ "new.esp": { name: "new.esp" } });
+    });
+
+    test("resets pluginList to {} when passed undefined rather than leaving it undefined", () => {
+      const next = reduce(initial(), actions.setPluginList(undefined));
+
+      expect(next.pluginList).toEqual({});
+    });
+  });
+
+  describe("setPluginInfo", () => {
+    test("stores the provided plugin info map", () => {
+      const info = { "a.esp": { name: "a.esp", filePath: "C:/a.esp" } };
+
+      const next = reduce(initial(), actions.setPluginInfo(info as any));
+
+      expect(next.pluginInfo).toEqual(info);
+    });
+  });
+
+  describe("setPluginFilePath", () => {
+    test("sets filePath on both pluginList and pluginInfo, preserving other fields", () => {
+      const state = {
+        ...initial(),
+        pluginList: { "a.esp": { name: "a.esp", enabled: true } },
+        pluginInfo: { "a.esp": { name: "a.esp" } },
+      };
+
+      const next = reduce(state, actions.setPluginFilePath("a.esp", "C:/a.esp"));
+
+      expect(next.pluginList["a.esp"]).toEqual({
+        name: "a.esp",
+        enabled: true,
+        filePath: "C:/a.esp",
+      });
+      expect(next.pluginInfo["a.esp"]).toEqual({ name: "a.esp", filePath: "C:/a.esp" });
+    });
+
+    test("creates the entry when the plugin is not yet present", () => {
+      const next = reduce(initial(), actions.setPluginFilePath("a.esp", "C:/a.esp"));
+
+      expect(next.pluginList["a.esp"]).toEqual({ filePath: "C:/a.esp" });
+      expect(next.pluginInfo["a.esp"]).toEqual({ filePath: "C:/a.esp" });
+    });
+  });
+
+  describe("updatePluginWarnings", () => {
+    test("sets the warning flag on an existing plugin", () => {
+      const state = { ...initial(), pluginList: { "a.esp": { name: "a.esp" } } };
+
+      const next = reduce(state, actions.updatePluginWarnings("a.esp", "missing-master", true));
+
+      expect(next.pluginList["a.esp"].warnings).toEqual({ "missing-master": true });
+      expect(next.pluginList["a.esp"].name).toBe("a.esp");
+    });
+
+    test("leaves state unchanged when the plugin is not in the list", () => {
+      const state = initial();
+
+      const next = reduce(
+        state,
+        actions.updatePluginWarnings("missing.esp", "missing-master", true),
+      );
+
+      expect(next).toBe(state);
+    });
+
+    test("does not throw after the plugin list has been cleared", () => {
+      // profile-will-change dispatches setPluginList(undefined); a late warning update must not crash
+      const cleared = reduce(initial(), actions.setPluginList(undefined));
+
+      expect(() =>
+        reduce(cleared, actions.updatePluginWarnings("some.esp", "missing-master", true)),
+      ).not.toThrow();
+    });
+  });
+
+  describe("new plugin counter", () => {
+    test("incrementNewPluginCounter adds to the running total", () => {
+      const once = reduce(initial(), actions.incrementNewPluginCounter(2));
+      const twice = reduce(once, actions.incrementNewPluginCounter(3));
+
+      expect(twice.newlyAddedPlugins).toBe(5);
+    });
+
+    test("clearNewPluginCounter resets the total to 0", () => {
+      const state = { ...initial(), newlyAddedPlugins: 7 };
+
+      const next = reduce(state, actions.clearNewPluginCounter());
+
+      expect(next.newlyAddedPlugins).toBe(0);
+    });
+  });
+});

--- a/extensions/gamebryo-plugin-management/src/reducers/plugins.ts
+++ b/extensions/gamebryo-plugin-management/src/reducers/plugins.ts
@@ -1,4 +1,5 @@
-import { types, util } from "@nexusmods/vortex-api";
+import type { types } from "@nexusmods/vortex-api";
+import update from "immutability-helper";
 
 import * as actions from "../actions/plugins";
 
@@ -8,33 +9,37 @@ import * as actions from "../actions/plugins";
 export const pluginsReducer: types.IReducerSpec = {
   reducers: {
     [actions.setPluginList as any]: (state, payload) =>
-      util.setSafe(state, ["pluginList"], payload.plugins),
+      update(state, { pluginList: { $set: payload.plugins ?? {} } }),
     [actions.setPluginInfo as any]: (state, payload) =>
-      util.setSafe(state, ["pluginInfo"], payload.plugins),
+      update(state, { pluginInfo: { $set: payload.plugins } }),
     [actions.setPluginFilePath as any]: (state, payload) => {
       const { pluginId, filePath } = payload;
-      return util.setSafe(
-        util.setSafe(state, ["pluginList", pluginId, "filePath"], filePath),
-        ["pluginInfo", pluginId, "filePath"],
-        filePath,
-      );
+      const withFilePath = (map: Record<string, any> = {}) => ({
+        ...map,
+        [pluginId]: { ...(map[pluginId] ?? {}), filePath },
+      });
+      return update(state, {
+        pluginList: { $set: withFilePath(state.pluginList) },
+        pluginInfo: { $set: withFilePath(state.pluginInfo) },
+      });
     },
-    [actions.updatePluginWarnings as any]: (state, payload) =>
-      state.pluginList[payload.id] !== undefined
-        ? util.setSafe(
-            state,
-            ["pluginList", payload.id, "warnings", payload.warning],
-            payload.value,
-          )
-        : state,
+    [actions.updatePluginWarnings as any]: (state, payload) => {
+      if (state.pluginList?.[payload.id] === undefined) {
+        return state;
+      }
+      const warnings = state.pluginList[payload.id].warnings ?? {};
+      return update(state, {
+        pluginList: {
+          [payload.id]: { warnings: { $set: { ...warnings, [payload.warning]: payload.value } } },
+        },
+      });
+    },
     [actions.incrementNewPluginCounter as any]: (state, payload) =>
-      util.setSafe(
-        state,
-        ["newlyAddedPlugins"],
-        util.getSafe(state, ["newlyAddedPlugins"], 0) + payload.counter,
-      ),
+      update(state, {
+        newlyAddedPlugins: { $set: (state.newlyAddedPlugins ?? 0) + payload.counter },
+      }),
     [actions.clearNewPluginCounter as any]: (state) =>
-      util.setSafe(state, ["newlyAddedPlugins"], 0),
+      update(state, { newlyAddedPlugins: { $set: 0 } }),
   },
   defaults: {
     pluginList: {},


### PR DESCRIPTION
setPluginList now coerces an undefined payload to {}, and updatePluginWarnings returns state untouched when the plugin list is empty or absent, so a warning update arriving after the list is cleared on profile change no longer throws "Cannot read properties of undefined".

Reworks the reducer onto immutability-helper so it no longer pulls util from the vortex-api barrel, and adds pluginsReducer unit tests covering every case.

closes LAZ-691
fixes fingerprint faad9d09