### PR TITLE
test: QA-245 mod disable e2e test

### DIFF
--- a/packages/e2e/src/fixtures/game-setup/fake-game.ts
+++ b/packages/e2e/src/fixtures/game-setup/fake-game.ts
@@ -103,5 +103,7 @@ export function setupFakeGame(configKey: keyof typeof GAME_CONFIGS): {
 
 /** Removes a fake game installation directory. */
 export function cleanupFakeGame(basePath: string): void {
-  fs.rmSync(basePath, { recursive: true, force: true });
+  // Retry on Windows: Vortex's async (un)deployment can still be touching
+  // files in the game folder when the test ends, causing transient ENOTEMPTY.
+  fs.rmSync(basePath, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
 }

--- a/packages/e2e/src/helpers/mods.ts
+++ b/packages/e2e/src/helpers/mods.ts
@@ -1,9 +1,42 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { expect, type Page } from "@playwright/test";
+import { expect, type ElectronApplication, type Page } from "@playwright/test";
 
-import { ModsPage, type ModStatus } from "../selectors/modsPage";
+import { GAME_CONFIGS } from "../fixtures/game-setup/fake-game";
+import { test } from "../fixtures/vortex-app";
+import { MOD_STATUS, ModsPage, type ModStatus } from "../selectors/modsPage";
+import { NavBar } from "../selectors/navbar";
+import { downloadModViaModManager } from "./modDownload";
+import { Timeouts } from "./timeouts";
+
+export const SDV_GAME_ID = "stardewvalley";
+export const SMAPI_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
+export const TARGET_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
+export const SMAPI_NAME = /SMAPI/i;
+export const TARGET_MOD_NAME = /Vintage Interface/i;
+
+export async function installStardewTestMods(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<void> {
+  await downloadModViaModManager(nexusPage, vortexApp, SMAPI_MOD_URL);
+  await downloadModViaModManager(nexusPage, vortexApp, TARGET_MOD_URL);
+
+  await test.step("Open the Mods page", async () => {
+    const navbar = new NavBar(vortexWindow);
+    await navbar.modsLink.click();
+    const modsPage = new ModsPage(vortexWindow);
+    await expect(modsPage.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+  });
+
+  await test.step("The target mod is installed and enabled", async () => {
+    await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.enabled, {
+      timeout: Timeouts.NETWORK,
+    });
+  });
+}
 
 export async function expectModStatus(
   vortexWindow: Page,
@@ -29,4 +62,24 @@ export async function expectArchiveOnDisk(
       return fs.readdirSync(downloadsDir).some((file) => archiveName.test(file));
     }, options)
     .toBe(present);
+}
+
+export async function expectModDeployed(
+  gamePath: string,
+  gameId: keyof typeof GAME_CONFIGS,
+  modName: RegExp,
+  present: boolean,
+  options?: { timeout?: number },
+): Promise<void> {
+  const modsDir = path.join(gamePath, GAME_CONFIGS[gameId].modFolderPath ?? "");
+  await expect.poll(() => containsMatch(modsDir, modName), options).toBe(present);
+}
+
+function containsMatch(dir: string, pattern: RegExp): boolean {
+  if (!fs.existsSync(dir)) return false;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (pattern.test(entry.name)) return true;
+    if (entry.isDirectory() && containsMatch(path.join(dir, entry.name), pattern)) return true;
+  }
+  return false;
 }

--- a/packages/e2e/src/helpers/mods.ts
+++ b/packages/e2e/src/helpers/mods.ts
@@ -43,11 +43,6 @@ export async function clickRemoveInRow(
   modName: string | RegExp,
 ): Promise<void> {
   const modsPage = new ModsPage(vortexWindow);
-  const row = modsPage.row(modName);
-  await row.evaluate((el: { scrollIntoView: (options: { block: string }) => void }) => {
-    el.scrollIntoView({ block: "center" });
-  });
-  await row.hover();
   await modsPage.removeButtonInRow(modName).click();
 }
 

--- a/packages/e2e/src/helpers/mods.ts
+++ b/packages/e2e/src/helpers/mods.ts
@@ -38,6 +38,19 @@ export async function installStardewTestMods(
   });
 }
 
