### PR TITLE
track game manage/unmanage in mixpanel (LAZ-704)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -75,6 +75,33 @@ export class AppUpsellClickedEvent implements MixpanelEvent {
   constructor() {}
 }
 
+/** Fields on the app_game_manage event. */
+export interface GameManagedProps {
+  game_id: number | null;
+  extension_version: string;
+}
+
+/**
+ * Sent the first time a game is managed, when its first profile is created.
+ * `extension_version` is the version of the game's support extension.
+ */
+export class AppGameManagedEvent implements MixpanelEvent {
+  readonly eventName = "app_game_manage";
+  readonly properties: Record<string, unknown>;
+  constructor(props: GameManagedProps) {
+    this.properties = { ...props };
+  }
+}
+
+/** Sent when a game is unmanaged (its profiles and mods are removed). */
+export class AppGameUnmanagedEvent implements MixpanelEvent {
+  readonly eventName = "app_game_unmanage";
+  readonly properties: Record<string, unknown>;
+  constructor(props: { game_id: number | null }) {
+    this.properties = { ...props };
+  }
+}
+
 /**
  * COLLECTION EVENTS
  */

--- a/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the game manage/unmanage analytics: app_game_manage carries the numeric game id and
+ * the support extension version; app_game_unmanage carries the game id.
+ */
+import { EventEmitter } from "events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { emitGameManaged, emitGameUnmanaged } from "./gameManageAnalytics";
+import type { MixpanelEvent } from "./MixpanelEvents";
+
+vi.mock("../../gamemode_management/util/getGame", () => ({
+  getGame: (id: string) => ({ id, name: id, version: "2.3.4" }),
+}));
+vi.mock("../../nexus_integration/util", () => ({
+  nexusGames: () => [{ domain_name: "skyrimspecialedition", id: 1704 }],
+}));
+vi.mock("../../nexus_integration/util/convertGameId", () => ({
+  nexusGameId: () => "skyrimspecialedition",
+}));
+
+function harness() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  return { api: { events: emitter } as unknown as IExtensionApi, events };
+}
+
+describe("game manage analytics", () => {
+  it("emits app_game_manage with the numeric game_id and extension version", () => {
+    const h = harness();
+    emitGameManaged(h.api, "skyrimse");
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].eventName).toBe("app_game_manage");
+    expect(h.events[0].properties).toMatchObject({ game_id: 1704, extension_version: "2.3.4" });
+  });
+
+  it("emits app_game_unmanage with the game_id", () => {
+    const h = harness();
+    emitGameUnmanaged(h.api, "skyrimse");
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].eventName).toBe("app_game_unmanage");
+    expect(h.events[0].properties).toMatchObject({ game_id: 1704 });
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.ts
@@ -1,0 +1,30 @@
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { getGame } from "../../gamemode_management/util/getGame";
+import { nexusGames } from "../../nexus_integration/util";
+import { nexusGameId } from "../../nexus_integration/util/convertGameId";
+import { AppGameManagedEvent, AppGameUnmanagedEvent } from "./MixpanelEvents";
+
+/** Numeric Nexus game id for an internal game id, matching the other analytics events; null when unresolved. */
+function toNumericGameId(internalGameId: string): number | null {
+  const domain = nexusGameId(getGame(internalGameId), internalGameId);
+  return nexusGames().find((game) => game.domain_name === domain)?.id ?? null;
+}
+
+/** Emits app_game_manage for a game managed for the first time, with its support extension version. */
+export function emitGameManaged(api: IExtensionApi, gameId: string): void {
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new AppGameManagedEvent({
+      game_id: toNumericGameId(gameId),
+      extension_version: getGame(gameId)?.version ?? "",
+    }),
+  );
+}
+
+/** Emits app_game_unmanage for a game the user stopped managing. */
+export function emitGameUnmanaged(api: IExtensionApi, gameId: string): void {
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new AppGameUnmanagedEvent({ game_id: toNumericGameId(gameId) }),
+  );
+}

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -55,6 +55,7 @@ import {
 } from "../../util/selectors";
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, truthy } from "../../util/util";
+import { emitGameManaged, emitGameUnmanaged } from "../analytics/mixpanel/gameManageAnalytics";
 import { readExtensions } from "../extension_manager/util";
 import { getGame, getGameStubDownloadInfo } from "../gamemode_management/util/getGame";
 import { ensureStagingDirectory } from "../mod_management/stagingDirectory";
@@ -540,6 +541,7 @@ function manageGameDiscovered(api: IExtensionApi, gameId: string) {
         }),
       );
       api.store.dispatch(setNextProfile(profileId));
+      emitGameManaged(api, gameId);
     })
     .catch((err) => {
       const instPath = installPathForGame(api.store.getState(), gameId);
@@ -796,7 +798,9 @@ function unmanageGame(api: IExtensionApi, gameId: string, gameName?: string): Pr
             ),
           )
           .then(() => PromiseBB.map(profileIds, (profileId) => removeProfileImpl(api, profileId)))
-          .then(() => PromiseBB.resolve())
+          .then(() => {
+            emitGameUnmanaged(api, gameId);
+          })
           .catch((err) => {
             if (err instanceof UserCanceled) {
               return PromiseBB.resolve();


### PR DESCRIPTION
Emit app_game_manage the first time a game is managed (from manageGameDiscovered, when its first profile is created), with game_id and the support extension version. Emit app_game_unmanage when a game is unmanaged, with game_id. game_id is the numeric Nexus id, null when unresolved.

closes LAZ-704