### PR TITLE
track mod enable/disable/remove and install kind in mixpanel

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -2192,6 +2192,10 @@ interface IEnableOptions {
     // (undocumented)
     installed?: boolean;
     // (undocumented)
+    reason?: ModChangeReason;
+    // (undocumented)
+    skipStateChangeEvent?: boolean;
+    // (undocumented)
     willBeReplaced?: boolean;
 }
 
@@ -3486,6 +3490,8 @@ interface IProfile {
 // @public (undocumented)
 interface IProfileMod {
     // (undocumented)
+    disabledTime?: number;
+    // (undocumented)
     enabled: boolean;
     // (undocumented)
     enabledTime: number;
@@ -3600,6 +3606,8 @@ interface IRemoveModOptions {
     modData?: IMod;
     // (undocumented)
     progressCB?: (numRemoved: number, numTotal: number, name: string) => void;
+    // (undocumented)
+    reason?: ModChangeReason;
     // (undocumented)
     silent?: boolean;
     // (undocumented)
@@ -4652,6 +4660,9 @@ export class Modal extends React_2.PureComponent<typeof Modal_2.prototype.props,
     // (undocumented)
     static Title: typeof ModalTitle;
 }
+
+// @public
+type ModChangeReason = "user_manual" | "variant_replace" | "version_update" | "profile_replace" | "collection_update" | "collection_uninstall" | "stop_managing_game" | "health_check";
 
 // Warning: (ae-forgotten-export) The symbol "INameOptions" needs to be exported by the entry point api.d.ts
 //
@@ -6468,6 +6479,7 @@ declare namespace util {
         Normalize,
         ISteamEntry,
         CollectionInstallOutcomeProps,
+        ModChangeReason,
         Archive,
         ArgumentInvalid,
         batchDispatch,

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -343,7 +343,12 @@ export class IPCDownloadAdapter {
     }
 
     if (eventType === "completed") {
-      const duration_ms = Date.now() - (download?.fileTime ?? Date.now());
+      // Elapsed since the download's durable startTime (stamped when it first transitions to
+      // "started", preserved across pause/resume and restarts). 0 when there is no start stamp
+      // (e.g. locally-added archives).
+      const startTime = download?.startTime;
+      const duration_ms =
+        typeof startTime === "number" && startTime > 0 ? Date.now() - startTime : 0;
       const file_size = download?.size ?? 0;
       if (isCollection && nexusIds.collectionId && nexusIds.revisionId) {
         this.#api.events.emit(

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -421,11 +421,30 @@ export class ModsDownloadFailedEvent implements MixpanelEvent {
   }
 }
 
+/**
+ * What kind of install produced a mod, on the mods_installation_* events. Lets the data team
+ * separate fresh installs from version bumps, reinstalls, and the two name-conflict resolutions.
+ *   - fresh: no prior version of this mod was installed.
+ *   - version_update: a different file (version) of an already-installed mod.
+ *   - reinstall: the same file (version) reinstalled over itself.
+ *   - variant: installed as a second, coexisting copy under a different variant name.
+ *   - profile_replace: replaced the existing mod across all local profiles.
+ */
+export type ModInstallKind =
+  | "fresh"
+  | "version_update"
+  | "reinstall"
+  | "variant"
+  | "profile_replace";
+
+/** Fields shared by every per-mod install event: identity + how the install came about. */
+type ModInstallProps = ModAnalyticsIdentity & { install_kind: ModInstallKind };
+
 /** Event sent when mod installation is started. Not sent for the collection bundle/manifest mod. */
 export class ModsInstallationStartedEvent implements MixpanelEvent {
   readonly eventName = "mods_installation_started";
   readonly properties: Record<string, any>;
-  constructor(props: ModAnalyticsIdentity) {
+  constructor(props: ModInstallProps) {
     this.properties = { ...props };
   }
 }
@@ -434,7 +453,7 @@ export class ModsInstallationStartedEvent implements MixpanelEvent {
 export class ModsInstallationCompletedEvent implements MixpanelEvent {
   readonly eventName = "mods_installation_completed";
   readonly properties: Record<string, any>;
-  constructor(props: ModAnalyticsIdentity & { duration_ms: number }) {
+  constructor(props: ModInstallProps & { duration_ms: number }) {
     this.properties = { ...props };
   }
 }
@@ -443,7 +462,7 @@ export class ModsInstallationCompletedEvent implements MixpanelEvent {
 export class ModsInstallationCancelledEvent implements MixpanelEvent {
   readonly eventName = "mods_installation_cancelled";
   readonly properties: Record<string, any>;
-  constructor(props: ModAnalyticsIdentity) {
+  constructor(props: ModInstallProps) {
     this.properties = { ...props };
   }
 }
@@ -452,7 +471,62 @@ export class ModsInstallationCancelledEvent implements MixpanelEvent {
 export class ModsInstallationFailedEvent implements MixpanelEvent {
   readonly eventName = "mods_installation_failed";
   readonly properties: Record<string, any>;
-  constructor(props: ModAnalyticsIdentity & { error_code: string; error_message: string }) {
+  constructor(props: ModInstallProps & { error_code: string; error_message: string }) {
+    this.properties = { ...props };
+  }
+}
+
+/**
+ * Why a mod was enabled/disabled/removed, on the ModsStateChanged / ModsRemoved events.
+ * A small, closed vocabulary so the data team can slice programmatic churn (collection
+ * updates/uninstalls, variant/version/profile replacement, health-check remediation) from
+ * user-driven changes. Install-completion enables are not represented here: they are covered
+ * by the mods_installation_* events, so no enable is emitted for them.
+ */
+export type ModChangeReason =
+  | "user_manual"
+  | "variant_replace"
+  | "version_update"
+  | "profile_replace"
+  | "collection_update"
+  | "collection_uninstall"
+  | "stop_managing_game"
+  | "health_check";
+
+/**
+ * Event sent when a mod is enabled or disabled in a profile. Shares the per-mod identity
+ * so it joins to the mod's download/install events; `reason` records what drove the change.
+ * Not sent for the collection mod itself (collections have their own lifecycle events) nor
+ * for mods without a Nexus file id (bundled/local), matching the other per-mod events.
+ *
+ * `duration_ms` is how long the mod spent in the prior state before this change: time enabled on
+ * a disable, time disabled on an enable. 0 when that span is unknown (never in that state).
+ */
+export class ModsStateChangedEvent implements MixpanelEvent {
+  readonly eventName = "mods_state_changed";
+  readonly properties: Record<string, any>;
+  constructor(
+    props: ModAnalyticsIdentity & {
+      change: "enabled" | "disabled";
+      reason: ModChangeReason;
+      duration_ms: number;
+    },
+  ) {
+    this.properties = { ...props };
+  }
+}
+
+/**
+ * Event sent when a mod is removed. `will_be_replaced` marks removals that are part of a
+ * reinstall/variant/version replacement (a new mod takes its place) rather than a genuine
+ * uninstall. Same gating and identity as ModsStateChangedEvent.
+ */
+export class ModsRemovedEvent implements MixpanelEvent {
+  readonly eventName = "mods_removed";
+  readonly properties: Record<string, any>;
+  constructor(
+    props: ModAnalyticsIdentity & { reason: ModChangeReason; will_be_replaced: boolean },
+  ) {
     this.properties = { ...props };
   }
 }

--- a/src/renderer/src/extensions/analytics/mixpanel/modAnalyticsIdentity.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modAnalyticsIdentity.ts
@@ -1,12 +1,16 @@
-import type { nexusIdsFromDownloadId } from "../../nexus_integration/selectors";
 import { makeModAndFileUIDs } from "../../nexus_integration/util/UIDs";
 import type { ModAnalyticsIdentity } from "./MixpanelEvents";
 
 /**
- * The resolved nexus identity of a download record. A collection is itself a mod, so
- * this same shape describes both a mod and a collection - we take the mod fields here.
+ * The nexus fields needed to build an analytics identity. A collection is itself a mod, so
+ * this same shape describes both; satisfied both by a resolved download record
+ * (nexusIdsFromDownloadId) and by an installed mod's own attributes.
  */
-type ResolvedNexusIds = NonNullable<ReturnType<typeof nexusIdsFromDownloadId>>;
+export interface ModNexusIds {
+  numericGameId: number;
+  modId: string;
+  fileId: string;
+}
 
 /**
  * Builds the shared per-mod analytics identity (mod/file ids + UIDs + collection_id)
@@ -14,7 +18,7 @@ type ResolvedNexusIds = NonNullable<ReturnType<typeof nexusIdsFromDownloadId>>;
  * identity. `collectionId` is the parent collection when installed as part of one, else null.
  */
 export function makeModAnalyticsIdentity(
-  nexusIds: ResolvedNexusIds,
+  nexusIds: ModNexusIds,
   collectionId: string | null,
 ): ModAnalyticsIdentity {
   const { modUID, fileUID } = makeModAndFileUIDs(

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the mod enable/disable/remove analytics. The emit helpers resolve identity from the
+ * mod's own Nexus attributes and gate out collections and non-Nexus (bundled/local) mods; the
+ * exported onRemoveMods is driven end to end to prove the removal reason threads onto mods_removed.
+ */
+import { expect } from "vitest";
+
+import { makeMod, makeProfile, makeProfileMod } from "../../../test-utils/builders";
+import type { IModChangeHarness } from "../../../test-utils/harnessTypes";
+import { test } from "../../../test-utils/modChangeTest";
+import { onRemoveMods } from "../../mod_management/eventHandlers";
+import type InstallManager from "../../mod_management/InstallManager";
+import type { IMod } from "../../mod_management/types/IMod";
+import type { IProfileMod } from "../../profile_management/types/IProfile";
+import { emitModRemoved, emitModStateChanged } from "./modChangeAnalytics";
+
+const GAME = "skyrimse";
+const MOD = "mod-1";
+const PROFILE = "prof-1";
+const NEXUS_ATTRS = { source: "nexus", modId: 100, fileId: 200, downloadGame: GAME };
+
+const nexusMod = (attributeOverrides: Record<string, unknown> = {}): IMod =>
+  makeMod({ id: MOD, attributes: { ...NEXUS_ATTRS, ...attributeOverrides } });
+
+const seed = (mod: IMod) => ({ mods: { [GAME]: { [MOD]: mod } } });
+
+// Seed the mod's state in the game's active profile, so a change can measure how long it had
+// spent in the prior state (enabledTime for a disable, disabledTime for an enable).
+const seedModState = (h: IModChangeHarness, modState: Partial<IProfileMod>) =>
+  h.setState((draft) => {
+    draft.settings.profiles.lastActiveProfile[GAME] = PROFILE;
+    draft.persistent.profiles[PROFILE] = makeProfile({
+      id: PROFILE,
+      gameId: GAME,
+      modState: { [MOD]: makeProfileMod(modState) },
+    });
+  });
+
+test("emitModStateChanged emits mods_state_changed with the change, reason and Nexus identity", ({
+  makeModChange,
+}) => {
+  const h = makeModChange(seed(nexusMod()));
+  emitModStateChanged(h.api, GAME, MOD, "enabled", "user_manual");
+  expect(h.mixpanelEvents).toHaveLength(1);
+  expect(h.mixpanelEvents[0].eventName).toBe("mods_state_changed");
+  expect(h.mixpanelEvents[0].properties).toMatchObject({
+    change: "enabled",
+    reason: "user_manual",
+    mod_id: "100",
+    file_id: "200",
+    collection_id: null,
+  });
+});
+
+test("carries a disabled change with the supplied reason and collection id", ({
+  makeModChange,
+}) => {
+  const h = makeModChange(seed(nexusMod()));
+  emitModStateChanged(h.api, GAME, MOD, "disabled", "variant_replace", "col-1");
+  expect(h.mixpanelEvents[0].properties).toMatchObject({
+    change: "disabled",
+    reason: "variant_replace",
+    collection_id: "col-1",
+  });
+});
+
+test("a disable reports how long the mod had been enabled as duration_ms", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod()));
+  seedModState(h, { enabled: true, enabledTime: Date.now() - 60_000 });
+  emitModStateChanged(h.api, GAME, MOD, "disabled", "user_manual");
+  expect(h.mixpanelEvents[0].properties.duration_ms).toBeGreaterThanOrEqual(60_000);
+});
+
+test("an enable reports how long the mod had been disabled as duration_ms", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod()));
+  seedModState(h, { enabled: false, disabledTime: Date.now() - 60_000 });
+  emitModStateChanged(h.api, GAME, MOD, "enabled", "user_manual");
+  expect(h.mixpanelEvents[0].properties.duration_ms).toBeGreaterThanOrEqual(60_000);
+});
+
+test("reports duration_ms 0 when the prior-state timestamp is unknown", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod()));
+  seedModState(h, { enabled: false }); // never disabled with a stamp -> unknown
+  emitModStateChanged(h.api, GAME, MOD, "enabled", "user_manual");
+  expect(h.mixpanelEvents[0].properties.duration_ms).toBe(0);
+});
+
+test("does not emit for a non-Nexus (bundled/local) mod", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod({ source: "user-generated" })));
+  emitModStateChanged(h.api, GAME, MOD, "enabled", "user_manual");
+  expect(h.mixpanelEvents).toHaveLength(0);
+});
+
+test("does not emit when the mod has no Nexus file id", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod({ fileId: undefined })));
+  emitModStateChanged(h.api, GAME, MOD, "enabled", "user_manual");
+  expect(h.mixpanelEvents).toHaveLength(0);
+});
+
+test("does not emit for an unknown mod id", ({ makeModChange }) => {
+  const h = makeModChange(seed(nexusMod()));
+  emitModStateChanged(h.api, GAME, "does-not-exist", "enabled", "user_manual");
+  expect(h.mixpanelEvents).toHaveLength(0);
+});
+
+test("emitModRemoved emits mods_removed with the reason and will_be_replaced", ({
+  makeModChange,
+}) => {
+  const h = makeModChange();
+  emitModRemoved(h.api, nexusMod(), "collection_uninstall", true);
+  expect(h.mixpanelEvents).toHaveLength(1);
+  expect(h.mixpanelEvents[0].eventName).toBe("mods_removed");
+  expect(h.mixpanelEvents[0].properties).toMatchObject({
+    reason: "collection_uninstall",
+    will_be_replaced: true,
+    mod_id: "100",
+  });
+});
+
+test("emitModRemoved does not emit for a non-Nexus mod", ({ makeModChange }) => {
+  const h = makeModChange();
+  emitModRemoved(
+    h.api,
+    makeMod({ id: MOD, attributes: { source: "user-generated" } }),
+    "user_manual",
+    false,
+  );
+  expect(h.mixpanelEvents).toHaveLength(0);
+});
+
+test("onRemoveMods threads the removal reason onto mods_removed", async ({ makeModChange }) => {
+  // no installationPath -> undeploy filters it out and the fs removal branch is skipped
+  const mod = nexusMod();
+  mod.installationPath = undefined;
+  const h = makeModChange(seed(mod));
+  const installManager = { markRecentRemoval: () => undefined } as unknown as InstallManager;
+
+  await new Promise<void>((resolve) =>
+    onRemoveMods(h.api, [], installManager, GAME, [MOD], () => resolve(), {
+      reason: "collection_uninstall",
+    }),
+  );
+
+  const removed = h.mixpanelEvents.filter((e) => e.eventName === "mods_removed");
+  expect(removed).toHaveLength(1);
+  expect(removed[0].properties).toMatchObject({
+    reason: "collection_uninstall",
+    mod_id: "100",
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
@@ -8,7 +8,6 @@ import { expect } from "vitest";
 import { makeMod, makeProfile, makeProfileMod } from "../../../test-utils/builders";
 import type { IModChangeHarness } from "../../../test-utils/harnessTypes";
 import { test } from "../../../test-utils/modChangeTest";
-import { onRemoveMods } from "../../mod_management/eventHandlers";
 import type InstallManager from "../../mod_management/InstallManager";
 import type { IMod } from "../../mod_management/types/IMod";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
@@ -129,6 +128,7 @@ test("emitModRemoved does not emit for a non-Nexus mod", ({ makeModChange }) => 
 });
 
 test("onRemoveMods threads the removal reason onto mods_removed", async ({ makeModChange }) => {
+  const { onRemoveMods } = await import("../../mod_management/eventHandlers");
   // no installationPath -> undeploy filters it out and the fs removal branch is skipped
   const mod = nexusMod();
   mod.installationPath = undefined;

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
@@ -1,14 +1,13 @@
 /**
- * Tests for the mod enable/disable/remove analytics. The emit helpers resolve identity from the
- * mod's own Nexus attributes and gate out collections and non-Nexus (bundled/local) mods; the
- * exported onRemoveMods is driven end to end to prove the removal reason threads onto mods_removed.
+ * Tests for the mod enable/disable/remove analytics: the emit helpers resolve identity from the
+ * mod's own Nexus attributes, gate out collections and non-Nexus (bundled/local) mods, and carry
+ * the change/reason/duration.
  */
 import { expect } from "vitest";
 
 import { makeMod, makeProfile, makeProfileMod } from "../../../test-utils/builders";
 import type { IModChangeHarness } from "../../../test-utils/harnessTypes";
 import { test } from "../../../test-utils/modChangeTest";
-import type InstallManager from "../../mod_management/InstallManager";
 import type { IMod } from "../../mod_management/types/IMod";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 import { emitModRemoved, emitModStateChanged } from "./modChangeAnalytics";
@@ -125,26 +124,4 @@ test("emitModRemoved does not emit for a non-Nexus mod", ({ makeModChange }) => 
     false,
   );
   expect(h.mixpanelEvents).toHaveLength(0);
-});
-
-test("onRemoveMods threads the removal reason onto mods_removed", async ({ makeModChange }) => {
-  const { onRemoveMods } = await import("../../mod_management/eventHandlers");
-  // no installationPath -> undeploy filters it out and the fs removal branch is skipped
-  const mod = nexusMod();
-  mod.installationPath = undefined;
-  const h = makeModChange(seed(mod));
-  const installManager = { markRecentRemoval: () => undefined } as unknown as InstallManager;
-
-  await new Promise<void>((resolve) =>
-    onRemoveMods(h.api, [], installManager, GAME, [MOD], () => resolve(), {
-      reason: "collection_uninstall",
-    }),
-  );
-
-  const removed = h.mixpanelEvents.filter((e) => e.eventName === "mods_removed");
-  expect(removed).toHaveLength(1);
-  expect(removed[0].properties).toMatchObject({
-    reason: "collection_uninstall",
-    mod_id: "100",
-  });
 });

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
@@ -1,0 +1,110 @@
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IState } from "../../../types/IState";
+import { getGame } from "../../gamemode_management/util/getGame";
+import type { IMod } from "../../mod_management/types/IMod";
+import { nexusGames } from "../../nexus_integration/util";
+import { nexusGameId } from "../../nexus_integration/util/convertGameId";
+import type { ModAnalyticsIdentity, ModChangeReason } from "./MixpanelEvents";
+import { ModsRemovedEvent, ModsStateChangedEvent } from "./MixpanelEvents";
+import { makeModAnalyticsIdentity } from "./modAnalyticsIdentity";
+
+/**
+ * Resolves the per-mod analytics identity from an installed mod's own attributes, or undefined
+ * when it should not be tracked: not a Nexus mod, or missing mod/file id (the collection
+ * container and bundled/local mods), matching the gating on the download/install events.
+ *
+ * Uses the mod's own attributes, not its download record (which may be gone or belong to a
+ * different collection). `collection_id` is set only when a caller passes the driving collection.
+ */
+function resolveModIdentity(
+  mod: IMod | undefined,
+  collectionId: string | null,
+): ModAnalyticsIdentity | undefined {
+  const attributes = mod?.attributes ?? {};
+  const modId = attributes.modId;
+  const fileId = attributes.fileId;
+  // Gate on the Nexus identity (as the download/install events do); non-Nexus (bundled/local)
+  // mods and the collection container have no modId/fileId and are not tracked.
+  if (attributes.source !== "nexus" || modId == null || fileId == null) {
+    return undefined;
+  }
+  // downloadGame is our internal game id; the games cache is keyed by Nexus domain, so convert
+  // (skyrimse -> skyrimspecialedition) before matching. NaN when the game/cache can't resolve.
+  const domain =
+    attributes.downloadGame != null
+      ? nexusGameId(getGame(attributes.downloadGame), attributes.downloadGame)
+      : undefined;
+  const numericGameId = nexusGames().find((game) => game.domain_name === domain)?.id ?? Number.NaN;
+  return makeModAnalyticsIdentity(
+    { numericGameId, modId: modId.toString(), fileId: fileId.toString() },
+    collectionId,
+  );
+}
+
+/**
+ * How long the mod had spent in the prior state before this change, from the game's active-profile
+ * timestamps: a disable measures time enabled (enabledTime), an enable measures time disabled
+ * (disabledTime). 0 when the relevant timestamp is unknown (e.g. the mod was never in that state).
+ */
+function priorStateDurationMs(
+  state: IState,
+  gameId: string,
+  modId: string,
+  change: "enabled" | "disabled",
+): number {
+  const profileId = state.settings.profiles.lastActiveProfile?.[gameId];
+  const modState =
+    profileId != null ? state.persistent.profiles[profileId]?.modState?.[modId] : undefined;
+  const since = change === "disabled" ? modState?.enabledTime : modState?.disabledTime;
+  return typeof since === "number" && since > 0 ? Math.max(0, Date.now() - since) : 0;
+}
+
+/**
+ * Emits mods_state_changed for a mod being enabled/disabled. No-op for untracked mods
+ * (collection container, bundled/local). Looks the mod up by id so callers only need ids.
+ */
+export function emitModStateChanged(
+  api: IExtensionApi,
+  gameId: string,
+  modId: string,
+  change: "enabled" | "disabled",
+  reason: ModChangeReason,
+  collectionId: string | null = null,
+): void {
+  const state = api.getState();
+  const mod = state.persistent.mods[gameId]?.[modId];
+  const identity = resolveModIdentity(mod, collectionId);
+  if (identity === undefined) {
+    return;
+  }
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new ModsStateChangedEvent({
+      ...identity,
+      change,
+      reason,
+      duration_ms: priorStateDurationMs(state, gameId, modId, change),
+    }),
+  );
+}
+
+/**
+ * Emits mods_removed for a mod. Takes the mod object (the removal handler still has it while
+ * the state entry is being torn down). No-op for untracked mods.
+ */
+export function emitModRemoved(
+  api: IExtensionApi,
+  mod: IMod,
+  reason: ModChangeReason,
+  willBeReplaced: boolean,
+  collectionId: string | null = null,
+): void {
+  const identity = resolveModIdentity(mod, collectionId);
+  if (identity === undefined) {
+    return;
+  }
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new ModsRemovedEvent({ ...identity, reason, will_be_replaced: willBeReplaced }),
+  );
+}

