### PR TITLE
track extension installs in mixpanel (LAZ-756)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -1,3 +1,5 @@
+import type { ExtensionInstallSource } from "./extensionInstallAnalytics";
+
 /**
  * Interface for all Mixpanel events
  */
@@ -582,6 +584,39 @@ export class ModsDeployedEvent implements MixpanelEvent {
   readonly eventName = "mods_deployed";
   readonly properties: Record<string, unknown>;
   constructor(props: ModsDeployedProps) {
+    this.properties = { ...props };
+  }
+}
+
+/**
+ * EXTENSION EVENTS
+ */
+
+/**
+ * Fields on the extension_installed event. The identity is sourced from the installed IExtension
+ * but reported in snake_case like every other event. `extension_type` collapses to "game" vs
+ * "other" (only game-support extensions are distinguished). `game_domain` / `game_name` name the
+ * supported game for game extensions (from the central manifest, so absent on manual installs).
+ * `is_update` marks an install that replaced a previous version.
+ */
+export interface ExtensionInstalledProps {
+  extension_id?: string;
+  extension_name: string;
+  author: string;
+  version: string;
+  mod_id?: number;
+  extension_type: "game" | "other";
+  game_domain?: string;
+  game_name?: string;
+  source: ExtensionInstallSource;
+  is_update: boolean;
+}
+
+/** Sent when a Vortex extension finishes installing. */
+export class ExtensionInstalledEvent implements MixpanelEvent {
+  readonly eventName = "extension_installed";
+  readonly properties: Record<string, unknown>;
+  constructor(props: ExtensionInstalledProps) {
     this.properties = { ...props };
   }
 }