+export async function clickRemoveInRow(
+  vortexWindow: Page,
+  modName: string | RegExp,
+): Promise<void> {
+  const modsPage = new ModsPage(vortexWindow);
+  const row = modsPage.row(modName);
+  await row.evaluate((el: { scrollIntoView: (options: { block: string }) => void }) => {
+    el.scrollIntoView({ block: "center" });
+  });
+  await row.hover();
+  await modsPage.removeButtonInRow(modName).click();
+}
+
 export async function expectModStatus(
   vortexWindow: Page,
   modName: string | RegExp,

--- a/packages/e2e/src/tests/mods-disable.spec.ts
+++ b/packages/e2e/src/tests/mods-disable.spec.ts
@@ -1,0 +1,42 @@
+import { test } from "../fixtures/vortex-app";
+import {
+  expectModDeployed,
+  expectModStatus,
+  installStardewTestMods,
+  SDV_GAME_ID,
+  TARGET_MOD_NAME,
+} from "../helpers/mods";
+import { Timeouts } from "../helpers/timeouts";
+import { freeUser } from "../helpers/users";
+import { MOD_STATUS, ModsPage } from "../selectors/modsPage";
+
+test.describe("Mods - Disable", () => {
+  test.use({ nexusUser: freeUser });
+
+  test("[QA-245] free user can disable a mod and its files are undeployed", async ({
+    vortexApp,
+    vortexWindow,
+    managedGame,
+    nexusPage,
+  }) => {
+    await installStardewTestMods(nexusPage, vortexApp, vortexWindow);
+    const modsPage = new ModsPage(vortexWindow);
+
+    await test.step("The mod's files are deployed to the game folder", async () => {
+      await expectModDeployed(managedGame.gamePath, SDV_GAME_ID, TARGET_MOD_NAME, true, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
+
+    await test.step("Disable the mod", async () => {
+      await modsPage.statusButtonInRow(TARGET_MOD_NAME).click();
+      await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.disabled);
+    });
+
+    await test.step("The mod's files are removed from the game folder", async () => {
+      await expectModDeployed(managedGame.gamePath, SDV_GAME_ID, TARGET_MOD_NAME, false, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
+  });
+});

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../fixtures/vortex-app";
 import {
   clickRemoveInRow,
   expectArchiveOnDisk,
+  expectModDeployed,
   expectModStatus,
   installStardewTestMods,
   SDV_GAME_ID,
@@ -19,7 +20,7 @@ test.describe("Mods - Uninstall", () => {
     vortexApp,
     vortexWindow,
     vortexUserDataDir,
-    managedGame: _g,
+    managedGame,
     nexusPage,
   }) => {
     await installStardewTestMods(nexusPage, vortexApp, vortexWindow);
@@ -95,13 +96,19 @@ test.describe("Mods - Uninstall", () => {
         timeout: Timeouts.NETWORK,
       });
     });
+
+    await test.step("The mod's files are removed from the game folder", async () => {
+      await expectModDeployed(managedGame.gamePath, SDV_GAME_ID, TARGET_MOD_NAME, false, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
   });
 
   test("[QA-246] free user can uninstall a mod and delete its archive in one step", async ({
     vortexApp,
     vortexWindow,
     vortexUserDataDir,
-    managedGame: _g,
+    managedGame,
     nexusPage,
   }) => {
     await installStardewTestMods(nexusPage, vortexApp, vortexWindow);
@@ -137,6 +144,12 @@ test.describe("Mods - Uninstall", () => {
 
     await test.step("The archive is deleted from disk", async () => {
       await expectArchiveOnDisk(vortexUserDataDir, SDV_GAME_ID, TARGET_MOD_NAME, false, {
+        timeout: Timeouts.NETWORK,
+      });
+    });
+
+    await test.step("The mod's files are removed from the game folder", async () => {
+      await expectModDeployed(managedGame.gamePath, SDV_GAME_ID, TARGET_MOD_NAME, false, {
         timeout: Timeouts.NETWORK,
       });
     });

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -1,42 +1,15 @@
-import type { ElectronApplication, Page } from "@playwright/test";
-
 import { test, expect } from "../fixtures/vortex-app";
-import { downloadModViaModManager } from "../helpers/modDownload";
-import { expectArchiveOnDisk, expectModStatus } from "../helpers/mods";
+import {
+  expectArchiveOnDisk,
+  expectModStatus,
+  installStardewTestMods,
+  SDV_GAME_ID,
+  TARGET_MOD_NAME,
+} from "../helpers/mods";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser } from "../helpers/users";
 import { MOD_STATUS, ModsPage } from "../selectors/modsPage";
-import { NavBar } from "../selectors/navbar";
 import { ConfirmRemovalDialog } from "../selectors/removeDialog";
-
-const SMAPI_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
-const TARGET_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
-
-const SMAPI_NAME = /SMAPI/i;
-const TARGET_MOD_NAME = /Vintage Interface/i;
-const GAME_ID = "stardewvalley";
-
-async function installTestMods(
-  nexusPage: Page,
-  vortexApp: ElectronApplication,
-  vortexWindow: Page,
-): Promise<void> {
-  await downloadModViaModManager(nexusPage, vortexApp, SMAPI_MOD_URL);
-  await downloadModViaModManager(nexusPage, vortexApp, TARGET_MOD_URL);
-
-  await test.step("Open the Mods page", async () => {
-    const navbar = new NavBar(vortexWindow);
-    await navbar.modsLink.click();
-    const modsPage = new ModsPage(vortexWindow);
-    await expect(modsPage.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
-  });
-
-  await test.step("The target mod is installed and enabled", async () => {
-    await expectModStatus(vortexWindow, TARGET_MOD_NAME, MOD_STATUS.enabled, {
-      timeout: Timeouts.NETWORK,
-    });
-  });
-}
 
 test.describe("Mods - Uninstall", () => {
   test.use({ nexusUser: freeUser });
@@ -48,7 +21,7 @@ test.describe("Mods - Uninstall", () => {
     managedGame: _g,
     nexusPage,
   }) => {
-    await installTestMods(nexusPage, vortexApp, vortexWindow);
+    await installStardewTestMods(nexusPage, vortexApp, vortexWindow);
     const modsPage = new ModsPage(vortexWindow);
     const dialog = new ConfirmRemovalDialog(vortexWindow);
 
@@ -93,7 +66,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("The archive is still on disk", async () => {
-      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, true);
+      await expectArchiveOnDisk(vortexUserDataDir, SDV_GAME_ID, TARGET_MOD_NAME, true);
     });
 
     await test.step("Open the removal dialog for the archive", async () => {
@@ -120,7 +93,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("The archive is deleted from disk", async () => {
-      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, false, {
+      await expectArchiveOnDisk(vortexUserDataDir, SDV_GAME_ID, TARGET_MOD_NAME, false, {
         timeout: Timeouts.NETWORK,
       });
     });
@@ -133,12 +106,12 @@ test.describe("Mods - Uninstall", () => {
     managedGame: _g,
     nexusPage,
   }) => {
-    await installTestMods(nexusPage, vortexApp, vortexWindow);
+    await installStardewTestMods(nexusPage, vortexApp, vortexWindow);
     const modsPage = new ModsPage(vortexWindow);
     const dialog = new ConfirmRemovalDialog(vortexWindow);
 
     await test.step("The archive is on disk", async () => {
-      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, true);
+      await expectArchiveOnDisk(vortexUserDataDir, SDV_GAME_ID, TARGET_MOD_NAME, true);
     });
 
     await test.step("Click Remove on the target mod's row", async () => {
@@ -166,7 +139,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("The archive is deleted from disk", async () => {
-      await expectArchiveOnDisk(vortexUserDataDir, GAME_ID, TARGET_MOD_NAME, false, {
+      await expectArchiveOnDisk(vortexUserDataDir, SDV_GAME_ID, TARGET_MOD_NAME, false, {
         timeout: Timeouts.NETWORK,
       });
     });

--- a/packages/e2e/src/tests/mods-uninstall.spec.ts
+++ b/packages/e2e/src/tests/mods-uninstall.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures/vortex-app";
 import {
+  clickRemoveInRow,
   expectArchiveOnDisk,
   expectModStatus,
   installStardewTestMods,
@@ -26,8 +27,7 @@ test.describe("Mods - Uninstall", () => {
     const dialog = new ConfirmRemovalDialog(vortexWindow);
 
     await test.step("Click Remove on the target mod's row", async () => {
-      await modsPage.row(TARGET_MOD_NAME).hover();
-      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await clickRemoveInRow(vortexWindow, TARGET_MOD_NAME);
       await expect(dialog.root).toBeVisible();
     });
 
@@ -49,8 +49,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("Open the removal dialog again", async () => {
-      await modsPage.row(TARGET_MOD_NAME).hover();
-      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await clickRemoveInRow(vortexWindow, TARGET_MOD_NAME);
       await expect(dialog.root).toBeVisible();
     });
 
@@ -70,8 +69,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("Open the removal dialog for the archive", async () => {
-      await modsPage.row(TARGET_MOD_NAME).hover();
-      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await clickRemoveInRow(vortexWindow, TARGET_MOD_NAME);
       await expect(dialog.root).toBeVisible();
     });
 
@@ -115,8 +113,7 @@ test.describe("Mods - Uninstall", () => {
     });
 
     await test.step("Click Remove on the target mod's row", async () => {
-      await modsPage.row(TARGET_MOD_NAME).hover();
-      await modsPage.removeButtonInRow(TARGET_MOD_NAME).click();
+      await clickRemoveInRow(vortexWindow, TARGET_MOD_NAME);
       await expect(dialog.root).toBeVisible();
     });
 


### PR DESCRIPTION
Disabling an enabled mod undeploys its files from the game folder, asserted on disk (proxy for launching the game without the mod - the fake game has no launcher). Extracts the shared SMAPI + Vintage Interface install setup from the uninstall spec into helpers/mods.