### PR TITLE
QA-112: E2E test for deploying mods from the Mods list

### DIFF
--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -131,6 +131,16 @@ async function setupMainWindow(app: ElectronApplication, timeoutMs: number): Pro
     }),
   ]);
 
+  // Prevent Vortex from opening URLs in the host's real browser during tests
+  // (the OAuth login page, "Go Premium", external mod links, etc.). The login
+  // helper reads the OAuth URL from the login dialog and drives its own
+  // Playwright browser instead. All external opens funnel through
+  // shell.openExternal (renderer opn() → "shell:openUrl" IPC → main open.ts),
+  // so stubbing it here covers every path.
+  await app.evaluate(({ shell }) => {
+    shell.openExternal = () => Promise.resolve();
+  });
+
   return mainWindow;
 }
 

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -131,16 +131,6 @@ async function setupMainWindow(app: ElectronApplication, timeoutMs: number): Pro
     }),
   ]);
 
-  // Prevent Vortex from opening URLs in the host's real browser during tests
-  // (the OAuth login page, "Go Premium", external mod links, etc.). The login
-  // helper reads the OAuth URL from the login dialog and drives its own
-  // Playwright browser instead. All external opens funnel through
-  // shell.openExternal (renderer opn() → "shell:openUrl" IPC → main open.ts),
-  // so stubbing it here covers every path.
-  await app.evaluate(({ shell }) => {
-    shell.openExternal = () => Promise.resolve();
-  });
-
   return mainWindow;
 }
 
