### PR TITLE
track deployment completion (LAZ-740)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -532,6 +532,33 @@ export class ModsRemovedEvent implements MixpanelEvent {
 }
 
 /**
+ * DEPLOYMENT EVENTS
+ */
+
+/** Fields on the mods_deployed event. */
+export interface ModsDeployedProps {
+  game_id: number | null;
+  deployment_method: string;
+  file_count: number;
+  enabled_mod_count: number;
+  manual: boolean;
+  is_collection_postprocess: boolean;
+}
+
+/**
+ * Sent when a deployment to the game directory completes successfully. `deployment_method` is the
+ * activator (hardlink, symlink, ...); `manual` marks a user-triggered deploy over an automatic one;
+ * `is_collection_postprocess` marks the deploy Vortex runs while finishing a collection install.
+ */
+export class ModsDeployedEvent implements MixpanelEvent {
+  readonly eventName = "mods_deployed";
+  readonly properties: Record<string, unknown>;
+  constructor(props: ModsDeployedProps) {
+    this.properties = { ...props };
+  }
+}
+
+/**
  * HEALTH CHECK EVENTS
  */
 

--- a/src/renderer/src/extensions/analytics/mixpanel/deployAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/deployAnalytics.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for the deploy analytics: mods_deployed carries the deployment method, file/enabled-mod
+ * counts, and the manual / collection-postprocess flags. game_id resolution is covered by
+ * numericGameId.test.ts; here it's unresolved (null) as in the other harness-based analytics tests.
+ */
+import { EventEmitter } from "events";
+
+import { describe, expect, it } from "vitest";
+
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { emitModsDeployed } from "./deployAnalytics";
+import type { MixpanelEvent } from "./MixpanelEvents";
+
+function harness() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  return { api: { events: emitter } as unknown as IExtensionApi, events };
+}
+
+describe("deploy analytics", () => {
+  it("emits mods_deployed with the deployment details", () => {
+    const h = harness();
+    emitModsDeployed(h.api, {
+      gameId: "skyrimse",
+      deploymentMethod: "hardlink",
+      fileCount: 42,
+      enabledModCount: 7,
+      manual: true,
+      isCollectionPostprocess: false,
+    });
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].eventName).toBe("mods_deployed");
+    expect(h.events[0].properties).toMatchObject({
+      deployment_method: "hardlink",
+      file_count: 42,
+      enabled_mod_count: 7,
+      manual: true,
+      is_collection_postprocess: false,
+    });
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/deployAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/deployAnalytics.ts
@@ -1,0 +1,33 @@
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { ModsDeployedEvent } from "./MixpanelEvents";
+import { numericNexusGameId } from "./numericGameId";
+
+export interface ModsDeployedInfo {
+  /** Internal game id (resolved to the numeric Nexus id on the event). */
+  gameId: string;
+  /** Deployment activator name (hardlink, symlink, ...). */
+  deploymentMethod: string;
+  /** Total files written across all mod types. */
+  fileCount: number;
+  /** Enabled mods on the deployed profile. */
+  enabledModCount: number;
+  /** A user-triggered deploy rather than an automatic one. */
+  manual: boolean;
+  /** The deploy Vortex runs while finishing a collection install. */
+  isCollectionPostprocess: boolean;
+}
+
+/** Emits mods_deployed for a successful deployment to the game directory. */
+export function emitModsDeployed(api: IExtensionApi, info: ModsDeployedInfo): void {
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new ModsDeployedEvent({
+      game_id: numericNexusGameId(info.gameId),
+      deployment_method: info.deploymentMethod,
+      file_count: info.fileCount,
+      enabled_mod_count: info.enabledModCount,
+      manual: info.manual,
+      is_collection_postprocess: info.isCollectionPostprocess,
+    }),
+  );
+}

--- a/src/renderer/src/extensions/analytics/mixpanel/numericGameId.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/numericGameId.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for the shared numeric-game-id resolution used by the analytics events. This is the one
+ * place the game-resolution globals (getGame / nexusGames / nexusGameId) are mocked; feature-level
+ * analytics tests follow the harness convention and don't assert the resolved id.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { numericNexusGameId } from "./numericGameId";
+
+vi.mock("../../gamemode_management/util/getGame", () => ({
+  getGame: (id: string) => ({ id, name: id }),
+}));
+vi.mock("../../nexus_integration/util", () => ({
+  nexusGames: () => [{ domain_name: "skyrimspecialedition", id: 1704 }],
+}));
+vi.mock("../../nexus_integration/util/convertGameId", () => ({
+  nexusGameId: (_game: unknown, id: string) =>
+    id === "skyrimse" ? "skyrimspecialedition" : "unknown-domain",
+}));
+
+describe("numericNexusGameId", () => {
+  it("resolves an internal game id to its numeric Nexus id", () => {
+    expect(numericNexusGameId("skyrimse")).toBe(1704);
+  });
+
+  it("returns null when the game isn't in the Nexus games cache", () => {
+    expect(numericNexusGameId("somethingelse")).toBeNull();
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/numericGameId.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/numericGameId.ts
@@ -1,0 +1,12 @@
+import { getGame } from "../../gamemode_management/util/getGame";
+import { nexusGames } from "../../nexus_integration/util";
+import { nexusGameId } from "../../nexus_integration/util/convertGameId";
+
+/**
+ * Numeric Nexus game id for an internal game id, so every analytics event carries game_id in the
+ * same form. null when the game isn't a Nexus game or the games cache hasn't loaded.
+ */
+export function numericNexusGameId(internalGameId: string): number | null {
+  const domain = nexusGameId(getGame(internalGameId), internalGameId);
+  return nexusGames().find((game) => game.domain_name === domain)?.id ?? null;
+}

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -53,6 +53,7 @@ import {
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, isChildPath, truthy, wrapExtCBAsync } from "../../util/util";
 import { waitForCondition } from "../../util/waitForCondition";
+import { emitModsDeployed } from "../analytics/mixpanel/deployAnalytics";
 import { emitModStateChanged } from "../analytics/mixpanel/modChangeAnalytics";
 import { setDownloadModInfo } from "../download_management/actions/state";
 import { getGame } from "../gamemode_management/util/getGame";
@@ -863,6 +864,15 @@ function genUpdateModDeployment(installManager: InstallManager) {
             await bakeSettings(api, profile, sortedModList);
 
             api.store.dispatch(setDeploymentNecessary(game.id, false));
+
+            emitModsDeployed(api, {
+              gameId,
+              deploymentMethod: activator.name,
+              fileCount: Object.values(newDeployment).reduce((sum, files) => sum + files.length, 0),
+              enabledModCount,
+              manual,
+              isCollectionPostprocess: deployOptions?.isCollectionPostprocessCall ?? false,
+            });
           } catch (unknownErr) {
             const err = unknownToError(unknownErr);
             if (err instanceof UserCanceled) {


### PR DESCRIPTION
Emit mods_deployed on a successful deploy, with deployment_method, file_count, enabled_mod_count, manual, and is_collection_postprocess. numericNexusGameId reports game_id in the same numeric form as other events.

closes LAZ-740