### PR TITLE
feat: add Ready or Not game extension with variant conflict detection

### DIFF
--- a/extensions/games/game-readyornot/package.json
+++ b/extensions/games/game-readyornot/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "game-readyornot",
+  "version": "1.0.0",
+  "description": "Support for Ready Or Not",
+  "author": "Nexus Mods",
+  "license": "GPL-3.0",
+  "type": "commonjs",
+  "private": true,
+  "config": {
+    "game": "Ready Or Not"
+  },
+  "scripts": {
+    "_assets": "copyfiles -u 1 -f ./assets/* dist",
+    "build": "copyfiles -u 1 -f ./src/*.js dist && pnpm run _assets && pnpm extractInfo"
+  },
+  "devDependencies": {
+    "@nexusmods/vortex-api": "workspace:*"
+  },
+  "nx": {
+    "tags": [
+      "vortex:extension"
+    ],
+    "targets": {
+      "build": {
+        "inputs": [
+          "default",
+          "typescript",
+          "vortex-api"
+        ]
+      }
+    }
+  }
+}

--- a/extensions/games/game-readyornot/src/conflictDetector.js
+++ b/extensions/games/game-readyornot/src/conflictDetector.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * @typedef {Object} ConflictResult
+ * @property {string}   groupId      - ID of the ExclusiveVariantGroup that triggered
+ * @property {string}   displayName  - Human-readable group name (for notification title)
+ * @property {Array<{ modName: string, variantLabel: string }>} hits - Each conflicting mod
+ */
+
+/**
+ * Pure function — no Vortex API dependency, safe to unit test.
+ *
+ * Given a list of installed mod display names and a list of variant groups,
+ * returns one ConflictResult per group where more than one variant is active.
+ *
+ * @param {Array<{ name: string, nexusModId: number|undefined }>} mods
+ * @param {import('./variantGroups').ExclusiveVariantGroup[]} groups
+ * @returns {ConflictResult[]}
+ */
+function detectConflicts(mods, groups) {
+  const results = [];
+
+  for (const group of groups) {
+    const hits = [];
+
+    for (const mod of mods) {
+      // For intra-mod groups, only consider mods from the matching Nexus page.
+      if (group.nexusModId !== undefined && mod.nexusModId !== group.nexusModId) {
+        continue;
+      }
+
+      const nameLower = mod.name.toLowerCase();
+      const matchedVariant = group.variants.find(v =>
+        nameLower.includes(v.match.toLowerCase())
+      );
+
+      if (matchedVariant) {
+        hits.push({ modName: mod.name, variantLabel: matchedVariant.label });
+      }
+    }
+
+    if (hits.length > 1) {
+      results.push({
+        groupId: group.id,
+        displayName: group.displayName,
+        hits,
+      });
+    }
+  }
+
+  return results;
+}
+
+module.exports = { detectConflicts };

