### PR TITLE
track game launch and exit in mixpanel (LAZ-703)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -102,6 +102,47 @@ export class AppGameUnmanagedEvent implements MixpanelEvent {
   }
 }
 
+/** How a game/tool launch was started, on the app_game_launched event. */
+export type GameLaunchMethod = "direct_exe" | "store" | "script_extender" | "tool";
+
+/**
+ * Sent when the user launches the game or a tool from Vortex. `launch_session_id` pairs it with
+ * the matching app_game_exited so launch and exit can be joined (and a duration derived).
+ */
+export interface GameLaunchedProps {
+  game_id: number | null;
+  launch_method: GameLaunchMethod;
+  enabled_mod_count: number;
+  launch_session_id: string;
+}
+
+export class AppGameLaunchedEvent implements MixpanelEvent {
+  readonly eventName = "app_game_launched";
+  readonly properties: Record<string, unknown>;
+  constructor(props: GameLaunchedProps) {
+    this.properties = { ...props };
+  }
+}
+
+/** Fields on the app_game_exited event. */
+export interface GameExitedProps {
+  game_id: number | null;
+  launch_session_id: string;
+  duration_ms: number;
+}
+
+/**
+ * Sent when a launched game/tool process exits. `duration_ms` is the time since its launch;
+ * `launch_session_id` matches the app_game_launched it pairs with.
+ */
+export class AppGameExitedEvent implements MixpanelEvent {
+  readonly eventName = "app_game_exited";
+  readonly properties: Record<string, unknown>;
+  constructor(props: GameExitedProps) {
+    this.properties = { ...props };
+  }
+}
+
 /**
  * COLLECTION EVENTS
  */

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -64,6 +64,7 @@ import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IGame } from "../types/IGame";
 import type { IState } from "../types/IState";
 import local from "../util/local";
+import type { IStarterInfo } from "../util/StarterInfo";
 import type {
   IApiHarness,
   IDownloadAdapterHarness,
@@ -179,6 +180,29 @@ export function makeProfile(overrides: Partial<IProfile> = {}): IProfile {
     name: "Profile",
     modState: {},
     lastActivated: 0,
+    ...overrides,
+  };
+}
+
+// A launch target as StarterInfo.run receives it. Defaults to the skyrimse game exe (isGame),
+// launched directly (no store); override isGame/store/defaultPrimary to model store/tool/SE launches.
+export function makeStarterInfo(overrides: Partial<IStarterInfo> = {}): IStarterInfo {
+  return {
+    id: "skyrimse",
+    gameId: "skyrimse",
+    isGame: true,
+    iconOutPath: "",
+    name: "Skyrim Special Edition",
+    exePath: "C:/games/skyrimse/SkyrimSE.exe",
+    commandLine: [],
+    workingDirectory: "",
+    exclusive: false,
+    detach: true,
+    shell: false,
+    store: "",
+    environment: {},
+    extensionPath: "",
+    logoName: "",
     ...overrides,
   };
 }

--- a/src/renderer/src/util/StarterInfo.ts
+++ b/src/renderer/src/util/StarterInfo.ts
@@ -22,6 +22,7 @@ import {
   ProcessCanceled,
   UserCanceled,
 } from "./CustomErrors";
+import { emitGameLaunched } from "./gameLaunchAnalytics";
 import GameStoreHelper from "./GameStoreHelper";
 import getVortexPath from "./getVortexPath";
 import { isWindowsExecutable } from "./linux/proton";
