### PR TITLE
Refine the e2e skill to try and reuse existing logic and create helpers rather than duplicate

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -31,6 +31,10 @@ Read the relevant existing files to understand patterns and available building b
 - `packages/e2e/src/selectors/` — existing POMs (check if a relevant one already exists)
 - `packages/e2e/src/helpers/` — shared utilities (navigation, timeouts, users, etc.)
 - `packages/e2e/src/fixtures/vortex-app.ts` — available fixtures
+- `packages/e2e/src/tests/` — existing specs; skim them for flows you'll need
+  (download a mod, log in, manage a game, navigate to a page). If another test
+  already does what you're about to write, that's a signal to reuse or extract
+  it — see "Reuse over duplication" in Step 3.
 - Source code under `src/renderer/` for UI component structure and text strings
 
 ## Step 3 — Write a first draft
@@ -50,6 +54,14 @@ await llmBreakpoint(vortexWindow, "after manage game");
 
 `llmBreakpoint` is a no-op unless `VORTEX_E2E_INSPECT` is set, so the calls are
 safe to leave in the spec while iterating. Strip them once the test is green.
+
+### Reuse over duplication (DRY)
+
+Before writing a block of logic, check whether an existing spec already does the
+same thing (a download flow, a login sequence, a multi-step navigation). If so,
+don't copy it — follow the **Helpers** guidance in `E2E-BEST-PRACTICES.md`:
+extract it into a `packages/e2e/src/helpers/` function, call it from your test,
+and update the other spec(s) to use the same helper.
 
 ## Step 4 — Inspector loop (run, walk, fix, repeat)
 

--- a/packages/e2e/E2E-BEST-PRACTICES.md
+++ b/packages/e2e/E2E-BEST-PRACTICES.md
@@ -177,6 +177,20 @@ test("settings loads", async ({ vortexWindow }) => {
 });
 ```
 
+When you catch yourself writing logic that another spec already contains (a
+download flow, a login sequence, a multi-step navigation, forwarding an `nxm://`
+URL to Vortex), **do not copy it**:
+
+1. Extract the shared logic into a helper under `packages/e2e/src/helpers/`
+   (parameterized as needed); keep selectors in POMs — helpers orchestrate POMs
+   and fixtures, they don't hold their own selectors.
+2. Call the helper from your test.
+3. Update the other spec(s) that had the inline copy to use the same helper.
+
+The behavior then lives in exactly one place, so an app change is fixed once.
+Prefer a small, well-named helper (e.g. `downloadModViaModManager`) over
+near-identical copies across specs.
+
 ### Auth Fixtures
 
 Tests that require a logged-in user use the `nexusUser` fixture option. Set it


### PR DESCRIPTION
E2E-BEST-PRACTICES.md: expand the Helpers section with the workflow for pulling logic that already exists in another spec into a shared helper and updating the other specs to use it. e2e-test skill: scan existing specs for reusable flows (Step 2) and reference the doc's Helpers guidance rather than duplicating it (Step 3).