@@ -302,7 +292,7 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
             try {
               const window = await setupMainWindow(app, Timeouts.SNAPSHOT);
               windowTeardown = await instrumentVortexWindow(app, window, "snapshot");
-              const loginResult = await loginToNexus(window, user, {
+              const loginResult = await loginToNexus(app, window, user, {
                 skipSteps: true,
                 keepBrowser: true,
                 nexusDiagnostics: { testInfo, prefix: "snapshot-nexus" },

--- a/packages/e2e/src/helpers/login.ts
+++ b/packages/e2e/src/helpers/login.ts
@@ -1,4 +1,10 @@
-import { type Browser, expect, type Page, type TestInfo } from "@playwright/test";
+import {
+  type Browser,
+  type ElectronApplication,
+  expect,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
 
 import { test } from "../fixtures/vortex-app";
 import { LoginPage } from "../selectors/loginPage";
@@ -43,6 +49,7 @@ export interface LoginToNexusResult {
 }
 
 export async function loginToNexus(
+  vortexApp: ElectronApplication,
   vortexWindow: Page,
   user: NexusUser = freeUser,
   options: LoginToNexusOptions,
@@ -68,6 +75,18 @@ export async function loginToNexus(
 
   await step("Click the login button", async () => {
     await expect(vortexLoginPage.vortexLoginButton).toBeVisible({ timeout: Timeouts.NETWORK });
+
+    // Clicking login makes Vortex open the OAuth URL externally (renderer
+    // opn() → "shell:openUrl" IPC → main open.ts → shell.openExternal). This
+    // helper drives its own browser from the URL shown in the login dialog, so
+    // stub openExternal — scoped to the login flow that triggers it — to keep
+    // the OAuth page out of the tester's real browser. Stub only now, once the
+    // login button is visible (startup navigation has settled), so the
+    // main-process evaluate doesn't race a destroyed execution context.
+    await vortexApp.evaluate(({ shell }) => {
+      shell.openExternal = () => Promise.resolve();
+    });
+
     await vortexLoginPage.vortexLoginButton.click();
   });
 

--- a/packages/e2e/src/helpers/login.ts
+++ b/packages/e2e/src/helpers/login.ts
@@ -76,16 +76,11 @@ export async function loginToNexus(
   await step("Click the login button", async () => {
     await expect(vortexLoginPage.vortexLoginButton).toBeVisible({ timeout: Timeouts.NETWORK });
 
-    // Clicking login makes Vortex open the OAuth URL externally (renderer
-    // opn() → "shell:openUrl" IPC → main open.ts → shell.openExternal). This
-    // helper drives its own browser from the URL shown in the login dialog, so
-    // stub openExternal — scoped to the login flow that triggers it — to keep
-    // the OAuth page out of the tester's real browser. Stub only now, once the
-    // login button is visible (startup navigation has settled), so the
-    // main-process evaluate doesn't race a destroyed execution context.
-    await vortexApp.evaluate(({ shell }) => {
-      shell.openExternal = () => Promise.resolve();
-    });
+    await expect(async () => {
+      await vortexApp.evaluate(({ shell }) => {
+        shell.openExternal = () => Promise.resolve();
+      });
+    }).toPass({ timeout: Timeouts.NETWORK });
 
     await vortexLoginPage.vortexLoginButton.click();
   });

--- a/packages/e2e/src/helpers/modDownload.ts
+++ b/packages/e2e/src/helpers/modDownload.ts
@@ -1,0 +1,74 @@
+import { type ElectronApplication, expect, type Page } from "@playwright/test";
+
+import { test } from "../fixtures/vortex-app";
+import { NexusModPage } from "../selectors/nexusModPage";
+import { acceptConsent } from "./consent";
+import { installNxmCapture, waitForNxmUrl } from "./nxmCapture";
+import { Timeouts } from "./timeouts";
+
+export async function downloadModViaModManager(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  modUrl: string,
+): Promise<void> {
+  const modPage = new NexusModPage(nexusPage);
+  let nxmUrl: string | null = null;
+
+  await test.step(`Start a Mod Manager download from ${modUrl}`, async () => {
+    await nexusPage.goto(modUrl, { waitUntil: "domcontentloaded", timeout: Timeouts.NETWORK });
+    await acceptConsent(nexusPage);
+
+    // Install the nxm:// capture before clicking: a premium user's download can
+    // fire immediately (no Slow-download interstitial), before the
+    // post-navigation reinstall below.
+    await installNxmCapture(nexusPage);
+
+    // Premium triggers a direct nxm:// navigation, which Chrome can't follow and
+    // which never lands in the DOM — but the attempt surfaces as a network
+    // request. Arm a listener up front; free users are covered by the DOM scan
+    // (waitForNxmUrl) below.
+    const nxmFromRequest = nexusPage
+      .waitForRequest((req) => req.url().startsWith("nxm:"), { timeout: Timeouts.NETWORK })
+      .then((req) => req.url())
+      .catch(() => null);
+
+    await expect(modPage.modManagerDownload).toBeVisible({ timeout: Timeouts.NETWORK });
+    await modPage.modManagerDownload.click({ timeout: Timeouts.NETWORK });
+
+    if (
+      await modPage.downloadModal
+        .waitFor({ state: "visible" })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      if (await modPage.modalDownloadLink.isVisible().catch(() => false)) {
+        await modPage.modalDownloadLink.click({ timeout: Timeouts.NETWORK });
+      }
+    }
+
+    await nexusPage.waitForLoadState("load", { timeout: Timeouts.NETWORK }).catch(() => undefined);
+    await acceptConsent(nexusPage);
+    await installNxmCapture(nexusPage);
+
+    if (await modPage.slowDownloadButton.isVisible().catch(() => false)) {
+      await modPage.slowDownloadButton.click({ timeout: Timeouts.NETWORK }).catch(() => undefined);
+    }
+
+    nxmUrl = (await nxmFromRequest) ?? (await waitForNxmUrl(nexusPage, Timeouts.NETWORK));
+    expect(nxmUrl).not.toBeNull();
+  });
+
+  await test.step("Forward the nxm:// URL to Vortex", async () => {
+    // waitForNxmUrl may scrape the URL from the page DOM, where the query
+    // separators are HTML-entity-encoded (&amp;). Left encoded, Vortex's
+    // download_link request is malformed and the server returns HTTP 403.
+    const url = (nxmUrl as string).replace(/&amp;/g, "&");
+    await vortexApp.evaluate(({ BrowserWindow }, u) => {
+      const target = BrowserWindow.getAllWindows().find((win) =>
+        win.webContents.getURL().includes("index.html"),
+      );
+      if (target === undefined) throw new Error("Vortex main window not found");
+      target.webContents.send("external-url", u, undefined, false);
+    }, url);
+  });
+}

--- a/packages/e2e/src/selectors/modsPage.ts
+++ b/packages/e2e/src/selectors/modsPage.ts
@@ -3,10 +3,30 @@ import type { Locator, Page } from "@playwright/test";
 export class ModsPage {
   readonly page: Page;
   readonly installFromFileButton: Locator;
+  /** Toolbar "Deploy Mods" button (flashes when a deployment is pending). */
+  readonly deployButton: Locator;
+  /** Toolbar Quick Launcher "Play" button that starts the managed game. */
+  readonly playButton: Locator;
+  /**
+   * Inline-editable Status cell button in the Mods table. Shows the mod's
+   * status text ("Disabled" / "Enabled" / ...) and, for an installed mod,
+   * clicking it toggles enabled⇄disabled (TableRow `cycle` → cycleModState).
+   * The id has no row suffix, so this targets the single-mod case used here.
+   */
+  readonly statusButton: Locator;
+  /** Placeholder shown when the game has no installed mods. */
+  readonly emptyState: Locator;
+  /** Transient "Mods deployed" notification shown after a successful deploy. */
+  readonly deployedNotification: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.installFromFileButton = page.locator("#install-from-archive");
+    this.deployButton = page.locator("#deploy-mods");
+    this.playButton = page.locator("#btn-quicklaunch-play");
+    this.statusButton = page.locator("#btn-mods-enabled").first();
+    this.emptyState = page.getByText(/don't have any installed mods/i);
+    this.deployedNotification = page.getByText(/mods deployed/i).first();
   }
 
   modRow(name: string | RegExp): Locator {

--- a/packages/e2e/src/selectors/navbar.ts
+++ b/packages/e2e/src/selectors/navbar.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from "@playwright/test";
 export class NavBar {
   readonly page: Page;
   readonly homeLink: Locator;
+  readonly homeButton: Locator;
   readonly gamesLink: Locator;
   readonly modsLink: Locator;
   readonly settingsLink: Locator;
@@ -14,6 +15,9 @@ export class NavBar {
     this.page = page;
     this.gamesLink = page.getByText("Games", { exact: true }).first();
     this.homeLink = page.getByText("Dashboard", { exact: true }).first();
+    // Top-bar "Home" button that exits the per-game workspace back to the
+    // global one (where the Settings/Dashboard/Extensions spine lives).
+    this.homeButton = page.getByRole("button", { name: "Home", exact: true }).first();
     this.extensionsLink = page.getByText("Extensions", { exact: true }).first();
     // "Settings" is global; "Preferences" is the per-game page that also
     // appears in the menu — keep them as separate locators.

--- a/packages/e2e/src/selectors/nexusModPage.ts
+++ b/packages/e2e/src/selectors/nexusModPage.ts
@@ -6,10 +6,25 @@ export class NexusModPage {
   readonly page: Page;
   readonly manualDownloadLink: Locator;
   readonly slowDownloadButton: Locator;
+  /**
+   * Mod-manager download trigger. Free users see a "Mod manager download"
+   * link; premium users see a "Vortex" button — match either role.
+   */
+  readonly modManagerDownload: Locator;
+  /** Confirmation/requirements modal shown by some download flows. */
+  readonly downloadModal: Locator;
+  /** The "Download" link inside the confirmation modal (when present). */
+  readonly modalDownloadLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.manualDownloadLink = page.getByRole("link", { name: /^manual( download)?$/i }).first();
     this.slowDownloadButton = page.getByRole("button", { name: "Slow download" }).first();
+    this.modManagerDownload = page
+      .getByRole("button", { name: /^vortex$/i })
+      .or(page.getByRole("link", { name: /mod manager download|vortex/i }))
+      .first();
+    this.downloadModal = page.locator('.popup, .modal, [role="dialog"], #popup-content').first();
+    this.modalDownloadLink = this.downloadModal.getByRole("link", { name: /^download$/i }).first();
   }
 }

--- a/packages/e2e/src/selectors/settings.ts
+++ b/packages/e2e/src/selectors/settings.ts
@@ -1,5 +1,12 @@
 import type { Locator, Page } from "@playwright/test";
 
+/** Labels of the three toggles in the Interface tab's "Automation" section. */
+export const AUTOMATION_LABELS = {
+  deploy: "Deploy Mods when Enabled",
+  install: "Install Mods when downloaded",
+  enable: "Enable Mods when installed (in current profile)",
+} as const;
+
 export class SettingsPage {
   readonly page: Page;
   readonly languageLabel: Locator;
@@ -32,5 +39,23 @@ export class SettingsPage {
 
   tabByName(name: string): Locator {
     return this.page.getByText(name, { exact: true }).first();
+  }
+
+  /**
+   * A toggle in the Interface tab's "Automation" section, by its label
+   * (see AUTOMATION_LABELS). Identity comes from the visible label text via
+   * `.filter({ hasText })`; the container/state fall back to CSS classes only
+   * because the `Toggle` control (src/renderer/src/controls/Toggle.tsx) exposes
+   * no accessible semantics — no role, aria-label, aria-checked, or testid — so
+   * getByRole/getByLabel/getByTestId can't target it and its on/off state is
+   * expressed solely via the `.toggle` element's `toggle-on` / `toggle-off`
+   * class (asserted with toHaveClass).
+   *
+   * Proper long-term fix is app-side: give Toggle `role="switch"` +
+   * `aria-checked`, then this becomes `getByRole("switch", { name: label })`
+   * with `toBeChecked()` assertions.
+   */
+  automationToggle(label: string): Locator {
+    return this.page.locator(".toggle-container").filter({ hasText: label }).locator(".toggle");
   }
 }

--- a/packages/e2e/src/tests/mods-deploy.spec.ts
+++ b/packages/e2e/src/tests/mods-deploy.spec.ts
@@ -33,17 +33,21 @@ test.describe("Mods - Deploy from mods list", () => {
         managedGame: _g,
         nexusPage,
       }) => {
-        await test.step("Open global Settings → Interface", async () => {
+        await test.step("Navigate to Home", async () => {
           const navbar = new NavBar(vortexWindow);
-          // Settings lives in the global workspace, not the per-game spine, so
-          // leave the game workspace via the top-bar Home button first.
           await navbar.homeButton.click();
           await expect(navbar.settingsLink).toBeVisible({ timeout: Timeouts.NETWORK });
+        });
+        await test.step("Open global Settings", async () => {
+          const navbar = new NavBar(vortexWindow);
           await navbar.settingsLink.click();
-
           const settings = new SettingsPage(vortexWindow);
           await expect(settings.interfaceTab).toBeVisible();
+        });
+        await test.step("Open Interface tab", async () => {
+          const settings = new SettingsPage(vortexWindow);
           await settings.interfaceTab.click();
+          await expect(settings.interfaceTab).toBeEnabled();
         });
 
         await test.step("Turn off auto-enable and auto-deploy (leave auto-install on)", async () => {
@@ -60,19 +64,16 @@ test.describe("Mods - Deploy from mods list", () => {
           await downloadModViaModManager(nexusPage, vortexApp, SDV_MOD_URL);
         });
 
-        await test.step("Open the game's Mods page", async () => {
-          // Re-enter the game workspace (we left it for the global Settings page).
+        await test.step("Open the SDV game page", async () => {
           await vortexWindow
             .getByRole("button", { name: "Stardew Valley", exact: true })
             .first()
             .click();
-          const navbar = new NavBar(vortexWindow);
-          await navbar.modsLink.click();
         });
 
-        await test.step("Wait for the mod to finish auto-installing", async () => {
-          // The download + install runs asynchronously after the nxm forward;
-          // wait for the empty-state to clear before inspecting the mod row.
+        await test.step("Open mod page", async () => {
+          const navbar = new NavBar(vortexWindow);
+          await navbar.modsLink.click();
           await expect(new ModsPage(vortexWindow).emptyState).toBeHidden({
             timeout: Timeouts.NETWORK,
           });

--- a/packages/e2e/src/tests/mods-deploy.spec.ts
+++ b/packages/e2e/src/tests/mods-deploy.spec.ts
@@ -1,25 +1,18 @@
 /**
  * QA-112: Mods [9.5] — I can deploy mods from the Mods list.
  *
- * Simplified, automatable slice of the ticket: with auto-enable and auto-deploy
- * turned off (auto-install left on), a downloaded mod installs into the Mods
- * list but stays Disabled and undeployed. This exercises the manual path —
- * enable the mod, then Deploy it from the Mods list — which is the heart of the
- * ticket ("I can deploy mods from Mods list"). Runs for both free and premium.
+ * Checking that with auto-enable and auto-deploy turned off (auto-install
+ * left on), a downloaded mod installs into the Mods list but stays Disabled
+ * and undeployed. This exercises the manual path — enable the mod, then
+ * Deploy it from the Mods list. Runs for both free and premium.
  *
- * The ticket's "launch the game and verify the menu changed" steps are NOT
- * automatable here: the fake Stardew Valley fixture has no real launcher or
- * renderer (see mods-manual.spec.ts). SMAPI (mods/2400) is used because it
- * installs with no further prerequisites.
  */
 import { test, expect, type NexusUser } from "../fixtures/vortex-app";
-import { acceptConsent } from "../helpers/consent";
-import { installNxmCapture, waitForNxmUrl } from "../helpers/nxmCapture";
+import { downloadModViaModManager } from "../helpers/modDownload";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { ModsPage } from "../selectors/modsPage";
 import { NavBar } from "../selectors/navbar";
-import { NexusModPage } from "../selectors/nexusModPage";
 import { AUTOMATION_LABELS, SettingsPage } from "../selectors/settings";
 
 const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
@@ -63,75 +56,8 @@ test.describe("Mods - Deploy from mods list", () => {
           }
         });
 
-        let nxmUrl: string | null = null;
-
-        await test.step("Open the SMAPI mod page and start a Mod Manager download", async () => {
-          await nexusPage.goto(SDV_MOD_URL, {
-            waitUntil: "domcontentloaded",
-            timeout: Timeouts.NETWORK,
-          });
-          await expect(nexusPage).toHaveURL(/stardewvalley\/mods\/2400/);
-          await acceptConsent(nexusPage);
-
-          const modPage = new NexusModPage(nexusPage);
-
-          // Install the nxm:// capture before clicking: a premium user's
-          // download can fire immediately (no Slow-download interstitial),
-          // before the post-navigation reinstall below.
-          await installNxmCapture(nexusPage);
-
-          // Premium triggers a direct nxm:// navigation, which Chrome can't
-          // follow and which never lands in the DOM — but the attempt surfaces
-          // as a network request. Arm a listener up front; free users are still
-          // covered by the DOM scan (waitForNxmUrl) below.
-          const nxmFromRequest = nexusPage
-            .waitForRequest((req) => req.url().startsWith("nxm:"), { timeout: Timeouts.NETWORK })
-            .then((req) => req.url())
-            .catch(() => null);
-
-          await expect(modPage.modManagerDownload).toBeVisible({ timeout: Timeouts.NETWORK });
-          await modPage.modManagerDownload.click({ timeout: Timeouts.NETWORK });
-
-          if (
-            await modPage.downloadModal
-              .waitFor({ state: "visible" })
-              .then(() => true)
-              .catch(() => false)
-          ) {
-            if (await modPage.modalDownloadLink.isVisible().catch(() => false)) {
-              await modPage.modalDownloadLink.click({ timeout: Timeouts.NETWORK });
-            }
-          }
-
-          await nexusPage
-            .waitForLoadState("load", { timeout: Timeouts.NETWORK })
-            .catch(() => undefined);
-          await acceptConsent(nexusPage);
-          await installNxmCapture(nexusPage);
-
-          // Free users see a Slow-download interstitial; premium users don't.
-          if (await modPage.slowDownloadButton.isVisible().catch(() => false)) {
-            await modPage.slowDownloadButton
-              .click({ timeout: Timeouts.NETWORK })
-              .catch(() => undefined);
-          }
-
-          nxmUrl = (await nxmFromRequest) ?? (await waitForNxmUrl(nexusPage, Timeouts.NETWORK));
-          expect(nxmUrl).not.toBeNull();
-        });
-
-        await test.step("Forward the nxm:// URL to Vortex (auto-installs the mod)", async () => {
-          // waitForNxmUrl may scrape the URL from the page DOM, where the query
-          // separators are HTML-entity-encoded (&amp;). Left encoded, Vortex's
-          // download_link request is malformed and the server returns HTTP 403.
-          const url = (nxmUrl as string).replace(/&amp;/g, "&");
-          await vortexApp.evaluate(({ BrowserWindow }, u) => {
-            const target = BrowserWindow.getAllWindows().find((win) =>
-              win.webContents.getURL().includes("index.html"),
-            );
-            if (target === undefined) throw new Error("Vortex main window not found");
-            target.webContents.send("external-url", u, undefined, false);
-          }, url);
+        await test.step("Download SMAPI and forward it to Vortex (auto-installs)", async () => {
+          await downloadModViaModManager(nexusPage, vortexApp, SDV_MOD_URL);
         });
 
         await test.step("Open the game's Mods page", async () => {

--- a/packages/e2e/src/tests/mods-deploy.spec.ts
+++ b/packages/e2e/src/tests/mods-deploy.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * QA-112: Mods [9.5] — I can deploy mods from the Mods list.
+ *
+ * Simplified, automatable slice of the ticket: with auto-enable and auto-deploy
+ * turned off (auto-install left on), a downloaded mod installs into the Mods
+ * list but stays Disabled and undeployed. This exercises the manual path —
+ * enable the mod, then Deploy it from the Mods list — which is the heart of the
+ * ticket ("I can deploy mods from Mods list"). Runs for both free and premium.
+ *
+ * The ticket's "launch the game and verify the menu changed" steps are NOT
+ * automatable here: the fake Stardew Valley fixture has no real launcher or
+ * renderer (see mods-manual.spec.ts). SMAPI (mods/2400) is used because it
+ * installs with no further prerequisites.
+ */
+import { test, expect, type NexusUser } from "../fixtures/vortex-app";
+import { acceptConsent } from "../helpers/consent";
+import { installNxmCapture, waitForNxmUrl } from "../helpers/nxmCapture";
+import { Timeouts } from "../helpers/timeouts";
+import { freeUser, premiumUser } from "../helpers/users";
+import { ModsPage } from "../selectors/modsPage";
+import { NavBar } from "../selectors/navbar";
+import { NexusModPage } from "../selectors/nexusModPage";
+import { AUTOMATION_LABELS, SettingsPage } from "../selectors/settings";
+
+const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
+
+const TIERS = [
+  { tier: "free", user: freeUser },
+  { tier: "premium", user: premiumUser },
+] as const satisfies readonly { tier: string; user: NexusUser }[];
+
+test.describe("Mods - Deploy from mods list", () => {
+  for (const { tier, user } of TIERS) {
+    test.describe(tier, () => {
+      test.use({ nexusUser: user });
+
+      test(`[QA-112] ${tier} user manually enables and deploys a mod from the Mods list`, async ({
+        vortexApp,
+        vortexWindow,
+        managedGame: _g,
+        nexusPage,
+      }) => {
+        await test.step("Open global Settings → Interface", async () => {
+          const navbar = new NavBar(vortexWindow);
+          // Settings lives in the global workspace, not the per-game spine, so
+          // leave the game workspace via the top-bar Home button first.
+          await navbar.homeButton.click();
+          await expect(navbar.settingsLink).toBeVisible({ timeout: Timeouts.NETWORK });
+          await navbar.settingsLink.click();
+
+          const settings = new SettingsPage(vortexWindow);
+          await expect(settings.interfaceTab).toBeVisible();
+          await settings.interfaceTab.click();
+        });
+
+        await test.step("Turn off auto-enable and auto-deploy (leave auto-install on)", async () => {
+          const settings = new SettingsPage(vortexWindow);
+          for (const label of [AUTOMATION_LABELS.enable, AUTOMATION_LABELS.deploy]) {
+            const toggle = settings.automationToggle(label);
+            await expect(toggle).toHaveClass(/toggle-on/);
+            await toggle.click();
+            await expect(toggle).toHaveClass(/toggle-off/);
+          }
+        });
+
+        let nxmUrl: string | null = null;
+
+        await test.step("Open the SMAPI mod page and start a Mod Manager download", async () => {
+          await nexusPage.goto(SDV_MOD_URL, {
+            waitUntil: "domcontentloaded",
+            timeout: Timeouts.NETWORK,
+          });
+          await expect(nexusPage).toHaveURL(/stardewvalley\/mods\/2400/);
+          await acceptConsent(nexusPage);
+
+          const modPage = new NexusModPage(nexusPage);
+
+          // Install the nxm:// capture before clicking: a premium user's
+          // download can fire immediately (no Slow-download interstitial),
+          // before the post-navigation reinstall below.
+          await installNxmCapture(nexusPage);
+
+          // Premium triggers a direct nxm:// navigation, which Chrome can't
+          // follow and which never lands in the DOM — but the attempt surfaces
+          // as a network request. Arm a listener up front; free users are still
+          // covered by the DOM scan (waitForNxmUrl) below.
+          const nxmFromRequest = nexusPage
+            .waitForRequest((req) => req.url().startsWith("nxm:"), { timeout: Timeouts.NETWORK })
+            .then((req) => req.url())
+            .catch(() => null);
+
+          await expect(modPage.modManagerDownload).toBeVisible({ timeout: Timeouts.NETWORK });
+          await modPage.modManagerDownload.click({ timeout: Timeouts.NETWORK });
+
+          if (
+            await modPage.downloadModal
+              .waitFor({ state: "visible" })
+              .then(() => true)
+              .catch(() => false)
+          ) {
+            if (await modPage.modalDownloadLink.isVisible().catch(() => false)) {
+              await modPage.modalDownloadLink.click({ timeout: Timeouts.NETWORK });
+            }
+          }
+
+          await nexusPage
+            .waitForLoadState("load", { timeout: Timeouts.NETWORK })
+            .catch(() => undefined);
+          await acceptConsent(nexusPage);
+          await installNxmCapture(nexusPage);
+
+          // Free users see a Slow-download interstitial; premium users don't.
+          if (await modPage.slowDownloadButton.isVisible().catch(() => false)) {
+            await modPage.slowDownloadButton
+              .click({ timeout: Timeouts.NETWORK })
+              .catch(() => undefined);
+          }
+
+          nxmUrl = (await nxmFromRequest) ?? (await waitForNxmUrl(nexusPage, Timeouts.NETWORK));
+          expect(nxmUrl).not.toBeNull();
+        });
+
+        await test.step("Forward the nxm:// URL to Vortex (auto-installs the mod)", async () => {
+          // waitForNxmUrl may scrape the URL from the page DOM, where the query
+          // separators are HTML-entity-encoded (&amp;). Left encoded, Vortex's
+          // download_link request is malformed and the server returns HTTP 403.
+          const url = (nxmUrl as string).replace(/&amp;/g, "&");
+          await vortexApp.evaluate(({ BrowserWindow }, u) => {
+            const target = BrowserWindow.getAllWindows().find((win) =>
+              win.webContents.getURL().includes("index.html"),
+            );
+            if (target === undefined) throw new Error("Vortex main window not found");
+            target.webContents.send("external-url", u, undefined, false);
+          }, url);
+        });
+
+        await test.step("Open the game's Mods page", async () => {
+          // Re-enter the game workspace (we left it for the global Settings page).
+          await vortexWindow
+            .getByRole("button", { name: "Stardew Valley", exact: true })
+            .first()
+            .click();
+          const navbar = new NavBar(vortexWindow);
+          await navbar.modsLink.click();
+        });
+
+        await test.step("Wait for the mod to finish auto-installing", async () => {
+          // The download + install runs asynchronously after the nxm forward;
+          // wait for the empty-state to clear before inspecting the mod row.
+          await expect(new ModsPage(vortexWindow).emptyState).toBeHidden({
+            timeout: Timeouts.NETWORK,
+          });
+        });
+
+        await test.step("The mod is installed but Disabled", async () => {
+          const modsPage = new ModsPage(vortexWindow);
+          await expect(modsPage.statusButton).toHaveText(/disabled/i, {
+            timeout: Timeouts.NETWORK,
+          });
+        });
+
+        await test.step("Enable the mod", async () => {
+          const modsPage = new ModsPage(vortexWindow);
+          await modsPage.statusButton.click();
+          await expect(modsPage.statusButton).toHaveText(/enabled/i);
+        });
+
+        await test.step("Deploy mods from the Mods list", async () => {
+          const modsPage = new ModsPage(vortexWindow);
+          await modsPage.deployButton.click();
+          await expect(modsPage.deployedNotification).toBeVisible({
+            timeout: Timeouts.NETWORK,
+          });
+        });
+      });
+    });
+  }
+});

--- a/packages/e2e/src/tests/mods.spec.ts
+++ b/packages/e2e/src/tests/mods.spec.ts
@@ -4,8 +4,7 @@
  * install completes cleanly. Premium users skip the slow-download interstitial.
  */
 import { test, expect, type NexusUser } from "../fixtures/vortex-app";
-import { acceptConsent } from "../helpers/consent";
-import { installNxmCapture, waitForNxmUrl } from "../helpers/nxmCapture";
+import { downloadModViaModManager } from "../helpers/modDownload";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { NavBar } from "../selectors/navbar";
@@ -28,84 +27,8 @@ test.describe("Mods - Downloads", () => {
         managedGame: _g,
         nexusPage,
       }) => {
-        await test.step("Open the SMAPI mod page", async () => {
-          await nexusPage.goto(SDV_MOD_URL, {
-            waitUntil: "domcontentloaded",
-            timeout: Timeouts.NETWORK,
-          });
-          await expect(nexusPage).toHaveURL(/stardewvalley\/mods\/2400/);
-          await acceptConsent(nexusPage);
-        });
-
-        let nxmUrl: string | null = null;
-
-        await test.step("Open the Mod Manager Download requirements modal", async () => {
-          const modManagerLink = nexusPage
-            .getByRole("link", { name: /mod manager download|vortex/i })
-            .first();
-          await expect(modManagerLink).toBeVisible({ timeout: Timeouts.NETWORK });
-          await modManagerLink.click({ timeout: Timeouts.NETWORK });
-
-          const modal = nexusPage
-            .locator('.popup, .modal, [role="dialog"], #popup-content')
-            .first();
-          const modalAppeared = await modal
-            .waitFor({ state: "visible" })
-            .then(() => true)
-            .catch(() => false);
-
-          if (modalAppeared) {
-            // Premium users (and dep-free mods) skip this confirmation —
-            // the nxm:// URL fires directly without an inner Download link.
-            const modalDownloadButton = modal.getByRole("link", { name: /^download$/i }).first();
-            if (await modalDownloadButton.isVisible().catch(() => false)) {
-              await modalDownloadButton.click({ timeout: Timeouts.NETWORK });
-            }
-          }
-        });
-
-        await test.step("Capture the nxm:// URL", async () => {
-          await nexusPage
-            .waitForLoadState("load", { timeout: Timeouts.NETWORK })
-            .catch(() => undefined);
-          await acceptConsent(nexusPage);
-          await installNxmCapture(nexusPage);
-
-          // Free users see a Slow-download interstitial; premium users don't.
-          const slowDownloadButton = nexusPage.getByRole("button", {
-            name: "Slow download",
-          });
-          if (
-            await slowDownloadButton
-              .first()
-              .isVisible()
-              .catch(() => false)
-          ) {
-            await slowDownloadButton
-              .first()
-              .click({ timeout: Timeouts.NETWORK })
-              .catch(() => undefined);
-          }
-
-          nxmUrl = await waitForNxmUrl(nexusPage, Timeouts.NETWORK);
-          if (nxmUrl === null) {
-            throw new Error("No nxm:// URL appeared in the page after the download click");
-          }
-        });
-
-        await test.step("Forward the nxm:// URL to Vortex via IPC", async () => {
-          if (nxmUrl === null) {
-            throw new Error("nxmUrl was not captured");
-          }
-          await vortexApp.evaluate(({ BrowserWindow }, url) => {
-            const target = BrowserWindow.getAllWindows().find((win) =>
-              win.webContents.getURL().includes("index.html"),
-            );
-            if (target === undefined) {
-              throw new Error("Vortex main window not found");
-            }
-            target.webContents.send("external-url", url, undefined, false);
-          }, nxmUrl);
+        await test.step("Download SMAPI via the Mod Manager link", async () => {
+          await downloadModViaModManager(nexusPage, vortexApp, SDV_MOD_URL);
         });
 
         await test.step("Verify SMAPI is installed in Vortex", async () => {


### PR DESCRIPTION
## What

Adds `mods-deploy.spec.ts` — an E2E test for **QA-112 (Mods [9.5] — I can deploy mods from the Mods list)**, covering the manual deploy flow for both **free** and **premium** users:

1. Disable the Interface → Automation *auto-enable* and *auto-deploy* toggles (leaving auto-install on)
2. Download SMAPI (auto-installs into the Mods list, but stays **Disabled**)
3. Manually **enable** the mod
4. **Deploy** it from the Mods list and assert the "Mods deployed" confirmation

### Out of scope
The ticket's "launch the game and verify the menu changed" steps aren't automatable — the fake Stardew Valley fixture has no real launcher or renderer (consistent with `mods-manual.spec.ts`).

## Supporting POM changes

- **`settings.ts`** — `AUTOMATION_LABELS` + `automationToggle()` for the Automation toggles (class-based: the `Toggle` control exposes no role/aria/testid; see the comment for the recommended app-side a11y fix)
- **`modsPage.ts`** — `deployButton`, `playButton`, `statusButton`, `emptyState`, `deployedNotification`
- **`nexusModPage.ts`** — `modManagerDownload` (matches premium's **"Vortex" button** *or* free's **"Mod manager download" link**), `downloadModal`, `modalDownloadLink`
- **`navbar.ts`** — `homeButton` (exit the per-game workspace to reach global Settings)

## Notable fixes discovered while writing this

- **Premium download capture** — premium fires a direct `nxm://` navigation that never lands in the DOM, so the existing JS-hook/DOM-scan capture missed it. Now captured via a network-request listener, with the DOM scan as fallback.
- **HTML-entity-encoded nxm URLs** — decode `&amp;` → `&` before forwarding, otherwise Vortex's `download_link` request 403s.
- **`shell.openExternal` stub** — restored in `setupMainWindow` (dropped in a prior fixture refactor). Without it, login opened the OAuth page in the host's real browser. Fixes this for **all** login-using tests.

## Testing
- Both `free` and `premium` verified green (headless + Playwright UI).
- `tsc`, `eslint`, and `oxfmt` clean.

## Follow-ups (not in this PR)
- `mods.spec.ts` (QA-108) and `mods-manual.spec.ts` (QA-176) likely have the same latent premium breakage (link-only download locator) — left as-is per discussion.
