### PR TITLE
test: QA-246 mod uninstall e2e tests (two-step and one-step)

### DIFF
--- a/packages/e2e/src/helpers/mods.ts
+++ b/packages/e2e/src/helpers/mods.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, type Page } from "@playwright/test";
+
+import { ModsPage, type ModStatus } from "../selectors/modsPage";
+
+export async function expectModStatus(
+  vortexWindow: Page,
+  modName: string | RegExp,
+  status: ModStatus,
+  options?: { timeout?: number },
+): Promise<void> {
+  const modsPage = new ModsPage(vortexWindow);
+  await expect(modsPage.statusButtonInRow(modName)).toHaveText(status, options);
+}
+
+export async function expectArchiveOnDisk(
+  vortexUserDataDir: string,
+  gameId: string,
+  archiveName: RegExp,
+  present: boolean,
+  options?: { timeout?: number },
+): Promise<void> {
+  const downloadsDir = path.join(vortexUserDataDir, "userData", "downloads", gameId);
+  await expect
+    .poll(() => {
+      if (!fs.existsSync(downloadsDir)) return false;
+      return fs.readdirSync(downloadsDir).some((file) => archiveName.test(file));
+    }, options)
+    .toBe(present);
+}

--- a/packages/e2e/src/selectors/modsPage.ts
+++ b/packages/e2e/src/selectors/modsPage.ts
@@ -32,4 +32,26 @@ export class ModsPage {
   modRow(name: string | RegExp): Locator {
     return this.page.getByText(name).first();
   }
+
+  /** Full table row in the Mods table for the mod matching `name`. */
+  row(name: string | RegExp): Locator {
+    return this.page.getByRole("row").filter({ hasText: name }).first();
+  }
+
+  /**
+   * Row-scoped variant of `statusButton` for tests with more than one mod
+   * installed (the button id is duplicated across rows).
+   */
+  statusButtonInRow(name: string | RegExp): Locator {
+    return this.row(name).locator("#btn-mods-enabled");
+  }
+
+  /**
+   * Default action button in the row's actions cell (ActionDropdown). "Remove"
+   * is the default table action for an installed mod, so the visible button
+   * carries the "Remove" label.
+   */
+  removeButtonInRow(name: string | RegExp): Locator {
+    return this.row(name).getByRole("button", { name: "Remove", exact: true });
+  }
 }

--- a/packages/e2e/src/selectors/modsPage.ts
+++ b/packages/e2e/src/selectors/modsPage.ts
@@ -33,24 +33,14 @@ export class ModsPage {
     return this.page.getByText(name).first();
   }
 
-  /** Full table row in the Mods table for the mod matching `name`. */
   row(name: string | RegExp): Locator {
     return this.page.getByRole("row").filter({ hasText: name }).first();
   }
 
-  /**
-   * Row-scoped variant of `statusButton` for tests with more than one mod
-   * installed (the button id is duplicated across rows).
-   */
   statusButtonInRow(name: string | RegExp): Locator {
     return this.row(name).locator("#btn-mods-enabled");
   }
 
-  /**
-   * Default action button in the row's actions cell (ActionDropdown). "Remove"
-   * is the default table action for an installed mod, so the visible button
-   * carries the "Remove" label.
-   */
   removeButtonInRow(name: string | RegExp): Locator {
     return this.row(name).getByRole("button", { name: "Remove", exact: true });
   }

--- a/packages/e2e/src/selectors/modsPage.ts
+++ b/packages/e2e/src/selectors/modsPage.ts
@@ -1,5 +1,13 @@
 import type { Locator, Page } from "@playwright/test";
 
