### PR TITLE
add exit code to app_game_exited (LAZ-703)

### DIFF
--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -2348,6 +2348,7 @@ class ExtensionManager {
                     reject(err);
                   })
                   .on("close", (code, signal) => {
+                    options.onExit?.(code);
                     const game = activeGameId(this.mApi.store.getState());
                     if (code === null) {
                       log("warn", "child process terminated by signal", {

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -129,6 +129,8 @@ export interface GameExitedProps {
   game_id: number | null;
   launch_session_id: string;
   duration_ms: number;
+  // Process exit code, when Vortex launched the process itself; null for store launches.
+  exit_code: number | null;
 }
 
 /**

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -407,6 +407,8 @@ export interface IRunOptions {
   // is set but in some cases (e.g. when the target process is run elevated) we don't know
   // the pid so this will be undefined.
   onSpawned?: (pid?: number) => void;
+  // called when the process exits, with its exit code (null when terminated by a signal).
+  onExit?: (code: number | null) => void;
 }
 
 /**

--- a/src/renderer/src/util/StarterInfo.ts
+++ b/src/renderer/src/util/StarterInfo.ts
@@ -22,7 +22,7 @@ import {
   ProcessCanceled,
   UserCanceled,
 } from "./CustomErrors";
-import { emitGameLaunched } from "./gameLaunchAnalytics";
+import { emitGameLaunched, recordLaunchExit } from "./gameLaunchAnalytics";
 import GameStoreHelper from "./GameStoreHelper";
 import getVortexPath from "./getVortexPath";
 import { isWindowsExecutable } from "./linux/proton";
@@ -290,6 +290,7 @@ class StarterInfo implements IStarterInfo {
         shell: info.shell,
         detach: info.detach || info.onStart === "close",
         onSpawned: spawned,
+        onExit: (code) => recordLaunchExit(info.exePath, code),
       })
       .catch(ProcessCanceled, () => undefined)
       .catch(UserCanceled, () => undefined)

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -10,7 +10,11 @@ import type {
 } from "../extensions/analytics/mixpanel/MixpanelEvents";
 import { makeExeId } from "../reducers/session";
 import { makeApiHarness, makeStarterInfo } from "../test-utils/builders";
-import { emitExitsForStoppedTools, emitGameLaunched } from "./gameLaunchAnalytics";
+import {
+  emitExitsForStoppedTools,
+  emitGameLaunched,
+  recordLaunchExit,
+} from "./gameLaunchAnalytics";
 import type { IStarterInfo } from "./StarterInfo";
 
 function harness() {
@@ -59,6 +63,19 @@ describe("game launch analytics", () => {
     expect(exited).toBeDefined();
     expect(exited?.properties.launch_session_id).toBe(sessionId);
     expect(typeof exited?.properties.duration_ms).toBe("number");
+    expect(exited?.properties.exit_code).toBeNull();
+  });
+
+  it("reports the exit code recorded from runExecutable on app_game_exited", () => {
+    const h = harness();
+    const info = makeStarterInfo({ exePath: "C:/g/coded.exe" });
+    emitGameLaunched(h.api, info);
+    recordLaunchExit(info.exePath, 0);
+
+    emitExitsForStoppedTools(h.api, { [makeExeId(info.exePath)]: { started: 0 } }, {});
+
+    const exited = h.events.find((e) => e.eventName === "app_game_exited");
+    expect(exited?.properties.exit_code).toBe(0);
   });
 
   it("does not emit app_game_exited for an exe that was not a tracked launch", () => {

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -21,6 +21,8 @@ interface ILaunchRecord {
   sessionId: string;
   gameId: number | null;
   launchTime: number;
+  // Set from runExecutable's exit for Vortex-spawned launches; stays null for store launches.
+  exitCode: number | null;
 }
 
 // Recorded launches awaiting their exit, keyed by exe id (makeExeId).
@@ -39,6 +41,17 @@ function launchMethod(info: IStarterInfo): GameLaunchMethod {
   }
   // Extensions flag script-extender tools (skse64, f4se, ...) with defaultPrimary.
   return info.defaultPrimary ? "script_extender" : "tool";
+}
+
+/**
+ * Records the exit code for a launched exe (from runExecutable) so the paired app_game_exited can
+ * report it. No-op when the launch isn't tracked, e.g. a store launch Vortex didn't spawn itself.
+ */
+export function recordLaunchExit(exePath: string, code: number | null): void {
+  const record = pendingLaunches.get(makeExeId(exePath));
+  if (record !== undefined) {
+    record.exitCode = code;
+  }
 }
 
 /** Emits app_game_exited for each recorded launch whose exe is in `previous` but absent from `current`. */
@@ -62,6 +75,7 @@ export function emitExitsForStoppedTools(
         game_id: record.gameId,
         launch_session_id: record.sessionId,
         duration_ms: Date.now() - record.launchTime,
+        exit_code: record.exitCode,
       }),
     );
   }
@@ -86,7 +100,12 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   const state: IState = api.getState();
   const gameId = toNumericGameId(info.gameId);
   const sessionId = shortid();
-  pendingLaunches.set(makeExeId(info.exePath), { sessionId, gameId, launchTime: Date.now() });
+  pendingLaunches.set(makeExeId(info.exePath), {
+    sessionId,
+    gameId,
+    launchTime: Date.now(),
+    exitCode: null,
+  });
   const profileId = lastActiveProfileForGame(state, info.gameId);
   api.events.emit(
     "analytics-track-mixpanel-event",


### PR DESCRIPTION
Add exit_code to the app_game_exited event. runExecutable gains an optional onExit callback (invoked from its close handler with the process code) so callers can observe an exit without changing its resolve contract. StarterInfo records the code against the launch, and the paired exit event reports it.

Populated for launches Vortex spawns directly (game exe, tool, script extender); null for store launches, where the game process is owned by the store client.

addition to LAZ-703 to cater for one of the lower priority missing data