### PR TITLE
dedupe feature flag sync and remove dead health check trigger (LAZ-762)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -1581,8 +1581,6 @@ enum HealthCheckTrigger {
     // (undocumented)
     ProfileChanged = "profile-changed",
     // (undocumented)
-    ResultsChanged = "health-check-results-changed",
-    // (undocumented)
     Scheduled = "scheduled",
     // (undocumented)
     SettingsChanged = "settings-changed",

--- a/src/main/src/unleash/client.test.ts
+++ b/src/main/src/unleash/client.test.ts
@@ -317,6 +317,77 @@ describe("UnleashClient", () => {
 
       expect(client.flags).toEqual(expected);
     });
+
+    it("does not call onUpdate again when a fetch returns a value-equal flag set", async () => {
+      const client = new UnleashClient("1.0.0");
+      vi.spyOn(client, "fetchFeatureFlags").mockImplementation(() =>
+        // fresh objects per fetch, like a real HTTP response
+        Promise.resolve([{ name: "vortex-test-flag" as const, variant: undefined }]),
+      );
+      const onUpdate = vi.fn();
+
+      client.start(1_000, onUpdate);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onUpdate again when a fetch returns the same flags reordered", async () => {
+      const client = new UnleashClient("1.0.0");
+      vi.spyOn(client, "fetchFeatureFlags")
+        .mockResolvedValueOnce([
+          { name: "vortex-test-flag", variant: undefined },
+          { name: "vortex-file-requirements-health-check", variant: undefined },
+        ])
+        .mockResolvedValueOnce([
+          { name: "vortex-file-requirements-health-check", variant: undefined },
+          { name: "vortex-test-flag", variant: undefined },
+        ]);
+      const onUpdate = vi.fn();
+
+      client.start(1_000, onUpdate);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onUpdate again when the flag set changes", async () => {
+      const client = new UnleashClient("1.0.0");
+      vi.spyOn(client, "fetchFeatureFlags")
+        .mockResolvedValueOnce([{ name: "vortex-test-flag", variant: undefined }])
+        .mockResolvedValueOnce([
+          { name: "vortex-test-flag", variant: { name: "variant-1", data: 1 } },
+        ]);
+      const onUpdate = vi.fn();
+
+      client.start(1_000, onUpdate);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+      expect(onUpdate).toHaveBeenLastCalledWith([
+        { name: "vortex-test-flag", variant: { name: "variant-1", data: 1 } },
+      ]);
+    });
+
+    it("updates the flags getter even when onUpdate is skipped", async () => {
+      const flags = [{ name: "vortex-test-flag" as const, variant: undefined }];
+      const client = new UnleashClient("1.0.0");
+      vi.spyOn(client, "fetchFeatureFlags").mockImplementation(() =>
+        Promise.resolve(structuredClone(flags)),
+      );
+      const onUpdate = vi.fn();
+
+      client.start(1_000, onUpdate);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      expect(client.flags).toEqual(flags);
+    });
   });
 
   // ============================================================
@@ -351,6 +422,22 @@ describe("UnleashClient", () => {
         client.start(1_000, onUpdate);
         await vi.advanceTimersByTimeAsync(0);
 
+        expect(onUpdate).toHaveBeenCalledWith([knownFlag]);
+      });
+
+      it("does not call onUpdate for a first fetch that matches the cache replay", async () => {
+        vi.mocked(fs.readFile).mockImplementation(() => Promise.resolve(makeCache()));
+
+        const onUpdate = vi.fn();
+        const client = new UnleashClient("1.0.0", { cachePath: CACHE_PATH });
+        vi.spyOn(client, "fetchFeatureFlags").mockImplementation(() =>
+          Promise.resolve([structuredClone(knownFlag)]),
+        );
+
+        client.start(1_000, onUpdate);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(onUpdate).toHaveBeenCalledTimes(1);
         expect(onUpdate).toHaveBeenCalledWith([knownFlag]);
       });
 

--- a/src/main/src/unleash/client.ts
+++ b/src/main/src/unleash/client.ts
@@ -5,6 +5,7 @@ import { platform } from "node:os";
 import type { FeatureFlag, KnownFlagName } from "@vortex/shared/flags";
 import { flagVariantSchemas } from "@vortex/shared/flags";
 import type { FlagContext, FlagMetricsBucket } from "@vortex/shared/ipc";
+import { dequal } from "dequal";
 import createClient from "openapi-fetch";
 import { z } from "zod";
 
