### PR TITLE
LAZ-692: restore checkpointless downloads instead of failing to resume

### DIFF
--- a/src/main/src/downloading/ipc.ts
+++ b/src/main/src/downloading/ipc.ts
@@ -40,7 +40,7 @@ export function init(manager: DownloadManager): void {
 
   const webContentsByDownloadId = new Map<string, WebContents>();
 
-  betterIpcMain.handle("download:start", async (event, dest, collationId) => {
+  betterIpcMain.handle("download:start", async (event, dest, collationId, downloadId) => {
     const webContents = event.sender;
     // free users must click through the website serially at their own pace (~10-13s each),
     // so any wall-clock timer abandons every download past the first few in a batch.
@@ -54,7 +54,7 @@ export function init(manager: DownloadManager): void {
     );
     const resource = wireToResolvedResource(wireResource);
     const resolver = () => Promise.resolve(resource);
-    const handle = manager.download(resource, dest, resolver);
+    const handle = manager.download(resource, dest, resolver, undefined, undefined, downloadId);
     webContentsByDownloadId.set(handle.downloadId, webContents);
     handle.promise.catch((err) =>
       log("error", "download failed", { downloadId: handle.downloadId, err }),

--- a/src/main/src/downloading/manager.ts
+++ b/src/main/src/downloading/manager.ts
@@ -188,14 +188,22 @@ export class DownloadManager {
     );
   }
 
+  /**
+   * A caller-supplied `downloadId` restores an existing download: the transfer starts
+   * from scratch under that id, replacing any previous attempt tracked for it. Used
+   * when the previous attempt left nothing resumable (no checkpoint, or none with
+   * completed ranges). Restore is only issued for a settled (paused or failed) attempt,
+   * so the replaced handle is never mid-transfer.
+   */
   download<T>(
     resource: T,
     dest: string,
     resolver: Resolver<T>,
     chunker: Chunker<T> = staticChunker(),
     retry: RetryStrategy = defaultRetryStrategy(),
+    downloadId?: string,
   ): DownloadHandle<T> {
-    return this.#download(resource, dest, resolver, chunker, retry);
+    return this.#download(resource, dest, resolver, chunker, retry, undefined, downloadId);
   }
 
   #download<T>(

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -261,7 +261,8 @@ try {
     },
 
     downloader: {
-      start: (dest, collationId) => betterIpcRenderer.invoke("download:start", dest, collationId),
+      start: (dest, collationId, downloadId) =>
+        betterIpcRenderer.invoke("download:start", dest, collationId, downloadId),
       pause: (downloadId) => betterIpcRenderer.invoke("download:pause", downloadId),
       resume: (checkpoint) => betterIpcRenderer.invoke("download:resume", checkpoint),
       cancel: (downloadId) => betterIpcRenderer.invoke("download:cancel", downloadId),

--- a/src/renderer/src/IPCDownloadAdapter.test.ts
+++ b/src/renderer/src/IPCDownloadAdapter.test.ts
@@ -1,7 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
 
+import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
+import type { Api, DownloaderApi } from "@vortex/shared/preload";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearDownloadCheckpoint } from "./actions/downloads";
+import {
+  downloadProgress,
+  finishDownload,
+  pauseDownload,
+} from "./extensions/download_management/actions/state";
+import type { IDownload } from "./extensions/download_management/types/IDownload";
 import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
-import { expandCompatibleGameIds } from "./IPCDownloadAdapter";
+import {
+  expandCompatibleGameIds,
+  IPCDownloadAdapter,
+  isResumableCheckpoint,
+} from "./IPCDownloadAdapter";
+
+// getDownloadPath reads electron's userData dir via ApplicationData, which isn't initialized in the
+// test env. The tests supply an absolute download root, so the value is never used for resolution.
+vi.mock("./util/getVortexPath", () => ({ default: () => "/vortex-userdata" }));
 
 function game(id: string, compatibleDownloads?: string[]): IGameStored {
   return {
@@ -55,5 +77,269 @@ describe("expandCompatibleGameIds", () => {
 
   it("preserves the undefined id (no managed game) as the sole entry", () => {
     expect(expandCompatibleGameIds(games, undefined)).toEqual([undefined]);
+  });
+});
+
+// TODO: in master these tests should be refactored to use test-utils
+function checkpoint(
+  completedRanges: Array<{ start: number; end: number }>,
+): WireDownloadCheckpoint {
+  return {
+    downloadId: "dl",
+    resource: "https://cdn.example/file",
+    dest: "d",
+    completedRanges,
+    etag: undefined,
+  };
+}
+
+describe("isResumableCheckpoint", () => {
+  it("is not resumable without a checkpoint (interrupted rather than cleanly paused)", () => {
+    expect(isResumableCheckpoint(undefined)).toBe(false);
+  });
+
+  it("is not resumable when no byte range completed (paused before the first chunk)", () => {
+    expect(isResumableCheckpoint(checkpoint([]))).toBe(false);
+  });
+
+  it("is resumable once at least one range completed", () => {
+    expect(isResumableCheckpoint(checkpoint([{ start: 0, end: 1023 }]))).toBe(true);
+  });
+});
+
+describe("runtime restore", () => {
+  let savedApi: Api;
+  let idCounter = 0;
+  const tmpDirs: string[] = [];
+
+  beforeEach(() => {
+    savedApi = window.api;
+    // Freeze the constructor's 200ms poll loop so it never fires (and leftover loops never touch a
+    // sibling test's mock). Timers are dropped in afterEach; nothing here advances them.
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    window.api = savedApi;
+    for (const dir of tmpDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  function wireState(status: string, bytesReceived: number) {
+    return { status, error: null, bytesReceived, size: 100, fileName: undefined, isChunked: false };
+  }
+
+  async function makeHarness(opts: {
+    download: Partial<IDownload>;
+    checkpoint?: WireDownloadCheckpoint;
+    automationInstall?: boolean;
+  }) {
+    const downloadId = `dl-${idCounter++}`;
+    const dlRoot = await mkdtemp(path.join(tmpdir(), "vortex-dl-"));
+    tmpDirs.push(dlRoot);
+    const gameDir = path.join(dlRoot, "skyrimse");
+    await mkdir(gameDir, { recursive: true });
+    const dest = path.join(gameDir, "file.bin");
+    await writeFile(dest, "partial-bytes");
+
+    const state = {
+      settings: {
+        downloads: { path: dlRoot },
+        automation: { install: opts.automationInstall ?? false },
+      },
+      session: { gameMode: { known: [] } },
+      persistent: {
+        downloads: {
+          files: {
+            [downloadId]: {
+              urls: ["https://cdn.example/file.bin"],
+              localPath: "file.bin",
+              game: ["skyrimse"],
+              state: "paused",
+              size: 100,
+              ...opts.download,
+            },
+          },
+          checkpoints:
+            opts.checkpoint !== undefined
+              ? { [downloadId]: { ...opts.checkpoint, downloadId } }
+              : {},
+        },
+      },
+    };
+
+    const events = new EventEmitter();
+    const dispatch = vi.fn();
+    const api = { getState: () => state, store: { getState: () => state, dispatch }, events };
+
+    let resolveHandler: ((collationId: number) => Promise<WireResolvedResource>) | undefined;
+    const started = { resolve: (): void => {}, promise: Promise.resolve() };
+    started.promise = new Promise<void>((r) => (started.resolve = r));
+
+    const resume = vi.fn().mockResolvedValue(undefined);
+    const getStates = vi.fn().mockResolvedValue({});
+    const start = vi
+      .fn()
+      .mockImplementation(async (_dest: string, collationId: number, id?: string) => {
+        await resolveHandler?.(collationId);
+        started.resolve();
+        return { downloadId: id ?? `new-${collationId}` };
+      });
+    const downloader: DownloaderApi = {
+      onResolve: vi.fn((handler: (collationId: number) => Promise<WireResolvedResource>) => {
+        resolveHandler = handler;
+        return () => {};
+      }),
+      getState: vi.fn(),
+      getStates,
+      configure: vi.fn().mockResolvedValue(undefined),
+      start,
+      resume,
+      pause: vi.fn(),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    };
+    window.api = { log: vi.fn(), downloader } as unknown as Api;
+
+    const adapter = new IPCDownloadAdapter(api as never);
+
+    return { adapter, events, dispatch, downloadId, dest, start, resume, started, getStates };
+  }
+
+  it("restores a checkpointless paused download under the same id", async () => {
+    const h = await makeHarness({ download: { state: "paused" } });
+
+    h.events.emit("resume-download", h.downloadId, () => undefined);
+    await h.started.promise;
+
+    // restarted under the SAME id, not resumed
+    expect(h.resume).not.toHaveBeenCalled();
+    expect(h.start).toHaveBeenCalledWith(h.dest, expect.any(Number), h.downloadId);
+
+    // the record is reset to zero and returned to its active state (no urls, so the record's stored
+    // source url is left untouched)
+    expect(h.dispatch).toHaveBeenCalledWith(downloadProgress(h.downloadId, 0, 100, undefined));
+    expect(h.dispatch).toHaveBeenCalledWith(pauseDownload(h.downloadId, false));
+    expect(h.dispatch).toHaveBeenCalledWith(clearDownloadCheckpoint(h.downloadId));
+  });
+
+  it("restores when the checkpoint has no completed ranges", async () => {
+    const h = await makeHarness({
+      download: { state: "paused" },
+      checkpoint: {
+        downloadId: "",
+        resource: "https://cdn.example/file.bin",
+        dest: "d",
+        completedRanges: [],
+        etag: undefined,
+      },
+    });
+
+    h.events.emit("resume-download", h.downloadId, () => undefined);
+    await h.started.promise;
+
+    expect(h.resume).not.toHaveBeenCalled();
+    expect(h.start).toHaveBeenCalledWith(h.dest, expect.any(Number), h.downloadId);
+  });
+
+  it("resumes normally when the checkpoint has completed ranges", async () => {
+    const h = await makeHarness({
+      download: { state: "paused" },
+      checkpoint: {
+        downloadId: "",
+        resource: "https://cdn.example/file.bin",
+        dest: "d",
+        completedRanges: [{ start: 0, end: 1023 }],
+        etag: "etag-1",
+      },
+    });
+
+    const resumed = new Promise<void>((resolve) => {
+      h.events.emit("resume-download", h.downloadId, () => resolve());
+    });
+    await resumed;
+
+    // usable checkpoint -> resume, not restart
+    expect(h.resume).toHaveBeenCalledWith(
+      expect.objectContaining({ completedRanges: [{ start: 0, end: 1023 }] }),
+    );
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs the nxm source url when the stored urls were wiped", async () => {
+    const h = await makeHarness({
+      download: {
+        state: "paused",
+        urls: [],
+        modInfo: { nexus: { ids: { gameId: "skyrimse", modId: 123, fileId: 456 } } },
+      },
+    });
+
+    const nxmHandler = vi
+      .fn()
+      .mockResolvedValue({ urls: ["https://cdn.example/resolved"], meta: {} });
+    h.adapter.registerProtocol("nxm", nxmHandler);
+
+    h.events.emit("resume-download", h.downloadId, () => undefined);
+    await h.started.promise;
+
+    // the rebuilt nxm url is resolved through the normal protocol flow
+    expect(nxmHandler).toHaveBeenCalledWith("nxm://skyrimse/mods/123/files/456");
+    // and healed back onto the record
+    expect(h.dispatch).toHaveBeenCalledWith(
+      downloadProgress(h.downloadId, 0, 100, ["nxm://skyrimse/mods/123/files/456"]),
+    );
+    expect(h.start).toHaveBeenCalledWith(h.dest, expect.any(Number), h.downloadId);
+  });
+
+  it("honors allowInstall: false from the resume options (no auto-install on completion)", async () => {
+    const h = await makeHarness({ download: { state: "paused" }, automationInstall: true });
+    const installSpy = vi.fn();
+    h.events.on("start-install-download", installSpy);
+    const finished = new Promise<void>((resolve) =>
+      h.events.on("did-finish-download", () => resolve()),
+    );
+
+    h.events.emit("resume-download", h.downloadId, () => undefined, { allowInstall: false });
+    await h.started.promise;
+
+    h.getStates.mockResolvedValue({ [h.downloadId]: wireState("completed", 100) });
+    await vi.advanceTimersByTimeAsync(250);
+    await finished;
+
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto-installs a restored download when automation is on and no override is given", async () => {
+    const h = await makeHarness({ download: { state: "paused" }, automationInstall: true });
+    const installed = new Promise<void>((resolve) =>
+      h.events.on("start-install-download", () => resolve()),
+    );
+
+    h.events.emit("resume-download", h.downloadId, () => undefined);
+    await h.started.promise;
+
+    h.getStates.mockResolvedValue({ [h.downloadId]: wireState("completed", 100) });
+    await vi.advanceTimersByTimeAsync(250);
+
+    // resolves only when start-install-download fires
+    await installed;
+  });
+
+  it("marks the record failed if the restart cannot be started", async () => {
+    const h = await makeHarness({ download: { state: "paused" } });
+    h.start.mockRejectedValueOnce(new Error("resolve failed"));
+
+    const err = await new Promise<Error | null>((resolve) => {
+      h.events.emit("resume-download", h.downloadId, (e: Error | null) => resolve(e));
+    });
+
+    // the caller gets the error (not left hanging) and the record is marked failed rather than
+    // stuck in an active state the poll never tracks
+    expect(err).toBeInstanceOf(Error);
+    expect(h.dispatch).toHaveBeenCalledWith(
+      finishDownload(h.downloadId, "failed", expect.anything()),
+    );
   });
 });

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -41,6 +41,7 @@ import { downloadPathForGame } from "./extensions/download_management/selectors"
 import type { IDownload } from "./extensions/download_management/types/IDownload";
 import { knownGames } from "./extensions/gamemode_management/selectors";
 import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
+import { nxmUrlFromDownload } from "./extensions/nexus_integration/NXMUrl";
 import { nexusIdsFromDownloadId } from "./extensions/nexus_integration/selectors";
 import { convertGameIdReverse } from "./extensions/nexus_integration/util/convertGameId";
 import { makeModAndFileUIDs } from "./extensions/nexus_integration/util/UIDs";
@@ -753,7 +754,7 @@ export class IPCDownloadAdapter {
     const state = this.#api.getState();
     // Treat an empty-string url as absent so a wiped record falls back to reconstruction.
     const storedUrl = download.urls?.[0] || undefined;
-    const rawUrl = storedUrl ?? this.#reconstructSourceUrl(state, downloadId, download);
+    const rawUrl = storedUrl ?? nxmUrlFromDownload(download);
     if (download.localPath === undefined || rawUrl === undefined) {
       throw new Error(`Cannot restore download ${downloadId}: no stored url or path`);
     }
@@ -816,30 +817,6 @@ export class IPCDownloadAdapter {
     } finally {
       this.#restoring.delete(downloadId);
     }
-  }
-
-  // Rebuild an nxm source url from the persisted nexus ids for a record whose stored urls are
-  // empty. The rebuilt url carries no key/expires query, so non-premium accounts get the resolver's
-  // normal free-user handling.
-  #reconstructSourceUrl(
-    state: ReturnType<IExtensionApi["getState"]>,
-    downloadId: string,
-    download: IDownload,
-  ): string | undefined {
-    const ids = nexusIdsFromDownloadId(state, downloadId);
-    if (ids?.gameDomainName === undefined) return undefined;
-
-    if (ids.collectionSlug !== undefined) {
-      const revisionNumber: number | undefined = download.modInfo?.nexus?.ids?.revisionNumber;
-      if (revisionNumber === undefined) return undefined;
-      return `nxm://${ids.gameDomainName}/collections/${ids.collectionSlug}/revisions/${revisionNumber}`;
-    }
-
-    if (ids.modId !== undefined && ids.fileId !== undefined) {
-      return `nxm://${ids.gameDomainName}/mods/${ids.modId}/files/${ids.fileId}`;
-    }
-
-    return undefined;
   }
 
   async #pollLoop(interval: number): Promise<void> {

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -6,7 +6,11 @@ import { pipeline } from "node:stream/promises";
 
 import { unknownToError, wireToDownloadError } from "@vortex/shared";
 import { AlreadyDownloaded, UserCanceled } from "@vortex/shared/errors";
-import type { WireDownloadState, WireResolvedResource } from "@vortex/shared/ipc";
+import type {
+  WireDownloadCheckpoint,
+  WireDownloadState,
+  WireResolvedResource,
+} from "@vortex/shared/ipc";
 import { z } from "zod";
 
 import { clearDownloadCheckpoint, setDownloadCheckpoint } from "./actions/downloads";
@@ -98,6 +102,26 @@ export function expandCompatibleGameIds(
   return Array.from(new Set([gameId, ...compatible]));
 }
 
+/**
+ * A download can only be resumed when its checkpoint recorded at least one completed byte range. A
+ * missing checkpoint (interrupted rather than cleanly paused) or one with no completed ranges has
+ * nothing to resume from, so the download has to be restored (restarted from scratch) instead.
+ */
+export function isResumableCheckpoint(checkpoint: WireDownloadCheckpoint | undefined): boolean {
+  return checkpoint !== undefined && checkpoint.completedRanges.length > 0;
+}
+
+/**
+ * Normalize the caller-facing allowInstall option to the stored per-download override: false
+ * suppresses auto-install, "force" (stored as true) always installs, anything else defers to the
+ * automation setting.
+ */
+function normalizeAllowInstall(allowInstall: boolean | "force" | undefined): boolean | undefined {
+  if (allowInstall === false) return false;
+  if (allowInstall === "force") return true;
+  return undefined;
+}
+
 type StoredDownloadInfo = {
   encodedUrl: EncodedUrl;
   callback?: (err: Error | null, id?: string) => void;
@@ -122,6 +146,10 @@ export class IPCDownloadAdapter {
   // nexus IDs (modId/fileId or collectionId/revisionId) here.
   readonly #resolvedMeta = new Map<number, unknown>();
   readonly #activeDownloads = new Map<string, ActiveDownload>();
+  // Ids with a restore in flight. A restore un-pauses the record and clears its checkpoint before
+  // awaiting the fresh start, so without this guard a second resume-download for the same id would
+  // re-enter and issue a duplicate rm + start racing the first.
+  readonly #restoring = new Set<string>();
   #speedAccumBytes = 0;
   #lastSpeedDispatch: number | null = null;
   #nextCollationId = 0;
@@ -195,8 +223,8 @@ export class IPCDownloadAdapter {
         return;
       }
 
-      const [downloadId, callback] = parsed.data;
-      this.#handleResumeDownload(downloadId, callback).catch((err) => {
+      const [downloadId, callback, options] = parsed.data;
+      this.#handleResumeDownload(downloadId, callback, options).catch((err) => {
         log("error", "failed to resume download", err);
       });
     });
@@ -582,12 +610,7 @@ export class IPCDownloadAdapter {
 
       const { downloadId } = await window.api.downloader.start(dest, collationId);
 
-      const allowInstall =
-        options?.allowInstall === false
-          ? false
-          : options?.allowInstall === "force"
-            ? true
-            : undefined;
+      const allowInstall = normalizeAllowInstall(options?.allowInstall);
 
       this.#activeDownloads.set(downloadId, {
         callback,
@@ -658,6 +681,18 @@ export class IPCDownloadAdapter {
     downloadId: string,
     callback?: (err: Error | null) => void,
   ): Promise<void> {
+    // Only downloads still in progress are pausable (same active-download check as
+    // hydrateFromState). For anything else - already finished/failed/paused, or no longer present -
+    // the manager would throw "is not paused: status is ...", so treat it as a no-op success.
+    const download = this.#api.getState().persistent.downloads.files[downloadId];
+    if (download === undefined || !["init", "started"].includes(download.state)) {
+      log("debug", "skipping pause for non-active download", {
+        downloadId,
+        state: download?.state,
+      });
+      callback?.(null);
+      return;
+    }
     try {
       log("debug", "pausing download", { downloadId });
       const checkpoint = await window.api.downloader.pause(downloadId);
@@ -672,11 +707,25 @@ export class IPCDownloadAdapter {
   async #handleResumeDownload(
     downloadId: string,
     callback?: (err: Error | null, id?: string) => void,
+    options?: { allowInstall?: boolean | "force" },
   ): Promise<void> {
     try {
-      const checkpoint = this.#api.getState().persistent.downloads.checkpoints[downloadId];
-      if (checkpoint === undefined) {
-        throw new Error(`No checkpoint stored for download ${downloadId}`);
+      const state = this.#api.getState();
+      const checkpoint = state.persistent.downloads.checkpoints[downloadId];
+      if (!isResumableCheckpoint(checkpoint)) {
+        // Interrupted rather than cleanly paused, or paused before any range completed: there is
+        // nothing to resume from, so restart the download from scratch under the same id.
+        const download = state.persistent.downloads.files?.[downloadId];
+        if (download === undefined) {
+          throw new Error(`Cannot restore download ${downloadId}: no record`);
+        }
+        await this.#restoreDownload(
+          downloadId,
+          download,
+          callback,
+          normalizeAllowInstall(options?.allowInstall),
+        );
+        return;
       }
 
       log("debug", "resuming download", { downloadId });
@@ -685,6 +734,112 @@ export class IPCDownloadAdapter {
     } catch (err) {
       callback?.(unknownToError(err));
     }
+  }
+
+  // Restart a download that has no usable checkpoint, keeping the same download id so callers
+  // (collection installer, downloads view) keep their reference while the transfer starts over from
+  // zero. Main holds neither the source url nor the mod ids for such a download, so the url comes
+  // from the persisted record (or is reconstructed from its nexus ids) and resolution runs through
+  // the same collation flow as a fresh start.
+  async #restoreDownload(
+    downloadId: string,
+    download: IDownload,
+    callback?: (err: Error | null, id?: string) => void,
+    allowInstall?: boolean,
+  ): Promise<void> {
+    // A concurrent resume-download for the same id would re-enter and issue a duplicate rm + start.
+    if (this.#restoring.has(downloadId)) return;
+
+    const state = this.#api.getState();
+    // Treat an empty-string url as absent so a wiped record falls back to reconstruction.
+    const storedUrl = download.urls?.[0] || undefined;
+    const rawUrl = storedUrl ?? this.#reconstructSourceUrl(state, downloadId, download);
+    if (download.localPath === undefined || rawUrl === undefined) {
+      throw new Error(`Cannot restore download ${downloadId}: no stored url or path`);
+    }
+    // Parse before any state mutation so a malformed url fails the resume without leaving the
+    // record half-reset.
+    const encodedUrl = parseEncodedUrl(rawUrl);
+
+    const gameId = toInternalGameId(this.#api, download.game?.[0] ?? activeGameId(state));
+    const dlPath = downloadPathForGame(state, gameId);
+    const dest = path.join(dlPath, download.localPath);
+
+    this.#restoring.add(downloadId);
+    try {
+      log("debug", "restoring download without usable checkpoint", { downloadId });
+      // Reset progress to zero and return the record to its active state so the UI and any
+      // re-entrant resume emitters see it downloading rather than paused. A reconstructed url is
+      // written back onto the record.
+      this.#api.store.dispatch(
+        downloadProgress(
+          downloadId,
+          0,
+          download.size ?? 0,
+          storedUrl === undefined ? [rawUrl] : undefined,
+        ),
+      );
+      this.#api.store.dispatch(pauseDownload(downloadId, false));
+
+      const collationId = this.#nextCollationId++;
+      this.#pending.set(collationId, { encodedUrl });
+
+      // Drop the unusable partial and stale checkpoint so the transfer starts over from zero.
+      await rm(dest, { force: true });
+      this.#api.store.dispatch(clearDownloadCheckpoint(downloadId));
+
+      try {
+        // Passing the existing downloadId makes main replace the previous attempt and start the
+        // transfer from scratch under the same id.
+        await window.api.downloader.start(dest, collationId, downloadId);
+      } catch (err) {
+        // The partial and checkpoint are already gone, so mark the record failed rather than
+        // leaving it stuck in an active state the poll loop never tracks.
+        this.#api.store.dispatch(finishDownload(downloadId, "failed", unknownToError(err)));
+        throw err;
+      } finally {
+        this.#pending.delete(collationId);
+        this.#resolvedMeta.delete(collationId);
+      }
+
+      // Register the poll entry after start resolves (as #handleStartDownload does) so the poll
+      // never acts on the previous attempt's terminal handle. allowInstall is threaded from the
+      // resume caller: the collection installer and mod-update flow pass false because they own the
+      // install, while a manual resume leaves it undefined and defers to the automation setting.
+      this.#activeDownloads.set(downloadId, {
+        callback,
+        allowInstall,
+        lastBytesReceived: 0,
+        lastProgressDispatch: 0,
+        startedEventEmitted: false,
+      });
+    } finally {
+      this.#restoring.delete(downloadId);
+    }
+  }
+
+  // Rebuild an nxm source url from the persisted nexus ids for a record whose stored urls are
+  // empty. The rebuilt url carries no key/expires query, so non-premium accounts get the resolver's
+  // normal free-user handling.
+  #reconstructSourceUrl(
+    state: ReturnType<IExtensionApi["getState"]>,
+    downloadId: string,
+    download: IDownload,
+  ): string | undefined {
+    const ids = nexusIdsFromDownloadId(state, downloadId);
+    if (ids?.gameDomainName === undefined) return undefined;
+
+    if (ids.collectionSlug !== undefined) {
+      const revisionNumber: number | undefined = download.modInfo?.nexus?.ids?.revisionNumber;
+      if (revisionNumber === undefined) return undefined;
+      return `nxm://${ids.gameDomainName}/collections/${ids.collectionSlug}/revisions/${revisionNumber}`;
+    }
+
+    if (ids.modId !== undefined && ids.fileId !== undefined) {
+      return `nxm://${ids.gameDomainName}/mods/${ids.modId}/files/${ids.fileId}`;
+    }
+
+    return undefined;
   }
 
   async #pollLoop(interval: number): Promise<void> {
@@ -706,6 +861,12 @@ export class IPCDownloadAdapter {
     const now = Date.now();
 
     let totalDeltaBytes = 0;
+    // Non-terminal progress updates are collected and dispatched as ONE batched store update per
+    // poll tick instead of one per download. Each separate dispatch replaces persistent.downloads
+    // and forces every subscriber to recompute; with many concurrent downloads (large collections)
+    // that per-download churn saturates the renderer. Terminal updates stay inline below to keep
+    // their ordering relative to finishDownload/removeDownload.
+    const progressActions: Array<ReturnType<typeof downloadProgress>> = [];
     for (const [downloadId, state] of Object.entries(states)) {
       const activeDownload = this.#activeDownloads.get(downloadId);
       if (activeDownload === undefined) continue;
@@ -730,9 +891,21 @@ export class IPCDownloadAdapter {
         activeDownload.lastProgressDispatch = now;
         // Update received/total bytes. The reducer transitions state from
         // "init" to "started" on first non-zero received, driving the progress bar.
-        this.#api.store.dispatch(
-          downloadProgress(downloadId, state.bytesReceived, state.size ?? 0, []),
+        // No urls: they would overwrite the download's stored source urls, which #restoreDownload
+        // needs to re-resolve a checkpointless download.
+        const action = downloadProgress(
+          downloadId,
+          state.bytesReceived,
+          state.size ?? 0,
+          undefined,
         );
+        if (isTerminal) {
+          // dispatch inline so it stays ordered before this download's terminal handling below;
+          // a batched progress landing after finishDownload could resurrect a finished download
+          this.#api.store.dispatch(action);
+        } else {
+          progressActions.push(action);
+        }
       }
 
       if (!isTerminal) continue;
@@ -759,6 +932,11 @@ export class IPCDownloadAdapter {
         this.#api.events.emit("did-finish-download", downloadId, "failed");
         activeDownload.callback?.(err ?? new Error("download failed"), downloadId);
       }
+    }
+
+    // one store update for all of this tick's non-terminal progress (see comment above the loop)
+    if (progressActions.length > 0) {
+      batchDispatch(this.#api.store, progressActions);
     }
 
     this.#speedAccumBytes += totalDeltaBytes;
@@ -872,5 +1050,10 @@ const resumeDownloadArgsSchema = z
   .tuple([
     z.string(),
     z.function({ input: [z.unknown().nullable(), z.string().optional()] }).optional(),
+    z
+      .object({
+        allowInstall: z.union([z.boolean(), z.literal("force")]).optional(),
+      })
+      .optional(),
   ])
   .rest(z.unknown());

--- a/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -11,6 +11,7 @@ import { useSelector } from "react-redux";
 
 import { CollectionsDownloadClickedEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
 import { getGame } from "@/extensions/gamemode_management/util/getGame";
+import { buildNXMCollectionUrl } from "@/extensions/nexus_integration/NXMUrl";
 import { nexusGameId } from "@/extensions/nexus_integration/util/convertGameId";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IState } from "@/types/IState";
@@ -132,7 +133,11 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
   const handleAddCollection = (collection: ICollection) => {
     const revisionNumber = collection.latestPublishedRevision?.revisionNumber || "latest";
     // Use the game domain name from the collection data (already converted)
-    const nxmUrl = `nxm://${collection.game.domainName}/collections/${collection.slug}/revisions/${revisionNumber}`;
+    const nxmUrl = buildNXMCollectionUrl(
+      collection.game.domainName,
+      collection.slug,
+      revisionNumber,
+    );
 
     // Track the download click event
     api.events.emit(

--- a/src/renderer/src/extensions/download_management/actions/state.test.ts
+++ b/src/renderer/src/extensions/download_management/actions/state.test.ts
@@ -15,11 +15,11 @@ describe("addLocalDownload", () => {
 
 describe("downloadProgress", () => {
   it("creates the action", () => {
-    const action = actions.downloadProgress("id", 42, 43, []);
+    const action = actions.downloadProgress("id", 42, 43, undefined);
     expect(action).toEqual({
       error: false,
       type: "DOWNLOAD_PROGRESS",
-      payload: { id: "id", received: 42, total: 43, urls: [] },
+      payload: { id: "id", received: 42, total: 43, urls: undefined },
     });
   });
 });

--- a/src/renderer/src/extensions/download_management/actions/state.ts
+++ b/src/renderer/src/extensions/download_management/actions/state.ts
@@ -24,7 +24,9 @@ export const initDownload = createAction(
  */
 export const downloadProgress = createAction(
   "DOWNLOAD_PROGRESS",
-  (id: string, received: number, total: number, urls: string[]) => ({
+  // urls replaces the download's stored source urls when given (e.g. after a redirect);
+  // undefined leaves them untouched
+  (id: string, received: number, total: number, urls: string[] | undefined) => ({
     id,
     received,
     total,

--- a/src/renderer/src/extensions/download_management/reducers/state.test.ts
+++ b/src/renderer/src/extensions/download_management/reducers/state.test.ts
@@ -50,6 +50,30 @@ describe("downloadProgress", () => {
       files: { id: { state: "started", received: 42, size: 43 } },
     });
   });
+  it("preserves the stored source urls when the payload carries none", () => {
+    // restart-on-resume re-resolves from urls[0]; a progress tick must not wipe it
+    const input = {
+      files: { id: { state: "started", received: 0, size: 43, urls: ["nxm://game/mods/1"] } },
+    };
+    const result = stateReducer.reducers.DOWNLOAD_PROGRESS(input, {
+      id: "id",
+      received: 42,
+      total: 43,
+    });
+    expect(result.files.id.urls).toEqual(["nxm://game/mods/1"]);
+  });
+  it("replaces the stored source urls when the payload carries some", () => {
+    const input = {
+      files: { id: { state: "started", received: 0, size: 43, urls: ["https://old"] } },
+    };
+    const result = stateReducer.reducers.DOWNLOAD_PROGRESS(input, {
+      id: "id",
+      received: 42,
+      total: 43,
+      urls: ["https://redirected"],
+    });
+    expect(result.files.id.urls).toEqual(["https://redirected"]);
+  });
   it("updates the total", () => {
     const input = { files: { id: { state: "started", received: 0, size: 0 } } };
     const result = stateReducer.reducers.DOWNLOAD_PROGRESS(input, {

--- a/src/renderer/src/extensions/nexus_integration/NXMUrl.ts
+++ b/src/renderer/src/extensions/nexus_integration/NXMUrl.ts
@@ -1,6 +1,9 @@
 import { URL } from "url";
 
 import { DataInvalid } from "../../util/CustomErrors";
+import type { IDownload } from "../download_management/types/IDownload";
+import type { IGameStoredExt } from "../gamemode_management/types/IGameStored";
+import { toNXMId } from "./util/convertGameId";
 
 const sUrlExpression = /\/mods\/(\d+)\/files\/(\d+)/i;
 const sCollectionUrlExpression = /\/collections\/(\w+)\/revisions\/(\d+|latest)/i;
@@ -196,6 +199,70 @@ class NXMUrl {
   public getParam(key: string): string {
     return this.mExtraParams[key];
   }
+}
+
+/**
+ * assemble an nxm mod-file url from an already nxm-ready domain. Prefer nxmModUrl when you hold a
+ * game object; use this only when the domain is already resolved (e.g. from a persisted download).
+ */
+export function buildNXMModUrl(
+  domain: string,
+  modId: number | string,
+  fileId: number | string,
+): string {
+  return `nxm://${domain}/mods/${modId}/files/${fileId}`;
+}
+
+/**
+ * assemble an nxm collection url from an already nxm-ready domain.
+ */
+export function buildNXMCollectionUrl(
+  domain: string,
+  slug: string,
+  revisionNumber: number | string,
+): string {
+  return `nxm://${domain}/collections/${slug}/revisions/${revisionNumber}`;
+}
+
+/**
+ * build the canonical nxm mod-file url for a game, resolving the nxm link id via toNXMId.
+ */
+export function nxmModUrl(
+  game: IGameStoredExt,
+  gameId: string,
+  modId: number | string,
+  fileId: number | string,
+): string {
+  return buildNXMModUrl(toNXMId(game, gameId), modId, fileId);
+}
+
+/**
+ * Rebuild the source nxm url for a download from its persisted nexus ids, for records whose stored
+ * urls are empty. Returns undefined when the download carries no usable nexus identity (or a
+ * collection download lacks a revision number). The rebuilt url carries no key/expires query, so
+ * non-premium accounts get the resolver's normal free-user handling.
+ */
+export function nxmUrlFromDownload(download: IDownload): string | undefined {
+  const ids = download?.modInfo?.nexus?.ids;
+  const meta = download?.modInfo?.meta;
+  // A record with neither a nexus nor a meta game id is not a resumable nexus download.
+  if (ids?.gameId == null && meta?.gameId == null) {
+    return undefined;
+  }
+  const domain = ids?.gameId || meta?.domainName;
+  if (!domain) {
+    return undefined;
+  }
+  if (ids?.collectionSlug != null) {
+    if (ids.revisionNumber == null) {
+      return undefined;
+    }
+    return buildNXMCollectionUrl(domain, ids.collectionSlug, ids.revisionNumber);
+  }
+  if (ids?.modId != null && ids?.fileId != null) {
+    return buildNXMModUrl(domain, ids.modId, ids.fileId);
+  }
+  return undefined;
 }
 
 export default NXMUrl;

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -1120,8 +1120,10 @@ export function onDownloadUpdate(
 
         if (existingId !== undefined) {
           if (downloads[existingId].state === "paused") {
+            // allowInstall: false - the caller (InstallManager.downloadMatching) owns the
+            // installation of this download; auto-install on completion would install it twice.
             return Bluebird.fromCallback((cb) =>
-              api.events.emit("resume-download", existingId, cb),
+              api.events.emit("resume-download", existingId, cb, { allowInstall: false }),
             ).then(() => ({ error: null, dlId: existingId }));
           } else {
             return Bluebird.resolve({ error: null, dlId: existingId });

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -55,6 +55,7 @@ import { setUpdatingMods } from "../mod_management/actions/session";
 import type { IModListItem } from "../news_dashlet/types";
 import { setUserInfo } from "./actions/persistent";
 import { NEXUS_BASE_URL, NEXUS_GAMES_URL } from "./constants";
+import { nxmModUrl } from "./NXMUrl";
 import { isLoggedIn } from "./selectors";
 import type { IValidateKeyDataV2 } from "./types/IValidateKeyData";
 import {
@@ -74,7 +75,7 @@ import {
   updateToken,
 } from "./util";
 import { findLatestUpdate, retrieveModInfo } from "./util/checkModsVersion";
-import { nexusGameId, toNXMId, convertGameIdReverse } from "./util/convertGameId";
+import { nexusGameId, convertGameIdReverse } from "./util/convertGameId";
 import {
   FULL_COLLECTION_INFO,
   FULL_REVISION_INFO,
@@ -375,7 +376,7 @@ function downloadFile(
     return Bluebird.reject(new ProcessCanceled("Only available to premium users"));
   }
   // TODO: Need some way to identify if this request is actually for a nexus mod
-  const url = `nxm://${toNXMId(game, gameId)}/mods/${modId}/files/${fileId}`;
+  const url = nxmModUrl(game, gameId, modId, fileId);
   log("debug", "downloading from generated nxm link", { url, fileName });
 
   const downloads = state.persistent.downloads.files;
@@ -519,7 +520,7 @@ export function onModUpdate(api: IExtensionApi, nexus: Nexus) {
       })
       .catch(DownloadIsHTML, (err) => undefined)
       .catch(DataInvalid, () => {
-        const url = `nxm://${toNXMId(game, gameId)}/mods/${modId}/files/${fileId}`;
+        const url = nxmModUrl(game, gameId, modId, fileId);
         api.showErrorNotification("Invalid URL", url, { allowReport: false });
       })
       .catch(ProcessCanceled, () => {
@@ -1102,9 +1103,7 @@ export function onDownloadUpdate(
           updateFileId = fileIdNum;
         }
 
-        const urlParsed = new URL(
-          `nxm://${toNXMId(game, gameId)}/mods/${modId}/files/${updateFileId}`,
-        );
+        const urlParsed = new URL(nxmModUrl(game, gameId, modId, updateFileId));
         if (campaign !== undefined) {
           urlParsed.searchParams.set("campaign", campaign);
         }
@@ -1147,7 +1146,7 @@ export function onDownloadUpdate(
         if (err instanceof UserCanceled) {
           // there is a really good chance that the download will fail
           log("warn", "failed to fetch mod file list", err.message);
-          const urlParsed = new URL(`nxm://${toNXMId(game, gameId)}/mods/${modId}/files/${fileId}`);
+          const urlParsed = new URL(nxmModUrl(game, gameId, modId, fileId));
           if (campaign !== undefined) {
             urlParsed.searchParams.set("campaign", campaign);
           }

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -86,7 +86,7 @@ import {
   REVALIDATION_FREQUENCY,
 } from "./constants";
 import * as eh from "./eventHandlers";
-import NXMUrl from "./NXMUrl";
+import NXMUrl, { buildNXMModUrl } from "./NXMUrl";
 import { accountReducer } from "./reducers/account";
 import { persistentReducer } from "./reducers/persistent";
 import { sessionReducer } from "./reducers/session";
@@ -921,7 +921,7 @@ function makeRepositoryLookup(api: IExtensionApi, nexusConn: NexusT) {
           fileVersion: modFileInfo.version,
           gameId: modFileInfo.game.id.toString(),
           domainName: modFileInfo.game.domainName,
-          sourceURI: `nxm://${repoInfo.gameId}/mods/${modId}/files/${fileId}`,
+          sourceURI: buildNXMModUrl(repoInfo.gameId, modId, fileId),
           source: "nexus",
           logicalFileName: modFileInfo.name,
           archived: modFileInfo.categoryId === 7,

--- a/src/renderer/src/extensions/nexus_integration/util/guessModID.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/guessModID.ts
@@ -13,8 +13,7 @@ import { setModAttribute } from "../../mod_management/actions/mods";
 import type { IMod } from "../../mod_management/types/IMod";
 import modName from "../../mod_management/util/modName";
 import { activeGameId } from "../../profile_management/selectors";
-import NXMUrl from "../NXMUrl";
-import { toNXMId } from "./convertGameId";
+import NXMUrl, { nxmModUrl } from "../NXMUrl";
 
 export function guessFromFileName(fileName: string): string {
   const match = fileName.match(/-([0-9]+)-/);
@@ -160,7 +159,12 @@ export function fillNexusIdByMD5(
           if (!game) {
             return acc;
           }
-          const url = `nxm://${toNXMId(game, iter.value.gameId)}/mods/${mod.attributes.modId}/files/${mod.attributes.fileId}`;
+          const url = nxmModUrl(
+            game,
+            iter.value.gameId,
+            mod.attributes.modId,
+            mod.attributes.fileId,
+          );
           acc.push({ ...iter, value: { ...iter.value, sourceURI: url } });
         } else if (hasUri) {
           acc.push(iter);

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -391,7 +391,11 @@ export interface InvokeChannels {
   "styles:compile": (filePaths: string[]) => Promise<string>;
 
   // Download channels
-  "download:start": (dest: string, collationId: number) => Promise<{ downloadId: string }>;
+  "download:start": (
+    dest: string,
+    collationId: number,
+    downloadId?: string,
+  ) => Promise<{ downloadId: string }>;
   "download:pause": (downloadId: string) => Promise<WireDownloadCheckpoint>;
   "download:resume": (checkpoint: WireDownloadCheckpoint) => Promise<void>;
   "download:cancel": (downloadId: string) => Promise<void>;

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -471,8 +471,11 @@ export interface DownloaderApi {
    * Enqueues a download. The caller must generate `collationId` and register
    * any resolve handler before calling this, so that the main-side resolve
    * callback cannot arrive before the handler is ready.
+   *
+   * Passing `downloadId` restores an existing download: the transfer starts from
+   * scratch under that id, replacing any previous attempt tracked for it.
    */
-  start(dest: string, collationId: number): Promise<{ downloadId: string }>;
+  start(dest: string, collationId: number, downloadId?: string): Promise<{ downloadId: string }>;
 
   /** Pauses an active download and returns a checkpoint for later resumption. */
   pause(downloadId: string): Promise<WireDownloadCheckpoint>;


### PR DESCRIPTION
`resume-download` throws `No checkpoint stored` for a paused download with no usable checkpoint (missing, or  completedRanges: []`), so collection installs and the Downloads page retry forever.

**Changed:**
- `IPCDownloadAdapter` restarts such a download under the same id instead of throwing: re-resolves the source (rebuilding the nxm url from stored nexus ids when `urls` were wiped), clears the partial/checkpoint, and starts fresh via a
new optional `downloadId` on `download:start`. `allowInstall` from the resume options is honored so the installer owns the install, and the poll no longer wipes stored urls.

- Consolidate nxm link construction into NXMUrl builders

**Testing**
Unit tests cover restore (missing/empty checkpoint), url reconstruction, `allowInstall`, start-failure, and the unchanged resume; full
renderer suite green. Dev-verified: pause-before-first-chunk resume, collection dependency, and checkpointed resume.

A refactor of the tests is required when merged into master to avoid the currently in-line harness.

Fixes LAZ-692