### PR TITLE
expose collection revision_id on per-mod download and install events (LAZ-673)

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -323,12 +323,14 @@ export class IPCDownloadAdapter {
     const download = state.persistent.downloads.files?.[downloadId];
     const isCollection = nexusIds.collectionSlug !== undefined && nexusIds.revisionId !== undefined;
 
-    // Mod downloads triggered by a collection install carry the parent collection's id
-    // under `modInfo.nexus.parentCollectionId` (see InstallManager.downloadURL).
-    // Cast narrows away the `[key: string]: any` index signature on nexus.
+    // Mod downloads triggered by a collection install carry the parent collection's id and
+    // revision under `modInfo.nexus.parentCollectionId`/`parentRevisionId` (see
+    // InstallManager.downloadURL).
     const parentCollectionId = download?.modInfo?.nexus?.parentCollectionId;
     const modCollectionId =
       isCollection || parentCollectionId === undefined ? null : parentCollectionId;
+    const parentRevisionId = download?.modInfo?.nexus?.parentRevisionId;
+    const modRevisionId = isCollection || parentRevisionId === undefined ? null : parentRevisionId;
 
     // Durable resume history (persisted on the record, accumulates across restarts).
     const pause_count = download?.pauseCount ?? 0;
@@ -338,7 +340,9 @@ export class IPCDownloadAdapter {
       if (isCollection || nexusIds.modId === undefined || nexusIds.fileId === undefined) return;
       this.#api.events.emit(
         "analytics-track-mixpanel-event",
-        new ModsDownloadStartedClientEvent(makeModAnalyticsIdentity(nexusIds, modCollectionId)),
+        new ModsDownloadStartedClientEvent(
+          makeModAnalyticsIdentity(nexusIds, modCollectionId, modRevisionId),
+        ),
       );
       return;
     }