@@ -159,6 +160,7 @@ class StarterInfo implements IStarterInfo {
 
     const onSpawned = () => {
       api.store.dispatch(setToolRunning(info.exePath, Date.now(), info.exclusive));
+      emitGameLaunched(api, info);
 
       // Flatpak can't reliably observe host game exit for now, so emulate stop after a short delay
       // for now. We'll come up with a better solution/design in the future.

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the game launch/exit analytics: app_game_launched carries the launch method and a
+ * session id, and app_game_exited pairs with it (same launch_session_id) with an elapsed duration.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  GameLaunchMethod,
+  MixpanelEvent,
+} from "../extensions/analytics/mixpanel/MixpanelEvents";
+import { makeExeId } from "../reducers/session";
+import { makeApiHarness, makeStarterInfo } from "../test-utils/builders";
+import { emitExitsForStoppedTools, emitGameLaunched } from "./gameLaunchAnalytics";
+import type { IStarterInfo } from "./StarterInfo";
+
+function harness() {
+  const base = makeApiHarness();
+  const events: MixpanelEvent[] = [];
+  base.api.events.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  return { api: base.api, events };
+}
+
+const launchMethodCases: Array<[Partial<IStarterInfo>, GameLaunchMethod]> = [
+  [{ isGame: true, store: "steam" }, "store"],
+  [{ isGame: true, store: "" }, "direct_exe"],
+  [{ isGame: false, defaultPrimary: true }, "script_extender"],
+  [{ isGame: false, defaultPrimary: false }, "tool"],
+];
+
+describe("game launch analytics", () => {
+  it("emits app_game_launched with a session id and enabled mod count", () => {
+    const h = harness();
+    emitGameLaunched(h.api, makeStarterInfo({ exePath: "C:/g/launched.exe" }));
+    const launched = h.events.find((e) => e.eventName === "app_game_launched");
+    expect(launched).toBeDefined();
+    expect(typeof launched?.properties.launch_session_id).toBe("string");
+    expect(typeof launched?.properties.enabled_mod_count).toBe("number");
+  });
+
+  for (const [overrides, expected] of launchMethodCases) {
+    it(`classifies launch_method as ${expected}`, () => {
+      const h = harness();
+      emitGameLaunched(h.api, makeStarterInfo({ ...overrides, exePath: `C:/g/${expected}.exe` }));
+      const launched = h.events.find((e) => e.eventName === "app_game_launched");
+      expect(launched?.properties.launch_method).toBe(expected);
+    });
+  }
+
+  it("pairs app_game_exited with the launch via launch_session_id and a duration", () => {
+    const h = harness();
+    const info = makeStarterInfo({ exePath: "C:/g/exited.exe" });
+    emitGameLaunched(h.api, info);
+    const sessionId = h.events.find((e) => e.eventName === "app_game_launched")?.properties
+      .launch_session_id;
+
+    emitExitsForStoppedTools(h.api, { [makeExeId(info.exePath)]: { started: 0 } }, {});
+
+    const exited = h.events.find((e) => e.eventName === "app_game_exited");
+    expect(exited).toBeDefined();
+    expect(exited?.properties.launch_session_id).toBe(sessionId);
+    expect(typeof exited?.properties.duration_ms).toBe("number");
+  });
+
+  it("does not emit app_game_exited for an exe that was not a tracked launch", () => {
+    const h = harness();
+    emitExitsForStoppedTools(h.api, { "unrelated.exe": { started: 0 } }, {});
+    expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+  });
+});

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -1,0 +1,100 @@
+import { generate as shortid } from "shortid";
+
+import {
+  AppGameExitedEvent,
+  AppGameLaunchedEvent,
+  type GameLaunchMethod,
+} from "../extensions/analytics/mixpanel/MixpanelEvents";
+import { getGame } from "../extensions/gamemode_management/util/getGame";
+import { nexusGames } from "../extensions/nexus_integration/util";
+import { nexusGameId } from "../extensions/nexus_integration/util/convertGameId";
+import {
+  enabledModCountForProfile,
+  lastActiveProfileForGame,
+} from "../extensions/profile_management/selectors";
+import { makeExeId } from "../reducers/session";
+import type { IExtensionApi } from "../types/IExtensionContext";
+import type { IState } from "../types/IState";
+import type { IStarterInfo } from "./StarterInfo";
+
+interface ILaunchRecord {
+  sessionId: string;
+  gameId: number | null;
+  launchTime: number;
+}
+
+// Recorded launches awaiting their exit, keyed by exe id (makeExeId).
+const pendingLaunches = new Map<string, ILaunchRecord>();
+let exitWatcherInstalled = false;
+
+/** Numeric Nexus game id for an internal game id, matching the other analytics events; null when unresolved. */
+function toNumericGameId(internalGameId: string): number | null {
+  const domain = nexusGameId(getGame(internalGameId), internalGameId);
+  return nexusGames().find((game) => game.domain_name === domain)?.id ?? null;
+}
+
+function launchMethod(info: IStarterInfo): GameLaunchMethod {
+  if (info.isGame) {
+    return info.store ? "store" : "direct_exe";
+  }
+  // Extensions flag script-extender tools (skse64, f4se, ...) with defaultPrimary.
+  return info.defaultPrimary ? "script_extender" : "tool";
+}
+
+/** Emits app_game_exited for each recorded launch whose exe is in `previous` but absent from `current`. */
+export function emitExitsForStoppedTools(
+  api: IExtensionApi,
+  previous: Record<string, unknown>,
+  current: Record<string, unknown>,
+): void {
+  for (const exeId of Object.keys(previous ?? {})) {
+    if (current?.[exeId] !== undefined) {
+      continue;
+    }
+    const record = pendingLaunches.get(exeId);
+    if (record === undefined) {
+      continue;
+    }
+    pendingLaunches.delete(exeId);
+    api.events.emit(
+      "analytics-track-mixpanel-event",
+      new AppGameExitedEvent({
+        game_id: record.gameId,
+        launch_session_id: record.sessionId,
+        duration_ms: Date.now() - record.launchTime,
+      }),
+    );
+  }
+}
+
+/** Installs the toolsRunning watcher that emits app_game_exited, once per session. */
+function ensureExitWatcher(api: IExtensionApi): void {
+  if (exitWatcherInstalled || api.onStateChange === undefined) {
+    return;
+  }
+  exitWatcherInstalled = true;
+  api.onStateChange(
+    ["session", "base", "toolsRunning"],
+    (previous: Record<string, unknown>, current: Record<string, unknown>) =>
+      emitExitsForStoppedTools(api, previous, current),
+  );
+}
+
+/** Emits app_game_launched and ensures the exit watcher is installed for the paired app_game_exited. */
+export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
+  ensureExitWatcher(api);
+  const state: IState = api.getState();
+  const gameId = toNumericGameId(info.gameId);
+  const sessionId = shortid();
+  pendingLaunches.set(makeExeId(info.exePath), { sessionId, gameId, launchTime: Date.now() });
+  const profileId = lastActiveProfileForGame(state, info.gameId);
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new AppGameLaunchedEvent({
+      game_id: gameId,
+      launch_method: launchMethod(info),
+      enabled_mod_count: enabledModCountForProfile(state, profileId),
+      launch_session_id: sessionId,
+    }),
+  );
+}


### PR DESCRIPTION
Emit app_game_launched from StarterInfo when a game or tool is spawned, carrying game_id (numeric Nexus id), launch_method, enabled_mod_count, and a launch_session_id. A toolsRunning watcher emits the paired app_game_exited with the same launch_session_id and a duration_ms when the process leaves the running set.

launch_method is direct_exe or store for games, script_extender or tool otherwise. game_id resolves via nexusGameId/nexusGames and is null when unresolved.

Note that script extenders or mod loaders usually exit early (acting as a game launcher, so the game duration for games like SDV/Gamebryo is not reliable)

closes LAZ-703