--- a/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the extension-install analytics: extension_installed carries the picked IExtension
+ * identity, collapses extension_type to game vs other, and surfaces the analytics-only source /
+ * game / is_update fields.
+ */
+import { EventEmitter } from "events";
+
+import { describe, expect, it } from "vitest";
+
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { emitExtensionInstalled } from "./extensionInstallAnalytics";
+import type { MixpanelEvent } from "./MixpanelEvents";
+
+function harness() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  return { api: { events: emitter } as unknown as IExtensionApi, events };
+}
+
+describe("extension install analytics", () => {
+  it("emits extension_installed as a game extension with the manifest game", () => {
+    const h = harness();
+    emitExtensionInstalled(
+      h.api,
+      {
+        id: "game-skyrimse",
+        name: "Skyrim SE Support",
+        author: "Nexus",
+        version: "1.2.3",
+        type: "game",
+        modId: 42,
+      },
+      {
+        source: "nexusmods",
+        isUpdate: false,
+        gameDomain: "skyrimspecialedition",
+        gameName: "Skyrim Special Edition",
+      },
+    );
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].eventName).toBe("extension_installed");
+    expect(h.events[0].properties).toMatchObject({
+      extension_id: "game-skyrimse",
+      extension_name: "Skyrim SE Support",
+      author: "Nexus",
+      version: "1.2.3",
+      mod_id: 42,
+      extension_type: "game",
+      game_domain: "skyrimspecialedition",
+      game_name: "Skyrim Special Edition",
+      source: "nexusmods",
+      is_update: false,
+    });
+  });
+
+  it("classifies non-game extensions as other and omits game fields", () => {
+    const h = harness();
+    emitExtensionInstalled(
+      h.api,
+      { id: "dark-theme", name: "Dark Theme", author: "Someone", version: "0.1.0", type: "theme" },
+      { source: "manual", isUpdate: true },
+    );
+    expect(h.events[0].properties).toMatchObject({
+      extension_type: "other",
+      source: "manual",
+      is_update: true,
+    });
+    expect(h.events[0].properties.game_domain).toBeUndefined();
+    expect(h.events[0].properties.game_name).toBeUndefined();
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.ts
@@ -1,0 +1,39 @@
+import type { IExtension } from "../../../types/extensions";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { ExtensionInstalledEvent } from "./MixpanelEvents";
+
+/** Where an extension install originated. */
+export type ExtensionInstallSource = "nexusmods" | "github" | "manual";
+
+/**
+ * Emits extension_installed for a Vortex extension that finished installing. The identity comes
+ * from the installed IExtension; `extra` carries the analytics-only bits that aren't on that
+ * contract (install source, the supported game, and whether it replaced a prior version).
+ * `extension_type` is "game" for game-support extensions, "other" for everything else.
+ */
+export function emitExtensionInstalled(
+  api: IExtensionApi,
+  ext: Pick<IExtension, "id" | "name" | "author" | "version" | "type" | "modId">,
+  extra: {
+    source: ExtensionInstallSource;
+    isUpdate: boolean;
+    gameDomain?: string;
+    gameName?: string;
+  },
+): void {
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new ExtensionInstalledEvent({
+      extension_id: ext.id,
+      extension_name: ext.name,
+      author: ext.author,
+      version: ext.version,
+      mod_id: ext.modId,
+      extension_type: ext.type === "game" ? "game" : "other",
+      game_domain: extra.gameDomain,
+      game_name: extra.gameName,
+      source: extra.source,
+      is_update: extra.isUpdate,
+    }),
+  );
+}

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -18,6 +18,10 @@ import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
 import { INVALID_FILENAME_RE } from "../../util/util";
 import { webpackRequireHack } from "../../util/webpack-hacks";
+import {
+  emitExtensionInstalled,
+  type ExtensionInstallSource,
+} from "../analytics/mixpanel/extensionInstallAnalytics";
 import { countryExists, languageExists } from "../settings_interface/languagemap";
 import { readExtensionInfo } from "./util";
 
@@ -312,17 +316,24 @@ function validateInstall(extPath: string, info?: IExtension): PromiseBB<Extensio
 // another process" (#23454). Dedupe them onto a single in-flight promise.
 const activeInstalls: Map<string, PromiseBB<void>> = new Map();
 
+interface InstallAnalytics {
+  source: ExtensionInstallSource;
+  gameDomain?: string;
+  gameName?: string;
+}
+
 function installExtension(
   api: IExtensionApi,
   archivePath: string,
   info?: IExtension,
+  analytics: InstallAnalytics = { source: "manual" },
 ): PromiseBB<void> {
   const key = path.basename(archivePath).toLowerCase();
   const active = activeInstalls.get(key);
   if (active !== undefined) {
     return active;
   }
-  const result = installExtensionImpl(api, archivePath, info).finally(() => {
+  const result = installExtensionImpl(api, archivePath, info, analytics).finally(() => {
     activeInstalls.delete(key);
   });
   activeInstalls.set(key, result);
@@ -332,7 +343,8 @@ function installExtension(
 function installExtensionImpl(
   api: IExtensionApi,
   archivePath: string,
-  info?: IExtension,
+  info: IExtension | undefined,
+  analytics: InstallAnalytics,
 ): PromiseBB<void> {
   const extensionsPath = path.join(getVortexPath("userData"), "plugins");
   let destPath: string;
@@ -459,6 +471,16 @@ function installExtensionImpl(
           .then(() => fs.renameAsync(tempPath, destPath))
           .then(() => {
             clearStaleRemovalFlags(api, removedKeys, destPath);
+            emitExtensionInstalled(
+              api,
+              { ...fullInfo, type, id: extName },
+              {
+                source: analytics.source,
+                isUpdate: removedKeys.length > 0,
+                gameDomain: analytics.gameDomain,
+                gameName: analytics.gameName,
+              },
+            );
             if (type === "translation") {
               return fs
                 .readdirAsync(destPath)

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -346,7 +346,11 @@ export function downloadAndInstallExtension(
 
       const state: IState = api.store.getState();
       const downloadPath = downloadPathForGame(state, SITE_ID);
-      return installExtension(api, path.join(downloadPath, download.localPath), info);
+      return installExtension(api, path.join(downloadPath, download.localPath), info, {
+        source: ext.modId !== undefined ? "nexusmods" : "github",
+        gameDomain: extDetail?.gameId,
+        gameName: extDetail?.gameName,
+      });
     })
     .then(() => PromiseBB.resolve(true))
     .catch(UserCanceled, () => null)


### PR DESCRIPTION
Emit extension_installed when a Vortex extension finishes installing, from the single install chokepoint so it covers nexus, github and manual installs. Carries the extension identity (id, name, author, version, mod_id), extension_type (game vs other), install source, is_update, and for game extensions the supported game_domain/game_name from the extension manifest.

closes LAZ-756