### PR TITLE
rename extension_installed mixpanel event to app_extension_installed

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -636,13 +636,13 @@ export class ModsDeployedEvent implements MixpanelEvent {
  */
 
 /**
- * Fields on the extension_installed event. The identity is sourced from the installed IExtension
+ * Fields on the app_extension_installed event. The identity is sourced from the installed IExtension
  * but reported in snake_case like every other event. `extension_type` collapses to "game" vs
  * "other" (only game-support extensions are distinguished). `game_domain` / `game_name` name the
  * supported game for game extensions (from the central manifest, so absent on manual installs).
  * `is_update` marks an install that replaced a previous version.
  */
-export interface ExtensionInstalledProps {
+export interface AppExtensionInstalledProps {
   extension_id?: string;
   extension_name: string;
   author: string;
@@ -656,10 +656,10 @@ export interface ExtensionInstalledProps {
 }
 
 /** Sent when a Vortex extension finishes installing. */
-export class ExtensionInstalledEvent implements MixpanelEvent {
-  readonly eventName = "extension_installed";
+export class AppExtensionInstalledEvent implements MixpanelEvent {
+  readonly eventName = "app_extension_installed";
   readonly properties: Record<string, unknown>;
-  constructor(props: ExtensionInstalledProps) {
+  constructor(props: AppExtensionInstalledProps) {
     this.properties = { ...props };
   }
 }

--- a/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the extension-install analytics: extension_installed carries the picked IExtension
+ * Tests for the extension install analytics: app_extension_installed carries the picked IExtension
  * identity, collapses extension_type to game vs other, and surfaces the analytics-only source /
  * game / is_update fields.
  */
@@ -19,7 +19,7 @@ function harness() {
 }
 
 describe("extension install analytics", () => {
-  it("emits extension_installed as a game extension with the manifest game", () => {
+  it("emits app_extension_installed as a game extension with the manifest game", () => {
     const h = harness();
     emitExtensionInstalled(
       h.api,
@@ -39,7 +39,7 @@ describe("extension install analytics", () => {
       },
     );
     expect(h.events).toHaveLength(1);
-    expect(h.events[0].eventName).toBe("extension_installed");
+    expect(h.events[0].eventName).toBe("app_extension_installed");
     expect(h.events[0].properties).toMatchObject({
       extension_id: "game-skyrimse",
       extension_name: "Skyrim SE Support",

--- a/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/extensionInstallAnalytics.ts
@@ -1,12 +1,12 @@
 import type { IExtension } from "../../../types/extensions";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
-import { ExtensionInstalledEvent } from "./MixpanelEvents";
+import { AppExtensionInstalledEvent } from "./MixpanelEvents";
 
 /** Where an extension install originated. */
 export type ExtensionInstallSource = "nexusmods" | "github" | "manual";
 
 /**
- * Emits extension_installed for a Vortex extension that finished installing. The identity comes
+ * Emits app_extension_installed for a Vortex extension that finished installing. The identity comes
  * from the installed IExtension; `extra` carries the analytics-only bits that aren't on that
  * contract (install source, the supported game, and whether it replaced a prior version).
  * `extension_type` is "game" for game-support extensions, "other" for everything else.
@@ -23,7 +23,7 @@ export function emitExtensionInstalled(
 ): void {
   api.events.emit(
     "analytics-track-mixpanel-event",
-    new ExtensionInstalledEvent({
+    new AppExtensionInstalledEvent({
       extension_id: ext.id,
       extension_name: ext.name,
       author: ext.author,


### PR DESCRIPTION
Requested due to mixpanel lexicon oddities