@@ -90,6 +91,16 @@ export class UnleashClient {
     let fetching = false;
     let consecutiveFailures = 0;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let lastNotified: FeatureFlag[] | undefined;
+
+    // Subscribers treat every push as a change, so only notify when the flag
+    // set differs by value from the last notification. New windows get the
+    // current set on demand via flags:get-current, not from this push.
+    const notify = (flags: FeatureFlag[]): void => {
+      if (lastNotified !== undefined && flagSetsEqual(lastNotified, flags)) return;
+      lastNotified = flags;
+      onUpdate?.(flags);
+    };
 
     const schedule = (): void => {
       const backoffMs = interval * Math.pow(2, consecutiveFailures);
@@ -103,7 +114,7 @@ export class UnleashClient {
       try {
         this.#flags = await this.fetchFeatureFlags();
         consecutiveFailures = 0;
-        onUpdate?.(this.#flags);
+        notify(this.#flags);
       } catch (err) {
         consecutiveFailures++;
         log("warn", "unleash fetch failed", { consecutiveFailures, err });
@@ -122,7 +133,7 @@ export class UnleashClient {
 
     const initialLoad = async (): Promise<void> => {
       const cached = await this.#loadCache();
-      if (cached !== undefined) onUpdate?.(cached);
+      if (cached !== undefined) notify(cached);
       void tick();
     };
     void initialLoad();
@@ -248,6 +259,14 @@ export class UnleashClient {
       },
     };
   }
+}
+
+/** Value equality for a whole flag set, independent of order. */
+function flagSetsEqual(a: readonly FeatureFlag[], b: readonly FeatureFlag[]): boolean {
+  if (a.length !== b.length) return false;
+  // Record<flag name, flag>
+  const byName = new Map<string, FeatureFlag>(a.map((flag) => [flag.name, flag]));
+  return b.every((flag) => dequal(byName.get(flag.name), flag));
 }
 
 function serializeContext(context: UnleashContext): string {

--- a/src/renderer/src/FlagService.test.ts
+++ b/src/renderer/src/FlagService.test.ts
@@ -180,13 +180,34 @@ describe("subscribeToFlag", () => {
   });
 
   it("does not fire when the flag is unchanged between pushes", () => {
-    const flag: FeatureFlag = { name: "vortex-test-flag" };
-    push([flag]);
+    // distinct-but-equal objects per push: IPC structured-clones the payload,
+    // so production never redelivers the same reference
+    push([{ name: "vortex-test-flag" }]);
     const cb = vi.fn();
     FlagService.instance.subscribeToFlag("vortex-test-flag", cb);
-    push([flag]);
+    push([{ name: "vortex-test-flag" }]);
     expect(cb).toHaveBeenCalledOnce();
-    expect(cb).toHaveBeenCalledWith(undefined, flag);
+    expect(cb).toHaveBeenCalledWith(undefined, { name: "vortex-test-flag" });
+  });
+
+  it("does not fire when an equal variant arrives as a new object", () => {
+    push([{ name: "vortex-test-flag", variant: { name: "variant-3", data: { foo: "bar" } } }]);
+    const cb = vi.fn();
+    FlagService.instance.subscribeToFlag("vortex-test-flag", cb);
+    push([{ name: "vortex-test-flag", variant: { name: "variant-3", data: { foo: "bar" } } }]);
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("fires when only the variant data changes", () => {
+    push([{ name: "vortex-test-flag", variant: { name: "variant-1", data: 1 } }]);
+    const cb = vi.fn();
+    FlagService.instance.subscribeToFlag("vortex-test-flag", cb);
+    push([{ name: "vortex-test-flag", variant: { name: "variant-1", data: 2 } }]);
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenLastCalledWith(
+      { name: "vortex-test-flag", variant: { name: "variant-1", data: 1 } },
+      { name: "vortex-test-flag", variant: { name: "variant-1", data: 2 } },
+    );
   });
 
   it("does not fire when a push contains no change to the subscribed flag", () => {

--- a/src/renderer/src/FlagService.ts
+++ b/src/renderer/src/FlagService.ts
@@ -1,5 +1,6 @@
 import type { FeatureFlag, KnownFlagName } from "@vortex/shared/flags";
 import type { FlagMetricsBucket } from "@vortex/shared/ipc";
+import { dequal } from "dequal";
 
 const METRICS_INTERVAL_MS = 60_000;
 
@@ -47,7 +48,9 @@ export class FlagService {
       for (const [name, subs] of this.#flagSubscribers) {
         const prevFlag = prev.get(name);
         const nextFlag = this.#flags.get(name);
-        if (prevFlag === nextFlag) continue;
+        // by value: IPC structured-clones the payload, so object identity
+        // never survives a push
+        if (dequal(prevFlag, nextFlag)) continue;
         for (const cb of subs) {
           cb(prevFlag, nextFlag);
         }

--- a/src/renderer/src/extensions/health_check/api/triggers.ts
+++ b/src/renderer/src/extensions/health_check/api/triggers.ts
@@ -70,13 +70,6 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
       void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.ModsChanged);
     });
 
-    api.onStateChange?.(["session", "healthCheck", "lastFullRun"], (lastFullRun) => {
-      log("debug", "Triggering requirements change health checks", {
-        lastFullRun,
-      });
-      void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.ResultsChanged);
-    });
-
     log("debug", "Automatic triggers setup complete");
   } catch (error) {
     const err = error as Error;

--- a/src/renderer/src/types/IHealthCheck.ts
+++ b/src/renderer/src/types/IHealthCheck.ts
@@ -23,7 +23,6 @@ export enum HealthCheckTrigger {
   GameChanged = "game-changed",
   ProfileChanged = "profile-changed",
   ModsChanged = "mods-changed",
-  ResultsChanged = "health-check-results-changed",
   SettingsChanged = "settings-changed",
   PluginsChanged = "plugins-changed",
   LootUpdated = "loot-updated",


### PR DESCRIPTION
The Unleash client pushed flags:synchronize on every 60s poll and the renderer detected per-flag changes by reference, which never holds across IPC structured clone, so every enabled flag counted as changed on every poll and the health check flag subscriber re-ran SettingsChanged checks each time.

- main: notify() gates cache-replay and poll pushes behind a value comparison (dequal per flag, order-independent); the flags getter still updates every fetch so flags:get-current stays fresh for new windows
- renderer: FlagService compares prev/next flags with dequal so subscribeToFlag fires only on real value changes
- health_check: remove the lastFullRun state listener and the ResultsChanged trigger; nothing registers for it and a future registrant would re-run unboundedly since every stored result re-stamps lastFullRun

closes LAZ-762