+export const MOD_STATUS = {
+  enabled: "Enabled",
+  disabled: "Disabled",
+  uninstalled: "Uninstalled",
+} as const;
+
+export type ModStatus = (typeof MOD_STATUS)[keyof typeof MOD_STATUS];
+
 export class ModsPage {
   readonly page: Page;
   readonly installFromFileButton: Locator;

--- a/packages/e2e/src/selectors/removeDialog.ts
+++ b/packages/e2e/src/selectors/removeDialog.ts
@@ -1,13 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
 
-/**
- * "Confirm removal" modal shown when removing a mod from the Mods list
- * (mod_management/views/ModList.tsx `removeSelected`).
- *
- * For an installed mod it offers two checkboxes: "Remove Mod" (checked) and
- * "Delete Archive" (unchecked). Once only the archive remains, it offers a
- * single "Delete Archive" checkbox, pre-checked.
- */
 export class ConfirmRemovalDialog {
   readonly page: Page;
   readonly root: Locator;
@@ -18,8 +10,6 @@ export class ConfirmRemovalDialog {
 
   constructor(page: Page) {
     this.page = page;
-    // The modal renders nested role="dialog" wrappers; .last() picks the
-    // innermost (the .modal element itself) to satisfy strict mode.
     this.root = page.getByRole("dialog").filter({ hasText: "Confirm removal" }).last();
     this.removeModCheckbox = this.root.getByRole("checkbox", { name: "Remove Mod" });
     this.deleteArchiveCheckbox = this.root.getByRole("checkbox", { name: "Delete Archive" });

--- a/packages/e2e/src/selectors/removeDialog.ts
+++ b/packages/e2e/src/selectors/removeDialog.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * "Confirm removal" modal shown when removing a mod from the Mods list
+ * (mod_management/views/ModList.tsx `removeSelected`).
+ *
+ * For an installed mod it offers two checkboxes: "Remove Mod" (checked) and
+ * "Delete Archive" (unchecked). Once only the archive remains, it offers a
+ * single "Delete Archive" checkbox, pre-checked.
+ */
+export class ConfirmRemovalDialog {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly removeModCheckbox: Locator;
+  readonly deleteArchiveCheckbox: Locator;
+  readonly cancelButton: Locator;
+  readonly removeButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    // The modal renders nested role="dialog" wrappers; .last() picks the
+    // innermost (the .modal element itself) to satisfy strict mode.
+    this.root = page.getByRole("dialog").filter({ hasText: "Confirm removal" }).last();
+    this.removeModCheckbox = this.root.getByRole("checkbox", { name: "Remove Mod" });
+    this.deleteArchiveCheckbox = this.root.getByRole("checkbox", { name: "Delete Archive" });
+    this.cancelButton = this.root.getByRole("button", { name: "Cancel" });
+    this.removeButton = this.root.getByRole("button", { name: "Remove", exact: true });
+  }
+}

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -1,0 +1,168 @@
+import type { ElectronApplication, Page } from "@playwright/test";
+
+/**
+ * QA-246: Mods [9.7] — I can uninstall a mod.
+ *
+ * Scenario 1 (two steps): remove the mod (archive kept), then remove again to
+ * delete the archive — including a Cancel pass to prove nothing is removed.
+ * Scenario 2 (one step): tick "Delete Archive" alongside "Remove Mod" and
+ * remove both at once.
+ *
+ * Setup installs SMAPI first (the target mod depends on it), then the target
+ * mod. The ticket's "verify the mod changes the main menu" step is skipped:
+ * the fake-game fixture has no real launcher, so install/uninstall state is
+ * asserted via the Mods list instead (same approach as QA-176).
+ *
+ * Uninstall behaviour is tier-independent (tier only affects the download
+ * interstitial, covered by QA-108), so this runs as freeUser only.
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { downloadModViaModManager } from "../helpers/modDownload";
+import { Timeouts } from "../helpers/timeouts";
+import { freeUser } from "../helpers/users";
+import { ModsPage } from "../selectors/modsPage";
+import { NavBar } from "../selectors/navbar";
+import { ConfirmRemovalDialog } from "../selectors/removeDialog";
+
+const SMAPI_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
+const TARGET_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
+
+const SMAPI_NAME = /SMAPI/i;
+const TARGET_MOD_NAME = /Vintage Interface/i;
+
+/** Install SMAPI, then the target mod, and land on the Mods page. */
+async function installTestMods(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<void> {
+  await downloadModViaModManager(nexusPage, vortexApp, SMAPI_MOD_URL);
+  await downloadModViaModManager(nexusPage, vortexApp, TARGET_MOD_URL);
+
+  await test.step("Open the Mods page", async () => {
+    const navbar = new NavBar(vortexWindow);
+    await navbar.modsLink.click();
+    const modsPage = new ModsPage(vortexWindow);
+    await expect(modsPage.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+  });
+
+  await test.step("The target mod is installed and enabled", async () => {
+    const modsPage = new ModsPage(vortexWindow);
+    await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/enabled/i, {
+      timeout: Timeouts.NETWORK,
+    });
+  });
+}
+
+test.describe("Mods - Uninstall", () => {
+  test.use({ nexusUser: freeUser });
+
+  test("[QA-246] free user can uninstall a mod in two steps", async ({
+    vortexApp,
+    vortexWindow,
+    managedGame: _g,
+    nexusPage,
+  }) => {
+    await installTestMods(nexusPage, vortexApp, vortexWindow);
+    const modsPage = new ModsPage(vortexWindow);
+    const dialog = new ConfirmRemovalDialog(vortexWindow);
+
+    await test.step("Click Remove on the target mod's row", async () => {
+      await modsPage.row(TARGET_MOD_NAME).hover();
+      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await expect(dialog.root).toBeVisible();
+    });
+
+    await test.step("'Remove Mod' is pre-checked", async () => {
+      await expect(dialog.removeModCheckbox).toBeChecked();
+    });
+
+    await test.step("'Delete Archive' is unchecked", async () => {
+      await expect(dialog.deleteArchiveCheckbox).not.toBeChecked();
+    });
+
+    await test.step("Cancel closes the dialog", async () => {
+      await dialog.cancelButton.click();
+      await expect(dialog.root).toBeHidden();
+    });
+
+    await test.step("The mod is still installed and enabled", async () => {
+      await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/enabled/i);
+    });
+
+    await test.step("Open the removal dialog again", async () => {
+      await modsPage.row(TARGET_MOD_NAME).hover();
+      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await expect(dialog.root).toBeVisible();
+    });
+
+    await test.step("Remove the mod, keeping the archive", async () => {
+      await dialog.removeButton.click();
+      await expect(dialog.root).toBeHidden();
+    });
+
+    await test.step("The mod is uninstalled but its archive remains", async () => {
+      await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/uninstalled/i, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
+
+    await test.step("Open the removal dialog for the archive", async () => {
+      await modsPage.row(TARGET_MOD_NAME).hover();
+      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await expect(dialog.root).toBeVisible();
+    });
+
+    await test.step("'Delete Archive' is now pre-checked", async () => {
+      await expect(dialog.deleteArchiveCheckbox).toBeChecked();
+    });
+
+    await test.step("'Remove Mod' checkbox is no longer offered", async () => {
+      await expect(dialog.removeModCheckbox).toBeHidden();
+    });
+
+    await test.step("Delete the archive", async () => {
+      await dialog.removeButton.click();
+      await expect(dialog.root).toBeHidden();
+    });
+
+    await test.step("The mod is gone from the Mods list", async () => {
+      await expect(modsPage.row(TARGET_MOD_NAME)).toBeHidden({ timeout: Timeouts.NETWORK });
+    });
+  });
+
+  test("[QA-246] free user can uninstall a mod and delete its archive in one step", async ({
+    vortexApp,
+    vortexWindow,
+    managedGame: _g,
+    nexusPage,
+  }) => {
+    await installTestMods(nexusPage, vortexApp, vortexWindow);
+    const modsPage = new ModsPage(vortexWindow);
+    const dialog = new ConfirmRemovalDialog(vortexWindow);
+
+    await test.step("Click Remove on the target mod's row", async () => {
+      await modsPage.row(TARGET_MOD_NAME).hover();
+      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await expect(dialog.root).toBeVisible();
+    });
+
+    await test.step("'Remove Mod' is pre-checked", async () => {
+      await expect(dialog.removeModCheckbox).toBeChecked();
+    });
+
+    await test.step("Check 'Delete Archive' as well", async () => {
+      await dialog.deleteArchiveCheckbox.check();
+      await expect(dialog.deleteArchiveCheckbox).toBeChecked();
+    });
+
+    await test.step("Remove the mod and its archive", async () => {
+      await dialog.removeButton.click();
+      await expect(dialog.root).toBeHidden();
+    });
+
+    await test.step("The mod is gone from the Mods list", async () => {
+      await expect(modsPage.row(TARGET_MOD_NAME)).toBeHidden({ timeout: Timeouts.NETWORK });
+    });
+  });
+});

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -1,21 +1,5 @@
 import type { ElectronApplication, Page } from "@playwright/test";
 
-/**
- * QA-246: Mods [9.7] — I can uninstall a mod.
- *
- * Scenario 1 (two steps): remove the mod (archive kept), then remove again to
- * delete the archive — including a Cancel pass to prove nothing is removed.
- * Scenario 2 (one step): tick "Delete Archive" alongside "Remove Mod" and
- * remove both at once.
- *
- * Setup installs SMAPI first (the target mod depends on it), then the target
- * mod. The ticket's "verify the mod changes the main menu" step is skipped:
- * the fake-game fixture has no real launcher, so install/uninstall state is
- * asserted via the Mods list instead (same approach as QA-176).
- *
- * Uninstall behaviour is tier-independent (tier only affects the download
- * interstitial, covered by QA-108), so this runs as freeUser only.
- */
 import { test, expect } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { Timeouts } from "../helpers/timeouts";
@@ -30,7 +14,6 @@ const TARGET_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
 const SMAPI_NAME = /SMAPI/i;
 const TARGET_MOD_NAME = /Vintage Interface/i;
 
-/** Install SMAPI, then the target mod, and land on the Mods page. */
 async function installTestMods(
   nexusPage: Page,
   vortexApp: ElectronApplication,

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -2,9 +2,10 @@ import type { ElectronApplication, Page } from "@playwright/test";
 
 import { test, expect } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
+import { expectArchiveOnDisk, expectModStatus } from "../helpers/mods";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser } from "../helpers/users";
-import { ModsPage } from "../selectors/modsPage";
+import { MOD_STATUS, ModsPage } from "../selectors/modsPage";
 import { NavBar } from "../selectors/navbar";
 import { ConfirmRemovalDialog } from "../selectors/removeDialog";
 
@@ -13,6 +14,7 @@ const TARGET_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
 
 const SMAPI_NAME = /SMAPI/i;
 const TARGET_MOD_NAME = /Vintage Interface/i;
+const GAME_ID = "stardewvalley";
 
 async function installTestMods(
   nexusPage: Page,
@@ -30,8 +32,7 @@ async function installTestMods(
   });
 
   await test.step("The target mod is installed and enabled", async () => {
-    const modsPage = new ModsPage(vortexWindow);
-    await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/enabled/i, {
+    await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.enabled, {
       timeout: Timeouts.NETWORK,
     });
   });
@@ -43,6 +44,7 @@ test.describe("Mods - Uninstall", () => {
   test("[QA-246] free user can uninstall a mod in two steps", async ({
     vortexApp,
     vortexWindow,
+    vortexUserDataDir,
     managedGame: _g,
     nexusPage,
   }) => {
@@ -70,7 +72,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("The mod is still installed and enabled", async () => {
-      await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/enabled/i);
+      await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.enabled);
     });
 
     await test.step("Open the removal dialog again", async () => {
@@ -85,9 +87,13 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("The mod is uninstalled but its archive remains", async () => {
-      await expect(modsPage.statusButtonInRow(TARGET_MOD_NAME)).toHaveText(/uninstalled/i, {
+      await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.uninstalled, {
         timeout: Timeouts.NETWORK,
       });
+    });
+
+    await test.step("The archive is still on disk", async () => {
+      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, true);
     });
 
     await test.step("Open the removal dialog for the archive", async () => {
@@ -112,17 +118,28 @@ test.describe("Mods - Uninstall", () => {
     await test.step("The mod is gone from the Mods list", async () => {
       await expect(modsPage.row(TARGET_MOD_NAME)).toBeHidden({ timeout: Timeouts.NETWORK });
     });
+
+    await test.step("The archive is deleted from disk", async () => {
+      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, false, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
   });
 
   test("[QA-246] free user can uninstall a mod and delete its archive in one step", async ({
     vortexApp,
     vortexWindow,
+    vortexUserDataDir,
     managedGame: _g,
     nexusPage,
   }) => {
     await installTestMods(nexusPage, vortexApp, vortexWindow);
     const modsPage = new ModsPage(vortexWindow);
     const dialog = new ConfirmRemovalDialog(vortexWindow);
+
+    await test.step("The archive is on disk", async () => {
+      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, true);
+    });
 
     await test.step("Click Remove on the target mod's row", async () => {
       await modsPage.row(TARGET_MOD_NAME).hover();
@@ -146,6 +163,12 @@ test.describe("Mods - Uninstall", () => {
 
     await test.step("The mod is gone from the Mods list", async () => {
       await expect(modsPage.row(TARGET_MOD_NAME)).toBeHidden({ timeout: Timeouts.NETWORK });
+    });
+
+    await test.step("The archive is deleted from disk", async () => {
+      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, false, {
+        timeout: Timeouts.NETWORK,
+      });
     });
   });
 });


### PR DESCRIPTION
Linear ticket: https://linear.app/nexus-mods/issue/QA-246/mods-97-i-can-uninstall-a-mod
Covers Mods [9.7]: remove dialog checkbox defaults, cancel path, uninstall keeping the archive, archive-only removal, and combined remove+delete-archive. Adds ConfirmRemovalDialog POM and row-scoped ModsPage locators.