### PR TITLE
remove health check success toasts, add Last updated label (LAZ-757)

### DIFF
--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -5,6 +5,7 @@
   "listing": {
     "title": "Health Check",
     "subtitle": "Review your Loadout for any issues and learn how to resolve them if needed.",
+    "last_updated": "Last updated: {{time}}",
     "item": {
       "title": "Additional mod may be required for: {{modName}}",
       "description": "Missing mod: {{dependencyModName}}",

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
@@ -120,8 +120,8 @@ export async function checkFileRequirements(api: IExtensionApi): Promise<IHealth
 
 /**
  * Registration descriptor for the file-level requirements check. Owns its own
- * enablement gate, running-state bracket and completion notification so that
- * index.ts only has to register it.
+ * enablement gate and running-state bracket so that index.ts only has to
+ * register it.
  */
 export const fileRequirementsHealthCheck: IHealthCheck = {
   id: FILE_REQUIREMENTS_CHECK_ID,
@@ -152,14 +152,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, true));
     try {
-      const result = await checkFileRequirements(api);
-      api.sendNotification({
-        type: "info",
-        message: "File Requirements check completed",
-        displayMS: 5000,
-        id: "health-check:file-requirements-complete",
-      });
-      return result;
+      return await checkFileRequirements(api);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -483,8 +483,8 @@ export async function checkModRequirements(
 
 /**
  * Registration descriptor for the Nexus mod requirements check. Owns its own
- * enablement gate, running-state bracket and completion notification so that
- * index.ts only has to register it.
+ * enablement gate and running-state bracket so that index.ts only has to
+ * register it.
  */
 export const modRequirementsHealthCheck: IHealthCheck = {
   id: MOD_REQUIREMENTS_CHECK_ID,
@@ -513,14 +513,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, true));
     try {
-      const result = await checkModRequirements(api);
-      api.sendNotification({
-        type: "info",
-        message: "Nexus Mod Requirements check completed",
-        displayMS: 5000,
-        id: "health-check:nexus-requirements-complete",
-      });
-      return result;
+      return await checkModRequirements(api);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/selectors.ts
+++ b/src/renderer/src/extensions/health_check/selectors.ts
@@ -110,6 +110,13 @@ export const modRequirementsArray = (state: IState): IModRequirementExt[] => {
 };
 
 /**
+ * Timestamp (epoch ms) of the most recently stored health check result, or
+ * undefined if no check has run this session.
+ */
+export const lastHealthCheckRun = (state: IState): number | undefined =>
+  healthCheckState(state).lastFullRun || undefined;
+
+/**
  * Get the list of currently running check IDs
  */
 export const runningHealthChecks = (state: IState): HealthCheckId[] =>

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -15,6 +15,7 @@ import { TabButton } from "@/ui/components/tabs/TabButton";
 import { TabPanel } from "@/ui/components/tabs/TabPanel";
 import { TabProvider } from "@/ui/components/tabs/Tabs.context";
 import { Typography } from "@/ui/components/typography/Typography";
+import { useRelativeTime } from "@/util/useRelativeTime";
 import MainPage from "@/views/MainPage";
 
 import { shouldShowPremiumAd } from "../../nexus_integration/selectors";
@@ -24,6 +25,8 @@ import {
   fileRequirementsCheckResult,
   hiddenFileRequirements,
   hiddenModRequirements,
+  isAnyHealthCheckRunning,
+  lastHealthCheckRun,
   modRequirementsCheckResult,
 } from "../selectors";
 import { healthCheckContent } from "./content/registry";
@@ -55,6 +58,25 @@ function selectListedEntries(state: IState): IListedEntry[] {
   return items;
 }
 
+/**
+ * "Last updated" header label. Leaf component: its periodic age tick and
+ * per-result lastFullRun subscription re-render only this label. Renders
+ * nothing until the first check run of the session.
+ */
+function LastUpdated() {
+  const { t } = useTranslation(["health_check", "common"]);
+  const lastRun = useSelector(lastHealthCheckRun);
+  const time = useRelativeTime(lastRun, t);
+  if (time === undefined) {
+    return null;
+  }
+  return (
+    <Typography appearance="moderate" typographyType="body-sm">
+      {t("listing::last_updated", { time })}
+    </Typography>
+  );
+}
+
 /** No-choice install items from every check, de-duplicated across checks by key. */
 function collectInstallAllItems(state: IState, api: IExtensionApi): IBulkInstallItem[] {
   const seen = new Set<string>();
@@ -77,16 +99,19 @@ function HealthCheckPage({ api, onRefresh }: IHealthCheckPageProps) {
   const [selectedTab, setSelectedTab] = useState("active");
 
   // Subscribe only to the slices the listing + install-all derive from, so the
-  // frequent unrelated dispatches during a check run (running-state toggles, mod-file
-  // and mod-attribute caching) neither recompute the list nor re-render the rows.
-  // setSafe preserves these refs across those writes, so the memos recompute only
-  // when results or hidden state actually change.
+  // frequent unrelated dispatches during a check run (mod-file and mod-attribute
+  // caching) don't recompute the list. setSafe preserves these refs across those
+  // writes, so the memos recompute only when results or hidden state actually
+  // change. The running-state boolean drives the refresh spinner, re-rendering
+  // (not recomputing) the page on run start/finish; the per-result lastFullRun
+  // subscription lives in LastUpdated.
   const fileResult = useSelector(fileRequirementsCheckResult);
   const modResult = useSelector(modRequirementsCheckResult);
   const hiddenFile = useSelector(hiddenFileRequirements);
   const hiddenMod = useSelector(hiddenModRequirements);
   const showPremiumAd = useSelector(shouldShowPremiumAd);
   const [showInstallAllPremium, setShowInstallAllPremium] = useState(false);
+  const isRefreshing = useSelector(isAnyHealthCheckRunning);
 
   // selectListedEntries / collectInstallAllItems read the slices above from the live
   // state; those slices fully determine their results. exhaustive-deps can't see the
@@ -199,10 +224,13 @@ function HealthCheckPage({ api, onRefresh }: IHealthCheckPageProps) {
               </div>
             </div>
 
-            <div className="flex shrink-0 gap-x-2">
+            <div className="flex shrink-0 items-center gap-x-2">
+              <LastUpdated />
+
               <Button
                 appearance="subdued"
                 brand="neutral"
+                isLoading={isRefreshing}
                 leftIconPath={mdiRefresh}
                 size="sm"
                 title={t("common:::refresh")}

--- a/src/renderer/src/util/useRelativeTime.ts
+++ b/src/renderer/src/util/useRelativeTime.ts
@@ -1,0 +1,31 @@
+import { useEffect, useReducer } from "react";
+import { useSelector } from "react-redux";
+
+import type { IState } from "../types/IState";
+import type { TFunction } from "./i18n";
+import { userFriendlyTime } from "./relativeTime";
+
+const AGE_INTERVAL_MS = 30_000;
+
+/**
+ * Formats a timestamp via userFriendlyTime and re-renders the consuming
+ * component periodically so a relative label ("3 minutes ago") ages on
+ * screen. Keep the consumer a leaf component: the tick re-renders whatever
+ * subscribes here. Returns undefined (and runs no interval) while the
+ * timestamp is undefined.
+ */
+export function useRelativeTime(timestamp: number | undefined, t: TFunction): string | undefined {
+  const language = useSelector((state: IState) => state.settings.interface.language);
+  const [, ageTick] = useReducer((tick: number) => tick + 1, 0);
+
+  const hasTimestamp = timestamp !== undefined;
+  useEffect(() => {
+    if (!hasTimestamp) {
+      return undefined;
+    }
+    const id = setInterval(ageTick, AGE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [hasTimestamp]);
+
+  return hasTimestamp ? userFriendlyTime(new Date(timestamp), t, language) : undefined;
+}


### PR DESCRIPTION
Success toasts fired on every automatic and manual check run; feedback now lives in the page state instead.

- drop the completion notifications from both requirement check descriptors; the wrappers only bracket running state
- add a lastHealthCheckRun selector over session.healthCheck.lastFullRun and a LastUpdated header label formatted with userFriendlyTime; a useRelativeTime hook owns the periodic age tick so only the leaf label re-renders
- drive the refresh button spinner from isAnyHealthCheckRunning

closes LAZ-757