### PR TITLE
restoring the tray icon (LAZ-764)

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -45,6 +45,7 @@ import {
 } from "./store/mainPersistence";
 import SubPersistor from "./store/SubPersistor";
 import { setTelemetryEnabled } from "./telemetry/state";
+import TrayIcon from "./TrayIcon";
 import { UnleashClient } from "./unleash/client";
 import { synchronizeFeatureFlags } from "./unleash/ipc";
 
@@ -116,6 +117,7 @@ class Application {
   private mArgs: IParameters;
   private mMainWindow: MainWindow | undefined;
   private mMainWindowReady: Promise<Electron.WebContents | undefined> | undefined;
+  private mTray: TrayIcon | undefined;
   private mAppMetadata: AppInitMetadata | undefined;
   private mFirstStart: boolean = false;
   private mStartupLogPath: string;
@@ -206,6 +208,7 @@ class Application {
         .then(() => {
           log("info", "clean application end");
           DuckDBSingleton.getInstance().close();
+          this.mTray?.close();
           if (process.platform !== "darwin") {
             app.quit();
           }
@@ -503,9 +506,17 @@ class Application {
     log("debug", "waiting for user interface");
     await this.awaitMainWindowReady();
 
+    log("debug", "setting up tray icon");
+    this.mTray = new TrayIcon();
+
     if (splash) {
       log("debug", "removing splash screen");
       await splash.fadeOut();
+    }
+
+    const windowHandle = this.mMainWindow?.getHandle();
+    if (this.mTray.initialized && windowHandle) {
+      this.mTray.setMainWindow(windowHandle);
     }
   }
 

--- a/src/main/src/TrayIcon.ts
+++ b/src/main/src/TrayIcon.ts
@@ -1,0 +1,87 @@
+import path from "node:path";
+
+import { BrowserWindow, Menu, Tray } from "electron";
+
+import { getVortexPath } from "./getVortexPath";
+import { log } from "./logging";
+
+/**
+ * Manages the system tray icon: clicking it toggles the main window
+ * visibility and its context menu offers quitting the app.
+ */
+class TrayIcon {
+  private mTrayIcon: Tray | undefined;
+  private mImagePath: string;
+  private mInitialized: boolean = false;
+
+  constructor() {
+    this.mImagePath = path.resolve(
+      getVortexPath("assets"),
+      "images",
+      process.platform === "win32" ? "vortex.ico" : "vortex.png",
+    );
+    try {
+      this.initTrayIcon();
+    } catch {
+      // This appears to be caused by a bug in electron. It happens randomly,
+      // very rarely and the error message looks like it's entirely internal
+      setTimeout(() => {
+        try {
+          this.initTrayIcon();
+        } catch (err) {
+          log("error", "failed to initialize tray icon", err);
+        }
+      }, 500);
+    }
+  }
+
+  public get initialized() {
+    return this.mInitialized;
+  }
+
+  public close() {
+    if (this.mTrayIcon !== undefined) {
+      this.mTrayIcon.destroy();
+    }
+  }
+
+  public setMainWindow(window: BrowserWindow) {
+    if (this.mTrayIcon === undefined || this.mTrayIcon.isDestroyed()) {
+      return;
+    }
+    this.mTrayIcon.on("click", () => {
+      if (window.isDestroyed()) {
+        return;
+      }
+      if (process.env.VORTEX_E2E_HEADLESS === "1") {
+        return;
+      }
+      if (window.isVisible()) {
+        window.hide();
+      } else {
+        window.show();
+      }
+    });
+  }
+
+  private initTrayIcon() {
+    this.mTrayIcon = new Tray(this.mImagePath);
+
+    this.mTrayIcon.setContextMenu(
+      Menu.buildFromTemplate([
+        {
+          label: "Quit",
+          click: () => {
+            for (const win of BrowserWindow.getAllWindows()) {
+              win.close();
+            }
+          },
+        },
+      ]),
+    );
+
+    this.mInitialized = true;
+  }
+}
+
+export default TrayIcon;


### PR DESCRIPTION
It's pretty much the exact same class restored from git history.

Left the "Run Game" button out as it was no-op.

closing LAZ-764