### PR TITLE
Don't display `__vortex_tmp_` if possible, use the friendly name instead

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -41,6 +41,7 @@ import {
 } from "./extensions/download_management/actions/state";
 import { downloadPathForGame } from "./extensions/download_management/selectors";
 import type { IDownload } from "./extensions/download_management/types/IDownload";
+import { TEMP_DOWNLOAD_PREFIX } from "./extensions/download_management/util/downloadNames";
 import { knownGames } from "./extensions/gamemode_management/selectors";
 import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
 import { nxmUrlFromDownload } from "./extensions/nexus_integration/NXMUrl";
@@ -564,7 +565,7 @@ export class IPCDownloadAdapter {
       // #completeDownload renames to the final name derived from Content-Disposition.
       // The real filename is passed as a hint; the server name takes priority.
       const collationStr = collationId.toString().padStart(8, "0");
-      const tempName = `__vortex_tmp_${collationStr}`;
+      const tempName = `${TEMP_DOWNLOAD_PREFIX}${collationStr}`;
       const dest = path.join(dlPath, tempName);
 
       log("debug", "starting download", {
@@ -592,6 +593,11 @@ export class IPCDownloadAdapter {
       this.#api.store.dispatch(initDownload(downloadId, rawUrls, modInfo, gameIds));
       // Set localPath to the temp name so the UI has something to display.
       this.#api.store.dispatch(setDownloadFilePath(downloadId, tempName));
+      // Seed a friendly name from the caller's hint so the UI shows it instead of
+      // the temp name; nxm downloads without a hint fall back to enriched metadata.
+      if (fileName !== undefined) {
+        this.#api.store.dispatch(setDownloadModInfo(downloadId, "name", fileName));
+      }
       // All IPC downloads support pause via checkpoint. DownloadView checks
       // download.pausable to show/hide the pause button.
       this.#api.store.dispatch(setDownloadPausable(downloadId, true));
@@ -622,20 +628,30 @@ export class IPCDownloadAdapter {
     callback?: (err: Error | null) => void,
   ): Promise<void> {
     try {
-      if (this.#activeDownloads.has(downloadId)) {
+      const state = this.#api.getState();
+      const download = state.persistent.downloads.files?.[downloadId];
+      const isRunning = download !== undefined && ["init", "started"].includes(download.state);
+
+      if (this.#activeDownloads.has(downloadId) && isRunning) {
+        // Still actively downloading: cancel it and let the poll loop's terminal
+        // "canceled" handling remove the record and fire the UserCanceled callback.
         log("debug", "cancelling download", { downloadId });
         await window.api.downloader.cancel(downloadId);
-      } else {
-        const state = this.#api.getState();
-        const download = state.persistent.downloads.files?.[downloadId];
-        if (download?.localPath) {
-          const gameId = toInternalGameId(this.#api, download.game?.[0] ?? activeGameId(state));
-          const dlPath = downloadPathForGame(state, gameId);
-          await rm(path.join(dlPath, download.localPath), { force: true });
-        }
-        // Remove record from Redux to clear it from the downloads list.
-        this.#api.store.dispatch(removeDownload(downloadId));
+        callback?.(null);
+        return;
       }
+
+      // Non-running downloads: the main-process cancel is a no-op (Manager cancel()
+      // only acts while running), so the poll loop never removes the record. Delete
+      // the temp file and Redux record directly.
+      this.#activeDownloads.delete(downloadId);
+      if (download?.localPath) {
+        const gameId = toInternalGameId(this.#api, download.game?.[0] ?? activeGameId(state));
+        const dlPath = downloadPathForGame(state, gameId);
+        await rm(path.join(dlPath, download.localPath), { force: true });
+      }
+      this.#api.store.dispatch(clearDownloadCheckpoint(downloadId));
+      this.#api.store.dispatch(removeDownload(downloadId));
       callback?.(null);
     } catch (err) {
       callback?.(unknownToError(err));

--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 
-import { makeDownload, makeMod, makeRule } from "../../../test-utils/builders";
+import { makeDownload, makeFileInfo, makeMod, makeRule } from "../../../test-utils/builders";
 import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
 import { modRuleId } from "../../../util/collectionInstallSession";
 import { reconstructSessionMods } from "../../../util/collectionSessionReconstruct";
@@ -75,7 +75,7 @@ describe("buildCollectionItemRows", () => {
       received: 50,
       size: 200,
       fileMD5: "abc",
-      modInfo: { nexus: { fileInfo: { name: "file.7z", mod_version: "2.0" } } },
+      modInfo: { nexus: { fileInfo: makeFileInfo({ name: "file.7z", mod_version: "2.0" }) } },
     });
 
     const rows = buildCollectionItemRows({

--- a/src/renderer/src/extensions/download_management/downloadAttributes.tsx
+++ b/src/renderer/src/extensions/download_management/downloadAttributes.tsx
@@ -17,10 +17,11 @@ import type { ITableAttribute } from "../../types/ITableAttribute";
 import * as fs from "../../util/fs";
 import { getCurrentLanguage } from "../../util/i18n";
 import { getSafe } from "../../util/storeHelper";
-import { bytesToString, truthy } from "../../util/util";
+import { bytesToString } from "../../util/util";
 import { SITE_ID } from "../gamemode_management/constants";
 import { gameName } from "../gamemode_management/selectors";
 import type { IDownload } from "./types/IDownload";
+import { friendlyDownloadName } from "./util/downloadNames";
 import getDownloadGames from "./util/getDownloadGames";
 import setDownloadGames from "./util/setDownloadGames";
 import DownloadGameList from "./views/DownloadGameList";
@@ -101,23 +102,6 @@ function downloadTime(download: IDownload) {
   return download.fileTime !== undefined ? new Date(download.fileTime) : undefined;
 }
 
-function nameFromUrl(input: string) {
-  if (input === undefined) {
-    return undefined;
-  }
-
-  const pathname = new URL(input).pathname;
-  if (!truthy(pathname)) {
-    return undefined;
-  }
-
-  try {
-    return decodeURI(path.basename(pathname));
-  } catch (err) {
-    return path.basename(pathname);
-  }
-}
-
 function createColumns(
   api: IExtensionApi,
   props: () => IDownloadViewProps,
@@ -147,8 +131,7 @@ function createColumns(
       name: "Filename",
       description: "Filename of the download",
       icon: "",
-      calc: (attributes: IDownload) =>
-        attributes.localPath || nameFromUrl(getSafe(attributes, ["urls", 0], undefined)),
+      calc: (attributes: IDownload) => friendlyDownloadName(attributes),
       placement: "both",
       isToggleable: true,
       edit: {},

--- a/src/renderer/src/extensions/download_management/types/IDownload.ts
+++ b/src/renderer/src/extensions/download_management/types/IDownload.ts
@@ -1,3 +1,5 @@
+import type { IFileInfo } from "@nexusmods/nexus-api";
+
 export type RedownloadMode = "always" | "never" | "ask" | "replace";
 
 export type DownloadState =
@@ -77,6 +79,7 @@ export interface IModInfo {
      * install attribute extractor. Consumed by Mixpanel mod download analytics.
      */
     parentCollectionId?: string;
+    fileInfo?: IFileInfo;
     [key: string]: any;
   };
   referenceTag?: string;

--- a/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 
+import { makeFileInfo } from "../../../test-utils/builders";
 import type { IDownload } from "../types/IDownload";
 import {
   TEMP_DOWNLOAD_PREFIX,
@@ -85,7 +86,10 @@ describe("friendlyDownloadName", () => {
 
   it("falls back to the resolved nexus file info name", () => {
     const result = friendlyDownloadName(
-      download({ localPath: tempName, modInfo: { nexus: { fileInfo: { name: "Nexus File" } } } }),
+      download({
+        localPath: tempName,
+        modInfo: { nexus: { fileInfo: makeFileInfo({ name: "Nexus File" }) } },
+      }),
     );
     expect(result).toBe("Nexus File");
   });

--- a/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+
+import type { IDownload } from "../types/IDownload";
+import {
+  TEMP_DOWNLOAD_PREFIX,
+  friendlyDownloadName,
+  isTempDownloadName,
+  nameFromUrl,
+} from "./downloadNames";
+
+const tempName = `${TEMP_DOWNLOAD_PREFIX}00000001`;
+
+const nxmUrl = "nxm://examplegame/mods/123/files/456?key=EXAMPLEKEY&expires=1700000000&user_id=1";
+const cdnUrl =
+  "https://cdn.example-cdn.com/100/123/Example Mod Name-123-1-0.7z?expires=1700000000&md5=EXAMPLEMD5&user_id=1";
+
+// friendlyDownloadName only reads a handful of fields; cast partial fixtures.
+const download = (props: Partial<IDownload>): IDownload => props as IDownload;
+
+describe("isTempDownloadName", () => {
+  it("recognises the temporary placeholder name", () => {
+    expect(isTempDownloadName(tempName)).toBe(true);
+  });
+
+  it("treats a real file name as non-temporary", () => {
+    expect(isTempDownloadName("My File.zip")).toBe(false);
+  });
+
+  it("is false for undefined", () => {
+    expect(isTempDownloadName(undefined)).toBe(false);
+  });
+});
+
+describe("nameFromUrl", () => {
+  it("returns the basename of a URL path", () => {
+    expect(nameFromUrl("https://example.com/files/My%20File.zip")).toBe("My File.zip");
+  });
+
+  it("decodes percent-encoded spaces", () => {
+    expect(nameFromUrl("https://example.com/a/b/mod%20patch.7z")).toBe("mod patch.7z");
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(nameFromUrl(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable URL", () => {
+    expect(nameFromUrl("not a url")).toBeUndefined();
+  });
+
+  it("extracts the file name from a resolved Nexus CDN URL (spaces + query string)", () => {
+    expect(nameFromUrl(cdnUrl)).toBe("Example Mod Name-123-1-0.7z");
+  });
+
+  it("returns only the file id for an nxm link (no useful name)", () => {
+    expect(nameFromUrl(nxmUrl)).toBe("456");
+  });
+});
+
+describe("friendlyDownloadName", () => {
+  it("uses the real on-disk name once it's known", () => {
+    expect(friendlyDownloadName(download({ localPath: "My File.zip" }))).toBe("My File.zip");
+  });
+
+  it("prefers modInfo.name while the temp name is still in use", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: tempName, modInfo: { name: "Cool Mod" } }),
+    );
+    expect(result).toBe("Cool Mod");
+  });
+
+  it("falls back to meta.logicalFileName when there's no modInfo.name", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: tempName, modInfo: { meta: { logicalFileName: "Logical Name" } } }),
+    );
+    expect(result).toBe("Logical Name");
+  });
+
+  it("falls back to meta.fileName when there's no logical name", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: tempName, modInfo: { meta: { fileName: "actual-file.zip" } } }),
+    );
+    expect(result).toBe("actual-file.zip");
+  });
+
+  it("falls back to the resolved nexus file info name", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: tempName, modInfo: { nexus: { fileInfo: { name: "Nexus File" } } } }),
+    );
+    expect(result).toBe("Nexus File");
+  });
+
+  it("falls back to the URL basename when no metadata is available", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: tempName, urls: ["https://example.com/files/from-url.7z"] }),
+    );
+    expect(result).toBe("from-url.7z");
+  });
+
+  it("returns the temp name as a last resort", () => {
+    expect(friendlyDownloadName(download({ localPath: tempName }))).toBe(tempName);
+  });
+
+  it("prefers a real localPath over any metadata", () => {
+    const result = friendlyDownloadName(
+      download({ localPath: "final.zip", modInfo: { name: "Cool Mod" } }),
+    );
+    expect(result).toBe("final.zip");
+  });
+
+  it("uses resolved metadata over the nxm link for a pending nxm download", () => {
+    const result = friendlyDownloadName(
+      download({
+        localPath: tempName,
+        urls: [nxmUrl],
+        modInfo: { meta: { logicalFileName: "Example Mod Name" } },
+      }),
+    );
+    expect(result).toBe("Example Mod Name");
+  });
+
+  it("falls back to the nxm file id when a pending nxm download has no metadata yet", () => {
+    const result = friendlyDownloadName(download({ localPath: tempName, urls: [nxmUrl] }));
+    expect(result).toBe("456");
+  });
+
+  it("prefers modInfo.name over meta.logicalFileName", () => {
+    const result = friendlyDownloadName(
+      download({
+        localPath: tempName,
+        modInfo: { name: "Cool Mod", meta: { logicalFileName: "Logical Name" } },
+      }),
+    );
+    expect(result).toBe("Cool Mod");
+  });
+});

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -19,9 +19,6 @@ export function nameFromUrl(input: string | undefined): string | undefined {
 
   try {
     const pathname = new URL(input).pathname;
-    if (!truthy(pathname)) {
-      return undefined;
-    }
     return decodeURI(path.basename(pathname));
   } catch (err) {
     return undefined;

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -35,7 +35,7 @@ export function nameFromUrl(input: string | undefined): string | undefined {
  */
 export function friendlyDownloadName(download: IDownload): string | undefined {
   const localPath = download.localPath;
-  if (truthy(localPath) && !isTempDownloadName(localPath)) {
+  if (localPath && !isTempDownloadName(localPath)) {
     return localPath;
   }
 

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -43,7 +43,7 @@ export function friendlyDownloadName(download: IDownload): string | undefined {
     download.modInfo?.nexus?.fileInfo?.name,
     nameFromUrl(download.urls?.[0]),
   ];
-  const friendly = candidates.find(truthy);
+  const friendly = candidates.find(Boolean);
 
   // Fall back to the temp name so sort/filter stay stable before metadata resolves.
   return friendly ?? localPath;

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -1,0 +1,53 @@
+import * as path from "path";
+
+import { truthy } from "../../../util/util";
+import type { IDownload } from "../types/IDownload";
+
+// Placeholder filename a download uses on disk while in progress, renamed to the
+// real name on completion. The UI shows friendlyDownloadName in its place.
+export const TEMP_DOWNLOAD_PREFIX = "__vortex_tmp_";
+
+export function isTempDownloadName(name: string | undefined): boolean {
+  return name !== undefined && name.startsWith(TEMP_DOWNLOAD_PREFIX);
+}
+
+/** File name from a URL's basename, best-effort; undefined if missing/unparseable. */
+export function nameFromUrl(input: string | undefined): string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  try {
+    const pathname = new URL(input).pathname;
+    if (!truthy(pathname)) {
+      return undefined;
+    }
+    return decodeURI(path.basename(pathname));
+  } catch (err) {
+    return undefined;
+  }
+}
+
+/**
+ * Name to show for a download. Prefers the real on-disk name; while the temp
+ * placeholder is still in use, falls back to metadata or the URL so the user
+ * doesn't see __vortex_tmp_*.
+ */
+export function friendlyDownloadName(download: IDownload): string | undefined {
+  const localPath = download.localPath;
+  if (truthy(localPath) && !isTempDownloadName(localPath)) {
+    return localPath;
+  }
+
+  const candidates: Array<string | undefined> = [
+    download.modInfo?.name,
+    download.modInfo?.meta?.logicalFileName,
+    download.modInfo?.meta?.fileName,
+    download.modInfo?.nexus?.fileInfo?.name,
+    nameFromUrl(download.urls?.[0]),
+  ];
+  const friendly = candidates.find(truthy);
+
+  // Fall back to the temp name so sort/filter stay stable before metadata resolves.
+  return friendly ?? localPath;
+}

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 
-import { truthy } from "../../../util/util";
 import type { IDownload } from "../types/IDownload";
 
 // Placeholder filename a download uses on disk while in progress, renamed to the
@@ -20,7 +19,7 @@ export function nameFromUrl(input: string | undefined): string | undefined {
   try {
     const pathname = new URL(input).pathname;
     return decodeURI(path.basename(pathname));
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }

--- a/src/renderer/src/extensions/download_management/views/DownloadView.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadView.tsx
@@ -53,6 +53,7 @@ import { convertGameIdReverse } from "../../nexus_integration/util/convertGameId
 import { setShowDLDropzone, setShowDLGraph } from "../actions/settings";
 import { finishDownload, setDownloadTime } from "../actions/state";
 import type { IDownload } from "../types/IDownload";
+import { friendlyDownloadName } from "../util/downloadNames";
 import getDownloadGames from "../util/getDownloadGames";
 import DownloadGraph from "./DownloadGraph";
 
@@ -598,7 +599,7 @@ class DownloadView extends ComponentEx<IDownloadViewProps, IComponentState> {
 
     const downloadNames = downloadIds
       .filter((downloadId) => this.getDownload(downloadId) !== undefined)
-      .map((downloadId: string) => this.getDownload(downloadId).localPath);
+      .map((downloadId: string) => friendlyDownloadName(this.getDownload(downloadId)));
 
     onShowDialog(
       "question",
@@ -707,8 +708,11 @@ class DownloadView extends ComponentEx<IDownloadViewProps, IComponentState> {
     }
   };
 
-  private inspect = (downloadId: string) => {
+  private inspect = (downloadIds: string[]) => {
     const { t, onShowDialog } = this.props;
+    // Row actions receive an array of instance ids (see IconBar); take the first.
+    // Passing the array on leaks it into the strictly-validated remove-download event.
+    const downloadId = downloadIds[0];
     const download = this.getDownload(downloadId);
     if (download === undefined) {
       // the download has been removed in the meantime?

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -21,6 +21,7 @@
 import { EventEmitter } from "events";
 import * as path from "path";
 
+import type { IFileInfo } from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
 import type { Api, DownloaderApi } from "@vortex/shared/preload";
 import { batch } from "redux-act";
@@ -140,6 +141,28 @@ export function makeDownload(overrides: Partial<IDownload> = {}): IDownload {
     size: 0,
     received: 0,
     verified: 0,
+    ...overrides,
+  };
+}
+
+export function makeFileInfo(overrides: Partial<IFileInfo> = {}): IFileInfo {
+  return {
+    file_id: 1,
+    category_id: 1,
+    category_name: "MAIN",
+    changelog_html: "",
+    content_preview_link: "",
+    name: "file",
+    description: "",
+    version: "1.0.0",
+    size: 0,
+    size_kb: 0,
+    file_name: "file.7z",
+    uploaded_timestamp: 0,
+    uploaded_time: "",
+    mod_version: "1.0.0",
+    external_virus_scan_url: "",
+    is_primary: true,
     ...overrides,
   };
 }


### PR DESCRIPTION
Fixed download not being deleteable because it was not properly cancelled

Closes LAZ-719