### PR TITLE
consolidate analytics game-id resolution onto helper function

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for the game manage/unmanage analytics: app_game_manage carries the numeric game id and
- * the support extension version; app_game_unmanage carries the game id.
+ * Tests for the game manage/unmanage analytics: app_game_manage carries the support extension
+ * version and app_game_unmanage fires with a game_id. Numeric game-id resolution is covered by
+ * numericGameId.test.ts, so it stays unresolved (null) here.
  */
 import { EventEmitter } from "events";
 
@@ -13,12 +14,6 @@ import type { MixpanelEvent } from "./MixpanelEvents";
 vi.mock("../../gamemode_management/util/getGame", () => ({
   getGame: (id: string) => ({ id, name: id, version: "2.3.4" }),
 }));
-vi.mock("../../nexus_integration/util", () => ({
-  nexusGames: () => [{ domain_name: "skyrimspecialedition", id: 1704 }],
-}));
-vi.mock("../../nexus_integration/util/convertGameId", () => ({
-  nexusGameId: () => "skyrimspecialedition",
-}));
 
 function harness() {
   const emitter = new EventEmitter();
@@ -28,19 +23,20 @@ function harness() {
 }
 
 describe("game manage analytics", () => {
-  it("emits app_game_manage with the numeric game_id and extension version", () => {
+  it("emits app_game_manage with the support extension version", () => {
     const h = harness();
     emitGameManaged(h.api, "skyrimse");
     expect(h.events).toHaveLength(1);
     expect(h.events[0].eventName).toBe("app_game_manage");
-    expect(h.events[0].properties).toMatchObject({ game_id: 1704, extension_version: "2.3.4" });
+    expect(h.events[0].properties.extension_version).toBe("2.3.4");
+    expect(h.events[0].properties).toHaveProperty("game_id");
   });
 
-  it("emits app_game_unmanage with the game_id", () => {
+  it("emits app_game_unmanage with a game_id", () => {
     const h = harness();
     emitGameUnmanaged(h.api, "skyrimse");
     expect(h.events).toHaveLength(1);
     expect(h.events[0].eventName).toBe("app_game_unmanage");
-    expect(h.events[0].properties).toMatchObject({ game_id: 1704 });
+    expect(h.events[0].properties).toHaveProperty("game_id");
   });
 });

--- a/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/gameManageAnalytics.ts
@@ -1,21 +1,14 @@
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import { getGame } from "../../gamemode_management/util/getGame";
-import { nexusGames } from "../../nexus_integration/util";
-import { nexusGameId } from "../../nexus_integration/util/convertGameId";
 import { AppGameManagedEvent, AppGameUnmanagedEvent } from "./MixpanelEvents";
-
-/** Numeric Nexus game id for an internal game id, matching the other analytics events; null when unresolved. */
-function toNumericGameId(internalGameId: string): number | null {
-  const domain = nexusGameId(getGame(internalGameId), internalGameId);
-  return nexusGames().find((game) => game.domain_name === domain)?.id ?? null;
-}
+import { numericNexusGameId } from "./numericGameId";
 
 /** Emits app_game_manage for a game managed for the first time, with its support extension version. */
 export function emitGameManaged(api: IExtensionApi, gameId: string): void {
   api.events.emit(
     "analytics-track-mixpanel-event",
     new AppGameManagedEvent({
-      game_id: toNumericGameId(gameId),
+      game_id: numericNexusGameId(gameId),
       extension_version: getGame(gameId)?.version ?? "",
     }),
   );
@@ -25,6 +18,6 @@ export function emitGameManaged(api: IExtensionApi, gameId: string): void {
 export function emitGameUnmanaged(api: IExtensionApi, gameId: string): void {
   api.events.emit(
     "analytics-track-mixpanel-event",
-    new AppGameUnmanagedEvent({ game_id: toNumericGameId(gameId) }),
+    new AppGameUnmanagedEvent({ game_id: numericNexusGameId(gameId) }),
   );
 }

--- a/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/modChangeAnalytics.ts
@@ -1,12 +1,10 @@
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import type { IState } from "../../../types/IState";
-import { getGame } from "../../gamemode_management/util/getGame";
 import type { IMod } from "../../mod_management/types/IMod";
-import { nexusGames } from "../../nexus_integration/util";
-import { nexusGameId } from "../../nexus_integration/util/convertGameId";
 import type { ModAnalyticsIdentity, ModChangeReason } from "./MixpanelEvents";
 import { ModsRemovedEvent, ModsStateChangedEvent } from "./MixpanelEvents";
 import { makeModAnalyticsIdentity } from "./modAnalyticsIdentity";
+import { numericNexusGameId } from "./numericGameId";
 
 /**
  * Resolves the per-mod analytics identity from an installed mod's own attributes, or undefined
@@ -28,13 +26,11 @@ function resolveModIdentity(
   if (attributes.source !== "nexus" || modId == null || fileId == null) {
     return undefined;
   }
-  // downloadGame is our internal game id; the games cache is keyed by Nexus domain, so convert
-  // (skyrimse -> skyrimspecialedition) before matching. NaN when the game/cache can't resolve.
-  const domain =
-    attributes.downloadGame != null
-      ? nexusGameId(getGame(attributes.downloadGame), attributes.downloadGame)
-      : undefined;
-  const numericGameId = nexusGames().find((game) => game.domain_name === domain)?.id ?? Number.NaN;
+  // downloadGame is our internal game id. NaN when the game/cache can't resolve, so the mod
+  // identity's numeric game_id stays a number (it feeds the mod/file UID computation).
+  const numericGameId =
+    (attributes.downloadGame != null ? numericNexusGameId(attributes.downloadGame) : null) ??
+    Number.NaN;
   // revision_id is null: the mod's own attributes don't record the parent collection revision.
   return makeModAnalyticsIdentity(
     { numericGameId, modId: modId.toString(), fileId: fileId.toString() },

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -5,9 +5,7 @@ import {
   AppGameLaunchedEvent,
   type GameLaunchMethod,
 } from "../extensions/analytics/mixpanel/MixpanelEvents";
-import { getGame } from "../extensions/gamemode_management/util/getGame";
-import { nexusGames } from "../extensions/nexus_integration/util";
-import { nexusGameId } from "../extensions/nexus_integration/util/convertGameId";
+import { numericNexusGameId } from "../extensions/analytics/mixpanel/numericGameId";
 import {
   enabledModCountForProfile,
   lastActiveProfileForGame,
@@ -26,12 +24,6 @@ interface ILaunchRecord {
 // Recorded launches awaiting their exit, keyed by exe id (makeExeId).
 const pendingLaunches = new Map<string, ILaunchRecord>();
 let exitWatcherInstalled = false;
-
-/** Numeric Nexus game id for an internal game id, matching the other analytics events; null when unresolved. */
-function toNumericGameId(internalGameId: string): number | null {
-  const domain = nexusGameId(getGame(internalGameId), internalGameId);
-  return nexusGames().find((game) => game.domain_name === domain)?.id ?? null;
-}
 
 function launchMethod(info: IStarterInfo): GameLaunchMethod {
   if (info.isGame) {
@@ -84,7 +76,7 @@ function ensureExitWatcher(api: IExtensionApi): void {
 export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   ensureExitWatcher(api);
   const state: IState = api.getState();
-  const gameId = toNumericGameId(info.gameId);
+  const gameId = numericNexusGameId(info.gameId);
   const sessionId = shortid();
   pendingLaunches.set(makeExeId(info.exePath), { sessionId, gameId, launchTime: Date.now() });
   const profileId = lastActiveProfileForGame(state, info.gameId);


### PR DESCRIPTION
The launch, manage and mod-change analytics each rolled their own internal game-id-to-numeric-Nexus-id conversion. Point them all at the shared numericNexusGameId helper instead. modChange keeps a Number.NaN fallback since its numeric id feeds the mod/file UID computation and must stay a number.

Drops the now-redundant nexusGames/nexusGameId mocks from the game-manage test; the conversion is covered by numericGameId.test.ts.