--- a/extensions/games/game-readyornot/src/index.js
+++ b/extensions/games/game-readyornot/src/index.js
@@ -1,0 +1,324 @@
+// Game registration adapted from BeYkeRYkt/vortex_readyornot_extension.
+// Variant conflict detection is new.
+'use strict';
+
+const path = require('path');
+const { actions, fs, selectors, util } = require('@nexusmods/vortex-api');
+
+const { VARIANT_GROUPS } = require('./variantGroups');
+const { detectConflicts } = require('./conflictDetector');
+
+// ---------------------------------------------------------------------------
+// Game constants
+// ---------------------------------------------------------------------------
+
+const GAME_ID        = 'readyornot';
+const GAME_NAME      = 'Ready Or Not';
+const GAME_CODE_NAME = 'ReadyOrNot';
+const GAME_PLATFORM  = 'Win64';
+const STEAMAPP_ID    = '1144200';
+const EPICAPP_ID     = '07e0052292f44e71a1efeb219d060ea5';
+
+const EXEC_SUBPATH = path.join(GAME_CODE_NAME, 'Binaries', GAME_PLATFORM);
+const MODS_PATH    = path.join(GAME_CODE_NAME, 'Content', 'Paks', '~mods');
+const FMOD_PATH    = path.join(GAME_CODE_NAME, 'Content', 'FMOD', 'Desktop');
+const CONFIG_PATH  = path.join(GAME_CODE_NAME, 'Saved', 'Config', 'Windows');
+const LO_FILE_NAME = 'loadOrder.json';
+
+// ---------------------------------------------------------------------------
+// Variant conflict detection
+// ---------------------------------------------------------------------------
+
+function getEnabledMods(api) {
+  const state   = api.getState();
+  const profile = selectors.activeProfile(state);
+  if (!profile || profile.gameId !== GAME_ID) return [];
+
+  const mods     = util.getSafe(state, ['persistent', 'mods', GAME_ID], {});
+  const modState = util.getSafe(profile, ['modState'], {});
+
+  return Object.keys(modState)
+    .filter(id => util.getSafe(modState, [id, 'enabled'], false))
+    .map(id => mods[id])
+    .filter(Boolean)
+    .map(mod => ({
+      name:       util.renderModName(mod),
+      nexusModId: util.getSafe(mod, ['attributes', 'modId'], undefined),
+    }));
+}
+
+function runVariantCheck(api) {
+  const state   = api.getState();
+  const profile = selectors.activeProfile(state);
+  if (!profile || profile.gameId !== GAME_ID) return;
+
+  const groups    = VARIANT_GROUPS.filter(g => g.gameId === GAME_ID);
+  const mods      = getEnabledMods(api);
+  const conflicts = detectConflicts(mods, groups);
+
+  // Dismiss stale notifications before re-evaluating.
+  groups.forEach(g => api.dismissNotification(`variant-conflict-${g.id}`));
+
+  for (const conflict of conflicts) {
+    const variantList = conflict.hits
+      .map(h => `• ${h.modName} (${h.variantLabel})`)
+      .join('\n');
+
+    api.sendNotification({
+      id:      `variant-conflict-${conflict.groupId}`,
+      type:    'warning',
+      title:   `Conflicting variants: ${conflict.displayName}`,
+      message: `You have ${conflict.hits.length} mutually exclusive variants enabled:\n`
+             + variantList
+             + '\n\nThe mod author recommends enabling only one variant at a time.',
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Game discovery
+// ---------------------------------------------------------------------------
+
+function findGame() {
+  return util.GameStoreHelper.findByAppId([STEAMAPP_ID, EPICAPP_ID])
+    .then(game => game.gamePath);
+}
+
+function getExecutable(discoveryPath) {
+  const egsExec = path.join(discoveryPath, `${GAME_CODE_NAME}EGS.exe`);
+  try {
+    fs.statSync(egsExec);
+    return `${GAME_CODE_NAME}EGS.exe`;
+  } catch (_) {
+    return `${GAME_CODE_NAME}.exe`;
+  }
+}
+
+async function prepareForModding(discovery) {
+  const localAppData = process.env['LOCALAPPDATA'];
+  await fs.ensureDirWritableAsync(path.join(localAppData, CONFIG_PATH));
+  return fs.ensureDirWritableAsync(path.join(discovery.path, MODS_PATH));
+}
+
+// ---------------------------------------------------------------------------
+// Load order
+// ---------------------------------------------------------------------------
+
+function generateProps(context, profileId) {
+  const api     = context.api;
+  const state   = api.getState();
+  const profile = profileId
+    ? selectors.profileById(state, profileId)
+    : selectors.activeProfile(state);
+
+  if (profile?.gameId !== GAME_ID) return undefined;
+
+  const discovery = util.getSafe(
+    state, ['settings', 'gameMode', 'discovered', GAME_ID], undefined
+  );
+  if (discovery?.path === undefined) return undefined;
+
+  const mods = util.getSafe(state, ['persistent', 'mods', GAME_ID], {});
+  return { api, state, profile, mods, discovery };
+}
+
+function makePrefix(input) {
+  let res = '';
+  let rest = input;
+  while (rest > 0) {
+    res  = String.fromCharCode(65 + (rest % 25)) + res;
+    rest = Math.floor(rest / 25);
+  }
+  return util.pad(res, 'A', 3);
+}
+
+function toLOPrefix(context, mod) {
+  const props = generateProps(context);
+  if (props === undefined) return 'ZZZZ-';
+
+  const loadOrder = util.getSafe(
+    props.state, ['persistent', 'loadOrder', props.profile.id], []
+  );
+  const index = loadOrder.findIndex(e => e.id === mod.id);
+  return index === -1 ? 'ZZZZ-' : makePrefix(index) + '-';
+}
+
+async function ensureLOFile(context, profileId, props) {
+  if (props === undefined) props = generateProps(context, profileId);
+  if (props === undefined) {
+    return Promise.reject(new util.ProcessCanceled('failed to generate game props'));
+  }
+
+  const targetPath = path.join(
+    props.discovery.path, `${props.profile.id}_${LO_FILE_NAME}`
+  );
+
+  await fs.statAsync(targetPath).catch(
+    { code: 'ENOENT' },
+    () => fs.writeFileAsync(targetPath, JSON.stringify([]), { encoding: 'utf8' })
+  );
+  return targetPath;
+}
+
+async function serialize(context, loadOrder) {
+  const props = generateProps(context);
+  if (props === undefined) {
+    return Promise.reject(new util.ProcessCanceled('invalid props'));
+  }
+
+  const loFilePath = await ensureLOFile(context, props.profile.id, props);
+  const filteredLO = loadOrder.filter(
+    lo => props.mods?.[lo?.modId]?.type === 'ue4-sortable-modtype'
+  );
+
+  await fs.removeAsync(loFilePath).catch({ code: 'ENOENT' }, () => Promise.resolve());
+  await fs.writeFileAsync(loFilePath, JSON.stringify(filteredLO, null, 4), { encoding: 'utf8' });
+  context.api.store.dispatch(actions.setDeploymentNecessary(GAME_ID, true));
+}
+
+async function deserialize(context) {
+  const props = generateProps(context);
+  if (props?.profile?.gameId !== GAME_ID) return [];
+
+  const currentModsState = util.getSafe(props.profile, ['modState'], {});
+  const enabledModIds    = Object.keys(currentModsState)
+    .filter(id => util.getSafe(currentModsState, [id, 'enabled'], false));
+  const mods       = util.getSafe(props.state, ['persistent', 'mods', GAME_ID], {});
+  const loFilePath = await ensureLOFile(context, props.profile.gameId, props);
+  const fileData   = await fs.readFileAsync(loFilePath, { encoding: 'utf8' });
+
+  let data = [];
+  try {
+    data = JSON.parse(fileData);
+  } catch (err) {
+    await new Promise((resolve, reject) => {
+      props.api.showDialog('error', 'Corrupt load order file', {
+        bbcode: props.api.translate(
+          'The load order file is corrupt. Vortex can regenerate it, '
+          + 'but that may result in loss of manually added load order items.'
+        ),
+      }, [
+        { label: 'Cancel',          action: () => reject(err) },
+        { label: 'Regenerate File', action: () => { data = []; resolve(); } },
+      ]);
+    });
+  }
+
+  const filteredData = data.filter(e => enabledModIds.includes(e.id));
+  const diff = enabledModIds.filter(
+    id =>
+      ['ue4-sortable-modtype'].includes(mods[id]?.type) &&
+      filteredData.find(e => e.id === id) === undefined
+  );
+
+  diff.forEach(id => {
+    filteredData.push({
+      id,
+      modId:   id,
+      enabled: true,
+      name:    mods[id] ? util.renderModName(mods[id]) : id,
+    });
+  });
+
+  return filteredData;
+}
+
+// ---------------------------------------------------------------------------
+// Mod installers
+// ---------------------------------------------------------------------------
+
+function testFmod(files, gameId) {
+  const supported = gameId === GAME_ID
+    && files.some(f => path.extname(f).toLowerCase() === '.bank');
+  return Promise.resolve({ supported, requiredFiles: [] });
+}
+
+function installFmod(files) {
+  const modFile = files.find(f => path.extname(f).toLowerCase() === '.bank');
+  const idx     = modFile.indexOf(path.basename(modFile));
+  const filtered = files.filter(
+    f => f.startsWith(path.dirname(modFile)) && !f.endsWith(path.sep)
+  );
+  return Promise.resolve({
+    instructions: [
+      ...filtered.map(f => ({ type: 'copy', source: f, destination: f.slice(idx) })),
+      { type: 'setmodtype', value: `${GAME_ID}-fmod` },
+    ],
+  });
+}
+
+function testFallback(files, gameId) {
+  return Promise.resolve({ supported: gameId === GAME_ID, requiredFiles: [] });
+}
+
+function installFallback(files) {
+  const filtered = files.filter(f => !f.endsWith(path.sep));
+  return Promise.resolve({
+    instructions: [
+      ...filtered.map(f => ({ type: 'copy', source: f, destination: f })),
+      { type: 'setmodtype', value: `${GAME_ID}-binaries` },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+function main(context) {
+  context.requireExtension('Unreal Engine Mod Installer');
+
+  context.registerGame({
+    id:              GAME_ID,
+    name:            GAME_NAME,
+    mergeMods:       true,
+    queryPath:       findGame,
+    requiresCleanup: true,
+    supportedTools:  [],
+    queryModPath:    () => '.',
+    compatible:      { unrealEngine: true },
+    logo:            'gameart.jpg',
+    executable:      getExecutable,
+    requiredFiles:   [GAME_CODE_NAME],
+    setup:           prepareForModding,
+    environment:     { SteamAPPId: STEAMAPP_ID, EpicAPPId: EPICAPP_ID },
+    details: {
+      unrealEngine: {
+        modsPath:            MODS_PATH,
+        fileExt:             '.pak',
+        loadOrder:           true,
+        loadOrderPrefixFunc: (mod) => toLOPrefix(context, mod),
+      },
+      steamAppId:        STEAMAPP_ID,
+      EpicAPPId:         EPICAPP_ID,
+      customOpenModsPath: MODS_PATH,
+    },
+    modTypes: [
+      { id: `${GAME_ID}-binaries`, name: 'Binaries', priority: 'high', targetPath: `{gamePath}\\${EXEC_SUBPATH}` },
+      { id: `${GAME_ID}-fmod`,     name: 'FMOD',     priority: 'high', targetPath: `{gamePath}\\${FMOD_PATH}` },
+      { id: `${GAME_ID}-root`,     name: 'Root',     priority: 'high', targetPath: '{gamePath}' },
+    ],
+  });
+
+  context.registerInstaller(`${GAME_ID}-fmod`,     45, testFmod,     installFmod);
+  context.registerInstaller(`${GAME_ID}-fallback`, 85, testFallback, installFallback);
+
+  context.registerLoadOrder({
+    gameId:               GAME_ID,
+    validate:             async () => Promise.resolve(undefined),
+    deserializeLoadOrder: async () => deserialize(context),
+    serializeLoadOrder:   async (lo) => serialize(context, lo),
+    toggleableEntries:    false,
+    usageInstructions:
+      'Drag and drop mods to change the load order. Ready or Not loads mods in '
+      + 'alphanumerical order; Vortex prefixes folder names with "AAA, AAB, AAC, ..." '
+      + 'to match the order you set here.',
+  });
+
+  // Variant conflict detection
+  context.api.events.on('profile-did-change', () => runVariantCheck(context.api));
+  context.api.events.on('mods-enabled',       () => runVariantCheck(context.api));
+  context.once(() => runVariantCheck(context.api));
+}
+
+module.exports = { default: main };

--- a/extensions/games/game-readyornot/src/variantGroups.js
+++ b/extensions/games/game-readyornot/src/variantGroups.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * @typedef {Object} Variant
+ * @property {string} match   - Case-insensitive substring matched against the mod's display name
+ * @property {string} label   - Human-readable label shown in warning notifications
+ */
+
+/**
+ * @typedef {Object} ExclusiveVariantGroup
+ * @property {string}   id          - Unique identifier for this group
+ * @property {string}   gameId      - Vortex/Nexus game identifier (e.g. 'readyornot')
+ * @property {number}   [nexusModId]- When set, only mods from this Nexus page are checked.
+ *                                    Omit for cross-mod groups spanning multiple Nexus pages.
+ * @property {string}   displayName - Shown in the warning notification title
+ * @property {Variant[]} variants   - Two or more mutually exclusive variants
+ */
+
+/** @type {ExclusiveVariantGroup[]} */
+const VARIANT_GROUPS = [
+  // -----------------------------------------------------------------
+  // Ready or Not — intra-mod variant groups
+  // (single Nexus page, multiple exclusive files)
+  // -----------------------------------------------------------------
+  {
+    id: 'ron-no-stress',
+    gameId: 'readyornot',
+    nexusModId: 3278,
+    displayName: 'No Stress for SWAT',
+    variants: [
+      { match: 'no stress',  label: 'Standard' },
+      { match: 'hardcore',   label: 'Hardcore Officers' },
+      { match: 'robocop',    label: 'Robocop' },
+    ],
+  },
+  {
+    id: 'ron-no-mercy',
+    gameId: 'readyornot',
+    nexusModId: 2208,
+    displayName: 'No Mercy for Terrorists',
+    variants: [
+      { match: 'standard',        label: 'Standard' },
+      { match: 'justified kills', label: 'Justified Kills' },
+      { match: 'wanted',          label: 'WANTED' },
+    ],
+  },
+
+  // -----------------------------------------------------------------
+  // Ready or Not — cross-mod conflict groups
+  // (separate Nexus pages covering the same feature)
+  // -----------------------------------------------------------------
+  {
+    id: 'ron-player-health',
+    gameId: 'readyornot',
+    displayName: 'Player Health',
+    variants: [
+      { match: 'hp plus',       label: 'HP PLUS' },
+      { match: 'hp edit',       label: 'HP Edit' },
+      { match: '350hp',         label: '350 HP Mod' },
+      { match: '1000hp',        label: '1000 HP Mod' },
+      { match: '1000 health',   label: '1000 Health' },
+      { match: 'player health', label: 'Player Health' },
+      { match: 'lesshp',        label: 'Less HP' },
+      { match: 'health nerf',   label: 'Health Nerf' },
+      { match: 'health buff',   label: 'Health Buff' },
+    ],
+  },
+];
+
+module.exports = { VARIANT_GROUPS };


### PR DESCRIPTION
## Summary

Adds a new game extension for **Ready Or Not** at `extensions/games/game-readyornot/`.

- Game discovery via Steam (`1144200`) and Epic Games Store
- PAK mod installation to `ReadyOrNot/Content/Paks/~mods`
- FMOD audio mod support (`.bank` files)
- Load order management using the alphanumeric prefix system (matches existing community extension behaviour)
- **Variant conflict detection** — warns the user when mutually exclusive mod variants are enabled at the same time

### Variant conflict detection

Vortex's existing file-level conflict detection doesn't catch a common modding problem: mods that are *variants* of the same feature and are never meant to coexist, but don't necessarily write to the same files.

This happens in two ways in the Ready or Not mod ecosystem:

**Intra-mod variants** — a single Nexus mod page ships multiple exclusive files (e.g. *No Stress for SWAT* ships Standard, Hardcore Officers, and Robocop variants). Installing two of them won't trigger a file conflict, but both will try to take effect in-game.

**Cross-mod conflicts** — multiple separate Nexus mod pages all modify the same gameplay system (e.g. the many player HP mods on Nexus — `350HP Mod`, `1000HP Mod`, `HP PLUS`, etc.). Installing two silently means only one wins.

The extension hooks into `profile-did-change` and `mods-enabled` events and shows a Vortex warning notification naming the specific conflicting mods.

The detection logic is split into two pure modules with no Vortex API dependency, making them straightforward to extend or unit test:

- `src/variantGroups.js` — curated list of exclusive variant groups (intra-mod and cross-mod)
- `src/conflictDetector.js` — stateless `detectConflicts(mods, groups)` function

### Notes

- Game registration code adapted from the community extension by [BeYkeRYkt](https://github.com/BeYkeRYkt/vortex_readyornot_extension) — credit included in source
- `assets/gameart.jpg` still needs to be added (binary file — happy to push separately if this PR approach is preferred)
- Variant group data in `variantGroups.js` can be extended by the community as new conflicting mod families are identified