### PR TITLE
rework Recently Managed dashlet for portrait game tiles (LAZ-761)

### DIFF
--- a/src/renderer/src/extensions/gamemode_management/views/ActiveModCount.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/ActiveModCount.tsx
@@ -1,0 +1,38 @@
+import type { TFunction } from "i18next";
+import * as React from "react";
+
+import { Icon as UiIcon } from "@/ui/components/icon/Icon";
+import { nxmCollections } from "@/ui/icon-paths";
+
+export interface IActiveModCountProps {
+  t: TFunction;
+  count?: number;
+  compact?: boolean;
+}
+
+function ActiveModCount(props: IActiveModCountProps): JSX.Element | null {
+  const { t, compact, count } = props;
+
+  if (count === undefined) {
+    return null;
+  }
+
+  const label = t("{{ count }} active mod", { count });
+
+  const icon = <UiIcon path={nxmCollections} size="sm" />;
+  return compact ? (
+    <div className="flex items-center gap-x-1 text-sm" title={label}>
+      {icon}
+
+      <span>{count}</span>
+    </div>
+  ) : (
+    <div className="active-mods flex items-center">
+      {icon}
+
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export default ActiveModCount;

--- a/src/renderer/src/extensions/gamemode_management/views/GameName.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameName.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+export interface IGameNameProps {
+  name: string;
+  // compact tiles (e.g. the Recently Managed dashlet) are too small to fit
+  // a name; rely on the thumbnail art and the container's tooltip instead
+  compact?: boolean;
+}
+
+function GameName(props: IGameNameProps): JSX.Element | null {
+  const { compact, name } = props;
+
+  return compact ? null : <div className="name">{name}</div>;
+}
+
+export default GameName;

--- a/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -20,7 +20,9 @@ import type { IMod, IProfile, IState } from "../../../types/IState";
 import { getSafe } from "../../../util/storeHelper";
 import { countIf } from "../../../util/util";
 import type { IGameStored } from "../types/IGameStored";
+import ActiveModCount from "./ActiveModCount";
 import GameInfoPopover from "./GameInfoPopover";
+import GameName from "./GameName";
 
 export interface IBaseProps {
   t: TFunction;
@@ -32,6 +34,10 @@ export interface IBaseProps {
   getBounds?: () => ClientRect;
   container?: HTMLElement;
   onLaunch?: () => void;
+  // artwork-only tile for tight spots like the Recently Managed dashlet:
+  // hides the name (exposed as a tooltip on the tile instead) and reduces
+  // the mod counter to icon and count
+  compact?: boolean;
 }
 
 interface IConnectedProps {
@@ -40,10 +46,6 @@ interface IConnectedProps {
 }
 
 type IProps = IBaseProps & IConnectedProps;
-
-function nop() {
-  // nop
-}
 
 /**
  * thumbnail + controls for a single game mode within the game picker
@@ -54,7 +56,7 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
   private mRef = null;
 
   public render(): JSX.Element {
-    const { t, active, discovered, game, mods, profile, type } = this.props;
+    const { t, active, compact, discovered, game, mods, profile, type } = this.props;
 
     if (game === undefined) {
       return null;
@@ -80,8 +82,6 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
           )
         : undefined;
 
-    const nameParts = game.name.split("\t");
-
     const classes = [
       "game-thumbnail",
       `game-thumbnail-${discovered !== false ? "discovered" : "undiscovered"}`,
@@ -103,29 +103,31 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
     }
 
     return (
-      <Panel className={classes.join(" ")} bsStyle={active ? "primary" : "default"}>
+      <Panel
+        bsStyle={active ? "primary" : "default"}
+        className={classes.join(" ")}
+        title={compact ? game.name.replace(/\t/g, " ") : undefined}
+      >
         <Panel.Body className="game-thumbnail-body">
           <Image
-            className="w-full"
-            imageType="game"
-            fit="cover"
-            src={imgurl}
             alt={game.name}
-            loading="lazy"
+            className="w-full"
             decoding="async"
+            fit="cover"
+            imageType="game"
+            loading="lazy"
+            src={imgurl}
           >
             <div className="bottom">
-              <div className="name">{game.name}</div>
-              {modCount !== undefined ? (
-                <div className="active-mods">
-                  <Icon name="mods" />
-                  <span>{t("{{ count }} active mod", { count: modCount })}</span>
-                </div>
-              ) : null}
+              <GameName compact={compact} name={game.name} />
+
+              <ActiveModCount compact={compact} count={modCount} t={t} />
             </div>
+
             <div className="hover-menu">
               {type === "launcher" ? this.renderLaunch() : this.renderMenu()}
             </div>
+
             {type !== "launcher" ? (
               game.contributed ? (
                 <div
@@ -152,7 +154,7 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
     const { onLaunch } = this.props;
     return (
       <div className="hover-content hover-launcher">
-        <Button style={{ width: "100%", height: "100%" }} onClick={onLaunch} className="btn-embed">
+        <Button className="btn-embed" style={{ width: "100%", height: "100%" }} onClick={onLaunch}>
           <Icon name="launch-application" />
         </Button>
       </div>
@@ -162,61 +164,62 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
   private renderMenu(): JSX.Element[] {
     const { t, container, game, getBounds, onRefreshGameInfo, type } = this.props;
     const gameInfoPopover = (
-      <Popover id={`popover-info-${game.id}`} className="popover-game-info">
+      <Popover className="popover-game-info" id={`popover-info-${game.id}`}>
         <Provider store={this.context.api.store}>
           <IconBar
-            id={`game-thumbnail-${game.id}`}
-            className="buttons"
-            group={`game-${type}-buttons`}
-            instanceId={game.id}
-            staticElements={[]}
-            collapse={false}
             buttonType="text"
-            orientation="vertical"
+            className="buttons"
+            collapse={false}
             filter={this.lowPriorityButtons}
+            group={`game-${type}-buttons`}
+            id={`game-thumbnail-${game.id}`}
+            instanceId={game.id}
+            orientation="vertical"
+            staticElements={[]}
             t={t}
           />
+
           <GameInfoPopover
-            t={t}
             game={game}
-            onRefreshGameInfo={onRefreshGameInfo}
+            t={t}
             onChange={this.redraw}
+            onRefreshGameInfo={onRefreshGameInfo}
           />
         </Provider>
       </Popover>
     );
 
     return [
-      <div key="primary-buttons" className="hover-content">
+      <div className="hover-content" key="primary-buttons">
         <IconBar
-          id={`game-thumbnail-${game.id}`}
-          className="buttons"
-          group={`game-${type}-buttons`}
-          instanceId={game.id}
-          staticElements={[]}
-          collapse={false}
           buttonType="text"
-          orientation="vertical"
-          filter={this.priorityButtons}
+          className="buttons"
           clickAnywhere={true}
+          collapse={false}
+          filter={this.priorityButtons}
+          group={`game-${type}-buttons`}
+          id={`game-thumbnail-${game.id}`}
+          instanceId={game.id}
+          orientation="vertical"
+          staticElements={[]}
           t={t}
         />
       </div>,
       <OverlayTrigger
-        key="info-overlay"
-        overlay={gameInfoPopover}
-        triggerRef={this.setRef}
-        getBounds={getBounds || this.getWindowBounds}
         container={container}
+        getBounds={getBounds || this.getWindowBounds}
+        key="info-overlay"
         orientation="horizontal"
+        overlay={gameInfoPopover}
+        rootClose={true}
         shouldUpdatePosition={true}
         trigger="click"
-        rootClose={true}
+        triggerRef={this.setRef}
       >
         <IconButton
-          id={`btn-info-${game.id}`}
-          icon="game-menu"
           className="game-thumbnail-info btn-embed"
+          icon="game-menu"
+          id={`btn-info-${game.id}`}
           tooltip={t("Show Details")}
         />
       </OverlayTrigger>,

--- a/src/renderer/src/extensions/gamemode_management/views/RecentlyManagedDashlet.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/RecentlyManagedDashlet.tsx
@@ -40,7 +40,9 @@ class RecentlyManaged extends ComponentEx<IProps, {}> {
           getSafe(discoveredGames, [game.id, "path"], undefined) !== undefined,
       )
       .sort((lhs, rhs) => lastManaged(rhs.id) - lastManaged(lhs.id))
-      .slice(0, 3);
+      // render enough candidates to fill a wide dashlet; the stylesheet clips
+      // whatever doesn't fit on one row
+      .slice(0, 10);
 
     let content: JSX.Element;
     if (games.length === 0) {
@@ -62,6 +64,7 @@ class RecentlyManaged extends ComponentEx<IProps, {}> {
                 game={game}
                 type="managed"
                 active={false}
+                compact={true}
                 onRefreshGameInfo={this.refreshGameInfo}
               />
             </div>

--- a/src/stylesheets/vortex/dashlet.scss
+++ b/src/stylesheets/vortex/dashlet.scss
@@ -392,21 +392,29 @@
 .dashlet-recently-managed {
     .list-recently-managed {
         display: flex;
-        //overflow-x: auto;
+        // take the dashlet height left over by the title so the tiles can
+        // scale to it; show as many whole tiles as fit the width by letting
+        // the rest wrap (not shrink) onto a line the fixed height clips away
+        flex: 1;
+        min-height: 0;
+        flex-wrap: wrap;
+        overflow: hidden;
         > * {
+            flex: 0 0 auto;
+            height: 100%;
             margin: 0 8px;
         }
     }
 }
 
-// The Recently Managed dashlet places GameThumbnail in a short flex row. Size
-// the tile by a fixed height (width follows the 2:3 aspect ratio) so it fits
-// the dashlet instead of overflowing from the default fixed width. The Image
-// wrapper is the direct child of .game-thumbnail-body; make the chain fill the
-// height so the aspect box derives its width from it.
+// The Recently Managed dashlet places GameThumbnail in a flex row that fills
+// the dashlet. Size the tile by the row height (width follows the 2:3 aspect
+// ratio) so it fits the dashlet instead of overflowing from the default fixed
+// width. The Image wrapper is the direct child of .game-thumbnail-body; make
+// the chain fill the height so the aspect box derives its width from it.
 .dashlet-recently-managed .list-recently-managed .game-thumbnail {
     width: auto;
-    height: 120px;
+    height: 100%;
 
     .game-thumbnail-body {
         height: 100%;


### PR DESCRIPTION
Add a compact GameThumbnail variant used by the dashlet: artwork-only tile with the game name as a tooltip and an icon-and-count mod counter. Extract ActiveModCount and GameName from GameThumbnail; the games page keeps its full rendering.

Size the dashlet tiles to the dashlet height and show as many whole tiles as fit on one row, rendering up to 10 recent games and clipping the wrapped overflow.

closes LAZ-761