--- a/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit tests for classifyInstallKind: how a mod install is labelled for the mods_installation_*
+ * install_kind, given the mod being replaced (captured before removal) and the incoming file id.
+ */
+import { describe, expect, it } from "vitest";
+
+import { makeMod } from "../../../test-utils/builders";
+import { classifyInstallKind } from "./modInstallAnalytics";
+
+describe("classifyInstallKind", () => {
+  it("is fresh when there is no prior version", () => {
+    expect(classifyInstallKind(undefined, 200)).toBe("fresh");
+  });
+
+  it("is reinstall when the same file id goes over itself", () => {
+    expect(classifyInstallKind(makeMod({ attributes: { fileId: 200 } }), 200)).toBe("reinstall");
+  });
+
+  it("is version_update for a different file id", () => {
+    expect(classifyInstallKind(makeMod({ attributes: { fileId: 150 } }), 200)).toBe(
+      "version_update",
+    );
+  });
+
+  it("is variant when the name conflict was resolved as a coexisting variant", () => {
+    expect(classifyInstallKind(makeMod({ attributes: { fileId: 200 } }), 200, "variant")).toBe(
+      "variant",
+    );
+  });
+
+  it("is profile_replace when the name conflict was resolved as a replace", () => {
+    expect(classifyInstallKind(makeMod({ attributes: { fileId: 150 } }), 200, "replace")).toBe(
+      "profile_replace",
+    );
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.ts
@@ -1,7 +1,9 @@
 import type { IExtensionApi } from "../../../types/IExtensionContext";
+import type { IMod } from "../../mod_management/types/IMod";
+import type { ReplaceChoice } from "../../mod_management/types/IReplaceChoice";
 import { nexusIdsFromDownloadId } from "../../nexus_integration/selectors";
 import { classifyErrorCode } from "./error-code";
-import type { ModAnalyticsIdentity } from "./MixpanelEvents";
+import type { ModAnalyticsIdentity, ModInstallKind } from "./MixpanelEvents";
 import {
   ModsInstallationCancelledEvent,
   ModsInstallationCompletedEvent,
@@ -11,6 +13,33 @@ import {
 import { makeModAnalyticsIdentity } from "./modAnalyticsIdentity";
 
 export type ModInstallOutcome = "completed" | "cancelled" | "failed";
+
+/**
+ * Classifies an install for the mods_installation_* `install_kind`. Must be called with the mod
+ * being replaced (if any) captured BEFORE it is removed - the replace/update path removes the old
+ * mod before the new one installs, so state can no longer tell an update apart from a fresh install.
+ *
+ * `replaceChoice` is how the user resolved a name clash, when one occurred, and takes precedence:
+ * "variant" installs a coexisting second copy, "replace" swaps the existing mod across all local
+ * profiles. Absent a name conflict it falls back to the version relationship.
+ */
+export function classifyInstallKind(
+  existingMod: IMod | undefined,
+  installingFileId: number | undefined,
+  replaceChoice?: ReplaceChoice,
+): ModInstallKind {
+  if (replaceChoice === "variant") {
+    return "variant";
+  }
+  if (replaceChoice === "replace") {
+    return "profile_replace";
+  }
+  if (existingMod === undefined) {
+    return "fresh";
+  }
+  const prevFileId = existingMod.attributes?.fileId;
+  return prevFileId != null && prevFileId === installingFileId ? "reinstall" : "version_update";
+}
 
 /** Extra context for a failed/completed install emit. */
 export interface ModInstallOutcomeContext {
@@ -44,12 +73,19 @@ function resolveModIdentity(
 }
 
 /** Emits mods_installation_started for a mod (standalone or collection member). */
-export function emitModInstallStarted(api: IExtensionApi, archiveId: string): void {
+export function emitModInstallStarted(
+  api: IExtensionApi,
+  archiveId: string,
+  installKind: ModInstallKind,
+): void {
   const identity = resolveModIdentity(api, archiveId);
   if (identity === undefined) {
     return;
   }
-  api.events.emit("analytics-track-mixpanel-event", new ModsInstallationStartedEvent(identity));
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new ModsInstallationStartedEvent({ ...identity, install_kind: installKind }),
+  );
 }
 
 /** Emits the terminal mods_installation_* event for the given outcome. "ignore" is not tracked. */
@@ -57,30 +93,29 @@ export function emitModInstallOutcome(
   api: IExtensionApi,
   archiveId: string,
   outcome: ModInstallOutcome,
+  installKind: ModInstallKind,
   context: ModInstallOutcomeContext = {},
 ): void {
   const identity = resolveModIdentity(api, archiveId);
   if (identity === undefined) {
     return;
   }
+  const base = { ...identity, install_kind: installKind };
   switch (outcome) {
     case "completed":
       api.events.emit(
         "analytics-track-mixpanel-event",
-        new ModsInstallationCompletedEvent({ ...identity, duration_ms: context.durationMs ?? 0 }),
+        new ModsInstallationCompletedEvent({ ...base, duration_ms: context.durationMs ?? 0 }),
       );
       break;
     case "cancelled":
-      api.events.emit(
-        "analytics-track-mixpanel-event",
-        new ModsInstallationCancelledEvent(identity),
-      );
+      api.events.emit("analytics-track-mixpanel-event", new ModsInstallationCancelledEvent(base));
       break;
     case "failed":
       api.events.emit(
         "analytics-track-mixpanel-event",
         new ModsInstallationFailedEvent({
-          ...identity,
+          ...base,
           error_code: classifyErrorCode(context.error),
           error_message: context.failReason ?? "unknown_error",
         }),

--- a/src/renderer/src/extensions/collections/eventHandlers.ts
+++ b/src/renderer/src/extensions/collections/eventHandlers.ts
@@ -6,6 +6,7 @@ import Bluebird from "bluebird";
 import SevenZip from "node-7z";
 
 import * as actions from "../../actions";
+import { emitModStateChanged } from "../../extensions/analytics/mixpanel/modChangeAnalytics";
 import type { IModRule } from "../../extensions/mod_management/types/IMod";
 import renderModName from "../../extensions/mod_management/util/modName";
 import type { IDialogResult } from "../../types/IDialog";
@@ -218,6 +219,7 @@ async function collectionUpdate(
       api.events.emit("remove-mods", gameMode, [oldModId, ...ops.remove], cb, {
         incomplete: true,
         ignoreInstalling: true,
+        reason: "collection_update",
       }),
     );
 
@@ -234,11 +236,14 @@ async function collectionUpdate(
     // Restore enabled state for optional mods that survived the update
     if (profile !== undefined && enabledOptionalMods.length > 0) {
       const currentMods = api.getState().persistent.mods[gameMode];
+      const restoreIds = enabledOptionalMods.filter((id) => currentMods?.[id] !== undefined);
       batchDispatch(
         api.store,
-        enabledOptionalMods
-          .filter((id) => currentMods?.[id] !== undefined)
-          .map((id) => actions.setModEnabled(profile.id, id, true)),
+        restoreIds.map((id) => actions.setModEnabled(profile.id, id, true)),
+      );
+      // this re-enable bypasses the mods-enabled event, so emit the state change directly.
+      restoreIds.forEach((id) =>
+        emitModStateChanged(api, gameMode, id, "enabled", "collection_update"),
       );
     }
   } catch (err) {

--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -517,6 +517,7 @@ async function removeCollection(
       await toPromise((cb) =>
         api.events.emit("remove-mods", gameId, removeMods, cb, {
           silent: true,
+          reason: "collection_uninstall",
           progressCB: (idx: number, length: number, name: string) => {
             // Progress will still be reported via activity notification
             doProgress(name, 50 + (50 * idx) / length);
@@ -541,6 +542,7 @@ async function removeCollection(
         api.events.emit("remove-mod", gameId, modId, cb, {
           silent: true,
           incomplete: true,
+          reason: "collection_uninstall",
         }),
       );
     }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -94,7 +94,7 @@ export function enableInstalledFile(api: IExtensionApi, file: IInstalledFile): v
     log("warn", "cannot enable installed file: no active profile", { modId: file.modId });
     return;
   }
-  void setModsEnabled(api, profile.id, [file.modId], true);
+  void setModsEnabled(api, profile.id, [file.modId], true, { reason: "health_check" });
 }
 
 /** One active-version switch: disable `wrong`, enable `correct`. */
@@ -124,8 +124,8 @@ export function switchActiveVersions(api: IExtensionApi, targets: ISwitchTarget[
   const wrongIds = [...new Set(targets.map((target) => target.wrong.modId))].filter(
     (id) => !correctSet.has(id),
   );
-  void setModsEnabled(api, profile.id, wrongIds, false).then(() =>
-    setModsEnabled(api, profile.id, correctIds, true),
+  void setModsEnabled(api, profile.id, wrongIds, false, { reason: "health_check" }).then(() =>
+    setModsEnabled(api, profile.id, correctIds, true, { reason: "health_check" }),
   );
 }
 

--- a/src/renderer/src/extensions/mod_management/InstallContext.analytics.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallContext.analytics.test.ts
@@ -39,6 +39,45 @@ describe("InstallContext per-mod analytics", () => {
     });
   });
 
+  test("defaults install_kind to fresh when startInstallCB is called without one", ({
+    makeInstallContext,
+  }) => {
+    const h = makeInstallContext(withDownload(memberInfo()));
+    h.ctx.startInstallCB(MOD, GAME, ARCHIVE);
+    expect(h.mixpanelEvents[0].properties.install_kind).toBe("fresh");
+  });
+
+  // The passed install_kind must ride the started event and whichever terminal event fires.
+  const terminalCases = [
+    { outcome: "success" as const, terminal: "mods_installation_completed" },
+    { outcome: "canceled" as const, terminal: "mods_installation_cancelled" },
+    { outcome: "failed" as const, terminal: "mods_installation_failed" },
+  ];
+  for (const { outcome, terminal } of terminalCases) {
+    test(`threads install_kind onto started and ${terminal}`, ({ makeInstallContext }) => {
+      const h = makeInstallContext(withDownload(memberInfo()));
+      h.ctx.startInstallCB(MOD, GAME, ARCHIVE, "variant");
+      if (outcome === "failed") {
+        h.ctx.finishInstallCB("failed", undefined, "bad archive", new DataInvalid("bad archive"));
+      } else {
+        h.ctx.finishInstallCB(outcome, {});
+      }
+      expect(names(h)).toEqual(["mods_installation_started", terminal]);
+      expect(h.mixpanelEvents[0].properties.install_kind).toBe("variant");
+      expect(h.mixpanelEvents[1].properties.install_kind).toBe("variant");
+    });
+  }
+
+  test("carries a profile_replace install_kind through to the completed event", ({
+    makeInstallContext,
+  }) => {
+    const h = makeInstallContext(withDownload(memberInfo()));
+    h.ctx.startInstallCB(MOD, GAME, ARCHIVE, "profile_replace");
+    h.ctx.finishInstallCB("success", {});
+    const completed = h.mixpanelEvents.find((e) => e.eventName === "mods_installation_completed");
+    expect(completed?.properties.install_kind).toBe("profile_replace");
+  });
+
   test("carries the parent collection_id for a collection member", ({ makeInstallContext }) => {
     const h = makeInstallContext(withDownload(memberInfo({ parentCollectionId: "col-9" })));
     h.ctx.startInstallCB(MOD, GAME, ARCHIVE);

--- a/src/renderer/src/extensions/mod_management/InstallContext.ts
+++ b/src/renderer/src/extensions/mod_management/InstallContext.ts
@@ -14,6 +14,7 @@ import { log } from "../../util/log";
 import type { IPrettifiedError } from "../../util/message";
 import { showError } from "../../util/message";
 import { getSafe } from "../../util/storeHelper";
+import type { ModInstallKind } from "../analytics/mixpanel/MixpanelEvents";
 import {
   emitModInstallOutcome,
   emitModInstallStarted,
@@ -59,6 +60,7 @@ class InstallContext implements IInstallContext {
   private mIndicatorId: string;
   private mGameId: string;
   private mArchiveId: string;
+  private mInstallKind: ModInstallKind = "fresh";
   private mInstallOutcome: InstallOutcome;
   private mFailReason: string;
   private mFailError: IPrettifiedError;
@@ -138,7 +140,8 @@ class InstallContext implements IInstallContext {
     this.mEnableMod = (modId: string) => {
       const state: IState = store.getState();
       const profileId = state.settings.profiles.lastActiveProfile[this.mGameId];
-      return setModsEnabled(api, profileId, [modId], true);
+      // enabling on install completion is implied by the install event.
+      return setModsEnabled(api, profileId, [modId], true, { skipStateChangeEvent: true });
     };
     this.mIsEnabled = (modId) => {
       const state: IState = store.getState();
@@ -238,7 +241,12 @@ class InstallContext implements IInstallContext {
     }
   }
 
-  public startInstallCB(id: string, gameId: string, archiveId: string): void {
+  public startInstallCB(
+    id: string,
+    gameId: string,
+    archiveId: string,
+    installKind: ModInstallKind = "fresh",
+  ): void {
     this.mAddMod({
       id,
       type: "",
@@ -253,8 +261,10 @@ class InstallContext implements IInstallContext {
     this.mAddedId = id;
     this.mGameId = gameId;
     this.mArchiveId = archiveId;
+    // Kept for the terminal events, which fire from finishInstallCB.
+    this.mInstallKind = installKind;
 
-    emitModInstallStarted(this.mApi, archiveId);
+    emitModInstallStarted(this.mApi, archiveId, installKind);
   }
 
   public finishInstallCB(
@@ -300,13 +310,13 @@ class InstallContext implements IInstallContext {
     // download record intact regardless of mod removal. "ignore" (bundled/subsumed) is not tracked.
     if (this.mArchiveId !== undefined) {
       if (outcome === "success") {
-        emitModInstallOutcome(this.mApi, this.mArchiveId, "completed", {
+        emitModInstallOutcome(this.mApi, this.mArchiveId, "completed", this.mInstallKind, {
           durationMs: Date.now() - this.mStartTime,
         });
       } else if (outcome === "canceled") {
-        emitModInstallOutcome(this.mApi, this.mArchiveId, "cancelled");
+        emitModInstallOutcome(this.mApi, this.mArchiveId, "cancelled", this.mInstallKind);
       } else if (outcome === "failed") {
-        emitModInstallOutcome(this.mApi, this.mArchiveId, "failed", {
+        emitModInstallOutcome(this.mApi, this.mArchiveId, "failed", this.mInstallKind, {
           error: this.mFailError,
           failReason: this.mFailReason,
         });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -133,8 +133,11 @@ import {
   setdefault,
   toPromise,
   truthy,
+  unique,
 } from "../../util/util";
 import walk from "../../util/walk";
+import { emitModStateChanged } from "../analytics/mixpanel/modChangeAnalytics";
+import { classifyInstallKind } from "../analytics/mixpanel/modInstallAnalytics";
 import { resolveCategoryId } from "../category_management/util/retrieveCategoryPath";
 import { finishDownload } from "../download_management/actions/state";
 import type { IDownload } from "../download_management/types/IDownload";
@@ -166,16 +169,10 @@ import type { Dependency, IDependency, IDependencyError, IModInfoEx } from "./ty
 import type { IInstallContext } from "./types/IInstallContext";
 import type { IInstallOptions } from "./types/IInstallOptions";
 import type { IInstallResult, IInstruction, InstructionType } from "./types/IInstallResult";
-import type {
-  IChoiceType,
-  IFileListItem,
-  IMod,
-  IModAttributes,
-  IModReference,
-  IModRule,
-} from "./types/IMod";
+import type { IChoiceType, IFileListItem, IMod, IModReference, IModRule } from "./types/IMod";
 import type { IModInstaller, ISupportedInstaller } from "./types/IModInstaller";
 import type { IInstallationDetails, InstallFunc } from "./types/InstallFunc";
+import type { IReplaceChoice, ReplaceChoice } from "./types/IReplaceChoice";
 import type { ISupportedResult, ITestSupportedDetails, TestSupported } from "./types/TestSupported";
 import { getCSharpScriptAllowListForGame } from "./util/cSharpScriptAllowList";
 import gatherDependencies, {
@@ -212,18 +209,6 @@ interface IActiveInstallation {
   callback: (error: Error, id: string) => void;
   startTime: number;
   baseName: string;
-}
-
-// Function to get current download manager free slots
-
-type ReplaceChoice = "replace" | "variant";
-interface IReplaceChoice {
-  id: string;
-  variant: string;
-  enable: boolean;
-  attributes: IModAttributes;
-  rules: IRule[];
-  replaceChoice: ReplaceChoice;
 }
 
 interface IInvalidInstruction {
@@ -1293,6 +1278,9 @@ class InstallManager {
           };
           let existingMod: IMod;
           let installingFileId: number;
+          // How the user resolved a name conflict (variant vs replace), if one arose; read at
+          // startInstallCB to classify the install for analytics.
+          let replacementChoice: ReplaceChoice;
           // Start the installation process - the promise will resolve when callback is called
           const dlInfo =
             archiveId != null ? api.getState().persistent.downloads.files[archiveId] : undefined;
@@ -1444,7 +1432,7 @@ class InstallManager {
                   // mod or provided a new, unused name
 
                   let variantCounter: number = 0;
-                  let replacementChoice: ReplaceChoice = undefined;
+                  replacementChoice = undefined;
                   const checkNameLoop = () => {
                     if (replacementChoice === "replace") {
                       log("debug", '(nameloop) replacement choice "replace"', {
@@ -1639,6 +1627,8 @@ class InstallManager {
                           setModsEnabled(api, installProfile.id, [existingMod.id], false, {
                             allowAutoDeploy,
                             installed: true,
+                            // mechanical disable for the reinstall, not a user-visible change.
+                            skipStateChangeEvent: true,
                           });
                         }
                         rules = existingMod.rules || [];
@@ -1668,7 +1658,7 @@ class InstallManager {
                                 resolve();
                               }
                             },
-                            { willBeReplaced: true },
+                            { willBeReplaced: true, reason: "version_update" },
                           );
                         });
                       }
@@ -1678,7 +1668,14 @@ class InstallManager {
                   }
                 })
                 .then(() => {
-                  installContext.startInstallCB(modId, installGameId, archiveId);
+                  // Classify for analytics: existingMod is the prior version (if any),
+                  // replacementChoice the name-conflict resolution (variant vs replace).
+                  const installKind = classifyInstallKind(
+                    existingMod,
+                    installingFileId,
+                    replacementChoice,
+                  );
+                  installContext.startInstallCB(modId, installGameId, archiveId, installKind);
 
                   destinationPath = path.join(this.mGetInstallPath(installGameId), modId);
                   log("info", "installing to", { modId, destinationPath });
@@ -1833,6 +1830,8 @@ class InstallManager {
                       setModsEnabled(api, installProfile.id, [modId], true, {
                         allowAutoDeploy,
                         installed: true,
+                        // enabling on install completion is implied by the install event.
+                        skipStateChangeEvent: true,
                       });
                     }
                   }
@@ -2556,10 +2555,12 @@ class InstallManager {
               batchContext?.get<string>("profileId") ?? activeProfile(state)?.id;
             const targetProfile = targetProfileId ? profileById(state, targetProfileId) : undefined;
 
+            // Superseded variants disabled here; the same set is disabled in every affected
+            // profile, so it's computed once for both the dispatch and the analytics emit.
+            const supersededVariantIds = this.checkModVariantsExist(api, gameId, downloadId);
             if (targetProfile) {
               // Only modify the target profile - disable other variants and enable this one
-              const otherModIds = this.checkModVariantsExist(api, gameId, downloadId);
-              for (const otherModId of otherModIds) {
+              for (const otherModId of supersededVariantIds) {
                 batchedActions.push(setModEnabled(targetProfile.id, otherModId, false));
               }
               batchedActions.push(setModEnabled(targetProfile.id, modId, true));
@@ -2569,8 +2570,7 @@ class InstallManager {
                 (prof) => prof.gameId === gameId && prof.modState?.[sourceModId]?.enabled,
               );
               profiles.forEach((prof) => {
-                const otherModIds = this.checkModVariantsExist(api, gameId, downloadId);
-                for (const otherModId of otherModIds) {
+                for (const otherModId of supersededVariantIds) {
                   batchedActions.push(setModEnabled(prof.id, otherModId, false));
                 }
                 batchedActions.push(setModEnabled(prof.id, modId, true));
@@ -2580,6 +2580,13 @@ class InstallManager {
             // Mark as installed as dependency
             batchedActions.push(setModAttribute(gameId, modId, "installedAsDependency", true));
             batchDispatch(api.store, batchedActions);
+
+            // Disabling superseded variants bypasses the mods-enabled event; emit directly.
+            // checkModVariantsExist includes modId itself (it shares the archive) - exclude it,
+            // since it ends up enabled and its enable is covered by mods_installation_completed.
+            supersededVariantIds
+              .filter((id) => id !== modId)
+              .forEach((id) => emitModStateChanged(api, gameId, id, "disabled", "variant_replace"));
 
             // Clear retry counter on successful installation
             this.mDependencyRetryCount.delete(installKey);
@@ -5135,7 +5142,7 @@ class InstallManager {
                     });
                   }
                 },
-                { willBeReplaced: true },
+                { willBeReplaced: true, reason: "profile_replace" },
               );
             };
 
@@ -5147,6 +5154,10 @@ class InstallManager {
               if (currentProfile !== undefined) {
                 const actions = modIds.map((id) => setModEnabled(currentProfile.id, id, false));
                 batchDispatch(api.store.dispatch, actions);
+                // this disable bypasses the mods-enabled event; emit the state change directly.
+                unique(modIds).forEach((id) =>
+                  emitModStateChanged(api, gameId, id, "disabled", "variant_replace"),
+                );
               }
               // We want the shortest possible modId paired against this archive
               //  before adding the variant name to it.
@@ -5718,10 +5729,12 @@ class InstallManager {
               batchContext?.get<string>("profileId") ?? activeProfile(state)?.id;
             const targetProfile = targetProfileId ? profileById(state, targetProfileId) : undefined;
 
+            // Superseded variants disabled here; the same set is disabled in every affected
+            // profile, so it's computed once for both the dispatch and the analytics emit.
+            const supersededVariantIds = this.checkModVariantsExist(api, gameId, downloadId);
             if (targetProfile) {
               // Only modify the target profile - disable other variants and enable this one
-              const otherModIds = this.checkModVariantsExist(api, gameId, downloadId);
-              for (const otherModId of otherModIds) {
+              for (const otherModId of supersededVariantIds) {
                 batchedActions.push(setModEnabled(targetProfile.id, otherModId, false));
               }
               batchedActions.push(setModEnabled(targetProfile.id, modId, true));
@@ -5731,8 +5744,7 @@ class InstallManager {
                 (prof) => prof.gameId === gameId && prof.modState?.[sourceModId]?.enabled,
               );
               profiles.forEach((prof) => {
-                const otherModIds = this.checkModVariantsExist(api, gameId, downloadId);
-                for (const otherModId of otherModIds) {
+                for (const otherModId of supersededVariantIds) {
                   batchedActions.push(setModEnabled(prof.id, otherModId, false));
                 }
                 batchedActions.push(setModEnabled(prof.id, modId, true));
@@ -5740,6 +5752,13 @@ class InstallManager {
             }
 
             batchDispatch(api.store, batchedActions);
+
+            // Disabling superseded variants bypasses the mods-enabled event; emit directly.
+            // checkModVariantsExist includes modId itself (it shares the archive) - exclude it,
+            // since it ends up enabled and its enable is covered by mods_installation_completed.
+            supersededVariantIds
+              .filter((id) => id !== modId)
+              .forEach((id) => emitModStateChanged(api, gameId, id, "disabled", "variant_replace"));
 
             this.applyExtraFromRule(api, gameId, modId, {
               ...dep.extra,

--- a/src/renderer/src/extensions/mod_management/eventHandlers.ts
+++ b/src/renderer/src/extensions/mod_management/eventHandlers.ts
@@ -25,6 +25,7 @@ import { downloadPathForGame } from "../../util/selectors";
 import { knownGames } from "../../util/selectors";
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, truthy } from "../../util/util";
+import { emitModRemoved } from "../analytics/mixpanel/modChangeAnalytics";
 import type { IDownload } from "../download_management/types/IDownload";
 import getDownloadGames from "../download_management/util/getDownloadGames";
 import { getGame } from "../gamemode_management/util/getGame";
@@ -798,6 +799,8 @@ export function onRemoveMods(
       installed: options?.incomplete,
       allowAutoDeploy: false,
       willBeReplaced: options?.willBeReplaced,
+      // this disable is a mechanical step of removal; the removal itself is tracked separately.
+      skipStateChangeEvent: true,
     });
   }
 
@@ -854,6 +857,13 @@ export function onRemoveMods(
               batchDispatch(store, batched);
               batched = [];
             }
+
+            emitModRemoved(
+              api,
+              mod,
+              options?.reason ?? "user_manual",
+              options?.willBeReplaced ?? false,
+            );
 
             // Update progress after successful removal
             completedCount++;

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -53,6 +53,7 @@ import {
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, isChildPath, truthy, wrapExtCBAsync } from "../../util/util";
 import { waitForCondition } from "../../util/waitForCondition";
+import { emitModStateChanged } from "../analytics/mixpanel/modChangeAnalytics";
 import { setDownloadModInfo } from "../download_management/actions/state";
 import { getGame } from "../gamemode_management/util/getGame";
 import { getModType } from "../gamemode_management/util/modTypeExtensions";
@@ -1170,6 +1171,15 @@ function onModsEnabled(api: IExtensionApi, deploymentTimer: Debouncer) {
       const notiId = `may-enable-${modId}`;
       if (notiIds.has(notiId)) {
         api.dismissNotification(notiId);
+      }
+      if (options?.skipStateChangeEvent !== true) {
+        emitModStateChanged(
+          api,
+          gameId,
+          modId,
+          enabled ? "enabled" : "disabled",
+          options?.reason ?? "user_manual",
+        );
       }
     });
     if (state.settings.automation.deploy && options?.allowAutoDeploy !== false) {

--- a/src/renderer/src/extensions/mod_management/types/IRemoveModOptions.ts
+++ b/src/renderer/src/extensions/mod_management/types/IRemoveModOptions.ts
@@ -1,8 +1,13 @@
+import type { ModChangeReason } from "../../analytics/mixpanel/MixpanelEvents";
 import type { IMod } from "./IMod";
 
 export interface IRemoveModOptions {
   // if true will not raise any notifications/toasts
   silent?: boolean;
+
+  // why the mod is being removed, for the mods_removed analytics event. Defaults to
+  // user_manual when unset (a direct user action). Programmatic removals should set it.
+  reason?: ModChangeReason;
 
   // Event emitters should set this to true if the mod is being replaced.
   //  e.g. when reinstalling or updating a mod.

--- a/src/renderer/src/extensions/mod_management/types/IReplaceChoice.ts
+++ b/src/renderer/src/extensions/mod_management/types/IReplaceChoice.ts
@@ -1,0 +1,18 @@
+import type { IRule } from "modmeta-db";
+
+import type { IModAttributes } from "./IMod";
+
+/**
+ * How the user resolved a mod name conflict at install time: "replace" swaps the existing mod
+ * across all local profiles, "variant" installs a second coexisting copy under a variant name.
+ */
+export type ReplaceChoice = "replace" | "variant";
+
+export interface IReplaceChoice {
+  id: string;
+  variant: string;
+  enable: boolean;
+  attributes: IModAttributes;
+  rules: IRule[];
+  replaceChoice: ReplaceChoice;
+}

--- a/src/renderer/src/extensions/profile_management/actions/profiles.ts
+++ b/src/renderer/src/extensions/profile_management/actions/profiles.ts
@@ -4,6 +4,7 @@ import * as reduxAct from "redux-act";
 import safeCreateAction from "../../../actions/safeCreateAction";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import { batchDispatch } from "../../../util/util";
+import type { ModChangeReason } from "../../analytics/mixpanel/MixpanelEvents";
 import type { IProfile } from "../types/IProfile";
 
 /**
@@ -50,6 +51,14 @@ export interface IEnableOptions {
   installed?: boolean;
   allowAutoDeploy?: boolean;
   willBeReplaced?: boolean;
+
+  // why the mods are being enabled/disabled, for the mods_state_changed analytics event.
+  // Defaults to user_manual when unset. Programmatic callers should set it.
+  reason?: ModChangeReason;
+
+  // set by callers whose enable/disable is a mechanical step of another already-tracked
+  // operation (install completion, removal prep) so it doesn't emit a duplicate state-change.
+  skipStateChangeEvent?: boolean;
 }
 
 const setModsEnabled = (() => {

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -735,13 +735,19 @@ function removeProfileImpl(api: IExtensionApi, profileId: string) {
 
 function removeMod(api: IExtensionApi, gameId: string, modId: string): PromiseBB<void> {
   return new PromiseBB((resolve, reject) => {
-    api.events.emit("remove-mod", gameId, modId, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
+    api.events.emit(
+      "remove-mod",
+      gameId,
+      modId,
+      (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      },
+      { reason: "stop_managing_game" },
+    );
   });
 }
 

--- a/src/renderer/src/extensions/profile_management/reducers/profiles.test.ts
+++ b/src/renderer/src/extensions/profile_management/reducers/profiles.test.ts
@@ -78,6 +78,26 @@ describe("setModEnabled", () => {
     expect(result.profileId1.modState.modId1.enabled).toBe(true);
     expect(result.profileId2.modState.modId1.enabled).toBe(false);
   });
+
+  it("stamps disabledTime on disable and leaves enabledTime intact", () => {
+    const input: ProfilesState = {
+      profileId1: {
+        id: "profileId1",
+        gameId: "game",
+        name: "Profile 1",
+        modState: { modId1: { enabled: true, enabledTime: 111 } },
+        lastActivated: 0,
+      },
+    };
+    const result = reduce.SET_MOD_ENABLED(input, {
+      profileId: "profileId1",
+      modId: "modId1",
+      enable: false,
+    });
+    expect(result.profileId1.modState.modId1.enabled).toBe(false);
+    expect(result.profileId1.modState.modId1.enabledTime).toBe(111);
+    expect(result.profileId1.modState.modId1.disabledTime).toBeGreaterThan(0);
+  });
 });
 
 describe("setFeature", () => {

--- a/src/renderer/src/extensions/profile_management/reducers/profiles.ts
+++ b/src/renderer/src/extensions/profile_management/reducers/profiles.ts
@@ -28,9 +28,10 @@ export const profilesReducer: IReducerSpec = {
         return state;
       }
 
-      if (enable) {
-        state = setSafe(state, [profileId, "modState", modId, "enabledTime"], Date.now());
-      }
+      // Stamp only the timestamp for this transition; the other is left intact so the analytics
+      // can measure how long the mod spent in the prior state.
+      const timeKey = enable ? "enabledTime" : "disabledTime";
+      state = setSafe(state, [profileId, "modState", modId, timeKey], Date.now());
 
       return setSafe(state, [profileId, "modState", modId, "enabled"], enable);
     },

--- a/src/renderer/src/extensions/profile_management/types/IProfile.ts
+++ b/src/renderer/src/extensions/profile_management/types/IProfile.ts
@@ -1,6 +1,10 @@
 export interface IProfileMod {
   enabled: boolean;
+  // MS timestamp of the last enable / last disable. Each is stamped on its own transition and
+  // left untouched by the other, so a change can measure how long the mod spent in the prior
+  // state (see mods_state_changed duration_ms). Persisted, so the span survives restarts.
   enabledTime: number;
+  disabledTime?: number;
 }
 
 export interface IProfile {

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -49,7 +49,7 @@ import type {
 } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
-import type { IProfileMod } from "../extensions/profile_management/types/IProfile";
+import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
 import type {
@@ -71,6 +71,7 @@ import type {
   IDriverHarnessState,
   IInstallContextHarness,
   IInstallManagerHarness,
+  IModChangeHarness,
   IRevisionFixture,
   IRevisionMemberSpec,
   ITrackedAction,
@@ -146,6 +147,17 @@ export function makeDownload(overrides: Partial<IDownload> = {}): IDownload {
 
 export function makeProfileMod(overrides: Partial<IProfileMod> = {}): IProfileMod {
   return { enabled: true, enabledTime: 0, ...overrides };
+}
+
+export function makeProfile(overrides: Partial<IProfile> = {}): IProfile {
+  return {
+    id: "profile-1",
+    gameId: "skyrimse",
+    name: "Profile",
+    modState: {},
+    lastActivated: 0,
+    ...overrides,
+  };
 }
 
 // A cached game entry. Defaults to skyrimse with its nexus page id under `details`, so
@@ -585,6 +597,13 @@ export function makeInstallManagerHarness(
  * download, then drives ctx.startInstallCB / finishInstallCB and asserts mixpanelEvents. The ctor
  * is passed in (like the other harnesses) to keep the heavy InstallContext import out of builders.
  */
+/** Collects every mixpanel event emitted on an api's bus, in order, into the returned array. */
+export function collectMixpanelEvents(api: IExtensionApi): MixpanelEvent[] {
+  const mixpanelEvents: MixpanelEvent[] = [];
+  api.events.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => mixpanelEvents.push(e));
+  return mixpanelEvents;
+}
+
 export function makeInstallContextHarness(
   ContextCtor: new (gameMode: string, api: IExtensionApi, silent: boolean) => InstallContext,
   overrides: Partial<IDriverHarnessState> = {},
@@ -592,12 +611,22 @@ export function makeInstallContextHarness(
 ): IInstallContextHarness {
   const gameId = opts.gameId ?? "skyrimse";
   const base = makeApiHarness(overrides);
-  const mixpanelEvents: MixpanelEvent[] = [];
-  base.api.events.on("analytics-track-mixpanel-event", (e: MixpanelEvent) =>
-    mixpanelEvents.push(e),
-  );
+  const mixpanelEvents = collectMixpanelEvents(base.api);
   const ctx = new ContextCtor(gameId, base.api, opts.silent ?? false);
   return { ctx, mixpanelEvents, ...base };
+}
+
+/**
+ * Api harness for the mod enable/disable/remove analytics: a seeded fake api plus a mixpanel
+ * collector. Tests seed mods/profiles via `overrides` then either call the emit helpers directly
+ * or drive the real (exported) onRemoveMods and assert the mods_state_changed / mods_removed events.
+ */
+export function makeModChangeHarness(
+  overrides: Partial<IDriverHarnessState> = {},
+): IModChangeHarness {
+  const base = makeApiHarness(overrides);
+  const mixpanelEvents = collectMixpanelEvents(base.api);
+  return { ...base, mixpanelEvents };
 }
 
 /**

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -97,6 +97,11 @@ export interface IInstallContextHarness extends IApiHarness {
   mixpanelEvents: MixpanelEvent[];
 }
 
+export interface IModChangeHarness extends IApiHarness {
+  // mods_state_changed / mods_removed events emitted on the api bus, collected in order
+  mixpanelEvents: MixpanelEvent[];
+}
+
 export interface IInstallManagerHarness extends IApiHarness {
   // the InstallManager under test, constructed against the fake api (its event handlers are wired
   // onto the same bus, so harness.emit drives them)

--- a/src/renderer/src/test-utils/modChangeTest.ts
+++ b/src/renderer/src/test-utils/modChangeTest.ts
@@ -1,0 +1,22 @@
+import { makeModChangeHarness } from "./builders";
+import { test as harnessTest } from "./harnessTest";
+import type { IDriverHarnessState, IModChangeHarness } from "./harnessTypes";
+
+export interface IModChangeFixtures {
+  // build a harness around the fake api with a mixpanel collector, for the mod
+  // enable/disable/remove analytics (emit helpers + the real onRemoveMods)
+  makeModChange: (overrides?: Partial<IDriverHarnessState>) => IModChangeHarness;
+}
+
+/**
+ * Base test for the mod change (enable/disable/remove) analytics suites. Extends the shared
+ * harnessTest with a `makeModChange` factory over the fake api + mixpanel collector, and inherits
+ * the registry/mock teardown.
+ */
+export const test = harnessTest.extend<IModChangeFixtures>({
+  makeModChange: async ({ task: _task }, use) => {
+    // `use` is the vitest fixture callback, not React's use() hook.
+    // eslint-disable-next-line @eslint-react/rules-of-hooks
+    await use((overrides) => makeModChangeHarness(overrides));
+  },
+});

--- a/src/renderer/src/util/api.ts
+++ b/src/renderer/src/util/api.ts
@@ -124,8 +124,12 @@ import {
   CollectionsDraftUploadedEvent,
   CollectionsDraftUpdateUploadedEvent,
 } from "../extensions/analytics/mixpanel/MixpanelEvents";
-// Prop type used by the exported collection-install event constructors.
-export type { CollectionInstallOutcomeProps } from "../extensions/analytics/mixpanel/MixpanelEvents";
+// CollectionInstallOutcomeProps: props for the exported collection-install event constructors.
+// ModChangeReason: reason vocabulary referenced by IRemoveModOptions.reason / IEnableOptions.reason.
+export type {
+  CollectionInstallOutcomeProps,
+  ModChangeReason,
+} from "../extensions/analytics/mixpanel/MixpanelEvents";
 import getTextModManagement from "../extensions/mod_management/texts";
 import getTextProfileManagement from "../extensions/profile_management/texts";
 import deepMerge from "./deepMerge";


### PR DESCRIPTION
- Add mods_state_changed and mods_removed events, gated to Nexus mods like the other per-mod events, carrying a ModChangeReason (user_manual, variant_replace, version_update, profile_replace, collection_update, collection_uninstall, stop_managing_game, health_check) threaded through IRemoveModOptions and IEnableOptions from the remove/enable call sites.
- Add install_kind (fresh / version_update / reinstall / variant / profile_replace) to the mods_installation_* events, classified in InstallManager and carried to the terminal events via InstallContext.
- Report mods_state_changed.duration_ms as time spent in the prior state in both directions; add a durable disabledTime to profile mod-state alongside enabledTime.
- Base mods_download_completed duration_ms on the durable startTime.
- Move ReplaceChoice/IReplaceChoice to their own types file.
- Add test harness (makeModChangeHarness/modChangeTest, makeProfile) and coverage for classifyInstallKind and the mod-change analytics.

closes LAZ-673