@@ -366,7 +370,7 @@ export class IPCDownloadAdapter {
         this.#api.events.emit(
           "analytics-track-mixpanel-event",
           new ModsDownloadCompletedEvent({
-            ...makeModAnalyticsIdentity(nexusIds, modCollectionId),
+            ...makeModAnalyticsIdentity(nexusIds, modCollectionId, modRevisionId),
             file_size,
             duration_ms,
             ...resumeInfo,
@@ -389,7 +393,9 @@ export class IPCDownloadAdapter {
       } else if (nexusIds.modId !== undefined && nexusIds.fileId !== undefined) {
         this.#api.events.emit(
           "analytics-track-mixpanel-event",
-          new ModsDownloadCancelledEvent(makeModAnalyticsIdentity(nexusIds, modCollectionId)),
+          new ModsDownloadCancelledEvent(
+            makeModAnalyticsIdentity(nexusIds, modCollectionId, modRevisionId),
+          ),
         );
       }
       return;
@@ -413,7 +419,7 @@ export class IPCDownloadAdapter {
         this.#api.events.emit(
           "analytics-track-mixpanel-event",
           new ModsDownloadFailedEvent({
-            ...makeModAnalyticsIdentity(nexusIds, modCollectionId),
+            ...makeModAnalyticsIdentity(nexusIds, modCollectionId, modRevisionId),
             error_code,
             error_message: message,
             ...resumeInfo,

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -352,8 +352,8 @@ export class CollectionsInstallationPausedEvent implements MixpanelEvent {
 /**
  * Identity shared by every per-mod analytics event (download and install), so the
  * mod-level events stay consistent with one another and joinable to their collection.
- * `collection_id` is the parent collection id when the mod is downloaded/installed as
- * part of a collection, otherwise null.
+ * `collection_id`/`revision_id` are the parent collection and its revision when the mod
+ * is downloaded/installed as part of a collection, otherwise null.
  */
 export interface ModAnalyticsIdentity {
   mod_id: string;
@@ -362,6 +362,7 @@ export interface ModAnalyticsIdentity {
   mod_uid: string;
   file_uid: string;
   collection_id: string | null;
+  revision_id: string | null;
 }
 
 /**

--- a/src/renderer/src/extensions/analytics/mixpanel/modAnalyticsIdentity.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modAnalyticsIdentity.ts
@@ -13,13 +13,15 @@ export interface ModNexusIds {
 }
 
 /**
- * Builds the shared per-mod analytics identity (mod/file ids + UIDs + collection_id)
+ * Builds the shared per-mod analytics identity (mod/file ids + UIDs + collection_id + revision_id)
  * from resolved nexus ids, so the download and install emit sites produce an identical
- * identity. `collectionId` is the parent collection when installed as part of one, else null.
+ * identity. `collectionId`/`revisionId` are the parent collection and its revision when installed
+ * as part of one, else null.
  */
 export function makeModAnalyticsIdentity(
   nexusIds: ModNexusIds,
   collectionId: string | null,
+  revisionId: string | null,
 ): ModAnalyticsIdentity {
   const { modUID, fileUID } = makeModAndFileUIDs(
     nexusIds.numericGameId.toString(),
@@ -33,5 +35,6 @@ export function makeModAnalyticsIdentity(
     mod_uid: modUID,
     file_uid: fileUID,
     collection_id: collectionId,
+    revision_id: revisionId,
   };
 }

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.test.ts
@@ -47,6 +47,7 @@ test("emitModStateChanged emits mods_state_changed with the change, reason and N
     mod_id: "100",
     file_id: "200",
     collection_id: null,
+    revision_id: null,
   });
 });
 

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
@@ -35,9 +35,11 @@ function resolveModIdentity(
       ? nexusGameId(getGame(attributes.downloadGame), attributes.downloadGame)
       : undefined;
   const numericGameId = nexusGames().find((game) => game.domain_name === domain)?.id ?? Number.NaN;
+  // revision_id is null: the mod's own attributes don't record the parent collection revision.
   return makeModAnalyticsIdentity(
     { numericGameId, modId: modId.toString(), fileId: fileId.toString() },
     collectionId,
+    null,
   );
 }
 

--- a/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modInstallAnalytics.ts
@@ -55,8 +55,8 @@ export interface ModInstallOutcomeContext {
  * Resolves the per-mod analytics identity for an install archive, or undefined when the
  * install should not be tracked: no nexus fileId (manual/bundled mods), or the archive is
  * the collection container itself (the collection has its own installation events). A mod
- * installed as part of a collection carries that collection's id under
- * modInfo.nexus.parentCollectionId.
+ * installed as part of a collection carries that collection's id and revision under
+ * modInfo.nexus.parentCollectionId/parentRevisionId.
  */
 function resolveModIdentity(
   api: IExtensionApi,
@@ -68,8 +68,12 @@ function resolveModIdentity(
   if (nexusIds?.fileId == null || isCollection) {
     return undefined;
   }
-  const download = state.persistent.downloads.files?.[archiveId];
-  return makeModAnalyticsIdentity(nexusIds, download?.modInfo?.nexus?.parentCollectionId ?? null);
+  const parent = state.persistent.downloads.files?.[archiveId]?.modInfo?.nexus;
+  return makeModAnalyticsIdentity(
+    nexusIds,
+    parent?.parentCollectionId ?? null,
+    parent?.parentRevisionId ?? null,
+  );
 }
 
 /** Emits mods_installation_started for a mod (standalone or collection member). */

--- a/src/renderer/src/extensions/download_management/types/IDownload.ts
+++ b/src/renderer/src/extensions/download_management/types/IDownload.ts
@@ -79,6 +79,8 @@ export interface IModInfo {
      * install attribute extractor. Consumed by Mixpanel mod download analytics.
      */
     parentCollectionId?: string;
+    /** Revision of the collection in `parentCollectionId`. Set together with it; analytics only. */
+    parentRevisionId?: string;
     fileInfo?: IFileInfo;
     [key: string]: any;
   };

--- a/src/renderer/src/extensions/mod_management/InstallContext.analytics.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallContext.analytics.test.ts
@@ -36,6 +36,7 @@ describe("InstallContext per-mod analytics", () => {
       mod_id: "100",
       file_id: "200",
       collection_id: null,
+      revision_id: null,
     });
   });
 
@@ -78,10 +79,17 @@ describe("InstallContext per-mod analytics", () => {
     expect(completed?.properties.install_kind).toBe("profile_replace");
   });
 
-  test("carries the parent collection_id for a collection member", ({ makeInstallContext }) => {
-    const h = makeInstallContext(withDownload(memberInfo({ parentCollectionId: "col-9" })));
+  test("carries the parent collection_id and revision_id for a collection member", ({
+    makeInstallContext,
+  }) => {
+    const h = makeInstallContext(
+      withDownload(memberInfo({ parentCollectionId: "col-9", parentRevisionId: "rev-3" })),
+    );
     h.ctx.startInstallCB(MOD, GAME, ARCHIVE);
-    expect(h.mixpanelEvents[0].properties.collection_id).toBe("col-9");
+    expect(h.mixpanelEvents[0].properties).toMatchObject({
+      collection_id: "col-9",
+      revision_id: "rev-3",
+    });
   });
 
   test("does not emit for the collection container itself", ({ makeInstallContext }) => {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -216,6 +216,12 @@ interface IInvalidInstruction {
   error: string;
 }
 
+/** The collection (and its revision) a dependency download belongs to, for download analytics. */
+interface IParentCollection {
+  collectionId: string;
+  revisionId?: string;
+}
+
 class InstructionGroups {
   public copy: IInstruction[] = [];
   public mkdir: IInstruction[] = [];
@@ -3434,9 +3440,15 @@ class InstallManager {
     if (collectionMod === undefined) {
       return;
     }
-    const parentCollectionId =
+    const parentCollection: IParentCollection | undefined =
       collectionMod.attributes?.collectionId != null
-        ? String(collectionMod.attributes.collectionId)
+        ? {
+            collectionId: String(collectionMod.attributes.collectionId),
+            revisionId:
+              collectionMod.attributes.revisionId != null
+                ? String(collectionMod.attributes.revisionId)
+                : undefined,
+          }
         : undefined;
     const stagingPath = installPathForGame(state, session.gameId);
     const pending = selectedOptionalRules(
@@ -3478,7 +3490,7 @@ class InstallManager {
             dep.lookupResults[0].value,
             () => !this.mDependencyInstalls[sourceModId],
             dep.extra?.fileName,
-            parentCollectionId,
+            parentCollection,
           );
         })
         .then((downloadId: string | undefined) => {
@@ -5272,7 +5284,7 @@ class InstallManager {
     referenceTag?: string,
     campaign?: string,
     fileName?: string,
-    parentCollectionId?: string,
+    parentCollection?: IParentCollection,
   ): Promise<string> {
     const call = (input: string | (() => PromiseLike<string>)): Promise<string> =>
       input !== undefined && typeof input === "function"
@@ -5306,12 +5318,15 @@ class InstallManager {
               referenceTag,
               meta: lookupResult,
             };
-            if (parentCollectionId !== undefined) {
-              // Tag the download with the parent collection's id for analytics only.
+            if (parentCollection !== undefined) {
+              // Tag the download with the parent collection's id and revision for analytics only.
               // Kept off `nexus.ids.collectionId` because the install attribute
               // extractor copies that field onto the installed mod, which would
               // make a regular mod look like a collection downstream.
-              startDownloadModInfo.nexus = { parentCollectionId };
+              startDownloadModInfo.nexus = {
+                parentCollectionId: parentCollection.collectionId,
+                parentRevisionId: parentCollection.revisionId,
+              };
             }
 
             if (
@@ -5350,7 +5365,7 @@ class InstallManager {
                         referenceTag,
                         campaign,
                         fileName,
-                        parentCollectionId,
+                        parentCollection,
                       );
                       return resolve(id);
                     } else {
@@ -5378,7 +5393,7 @@ class InstallManager {
     wasCanceled: () => boolean,
     campaign: string,
     fileName?: string,
-    parentCollectionId?: string,
+    parentCollection?: IParentCollection,
   ): Promise<string> {
     const modId: string = getSafe(lookupResult, ["details", "modId"], undefined);
     const fileId: string = getSafe(lookupResult, ["details", "fileId"], undefined);
@@ -5390,7 +5405,7 @@ class InstallManager {
         referenceTag,
         fileName,
         undefined,
-        parentCollectionId,
+        parentCollection,
       );
     }
 
@@ -5429,16 +5444,25 @@ class InstallManager {
                 api.store.dispatch(
                   setDownloadModInfo(results[0].dlId, "referenceTag", referenceTag),
                 );
-                if (parentCollectionId !== undefined) {
+                if (parentCollection !== undefined) {
                   // See downloadURL: kept off nexus.ids.collectionId to avoid the
                   // install attribute extractor copying it onto the installed mod.
                   api.store.dispatch(
                     setDownloadModInfo(
                       results[0].dlId,
                       "nexus.parentCollectionId",
-                      parentCollectionId,
+                      parentCollection.collectionId,
                     ),
                   );
+                  if (parentCollection.revisionId !== undefined) {
+                    api.store.dispatch(
+                      setDownloadModInfo(
+                        results[0].dlId,
+                        "nexus.parentRevisionId",
+                        parentCollection.revisionId,
+                      ),
+                    );
+                  }
                 }
                 return Promise.resolve(results[0].dlId);
               }
@@ -5454,7 +5478,7 @@ class InstallManager {
     lookupResult: IModInfoEx,
     wasCanceled: () => boolean,
     fileName: string,
-    parentCollectionId?: string,
+    parentCollection?: IParentCollection,
   ): Promise<string> {
     const referenceTag = requirement["tag"];
     const { campaign } = requirement["repo"] ?? {};
@@ -5473,7 +5497,7 @@ class InstallManager {
         wasCanceled,
         campaign,
         fileName,
-        parentCollectionId,
+        parentCollection,
       )
         .catch((err) => {
           if (err instanceof HTTPError) {
@@ -5493,7 +5517,7 @@ class InstallManager {
                 referenceTag,
                 campaign,
                 fileName,
-                parentCollectionId,
+                parentCollection,
               )
             : res,
         );
@@ -5505,7 +5529,7 @@ class InstallManager {
         referenceTag,
         campaign,
         fileName,
-        parentCollectionId,
+        parentCollection,
       ).catch((err) => {
         if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
           return Promise.reject(err);
@@ -5520,7 +5544,7 @@ class InstallManager {
             wasCanceled,
             campaign,
             fileName,
-            parentCollectionId,
+            parentCollection,
           );
         } else {
           return Promise.reject(err);
@@ -6030,10 +6054,16 @@ class InstallManager {
     }
 
     // When installing a collection, tag each dependency download with the parent
-    // collection id so the Mixpanel mod download events can carry collection_id.
-    const parentCollectionId: string | undefined =
+    // collection id and revision so the Mixpanel mod download events can carry them.
+    const parentCollection: IParentCollection | undefined =
       sourceMod.type === "collection" && sourceMod.attributes?.collectionId !== undefined
-        ? String(sourceMod.attributes.collectionId)
+        ? {
+            collectionId: String(sourceMod.attributes.collectionId),
+            revisionId:
+              sourceMod.attributes.revisionId !== undefined
+                ? String(sourceMod.attributes.revisionId)
+                : undefined,
+          }
         : undefined;
 
     let queuedDownloads: IModReference[] = [];
@@ -6079,7 +6109,7 @@ class InstallManager {
                 dep.lookupResults[0].value,
                 () => abort.signal.aborted,
                 dep.extra?.fileName,
-                parentCollectionId,
+                parentCollection,
               ),
             )
             .then((dlId) => {


### PR DESCRIPTION
Added revision_id to the shared per-mod analytics identity, so mods_download_* and mods_installation_* events join to a specific collection revision, not just its collection_id. Member downloads are tagged with modInfo.nexus.parentRevisionId (from the collection mod attributes.revisionId), threaded through the download path as a single parentCollection object. Standalone mods and the state changed/removed events carry null.

part of LAZ-673