### PR TITLE
improve load order page performance for large mod counts (LAZ-717)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -2867,7 +2867,11 @@ interface IItemRendererProps {
     // (undocumented)
     invalidEntries?: IInvalidResult[];
     // (undocumented)
+    lockedEntriesCount?: number;
+    // (undocumented)
     loEntry: ILoadOrderEntry_2;
+    // (undocumented)
+    position?: number;
     // (undocumented)
     setRef?: (ref: any) => void;
 }
@@ -2961,6 +2965,7 @@ interface ILoadOrderGameInfo {
     noCollectionGeneration?: boolean;
     serializeLoadOrder: (loadOrder: LoadOrder, prev: LoadOrder) => Promise<void>;
     toggleableEntries?: boolean;
+    uniformRowHeight?: boolean;
     usageInstructions?: string | React.ComponentType<{}>;
     validate: (prev: LoadOrder, current: LoadOrder) => Promise<IValidationResult>;
 }

--- a/extensions/games/game-baldursgate3/src/cache.ts
+++ b/extensions/games/game-baldursgate3/src/cache.ts
@@ -78,6 +78,13 @@ export default class PakInfoCache {
         mod,
         isListed,
       });
+    } else if (mod !== undefined && cacheEntry.mod?.id !== mod.id) {
+      // Refresh the mod link without re-reading the pak; the cache persists
+      //  to disk, so entries written while the deployment manifest was
+      //  unavailable carry mod: undefined. An undefined mod deliberately
+      //  does not clear a cached link - transient manifest failures must
+      //  not unlink entries.
+      this.mCache.set(id, { ...cacheEntry, mod });
     }
     return this.mCache.get(id);
   }

--- a/extensions/games/game-baldursgate3/src/loadOrder.ts
+++ b/extensions/games/game-baldursgate3/src/loadOrder.ts
@@ -24,6 +24,16 @@ import {
   profilesPath,
 } from "./util";
 
+// Coalesces the per-change auto-exports while the user is actively sorting;
+//  the export reads the load order from state, so the last scheduled run
+//  always writes the latest order. exportTo targets the BG3 profile
+//  regardless of the active game, so a run that lands after the user
+//  switched away still writes the correct order.
+const autoExportDebouncer = new util.Debouncer(
+  (api: types.IExtensionApi) => exportToGame(api, true),
+  1000,
+);
+
 export async function serialize(
   context: types.IExtensionContext,
   loadOrder: types.LoadOrder,
@@ -53,7 +63,7 @@ export async function serialize(
 
   logDebug("serialize autoExportToGame=", autoExportToGame);
 
-  if (autoExportToGame) await exportToGame(context.api);
+  if (autoExportToGame) autoExportDebouncer.schedule(undefined, context.api);
 
   return Promise.resolve();
 }
@@ -109,31 +119,32 @@ export async function deserialize(context: types.IExtensionContext): Promise<typ
 
     logDebug("deserialize loadOrder=", loadOrder);
 
-    // filter out any pak files that no longer exist
-    const filteredLoadOrder: types.LoadOrder = loadOrder.filter((entry) =>
-      paks.find((pak) => pak.fileName === entry.id),
-    );
+    // Map of pak file name to its cache entry
+    const paksByFileName = new Map(paks.map((pak): [string, ICacheEntry] => [pak.fileName, pak]));
+
+    // A pak's cache entry can hold a stale mod link (the cache never clears a
+    //  link on a manifest miss), so only treat it as managed when the mod is
+    //  still installed.
+    const managedModId = (pak: ICacheEntry): string | undefined => {
+      const modId = pak?.mod?.id;
+      return modId !== undefined && props.mods[modId] !== undefined ? modId : undefined;
+    };
+
+    // filter out any pak files that no longer exist and re-link entries that
+    //  lost their mod association (e.g. serialized while the deployment
+    //  manifest was unavailable)
+    const filteredLoadOrder: types.LoadOrder = loadOrder
+      .filter((entry) => paksByFileName.has(entry.id))
+      .map((entry) => {
+        const modId = managedModId(paksByFileName.get(entry.id));
+        return entry.modId === undefined && modId !== undefined ? { ...entry, modId } : entry;
+      });
 
     logDebug("deserialize filteredLoadOrder=", filteredLoadOrder);
 
-    // filter out pak files that don't have a corresponding mod (which means Vortex didn't install it/isn't aware of it)
-    //const paksWithMods:BG3Pak[] = paks.filter(pak => pak.mod !== undefined);
-
-    // go through each pak file in the Mods folder...
-    const processedPaks = paks.reduce(
-      (acc, curr) => {
-        acc.valid.push(curr);
-        return acc;
-      },
-      { valid: [], invalid: [] },
-    );
-
-    logDebug("deserialize processedPaks=", processedPaks);
-
     // get any pak files that aren't in the filteredLoadOrder
-    const addedMods: BG3Pak[] = processedPaks.valid.filter(
-      (pak) => filteredLoadOrder.find((entry) => entry.id === pak.fileName) === undefined,
-    );
+    const loEntryIds = new Set(filteredLoadOrder.map((entry) => entry.id));
+    const addedMods: BG3Pak[] = paks.filter((pak) => !loEntryIds.has(pak.fileName));
 
     logDebug("deserialize addedMods=", addedMods);
 
@@ -147,7 +158,7 @@ export async function deserialize(context: types.IExtensionContext): Promise<typ
     addedMods.forEach((pak) => {
       filteredLoadOrder.push({
         id: pak.fileName,
-        modId: pak.mod?.id,
+        modId: managedModId(pak),
         enabled: true, // not using load order for enabling/disabling
         name: pak.info?.name || path.basename(pak.fileName, ".pak"),
         data: pak.info,
@@ -455,9 +466,15 @@ export async function processLsxFile(api: types.IExtensionApi, lsxPath: string) 
   }
 }
 
-async function exportTo(api: types.IExtensionApi, filepath: string) {
+async function exportTo(
+  api: types.IExtensionApi,
+  filepath: string,
+  silent: boolean = false,
+): Promise<void> {
   const state = api.getState();
-  const profileId = selectors.activeProfile(state)?.id;
+  // Target the BG3 profile so a debounced export that lands after the user
+  //  switched games still writes the correct load order.
+  const profileId = selectors.lastActiveProfileForGame(state, GAME_ID);
 
   // get load order from state
   const loadOrder: types.LoadOrder = util.getSafe(
@@ -565,15 +582,17 @@ async function exportTo(api: types.IExtensionApi, filepath: string) {
       }
     }
 
-    writeModSettings(api, modSettings, filepath);
+    await writeModSettings(api, modSettings, filepath);
 
-    api.sendNotification({
-      type: "success",
-      id: "bg3-loadorder-exported",
-      title: "Load Order Exported",
-      message: filepath,
-      displayMS: 3000,
-    });
+    if (!silent) {
+      api.sendNotification({
+        type: "success",
+        id: "bg3-loadorder-exported",
+        title: "Load Order Exported",
+        message: filepath,
+        displayMS: 3000,
+      });
+    }
   } catch (err) {
     api.showErrorNotification("Failed to write load order", err, {
       allowReport: false,
@@ -613,13 +632,16 @@ export async function exportToFile(api: types.IExtensionApi): Promise<boolean | 
   exportTo(api, selectedPath);
 }
 
-export async function exportToGame(api: types.IExtensionApi): Promise<boolean | void> {
+export async function exportToGame(
+  api: types.IExtensionApi,
+  silent: boolean = false,
+): Promise<void> {
   const bg3ProfileId = await getActivePlayerProfile(api);
   const settingsPath: string = path.join(profilesPath(), bg3ProfileId, "modsettings.lsx");
 
   logDebug(`exportToGame ${settingsPath}`);
 
-  exportTo(api, settingsPath);
+  await exportTo(api, settingsPath, silent);
 }
 
 export async function deepRefresh(api: types.IExtensionApi): Promise<boolean | void> {

--- a/src/renderer/src/controls/DraggableList.test.tsx
+++ b/src/renderer/src/controls/DraggableList.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { makeLoadOrderEntry } from "../test-utils/builders";
+import DraggableList from "./DraggableList";
+
+// --- Helpers ---
+
+// ListWindow creates a ResizeObserver on attach; happy-dom does not provide one.
+beforeAll(() => {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    public observe(): void {}
+    public unobserve(): void {}
+    public disconnect(): void {}
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const Row: React.FC<{ item: { id: string } }> = ({ item }) => (
+  <div data-testid="lo-row">{item.id}</div>
+);
+
+const renderComponent = (itemCount: number, virtualized: boolean) => {
+  const items = Array.from({ length: itemCount }, () => makeLoadOrderEntry());
+
+  render(
+    <DndProvider backend={HTML5Backend}>
+      <DraggableList
+        id="test-lo"
+        itemTypeId="test-lo-item"
+        items={items}
+        itemRenderer={Row as React.ComponentType<{ item: any }>}
+        idFunc={(item) => item.id}
+        apply={() => undefined}
+        virtualized={virtualized}
+      />
+    </DndProvider>,
+  );
+
+  return { items };
+};
+
+const rowCount = () => screen.queryAllByTestId("lo-row").length;
+
+// --- Tests ---
+
+describe("DraggableList virtualization", () => {
+  it("renders only a window of rows for a large virtualized list", () => {
+    renderComponent(1000, true);
+    expect(rowCount()).toBeGreaterThan(0);
+    expect(rowCount()).toBeLessThan(100);
+  });
+
+  it("renders every row when not virtualized", () => {
+    renderComponent(1000, false);
+    expect(rowCount()).toBe(1000);
+  });
+});

--- a/src/renderer/src/controls/DraggableList.tsx
+++ b/src/renderer/src/controls/DraggableList.tsx
@@ -9,9 +9,10 @@ import {
   type DropTargetSpec,
 } from "react-dnd";
 
-import { ListWindow } from "../util/ListWindow";
+import { keepIndicesInRange, ListWindow } from "../util/ListWindow";
 import { ComponentEx } from "./ComponentEx";
 import DraggableItem from "./DraggableListItem";
+import { moveItems } from "./dragReorder";
 
 export interface IDraggableListProps {
   disabled?: boolean;
@@ -98,21 +99,15 @@ class DraggableList extends ComponentEx<IProps, IDraggableListState> {
     let end = length - 1;
     let listStyle: React.CSSProperties;
     if (this.virtualized()) {
-      const range = this.mWindow.range(length);
+      // Keep dragged rows inside the rendered slice so their react-dnd source
+      //  is never unmounted mid-drag (which would drop the reorder).
+      const range = keepIndicesInRange(
+        this.mWindow.range(length),
+        draggedItems.map((item) => this.findItemIndex(item)),
+      );
       start = range.start;
       end = range.end;
-      // Keep dragged rows inside the rendered slice so their react-dnd source
-      //  is never unmounted mid-drag (which would drop the reorder). During a
-      //  drag the dragged row tracks the hovered - and therefore visible -
-      //  index, so this stays close to the base window.
-      for (const item of draggedItems) {
-        const idx = this.findItemIndex(item);
-        if (idx !== -1) {
-          start = Math.min(start, idx);
-          end = Math.max(end, idx);
-        }
-      }
-      listStyle = this.mWindow.padding(start, end, length);
+      listStyle = this.mWindow.padding(range, length);
     }
 
     return connectDropTarget(
@@ -191,27 +186,12 @@ class DraggableList extends ComponentEx<IProps, IDraggableListState> {
     const { selectedItems, ordered } = this.state;
     const copy = ordered.slice();
 
-    // If multiple items are selected, handle reordering for all of them
-    let itemsToMove = selectedItems.includes(copy[oldIndex])
+    // If multiple items are selected, move all of them; otherwise the single item
+    const itemsToMove = selectedItems.includes(copy[oldIndex])
       ? selectedItems
-      : [take(changeContainer ? undefined : copy)]; // Fall back to single item
+      : [take(changeContainer ? undefined : copy)];
 
-    // Remove selected items from their old position
-    itemsToMove.forEach((item) => {
-      const index = copy.indexOf(item);
-      if (index !== -1) {
-        copy.splice(index, 1);
-      }
-    });
-
-    // Insert items in new position
-    itemsToMove.forEach((itm) => {
-      const item = Array.isArray(itm) ? itm[0] : itm;
-      copy.splice(newIndex, 0, item);
-      newIndex++;
-    });
-
-    this.nextState.ordered = copy;
+    this.nextState.ordered = moveItems(copy, itemsToMove, newIndex);
   };
 
   private itemLocked(item: any) {

--- a/src/renderer/src/controls/DraggableList.tsx
+++ b/src/renderer/src/controls/DraggableList.tsx
@@ -9,6 +9,7 @@ import {
   type DropTargetSpec,
 } from "react-dnd";
 
+import { ListWindow } from "../util/ListWindow";
 import { ComponentEx } from "./ComponentEx";
 import DraggableItem from "./DraggableListItem";
 
@@ -23,6 +24,9 @@ export interface IDraggableListProps {
   apply: (ordered: any[]) => void;
   style?: React.CSSProperties;
   className?: string;
+  // Window the rendered rows to the visible scroll range. Requires uniform
+  //  row heights (the pitch is measured from the first two rendered rows).
+  virtualized?: boolean;
 }
 
 interface IDraggableListState {
@@ -34,6 +38,9 @@ interface IDraggableListState {
 
 type IProps = IDraggableListProps & { connectDropTarget: ConnectDropTarget };
 
+// below this row count everything is rendered; windowing isn't worth it
+const VIRTUALIZE_THRESHOLD = 100;
+
 /**
  * A list component that allows the user to manually re-order the items
  * in it.
@@ -43,6 +50,8 @@ type IProps = IDraggableListProps & { connectDropTarget: ConnectDropTarget };
  *   to specify idFunc through props
  */
 class DraggableList extends ComponentEx<IProps, IDraggableListState> {
+  private mWindow = new ListWindow({ onChange: () => this.forceUpdate() });
+
   constructor(props: IProps) {
     super(props);
 
@@ -54,46 +63,93 @@ class DraggableList extends ComponentEx<IProps, IDraggableListState> {
     });
   }
 
+  public componentDidMount() {
+    if (this.virtualized()) {
+      this.mWindow.attach();
+      this.mWindow.measurePitch(this.props.items);
+    }
+  }
+
+  public componentWillUnmount() {
+    this.mWindow.detach();
+  }
+
   public componentDidUpdate(prevProps: IProps) {
     if (prevProps.items !== this.props.items) {
       this.nextState.ordered = this.props.items.slice(0);
+      // The row count changed (filter cleared, mods deployed); recompute the
+      //  window from the current scroll position, otherwise a stale window
+      //  can leave the viewport showing only padding.
+      this.mWindow.update();
+    }
+    if (this.virtualized()) {
+      this.mWindow.attach();
+      this.mWindow.measurePitch(this.props.items);
     }
   }
 
   public render(): JSX.Element {
     const { connectDropTarget, id, itemRenderer, style, className } = this.props;
     const { ordered, selectedItems, draggedItems } = this.state;
-    const isSelected = (item) => selectedItems.some((it) => this.itemId(item) === this.itemId(it));
+    const selectedIds = new Set(selectedItems.map((it) => this.itemId(it)));
+
+    const length = ordered.length;
+    let start = 0;
+    let end = length - 1;
+    let listStyle: React.CSSProperties;
+    if (this.virtualized()) {
+      const range = this.mWindow.range(length);
+      start = range.start;
+      end = range.end;
+      // Keep dragged rows inside the rendered slice so their react-dnd source
+      //  is never unmounted mid-drag (which would drop the reorder). During a
+      //  drag the dragged row tracks the hovered - and therefore visible -
+      //  index, so this stays close to the base window.
+      for (const item of draggedItems) {
+        const idx = this.findItemIndex(item);
+        if (idx !== -1) {
+          start = Math.min(start, idx);
+          end = Math.max(end, idx);
+        }
+      }
+      listStyle = this.mWindow.padding(start, end, length);
+    }
 
     return connectDropTarget(
       <div style={style} className={className}>
-        <ListGroup>
-          {ordered.map((item, idx) => (
-            <DraggableItem
-              disabled={this.props.disabled}
-              containerId={id}
-              key={this.itemId(item)}
-              item={item}
-              index={idx}
-              findItemIndex={this.findItemIndex}
-              isLocked={this.itemLocked(item)}
-              itemRenderer={itemRenderer}
-              take={this.take}
-              onChangeIndex={this.changeIndex}
-              apply={this.apply}
-              onClick={this.handleItemClick(idx)}
-              selectedItems={selectedItems}
-              isSelected={isSelected(item)}
-              draggedItems={draggedItems}
-              onDragStart={this.handleDragStart}
-            />
-          ))}
-        </ListGroup>
+        <div ref={this.mWindow.setContent}>
+          <ListGroup style={listStyle}>
+            {ordered.slice(start, end + 1).map((item, idx) => (
+              <DraggableItem
+                disabled={this.props.disabled}
+                containerId={id}
+                key={this.itemId(item)}
+                item={item}
+                index={start + idx}
+                findItemIndex={this.findItemIndex}
+                isLocked={this.itemLocked(item)}
+                itemRenderer={itemRenderer}
+                take={this.take}
+                onChangeIndex={this.changeIndex}
+                apply={this.apply}
+                onClick={this.handleItemClick}
+                selectedItems={selectedItems}
+                isSelected={selectedIds.has(this.itemId(item))}
+                draggedItems={draggedItems}
+                onDragStart={this.handleDragStart}
+              />
+            ))}
+          </ListGroup>
+        </div>
       </div>,
     );
   }
 
-  private handleItemClick = (index: number) => (event: React.MouseEvent) => {
+  private virtualized(): boolean {
+    return this.props.virtualized === true && this.props.items.length > VIRTUALIZE_THRESHOLD;
+  }
+
+  private handleItemClick = (index: number, event: React.MouseEvent) => {
     const { ordered, selectedItems, lastSelectedIndex } = this.state;
     const item = ordered[index];
     if (this.itemLocked(item) || this.props.disabled) {

--- a/src/renderer/src/controls/DraggableListItem.tsx
+++ b/src/renderer/src/controls/DraggableListItem.tsx
@@ -25,7 +25,7 @@ export interface IDraggableListItemProps {
     changeContainer: boolean,
     take: (list: any[]) => any,
   ) => void;
-  onClick: (event: React.MouseEvent) => void;
+  onClick: (index: number, event: React.MouseEvent) => void;
   onDragStart: (items: any[]) => void;
 }
 
@@ -47,51 +47,48 @@ const DraggableItem: React.FC<IDraggableListItemProps> = ({
   apply,
 }) => {
   const itemRef = useRef<HTMLDivElement | null>(null);
-  const [startedDrag, setStartedDrag] = React.useState(false);
 
-  const sortByIndex = (list: any[]) => list.sort((a, b) => findItemIndex(a) - findItemIndex(b));
-
-  const isDraggedItem = React.useCallback(() => findItemIndex(item) !== -1, [draggedItems]);
-  const classes = isSelected ? ["selected"] : [];
-
-  const sortedSelected = React.useMemo(() => sortByIndex(selectedItems), [selectedItems]);
-
-  const [{ isDraggingItem, draggedStyle }, drag, dragPreview] = useDrag(
+  // collect must only return stable primitives: every row's collector runs on
+  //  each drag-state change (every mousemove during a drag) and react-dnd
+  //  re-renders the row whenever the collected object isn't shallow-equal.
+  const [{ isDraggingItem }, drag, dragPreview] = useDrag(
     {
       type: containerId,
-      item: {
-        index,
-        items: isSelected ? sortedSelected : [item],
-        containerId,
-        take: (list: any[]) => sortedSelected.map((item) => take(item, list)),
+      item: () => {
+        // Only the row a drag starts on needs the sorted selection.
+        const sortedSelected = selectedItems
+          .slice()
+          .sort((a, b) => findItemIndex(a) - findItemIndex(b));
+        const items = isSelected ? sortedSelected : [item];
+        onDragStart(items);
+        return {
+          index,
+          items,
+          containerId,
+          take: (list: any[]) => items.map((itm) => take(itm, list)),
+        };
       },
       end: () => {
         apply();
       },
       canDrag: () => !isLocked && !disabled,
-
-      collect: (monitor: DragSourceMonitor) => {
-        if (isDraggedItem() && !startedDrag) {
-          onDragStart(sortedSelected);
-          setStartedDrag(true);
-        }
-
-        if (isDraggedItem() && !classes.includes("dragging")) {
-          classes.push("dragging");
-        }
-
-        return {
-          isDraggingItem: monitor.isDragging(),
-          draggedStyle: {
-            border:
-              monitor.isDragging() && !isSelected && draggedItems.length === 0
-                ? "2px solid #A1A1AA"
-                : undefined,
-          } as React.CSSProperties,
-        };
-      },
+      collect: (monitor: DragSourceMonitor) => ({
+        isDraggingItem: monitor.isDragging(),
+      }),
     },
-    [startedDrag, sortedSelected, isSelected],
+    [
+      index,
+      item,
+      isSelected,
+      selectedItems,
+      findItemIndex,
+      isLocked,
+      disabled,
+      containerId,
+      onDragStart,
+      take,
+      apply,
+    ],
   );
 
   const [, drop] = useDrop({
@@ -111,10 +108,10 @@ const DraggableItem: React.FC<IDraggableListItemProps> = ({
 
       const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
       const hoverActualY = clientOffset.y - hoverBoundingRect.top;
-      // if dragging down, continue only when hover is smaller than middle Y
-      if (index < hoverIndex && hoverActualY < hoverMiddleY) return;
-      // if dragging up, continue only when hover is bigger than middle Y
-      if (index > hoverIndex && hoverActualY > hoverMiddleY) return;
+      // dragging down: swap only once the cursor passes this row's middle
+      if (dragIndex < hoverIndex && hoverActualY < hoverMiddleY) return;
+      // dragging up: swap only once the cursor passes this row's middle
+      if (dragIndex > hoverIndex && hoverActualY > hoverMiddleY) return;
 
       onChangeIndex(dragIndex, hoverIndex, sourceContainerId !== containerId, (list) =>
         items.map((item) => take(item, list)),
@@ -126,11 +123,20 @@ const DraggableItem: React.FC<IDraggableListItemProps> = ({
         draggedItem.take = (list: any[]) => take(items, list);
       }
     },
-    drop(item, monitor) {
-      setStartedDrag(false);
-      return undefined;
-    },
   });
+
+  const classes = [];
+  if (isSelected) {
+    classes.push("selected");
+  }
+  if (isDraggingItem || draggedItems.indexOf(item) !== -1) {
+    classes.push("dragging");
+  }
+
+  const draggedStyle: React.CSSProperties = {
+    border:
+      isDraggingItem && !isSelected && draggedItems.length === 0 ? "2px solid #A1A1AA" : undefined,
+  };
 
   const setRef = useCallback(
     (ref: HTMLDivElement | null) => {
@@ -140,13 +146,18 @@ const DraggableItem: React.FC<IDraggableListItemProps> = ({
     [drag, drop],
   );
 
+  const handleClick = useCallback(
+    (event: React.MouseEvent) => onClick(index, event),
+    [onClick, index],
+  );
+
   return (
     <div key={item.id} ref={dragPreview}>
-      <div style={draggedStyle} ref={setRef} onClick={onClick}>
+      <div style={draggedStyle} ref={setRef} onClick={handleClick}>
         <ItemRendererComponent className={classes.join(" ")} item={item} />
       </div>
     </div>
   );
 };
 
-export default DraggableItem;
+export default React.memo(DraggableItem);

--- a/src/renderer/src/controls/DraggableListItem.tsx
+++ b/src/renderer/src/controls/DraggableListItem.tsx
@@ -2,6 +2,8 @@
 import React, { useCallback, useRef } from "react";
 import { type DragSourceMonitor, useDrag, useDrop } from "react-dnd";
 
+import { shouldReorder } from "./dragReorder";
+
 export interface IDraggableListItemProps {
   disabled?: boolean;
   index: number;
@@ -108,10 +110,9 @@ const DraggableItem: React.FC<IDraggableListItemProps> = ({
 
       const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
       const hoverActualY = clientOffset.y - hoverBoundingRect.top;
-      // dragging down: swap only once the cursor passes this row's middle
-      if (dragIndex < hoverIndex && hoverActualY < hoverMiddleY) return;
-      // dragging up: swap only once the cursor passes this row's middle
-      if (dragIndex > hoverIndex && hoverActualY > hoverMiddleY) return;
+      if (!shouldReorder(dragIndex, hoverIndex, hoverActualY, hoverMiddleY)) {
+        return;
+      }
 
       onChangeIndex(dragIndex, hoverIndex, sourceContainerId !== containerId, (list) =>
         items.map((item) => take(item, list)),

--- a/src/renderer/src/controls/dragReorder.test.ts
+++ b/src/renderer/src/controls/dragReorder.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { moveItems, shouldReorder } from "./dragReorder";
+
+describe("moveItems", () => {
+  it("moves a single item down", () => {
+    expect(moveItems(["a", "b", "c", "d"], ["a"], 2)).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves a single item up", () => {
+    expect(moveItems(["a", "b", "c", "d"], ["c"], 0)).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("moves a multi-selection, preserving its order", () => {
+    expect(moveItems(["a", "b", "c", "d", "e"], ["b", "d"], 0)).toEqual(["b", "d", "a", "c", "e"]);
+  });
+
+  it("does not mutate the input list", () => {
+    const list = ["a", "b", "c"];
+    moveItems(list, ["a"], 2);
+    expect(list).toEqual(["a", "b", "c"]);
+  });
+
+  it("inserts an item not present in the list (cross-container drop)", () => {
+    // a multi-select take yields single-element arrays; the first element is used
+    expect(moveItems(["a", "b"], [["x"]], 1)).toEqual(["a", "x", "b"]);
+  });
+});
+
+describe("shouldReorder", () => {
+  it("does not swap a row with itself", () => {
+    expect(shouldReorder(2, 2, 30, 20)).toBe(false);
+  });
+
+  it("swaps downward once the cursor passes the middle", () => {
+    expect(shouldReorder(1, 3, 30, 20)).toBe(true);
+  });
+
+  it("waits while dragging down above the middle", () => {
+    expect(shouldReorder(1, 3, 10, 20)).toBe(false);
+  });
+
+  it("swaps upward once the cursor passes the middle", () => {
+    expect(shouldReorder(3, 1, 10, 20)).toBe(true);
+  });
+
+  it("waits while dragging up below the middle", () => {
+    expect(shouldReorder(3, 1, 30, 20)).toBe(false);
+  });
+});

--- a/src/renderer/src/controls/dragReorder.ts
+++ b/src/renderer/src/controls/dragReorder.ts
@@ -1,0 +1,48 @@
+/**
+ * Whether a hovered row should swap with the dragged row. The swap only happens
+ * once the cursor has passed the hovered row's vertical middle, so rows don't
+ * flip back and forth while the cursor sits near a boundary. `cursorY` and
+ * `midpointY` are relative to the hovered row's top.
+ */
+export function shouldReorder(
+  dragIndex: number,
+  hoverIndex: number,
+  cursorY: number,
+  midpointY: number,
+): boolean {
+  if (dragIndex === hoverIndex) {
+    return false;
+  }
+  // dragging down: wait until the cursor is past the middle
+  if (dragIndex < hoverIndex && cursorY < midpointY) {
+    return false;
+  }
+  // dragging up: wait until the cursor is past the middle
+  if (dragIndex > hoverIndex && cursorY > midpointY) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Move `movers` to `toIndex` within a copy of `list`, preserving their relative
+ * order. Each mover may be an item or a single-element array (a multi-select
+ * take yields arrays); the array's first element is used. Items not found in
+ * the list are simply inserted.
+ */
+export function moveItems<T>(list: T[], movers: Array<T | T[]>, toIndex: number): T[] {
+  const copy = list.slice();
+  movers.forEach((item) => {
+    const index = copy.indexOf(item as T);
+    if (index !== -1) {
+      copy.splice(index, 1);
+    }
+  });
+  let insertAt = toIndex;
+  movers.forEach((itm) => {
+    const item = (Array.isArray(itm) ? itm[0] : itm) as T;
+    copy.splice(insertAt, 0, item);
+    insertAt += 1;
+  });
+  return copy;
+}

--- a/src/renderer/src/extensions/file_based_loadorder/UpdateSet.test.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/UpdateSet.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect } from "vitest";
+
+import { makeLoadOrderEntry, makeMod } from "../../test-utils/builders";
+import { test } from "../../test-utils/fbloTest";
+import type { ILoadOrderEntryExt } from "./types/types";
+
+const ext = (overrides: Partial<ILoadOrderEntryExt> = {}): ILoadOrderEntryExt => ({
+  ...makeLoadOrderEntry(overrides),
+  index: 0,
+  ...overrides,
+});
+
+describe("UpdateSet.findEntry", () => {
+  test("returns null for an entry that was never added", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [ext({ id: "a.pak", modId: "mod-a", index: 0 })]);
+    expect(updateSet.findEntry(makeLoadOrderEntry({ id: "b.pak", modId: "mod-b" }))).toBeNull();
+  });
+
+  test("finds a managed entry by its modId", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [ext({ id: "a.pak", modId: "mod-a", index: 0 })]);
+    const found = updateSet.findEntry(makeLoadOrderEntry({ id: "a.pak", modId: "mod-a" }));
+    expect(found?.entries.map((e) => e.id)).toEqual(["a.pak"]);
+  });
+
+  test("finds a managed entry by id when its modId changed", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [ext({ id: "a.pak", modId: "mod-old", index: 0 })]);
+    // the mod was reinstalled under a new Vortex id but the same pak id
+    const found = updateSet.findEntry(makeLoadOrderEntry({ id: "a.pak", modId: "mod-new" }));
+    expect(found?.entries.map((e) => e.id)).toEqual(["a.pak"]);
+  });
+
+  test("resolves each pak to its own bucket when two share a non-numeric modId", ({ makeFblo }) => {
+    // A manually-installed mod (no numeric attributes.modId) shipping two paks: both entries carry
+    // the same modId but must resolve to the bucket that actually contains the looked-up id.
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [
+      ext({ id: "a.pak", modId: "manual", index: 0 }),
+      ext({ id: "b.pak", modId: "manual", index: 1 }),
+    ]);
+    const a = updateSet.findEntry(makeLoadOrderEntry({ id: "a.pak", modId: "manual" }));
+    const b = updateSet.findEntry(makeLoadOrderEntry({ id: "b.pak", modId: "manual" }));
+    expect(a?.entries.some((e) => e.id === "a.pak")).toBe(true);
+    expect(b?.entries.some((e) => e.id === "b.pak")).toBe(true);
+  });
+
+  test("groups paks of one Nexus mod (numeric modId) into a shared bucket", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo({
+      mods: { "mod-a": makeMod({ id: "mod-a", attributes: { modId: 42 } }) },
+    });
+    updateSet.init(gameId, [
+      ext({ id: "a.pak", modId: "mod-a", index: 0 }),
+      ext({ id: "b.pak", modId: "mod-a", index: 1 }),
+    ]);
+    const found = updateSet.findEntry(makeLoadOrderEntry({ id: "a.pak", modId: "mod-a" }));
+    expect(found?.entries.map((e) => e.id).sort()).toEqual(["a.pak", "b.pak"]);
+  });
+
+  test("finds an external entry (no modId) by id", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [ext({ id: "ext.pak", modId: undefined, index: 0 })]);
+    const found = updateSet.findEntry(makeLoadOrderEntry({ id: "ext.pak" }));
+    expect(found?.entries.map((e) => e.id)).toEqual(["ext.pak"]);
+  });
+});
+
+describe("UpdateSet.restore", () => {
+  test("reorders entries by their stored index", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [
+      ext({ id: "a.pak", name: "A", modId: "mod-a", index: 0 }),
+      ext({ id: "b.pak", name: "B", modId: "mod-b", index: 1 }),
+      ext({ id: "c.pak", name: "C", modId: "mod-c", index: 2 }),
+    ]);
+    updateSet.shouldRestore = true;
+    // present them out of order; restore should sort back to a, b, c
+    const restored = updateSet.restore([
+      makeLoadOrderEntry({ id: "c.pak", name: "C", modId: "mod-c" }),
+      makeLoadOrderEntry({ id: "a.pak", name: "A", modId: "mod-a" }),
+      makeLoadOrderEntry({ id: "b.pak", name: "B", modId: "mod-b" }),
+    ]);
+    expect(restored.map((e) => e.id)).toEqual(["a.pak", "b.pak", "c.pak"]);
+  });
+});
+
+describe("UpdateSet.reset", () => {
+  test("forceReset clears stored entries", ({ makeFblo }) => {
+    const { updateSet, gameId } = makeFblo();
+    updateSet.init(gameId, [ext({ id: "a.pak", modId: "mod-a", index: 0 })]);
+    updateSet.forceReset();
+    expect(updateSet.findEntry(makeLoadOrderEntry({ id: "a.pak", modId: "mod-a" }))).toBeNull();
+    expect(updateSet.isInitialized()).toBe(false);
+  });
+});

--- a/src/renderer/src/extensions/file_based_loadorder/UpdateSet.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/UpdateSet.ts
@@ -1,7 +1,4 @@
-import * as _ from "lodash";
-
-import type { IExtensionApi, IMod } from "../../types/api";
-import { log } from "../../util/log";
+import type { IExtensionApi } from "../../types/api";
 import { getSafe } from "../../util/storeHelper";
 import { activeGameId, lastActiveProfileForGame } from "../profile_management/selectors";
 import { currentLoadOrderForProfile } from "./selectors";
@@ -12,6 +9,14 @@ export default class UpdateSet {
   private mApi: IExtensionApi;
   private mModEntries: { [modId: number]: ILoadOrderEntryExt[] } = {};
   private mExternalEntries: { [modId: string]: ILoadOrderEntryExt[] } = {};
+  // O(1) lookup indexes into the buckets above; findEntry runs once per load
+  //  order entry on every change.
+  // Map of mod id to its mModEntries bucket
+  private mModsByModId = new Map<string, ILoadOrderEntryExt[]>();
+  // Map of entry id to its mModEntries bucket
+  private mModsByEntryId = new Map<string, ILoadOrderEntryExt[]>();
+  // Map of entry id to its mExternalEntries bucket
+  private mExternalByEntryId = new Map<string, ILoadOrderEntryExt[]>();
   private mInitialized = false;
   private mShouldRestore = false;
   private mIsFBLO: (gameId: string) => boolean;
@@ -52,6 +57,12 @@ export default class UpdateSet {
     } else if (!target[key].some((entry) => entry.id === lo.id)) {
       target[key].push(lo);
     }
+    if (lo.modId) {
+      this.mModsByModId.set(lo.modId, target[key]);
+      this.mModsByEntryId.set(lo.id, target[key]);
+    } else {
+      this.mExternalByEntryId.set(lo.id, target[key]);
+    }
   };
 
   public init = (gameId: string, modEntries?: ILoadOrderEntryExt[]) => {
@@ -90,22 +101,11 @@ export default class UpdateSet {
   private reset = () => {
     this.mModEntries = {};
     this.mExternalEntries = {};
+    this.mModsByModId.clear();
+    this.mModsByEntryId.clear();
+    this.mExternalByEntryId.clear();
     this.mInitialized = false;
     this.mShouldRestore = false;
-  };
-
-  public has = (value: number | string): boolean => {
-    return typeof value === "string"
-      ? this.mExternalEntries[value] !== undefined
-      : this.mModEntries[value] !== undefined;
-  };
-
-  public hasEntry = (entry: ILoadOrderEntry): boolean => {
-    return entry.modId
-      ? Object.values(this.mModEntries).some((l) =>
-          l.some((m) => m.modId === entry.modId || m.id === entry.id),
-        )
-      : Object.values(this.mExternalEntries).some((l) => l.some((m) => m.id === entry.id));
   };
 
   public restore = (loadOrder: ILoadOrderEntry[]): ILoadOrderEntry[] => {
@@ -147,45 +147,17 @@ export default class UpdateSet {
 
   // The modId of the mod we are looking for as stored in Vortex's state.
   public findEntry = (lookUpEntry: ILoadOrderEntry): { entries: ILoadOrderEntryExt[] } | null => {
-    if (!this.hasEntry(lookUpEntry)) {
-      return null;
-    }
-
     if (lookUpEntry.modId === undefined) {
       // This is an external entry, we need to find it in the external entries.
-      const extEntry = Object.entries(this.mExternalEntries).find((entry) => {
-        const [eId, loEntries] = entry;
-        return Array.isArray(loEntries) && loEntries.some((l) => l.id === lookUpEntry.id);
-      });
-      if (extEntry !== undefined) {
-        return { entries: this.mExternalEntries[extEntry[0]] };
-      }
-    } else {
-      const numericId = Object.entries(this.mModEntries).find((entry) => {
-        const [nId, loEntries] = entry;
-        return (
-          Array.isArray(loEntries) &&
-          loEntries.some((l) => l.modId === lookUpEntry.modId || l.id === lookUpEntry.id)
-        );
-      })?.[0];
-      if (numericId === undefined) {
-        return null;
-      }
-      return { entries: this.mModEntries[numericId] };
+      const entries = this.mExternalByEntryId.get(lookUpEntry.id);
+      return entries !== undefined ? { entries } : null;
     }
-  };
-
-  public get = (modId: number | string): ILoadOrderEntryExt[] => {
-    if (typeof modId === "string") {
-      return this.mExternalEntries[modId] || [];
-    } else {
-      return this.mModEntries[modId] || [];
-    }
-  };
-
-  public add = (x: number): this => {
-    log("warn", "Use addEntry", x);
-    return;
+    // Prefer the entry-id index: that bucket is guaranteed to contain this
+    //  exact entry. The modId index is the fallback for when the entry's id
+    //  changed (mod reinstalled under a new Vortex id).
+    const entries =
+      this.mModsByEntryId.get(lookUpEntry.id) ?? this.mModsByModId.get(lookUpEntry.modId);
+    return entries !== undefined ? { entries } : null;
   };
 
   public isInitialized = (): boolean => {

--- a/src/renderer/src/extensions/file_based_loadorder/index.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/index.ts
@@ -96,11 +96,14 @@ async function genLoadOrderChange(api: types.IExtensionApi, oldState: any, newSt
   const loadOrder: LoadOrder = Array.isArray(newState[profile.id]) ? newState[profile.id] : [];
   const prevIds = prevLO.map((lo) => lo.id);
   const newIds = loadOrder.map((lo) => lo.id);
+  // Map of entry id to its index in the previous load order
+  const prevIdIndices = new Map(prevIds.map((id, idx): [string, number] => [id, idx]));
+  const newIdSet = new Set(newIds);
 
-  const added = newIds.filter((id) => !prevIds.includes(id));
-  const removed = prevIds.filter((id) => !newIds.includes(id));
+  const added = newIds.filter((id) => !prevIdIndices.has(id));
+  const removed = prevIds.filter((id) => !newIdSet.has(id));
   const same = loadOrder.reduce((acc, lo, idx) => {
-    if (!prevIds.includes(lo.id) || prevIds.indexOf(lo.id) !== idx) {
+    if (prevIdIndices.get(lo.id) !== idx) {
       return acc;
     }
     const currFileId = util.getSafe(

--- a/src/renderer/src/extensions/file_based_loadorder/index.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/index.ts
@@ -13,6 +13,7 @@ import { setFBLoadOrder } from "./actions/loadOrder";
 import { setValidationResult } from "./actions/session";
 import { generate, Interface, parser } from "./collections/loadOrder";
 import { addGameEntry, addGameEntryInline, findGameEntry } from "./gameSupport";
+import { diffLoadOrder } from "./loadOrderDiff";
 import { modLoadOrderReducer } from "./reducers/loadOrder";
 import { sessionReducer } from "./reducers/session";
 import { currentGameMods, currentLoadOrderForProfile } from "./selectors";
@@ -94,42 +95,25 @@ async function genLoadOrderChange(api: types.IExtensionApi, oldState: any, newSt
 
   const prevLO: LoadOrder = Array.isArray(oldState[profile.id]) ? oldState[profile.id] : [];
   const loadOrder: LoadOrder = Array.isArray(newState[profile.id]) ? newState[profile.id] : [];
-  const prevIds = prevLO.map((lo) => lo.id);
-  const newIds = loadOrder.map((lo) => lo.id);
-  // Map of entry id to its index in the previous load order
-  const prevIdIndices = new Map(prevIds.map((id, idx): [string, number] => [id, idx]));
-  const newIdSet = new Set(newIds);
 
-  const added = newIds.filter((id) => !prevIdIndices.has(id));
-  const removed = prevIds.filter((id) => !newIdSet.has(id));
-  const same = loadOrder.reduce((acc, lo, idx) => {
-    if (prevIdIndices.get(lo.id) !== idx) {
-      return acc;
-    }
-    const currFileId = util.getSafe(
-      state,
-      ["persistent", "mods", profile.gameId, lo?.modId, "attributes", "fileId"],
-      undefined,
-    );
-    const prevFileId =
+  const diff = diffLoadOrder(prevLO, loadOrder, {
+    currentFileId: (lo) =>
+      util.getSafe(
+        state,
+        ["persistent", "mods", profile.gameId, lo?.modId, "attributes", "fileId"],
+        undefined,
+      ),
+    storedFileId: (lo) =>
       updateSet.findEntry(lo)?.entries?.filter((e) => e.id === lo.id && e.name === lo.name)?.[0]
-        ?.fileId ?? -1;
-    if (!!currFileId && currFileId !== prevFileId) {
-      updateSet.shouldRestore = true;
-      return acc;
-    }
-
-    if (lo.enabled !== prevLO[idx].enabled) {
-      return acc;
-    }
-
-    acc.push(lo.id);
-    return acc;
-  }, []);
+        ?.fileId,
+  });
+  if (diff.shouldRestore) {
+    updateSet.shouldRestore = true;
+  }
 
   if (
     !updateSet.shouldRestore &&
-    (added.length > 0 || removed.length > 0 || same.length !== newIds.length)
+    (diff.added.length > 0 || diff.removed.length > 0 || diff.same.length !== loadOrder.length)
   ) {
     try {
       // This is the only place where we want applyNewLoadOrder to be called

--- a/src/renderer/src/extensions/file_based_loadorder/loadOrderDiff.test.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/loadOrderDiff.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { makeLoadOrderEntry } from "../../test-utils/builders";
+import { diffLoadOrder, type ILoadOrderDiffOptions } from "./loadOrderDiff";
+
+// No mod-backed fileId change unless a test opts in.
+const noFileIds: ILoadOrderDiffOptions = {
+  currentFileId: () => undefined,
+  storedFileId: () => undefined,
+};
+
+describe("diffLoadOrder", () => {
+  it("reports no change for an identical order", () => {
+    const lo = [makeLoadOrderEntry({ id: "a" }), makeLoadOrderEntry({ id: "b" })];
+    const diff = diffLoadOrder(lo, lo, noFileIds);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.same).toEqual(["a", "b"]);
+    expect(diff.shouldRestore).toBe(false);
+  });
+
+  it("detects an added entry", () => {
+    const prev = [makeLoadOrderEntry({ id: "a" })];
+    const next = [makeLoadOrderEntry({ id: "a" }), makeLoadOrderEntry({ id: "b" })];
+    const diff = diffLoadOrder(prev, next, noFileIds);
+    expect(diff.added).toEqual(["b"]);
+    expect(diff.removed).toEqual([]);
+  });
+
+  it("detects a removed entry", () => {
+    const prev = [makeLoadOrderEntry({ id: "a" }), makeLoadOrderEntry({ id: "b" })];
+    const next = [makeLoadOrderEntry({ id: "a" })];
+    const diff = diffLoadOrder(prev, next, noFileIds);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual(["b"]);
+  });
+
+  it("excludes reordered entries from same", () => {
+    const ids = ["a", "b", "c"];
+    const prev = ids.map((id) => makeLoadOrderEntry({ id }));
+    // a and b swap; c stays put
+    const next = ["b", "a", "c"].map((id) => makeLoadOrderEntry({ id }));
+    const diff = diffLoadOrder(prev, next, noFileIds);
+    expect(diff.same).toEqual(["c"]);
+    expect(diff.same.length).not.toBe(next.length);
+  });
+
+  it("excludes an entry whose enabled state changed", () => {
+    const prev = [makeLoadOrderEntry({ id: "a", enabled: true })];
+    const next = [makeLoadOrderEntry({ id: "a", enabled: false })];
+    const diff = diffLoadOrder(prev, next, noFileIds);
+    expect(diff.same).toEqual([]);
+    expect(diff.shouldRestore).toBe(false);
+  });
+
+  it("flags a restore when an in-place entry's backing fileId changed", () => {
+    const lo = [makeLoadOrderEntry({ id: "a", modId: "mod-a" })];
+    const diff = diffLoadOrder(lo, lo, {
+      currentFileId: () => 200,
+      storedFileId: () => 100,
+    });
+    expect(diff.shouldRestore).toBe(true);
+    expect(diff.same).toEqual([]);
+  });
+
+  it("does not flag a restore when the fileId is unchanged", () => {
+    const lo = [makeLoadOrderEntry({ id: "a", modId: "mod-a" })];
+    const diff = diffLoadOrder(lo, lo, {
+      currentFileId: () => 100,
+      storedFileId: () => 100,
+    });
+    expect(diff.shouldRestore).toBe(false);
+    expect(diff.same).toEqual(["a"]);
+  });
+
+  it("treats a falsy current fileId as no change", () => {
+    const lo = [makeLoadOrderEntry({ id: "a", modId: "mod-a" })];
+    const diff = diffLoadOrder(lo, lo, {
+      currentFileId: () => 0,
+      storedFileId: () => 100,
+    });
+    expect(diff.shouldRestore).toBe(false);
+    expect(diff.same).toEqual(["a"]);
+  });
+});

--- a/src/renderer/src/extensions/file_based_loadorder/loadOrderDiff.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/loadOrderDiff.ts
@@ -1,0 +1,59 @@
+import type { ILoadOrderEntry, LoadOrder } from "./types/types";
+
+export interface ILoadOrderDiffOptions {
+  // fileId of the mod currently backing this entry (from state)
+  currentFileId: (entry: ILoadOrderEntry) => number | undefined;
+  // fileId recorded for this entry before the change (from the update set)
+  storedFileId: (entry: ILoadOrderEntry) => number | undefined;
+}
+
+export interface ILoadOrderDiff {
+  // ids present in next but not prev
+  added: string[];
+  // ids present in prev but not next
+  removed: string[];
+  // ids unchanged in id, position and enabled state
+  same: string[];
+  // a mod backing an in-place entry changed file, so the order needs restoring
+  shouldRestore: boolean;
+}
+
+/**
+ * Classify how a load order changed. An entry counts as "same" only when its id
+ * sits at the same index in both orders and its enabled state is unchanged; a
+ * differing backing fileId at the same position instead flags a restore.
+ */
+export function diffLoadOrder(
+  prev: LoadOrder,
+  next: LoadOrder,
+  options: ILoadOrderDiffOptions,
+): ILoadOrderDiff {
+  const prevIds = prev.map((lo) => lo.id);
+  const nextIds = next.map((lo) => lo.id);
+  // Map of entry id to its index in the previous order
+  const prevIdIndices = new Map(prevIds.map((id, idx): [string, number] => [id, idx]));
+  const nextIdSet = new Set(nextIds);
+
+  const added = nextIds.filter((id) => !prevIdIndices.has(id));
+  const removed = prevIds.filter((id) => !nextIdSet.has(id));
+
+  let shouldRestore = false;
+  const same: string[] = [];
+  next.forEach((lo, idx) => {
+    if (prevIdIndices.get(lo.id) !== idx) {
+      return;
+    }
+    const currentFileId = options.currentFileId(lo);
+    const storedFileId = options.storedFileId(lo) ?? -1;
+    if (currentFileId && currentFileId !== storedFileId) {
+      shouldRestore = true;
+      return;
+    }
+    if (lo.enabled !== prev[idx].enabled) {
+      return;
+    }
+    same.push(lo.id);
+  });
+
+  return { added, removed, same, shouldRestore };
+}

--- a/src/renderer/src/extensions/file_based_loadorder/renderRows.test.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/renderRows.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { makeLoadOrderEntry } from "../../test-utils/builders";
+import { RenderRowsCache } from "./renderRows";
+
+const order = (...ids: string[]) => ids.map((id) => makeLoadOrderEntry({ id }));
+
+describe("RenderRowsCache", () => {
+  it("preserves row-object identity across calls with unchanged inputs", () => {
+    const cache = new RenderRowsCache();
+    const lo = order("a", "b", "c");
+    const first = cache.build(lo, undefined, false, "");
+    const second = cache.build(lo, undefined, false, "");
+    expect(second).toBe(first);
+    expect(second[0]).toBe(first[0]);
+  });
+
+  it("rebuilds when the load order reference changes", () => {
+    const cache = new RenderRowsCache();
+    const first = cache.build(order("a", "b"), undefined, false, "");
+    const second = cache.build(order("a", "b"), undefined, false, "");
+    expect(second).not.toBe(first);
+  });
+
+  it("numbers position 1-based over the full order", () => {
+    const cache = new RenderRowsCache();
+    const rows = cache.build(order("a", "b", "c"), undefined, false, "");
+    expect(rows.map((r) => r.position)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps position from the full order when filtering", () => {
+    const cache = new RenderRowsCache();
+    const lo = [
+      makeLoadOrderEntry({ id: "alpha", name: "alpha" }),
+      makeLoadOrderEntry({ id: "beta", name: "beta" }),
+      makeLoadOrderEntry({ id: "gamma", name: "gamma" }),
+    ];
+    const rows = cache.build(lo, undefined, false, "gam");
+    expect(rows.map((r) => r.loEntry.id)).toEqual(["gamma"]);
+    expect(rows[0].position).toBe(3);
+  });
+
+  it("reuses the filtered result for the same filter text", () => {
+    const cache = new RenderRowsCache();
+    const lo = order("a", "b");
+    const first = cache.build(lo, undefined, false, "a");
+    const second = cache.build(lo, undefined, false, "a");
+    expect(second).toBe(first);
+  });
+
+  it("counts locked entries over the full order", () => {
+    const cache = new RenderRowsCache();
+    const lo = [
+      makeLoadOrderEntry({ id: "a", locked: true }),
+      makeLoadOrderEntry({ id: "b", locked: "always" }),
+      makeLoadOrderEntry({ id: "c" }),
+    ];
+    const rows = cache.build(lo, undefined, false, "");
+    expect(rows.every((r) => r.lockedEntriesCount === 2)).toBe(true);
+  });
+
+  it("passes the toggleable flag through as displayCheckboxes", () => {
+    const cache = new RenderRowsCache();
+    const rows = cache.build(order("a"), undefined, true, "");
+    expect(rows[0].displayCheckboxes).toBe(true);
+  });
+});

--- a/src/renderer/src/extensions/file_based_loadorder/renderRows.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/renderRows.ts
@@ -1,0 +1,69 @@
+import type { IItemRendererProps, LoadOrder } from "./types/types";
+import { isEntryLocked } from "./util";
+
+type InvalidEntries = IItemRendererProps["invalidEntries"];
+
+/**
+ * Memoizes the per-row props for the load order page. The full-list build is
+ * cached on (loadOrder, invalid, toggleable) and the filter separately on the
+ * filter text, so an unrelated re-render reuses the same row objects (keeping
+ * the rows' React.memo intact) and the filter only recomputes on a keystroke.
+ * Row position is 1-based over the full order, computed before filtering.
+ */
+export class RenderRowsCache {
+  #rows:
+    | {
+        loadOrder: LoadOrder;
+        invalid: InvalidEntries;
+        toggleable: boolean;
+        result: IItemRendererProps[];
+      }
+    | undefined;
+  #filtered:
+    | { rows: IItemRendererProps[]; filterText: string; result: IItemRendererProps[] }
+    | undefined;
+
+  public build(
+    loadOrder: LoadOrder,
+    invalid: InvalidEntries,
+    toggleable: boolean,
+    filterText: string,
+  ): IItemRendererProps[] {
+    const cache = this.#rows;
+    let rows: IItemRendererProps[];
+    if (
+      cache !== undefined &&
+      cache.loadOrder === loadOrder &&
+      cache.invalid === invalid &&
+      cache.toggleable === toggleable
+    ) {
+      rows = cache.result;
+    } else {
+      const lockedEntriesCount = loadOrder.filter((entry) => isEntryLocked(entry.locked)).length;
+      rows = loadOrder.map(
+        (loEntry, idx): IItemRendererProps => ({
+          loEntry,
+          displayCheckboxes: toggleable,
+          invalidEntries: invalid,
+          position: idx + 1,
+          lockedEntriesCount,
+        }),
+      );
+      this.#rows = { loadOrder, invalid, toggleable, result: rows };
+    }
+
+    if (filterText === "") {
+      return rows;
+    }
+    const filtered = this.#filtered;
+    if (filtered !== undefined && filtered.rows === rows && filtered.filterText === filterText) {
+      return filtered.result;
+    }
+    const lower = filterText.toLowerCase();
+    const result = rows.filter((row) =>
+      (row.loEntry.name ?? row.loEntry.id).toLowerCase().includes(lower),
+    );
+    this.#filtered = { rows, filterText, result };
+    return result;
+  }
+}

--- a/src/renderer/src/extensions/file_based_loadorder/types/types.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/types/types.ts
@@ -12,6 +12,13 @@ export interface IItemRendererProps {
   //  describing the issue directly on the mod entry in the LO page.
   invalidEntries?: IInvalidResult[];
 
+  // 1-based position of this entry in the full load order, precomputed by
+  //  the page.
+  position?: number;
+
+  // Number of locked entries in the load order, precomputed by the page.
+  lockedEntriesCount?: number;
+
   // Function components cannot be given refs, which means that DnD
   //  will not work when using the Vortex API's DraggableItem without
   //  forwarding the ref to the itemRenderer.
@@ -112,6 +119,14 @@ export interface ILoadOrderGameInfo {
     item: IItemRendererProps;
     forwardedRef?: (ref: any) => void;
   }>;
+
+  /**
+   * Set to true if a custom item renderer produces rows of a single, uniform
+   *  height. The load order page virtualizes long lists (rendering only the
+   *  rows on screen), which requires uniform row heights; the default renderer
+   *  guarantees this, so custom renderers must opt in.
+   */
+  uniformRowHeight?: boolean;
 
   /**
    * By default the FBLO extension will attempt to automatically generate the data

--- a/src/renderer/src/extensions/file_based_loadorder/util.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/util.ts
@@ -1,5 +1,7 @@
+import { DataInvalid, ProcessCanceled, UserCanceled } from "@vortex/shared/errors";
+
 import type * as types from "../../types/api";
-import * as util from "../../util/api";
+import { findRuleByRef } from "../mod_management/util/testModReference";
 import { activeGameId, lastActiveProfileForGame } from "../profile_management/selectors";
 import { setValidationResult } from "./actions/session";
 import { findGameEntry } from "./gameSupport";
@@ -30,7 +32,7 @@ export const toExtendedLoadOrderEntry = (api: types.IExtensionApi) => {
 };
 
 export function isModInCollection(collection: types.IMod, mod: types.IMod) {
-  return util.findRuleByRef(collection.rules, mod) !== undefined;
+  return findRuleByRef(collection.rules, mod) !== undefined;
 }
 
 export async function genCollectionLoadOrder(
@@ -81,9 +83,9 @@ export async function errorHandler(api: types.IExtensionApi, gameId: string, err
   const gameEntry: ILoadOrderGameInfoExt = findGameEntry(gameId);
   const allowReport =
     !gameEntry.isContributed &&
-    !(err instanceof util.ProcessCanceled) &&
-    !(err instanceof util.DataInvalid) &&
-    !(err instanceof util.UserCanceled);
+    !(err instanceof ProcessCanceled) &&
+    !(err instanceof DataInvalid) &&
+    !(err instanceof UserCanceled);
   if (err instanceof LoadOrderValidationError) {
     const invalLOErr = err as LoadOrderValidationError;
     const profileId = lastActiveProfileForGame(api.getState(), gameId);

--- a/src/renderer/src/extensions/file_based_loadorder/util.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/util.ts
@@ -11,7 +11,14 @@ import {
   LoadOrderSerializationError,
   LoadOrderValidationError,
   type ILoadOrderEntryExt,
+  type LockedState,
 } from "./types/types";
+
+// A load order entry is locked (pinned, not user-orderable) for any of the
+//  truthy LockedState values.
+export function isEntryLocked(locked: LockedState): boolean {
+  return locked === true || locked === "true" || locked === "always";
+}
 
 export const toExtendedLoadOrderEntry = (api: types.IExtensionApi) => {
   return (entry: types.ILoadOrderEntry, index: number) => {

--- a/src/renderer/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
@@ -22,6 +22,7 @@ import * as util from "../../../util/api";
 import * as selectors from "../../../util/selectors";
 import { DNDContainer, MainPage } from "../../../views/api";
 import { setFBForceUpdate } from "../actions/session";
+import { RenderRowsCache } from "../renderRows";
 import { currentLoadOrderForProfile } from "../selectors";
 import {
   type IItemRendererProps,
@@ -86,20 +87,10 @@ type IComponentState = IBaseState;
 class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
   private mStaticButtons: types.IActionDefinition[];
 
-  // Memoize the per-row props so an unrelated re-render keeps the same row
+  // Memoizes the per-row props so an unrelated re-render keeps the same row
   //  object identities, preserving the rows' React.memo and avoiding a layout
   //  measure in DraggableList.
-  private mRendOpsCache:
-    | {
-        loadOrder: LoadOrder;
-        invalid: IItemRendererProps["invalidEntries"];
-        toggleable: boolean;
-        result: IItemRendererProps[];
-      }
-    | undefined;
-  private mFilterCache:
-    | { rendOps: IItemRendererProps[]; filterText: string; result: IItemRendererProps[] }
-    | undefined;
+  private mRenderRows = new RenderRowsCache();
 
   constructor(props: IProps) {
     super(props);
@@ -255,7 +246,12 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
     const chosenItemRenderer = gameEntry?.customItemRenderer ?? ItemRenderer;
     const enabled =
       gameEntry !== undefined
-        ? this.getRenderRows(gameEntry, loadOrder, this.state.filterText)
+        ? this.mRenderRows.build(
+            loadOrder,
+            validationError?.validationResult?.invalid,
+            gameEntry.toggleableEntries || false,
+            this.state.filterText,
+          )
         : [];
 
     const infoPanel = () => (
@@ -339,59 +335,6 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
   private isLocked = (item: IItemRendererProps): boolean => {
     return item?.loEntry?.locked !== undefined && isEntryLocked(item.loEntry.locked);
   };
-
-  // Builds the filtered per-row props, memoizing the (expensive) full-list
-  //  build separately from the (cheap) filter so an unrelated re-render reuses
-  //  the same row objects and the filter only recomputes on a keystroke.
-  private getRenderRows(
-    gameEntry: ILoadOrderGameInfo,
-    loadOrder: LoadOrder,
-    filterText: string,
-  ): IItemRendererProps[] {
-    const invalid = this.state.validationError?.validationResult?.invalid;
-    const toggleable = gameEntry.toggleableEntries || false;
-    const cache = this.mRendOpsCache;
-    let rendOps: IItemRendererProps[];
-    if (
-      cache !== undefined &&
-      cache.loadOrder === loadOrder &&
-      cache.invalid === invalid &&
-      cache.toggleable === toggleable
-    ) {
-      rendOps = cache.result;
-    } else {
-      const lockedEntriesCount = loadOrder.filter((entry) => isEntryLocked(entry.locked)).length;
-      rendOps = loadOrder.map(
-        (loEntry, idx): IItemRendererProps => ({
-          loEntry,
-          displayCheckboxes: toggleable,
-          invalidEntries: invalid,
-          position: idx + 1,
-          lockedEntriesCount,
-        }),
-      );
-      this.mRendOpsCache = { loadOrder, invalid, toggleable, result: rendOps };
-    }
-
-    if (filterText === "") {
-      return rendOps;
-    }
-    const filterCache = this.mFilterCache;
-    if (
-      filterCache !== undefined &&
-      filterCache.rendOps === rendOps &&
-      filterCache.filterText === filterText
-    ) {
-      return filterCache.result;
-    }
-    const lower = filterText.toLowerCase();
-    const result = rendOps.filter((rendOp) => {
-      const entryName = rendOp.loEntry.name ?? rendOp.loEntry.id;
-      return !!entryName && entryName.toLowerCase().includes(lower);
-    });
-    this.mFilterCache = { rendOps, filterText, result };
-    return result;
-  }
 
   private onApply = (ordered: IItemRendererProps[]) => {
     const { t } = this.props;

--- a/src/renderer/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/FileBasedLoadOrderPage.tsx
@@ -29,6 +29,7 @@ import {
   type LoadOrder,
   LoadOrderValidationError,
 } from "../types/types";
+import { isEntryLocked } from "../util";
 import FilterBox from "./FilterBox";
 import InfoPanel from "./InfoPanel";
 import ItemRenderer from "./ItemRenderer";
@@ -84,6 +85,21 @@ type IComponentState = IBaseState;
 
 class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
   private mStaticButtons: types.IActionDefinition[];
+
+  // Memoize the per-row props so an unrelated re-render keeps the same row
+  //  object identities, preserving the rows' React.memo and avoiding a layout
+  //  measure in DraggableList.
+  private mRendOpsCache:
+    | {
+        loadOrder: LoadOrder;
+        invalid: IItemRendererProps["invalidEntries"];
+        toggleable: boolean;
+        result: IItemRendererProps[];
+      }
+    | undefined;
+  private mFilterCache:
+    | { rendOps: IItemRendererProps[]; filterText: string; result: IItemRendererProps[] }
+    | undefined;
 
   constructor(props: IProps) {
     super(props);
@@ -239,22 +255,7 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
     const chosenItemRenderer = gameEntry?.customItemRenderer ?? ItemRenderer;
     const enabled =
       gameEntry !== undefined
-        ? loadOrder.reduce((accum, loEntry) => {
-            const rendOps: IItemRendererProps = {
-              loEntry,
-              displayCheckboxes: gameEntry.toggleableEntries || false,
-              invalidEntries: validationError?.validationResult?.invalid,
-            };
-            // Filter based on the filterText, matching on loEntry.name or other attributes as needed
-            const entryName = loEntry.name ?? loEntry.id;
-            if (!entryName) {
-              return accum; // Skip entries without a name
-            }
-            if (entryName.toLowerCase().includes(this.state.filterText.toLowerCase())) {
-              accum.push(rendOps);
-            }
-            return accum;
-          }, [])
+        ? this.getRenderRows(gameEntry, loadOrder, this.state.filterText)
         : [];
 
     const infoPanel = () => (
@@ -274,6 +275,9 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
           apply={this.onApply}
           idFunc={this.getItemId}
           isLocked={this.isLocked}
+          virtualized={
+            gameEntry?.customItemRenderer === undefined || gameEntry?.uniformRowHeight === true
+          }
         />
       ) : (
         <EmptyPlaceholder
@@ -333,8 +337,61 @@ class FileBasedLoadOrderPage extends ComponentEx<IProps, IComponentState> {
   private getItemId = (item: IItemRendererProps): string => item.loEntry.id;
 
   private isLocked = (item: IItemRendererProps): boolean => {
-    return [true, "true", "always"].includes(item?.loEntry?.locked);
+    return item?.loEntry?.locked !== undefined && isEntryLocked(item.loEntry.locked);
   };
+
+  // Builds the filtered per-row props, memoizing the (expensive) full-list
+  //  build separately from the (cheap) filter so an unrelated re-render reuses
+  //  the same row objects and the filter only recomputes on a keystroke.
+  private getRenderRows(
+    gameEntry: ILoadOrderGameInfo,
+    loadOrder: LoadOrder,
+    filterText: string,
+  ): IItemRendererProps[] {
+    const invalid = this.state.validationError?.validationResult?.invalid;
+    const toggleable = gameEntry.toggleableEntries || false;
+    const cache = this.mRendOpsCache;
+    let rendOps: IItemRendererProps[];
+    if (
+      cache !== undefined &&
+      cache.loadOrder === loadOrder &&
+      cache.invalid === invalid &&
+      cache.toggleable === toggleable
+    ) {
+      rendOps = cache.result;
+    } else {
+      const lockedEntriesCount = loadOrder.filter((entry) => isEntryLocked(entry.locked)).length;
+      rendOps = loadOrder.map(
+        (loEntry, idx): IItemRendererProps => ({
+          loEntry,
+          displayCheckboxes: toggleable,
+          invalidEntries: invalid,
+          position: idx + 1,
+          lockedEntriesCount,
+        }),
+      );
+      this.mRendOpsCache = { loadOrder, invalid, toggleable, result: rendOps };
+    }
+
+    if (filterText === "") {
+      return rendOps;
+    }
+    const filterCache = this.mFilterCache;
+    if (
+      filterCache !== undefined &&
+      filterCache.rendOps === rendOps &&
+      filterCache.filterText === filterText
+    ) {
+      return filterCache.result;
+    }
+    const lower = filterText.toLowerCase();
+    const result = rendOps.filter((rendOp) => {
+      const entryName = rendOp.loEntry.name ?? rendOp.loEntry.id;
+      return !!entryName && entryName.toLowerCase().includes(lower);
+    });
+    this.mFilterCache = { rendOps, filterText, result };
+    return result;
+  }
 
   private onApply = (ordered: IItemRendererProps[]) => {
     const { t } = this.props;

--- a/src/renderer/src/extensions/file_based_loadorder/views/ItemRenderer.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/ItemRenderer.tsx
@@ -8,12 +8,12 @@ import { ComponentEx } from "../../../controls/ComponentEx";
 import type { IProfile, IState } from "../../../types/api";
 import * as selectors from "../../../util/selectors";
 import { setFBLoadOrder, setFBLoadOrderEntry } from "../actions/loadOrder";
-import { currentLoadOrderForProfile, currentModStateForProfile } from "../selectors";
+import { currentLoadOrderForProfile } from "../selectors";
 import type { IItemRendererProps, ILoadOrderEntry, LoadOrder } from "../types/types";
+import { isEntryLocked } from "../util";
 import { LoadOrderIndexInput } from "./loadOrderIndex";
 
 interface IConnectedProps {
-  modState: any;
   loadOrder: LoadOrder;
   profile: IProfile;
 }
@@ -68,7 +68,7 @@ class ItemRenderer extends ComponentEx<IProps, {}> {
     const { loadOrder, className } = this.props;
     const key = !!item.name ? `${item.name}` : `${item.id}`;
 
-    let classes = ["load-order-entry"];
+    let classes = ["load-order-entry", "fblo-uniform-row"];
     if (className !== undefined) {
       classes = classes.concat(className.split(" "));
     }
@@ -82,13 +82,13 @@ class ItemRenderer extends ComponentEx<IProps, {}> {
         <Checkbox
           className="entry-checkbox"
           checked={item.enabled}
-          disabled={this.isLocked(item)}
+          disabled={isEntryLocked(item.locked)}
           onChange={this.onStatusChange}
         />
       ) : null;
 
     const lock = () =>
-      this.isLocked(item) ? <Icon className="locked-entry-logo" name="locked" /> : null;
+      isEntryLocked(item.locked) ? <Icon className="locked-entry-logo" name="locked" /> : null;
 
     return (
       <ListGroupItem key={key} className={classes.join(" ")} ref={this.props.item.setRef}>
@@ -100,20 +100,17 @@ class ItemRenderer extends ComponentEx<IProps, {}> {
           currentPosition={this.currentPosition()}
           lockedEntriesCount={this.lockedEntriesCount()}
           loadOrder={loadOrder}
-          isLocked={this.isLocked}
           onApplyIndex={this.onApplyIndex}
         />
         {this.renderValidationError()}
-        <p className="load-order-name">{key}</p>
+        <p className="load-order-name" title={key}>
+          {key}
+        </p>
         {this.renderExternalBanner(item)}
         {checkBox()}
         {lock()}
       </ListGroupItem>
     );
-  }
-
-  private isLocked(item: ILoadOrderEntry): boolean {
-    return [true, "true", "always"].includes(item.locked);
   }
 
   private isExternal(item: ILoadOrderEntry): boolean {
@@ -131,7 +128,7 @@ class ItemRenderer extends ComponentEx<IProps, {}> {
 
   private currentPosition = (): number => {
     const { item, loadOrder } = this.props;
-    return loadOrder.findIndex((entry) => entry.id === item.loEntry.id) + 1;
+    return item.position ?? loadOrder.findIndex((entry) => entry.id === item.loEntry.id) + 1;
   };
 
   private onApplyIndex = (idx: number) => {
@@ -152,9 +149,10 @@ class ItemRenderer extends ComponentEx<IProps, {}> {
   };
 
   private lockedEntriesCount = (): number => {
-    const { loadOrder } = this.props;
-    const locked = loadOrder.filter((item) => this.isLocked(item));
-    return locked.length;
+    const { item, loadOrder } = this.props;
+    return (
+      item.lockedEntriesCount ?? loadOrder.filter((entry) => isEntryLocked(entry.locked)).length
+    );
   };
 }
 
@@ -163,7 +161,6 @@ function mapStateToProps(state: IState, ownProps: IProps): IConnectedProps {
   return {
     profile: profile,
     loadOrder: currentLoadOrderForProfile(state, profile.id),
-    modState: currentModStateForProfile(state, profile.id),
   };
 }
 

--- a/src/renderer/src/extensions/file_based_loadorder/views/loadOrderIndex.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/loadOrderIndex.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import type { ILoadOrderEntry } from "../../../types/api";
 import type { IExtensionApi, LoadOrder } from "../../../types/api";
+import { isEntryLocked } from "../util";
 
 interface IProps {
   className?: string;
@@ -10,7 +11,8 @@ interface IProps {
   loadOrder: LoadOrder;
   currentPosition: number;
   lockedEntriesCount: number;
-  isLocked: (item: ILoadOrderEntry) => boolean;
+  // Defaults to isEntryLocked; overridable for renderers with bespoke locking.
+  isLocked?: (item: ILoadOrderEntry) => boolean;
   onApplyIndex: (idx: number) => void;
 }
 
@@ -62,7 +64,8 @@ export function LoadOrderIndexInput(props: IProps) {
     setInputValue(currentPosition.toString());
   }, [currentPosition]);
 
-  return props.isLocked(item) ? (
+  const locked = props.isLocked?.(item) ?? isEntryLocked(item.locked);
+  return locked ? (
     <p className={props.className}>{inputValue}</p>
   ) : (
     <div className={props.className}>

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -36,6 +36,8 @@ import type {
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import { downloadPathForGame } from "../extensions/download_management/selectors";
 import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
+import type { ILoadOrderEntry } from "../extensions/file_based_loadorder/types/types";
+import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
@@ -71,6 +73,8 @@ import type {
   IDownloadAdapterOpts,
   IDriverHarness,
   IDriverHarnessState,
+  IFbloHarness,
+  IFbloHarnessOpts,
   IInstallContextHarness,
   IInstallManagerHarness,
   IModChangeHarness,
@@ -575,6 +579,29 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
 }
 
 /**
+ * A file-based load order harness: a fake api seeded with an active profile and the game's mods,
+ * plus an UpdateSet constructed against it. UpdateSet is injected so builders.ts stays free of the
+ * renderer view layer, mirroring makeDriverHarness.
+ */
+export function makeFbloHarness(
+  UpdateSetCtor: new (api: IExtensionApi, isFBLO: (gameId: string) => boolean) => UpdateSet,
+  opts: IFbloHarnessOpts = {},
+): IFbloHarness {
+  const gameId = opts.gameId ?? "skyrimse";
+  const profileId = opts.profileId ?? "profile-1";
+  const base = makeApiHarness({
+    profiles: { [profileId]: makeProfile({ id: profileId, gameId }) },
+    mods: { [gameId]: opts.mods ?? {} },
+  });
+  base.setState((draft) => {
+    draft.settings.profiles.activeProfileId = profileId;
+    draft.settings.profiles.lastActiveProfile = { [gameId]: profileId };
+  });
+  const updateSet = new UpdateSetCtor(base.api, opts.isFBLO ?? (() => true));
+  return { ...base, updateSet, gameId, profileId };
+}
+
+/**
  * Resolve once the driver reaches `step`. The driver fires onUpdate on every step transition, so
  * this awaits that exact event rather than a fixed delay (a fixed tick races the async
  * did-install-dependencies handler under load). A driver that never reaches the step is bounded by
@@ -766,5 +793,17 @@ export function makeDownloadAdapterHarness(
     start,
     resume,
     getStates,
+  };
+}
+
+let loEntrySeq = 0;
+
+export function makeLoadOrderEntry(overrides: Partial<ILoadOrderEntry> = {}): ILoadOrderEntry {
+  const id = overrides.id ?? `entry-${(loEntrySeq += 1)}.pak`;
+  return {
+    id,
+    name: id,
+    enabled: true,
+    ...overrides,
   };
 }

--- a/src/renderer/src/test-utils/fbloTest.ts
+++ b/src/renderer/src/test-utils/fbloTest.ts
@@ -1,0 +1,21 @@
+import UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
+import { makeFbloHarness } from "./builders";
+import { test as harnessTest } from "./harnessTest";
+import type { IFbloHarness, IFbloHarnessOpts } from "./harnessTypes";
+
+export interface IFbloFixtures {
+  // build a file-based load order harness (fake api + UpdateSet) over the given seeded state
+  makeFblo: (opts?: IFbloHarnessOpts) => IFbloHarness;
+}
+
+/**
+ * Base test for file-based load order suites. Extends the shared harnessTest with a `makeFblo`
+ * factory bound to the real UpdateSet, and inherits the mock teardown. Kept separate from
+ * harnessTest so only FBLO suites import UpdateSet.
+ */
+export const test = harnessTest.extend<IFbloFixtures>({
+  // `task` is destructured + ignored only to satisfy vitest's object-pattern requirement
+  makeFblo: async ({ task: _task }, use) => {
+    await use((opts?: IFbloHarnessOpts) => makeFbloHarness(UpdateSet, opts));
+  },
+});

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -10,6 +10,7 @@ import type { MixpanelEvent } from "../extensions/analytics/mixpanel/MixpanelEve
 import type { ICollectionMod } from "../extensions/collections/types/ICollection";
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import type { IDownload } from "../extensions/download_management/types/IDownload";
+import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
@@ -61,6 +62,25 @@ export interface IApiHarness {
 export interface IDriverHarness extends IApiHarness {
   // the driver under test, constructed against the fake api
   driver: InstallDriver;
+}
+
+/** What a file-based load order test arranges. */
+export interface IFbloHarnessOpts {
+  // the managed game (defaults to skyrimse); set active + last-active in state
+  gameId?: string;
+  // the active profile id (defaults to profile-1)
+  profileId?: string;
+  // the game's installed mods, keyed by modId (state.persistent.mods[gameId])
+  mods?: Record<string, IMod>;
+  // whether a game uses FBLO, as UpdateSet asks (defaults to always true)
+  isFBLO?: (gameId: string) => boolean;
+}
+
+export interface IFbloHarness extends IApiHarness {
+  // an UpdateSet constructed against the fake api
+  updateSet: UpdateSet;
+  gameId: string;
+  profileId: string;
 }
 
 // What a download-adapter test arranges: the single seeded download's fields, an optional stored

--- a/src/renderer/src/util/ListWindow.test.ts
+++ b/src/renderer/src/util/ListWindow.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { clampRange, keepIndicesInRange, rangePadding, visibleRange } from "./ListWindow";
+
+describe("visibleRange", () => {
+  it("covers the viewport plus overscan at the top", () => {
+    // viewport 500 / pitch 46 ~= 11 visible rows, + 10 overscan each side
+    expect(visibleRange(0, 500, 46, 10)).toEqual({ start: 0, end: 21 });
+  });
+
+  it("follows the scroll offset", () => {
+    // scrolled 100 rows down (100 * 46)
+    expect(visibleRange(4600, 500, 46, 10)).toEqual({ start: 90, end: 121 });
+  });
+
+  it("never returns a negative start", () => {
+    expect(visibleRange(46, 500, 46, 10).start).toBe(0);
+  });
+
+  it("scales with the row pitch", () => {
+    // scrolled 100 rows down at pitch 60
+    expect(visibleRange(6000, 500, 60, 10).start).toBe(90);
+  });
+});
+
+describe("clampRange", () => {
+  it("leaves a range within bounds untouched", () => {
+    expect(clampRange({ start: 0, end: 21 }, 1000)).toEqual({ start: 0, end: 21 });
+  });
+
+  it("clamps a range past the end of a short list", () => {
+    expect(clampRange({ start: 90, end: 121 }, 5)).toEqual({ start: 4, end: 4 });
+  });
+
+  it("handles an empty list", () => {
+    expect(clampRange({ start: 5, end: 10 }, 0)).toEqual({ start: 0, end: 0 });
+  });
+});
+
+describe("rangePadding", () => {
+  it("pads for the rows above and below the window", () => {
+    expect(rangePadding({ start: 90, end: 121 }, 1000, 46)).toEqual({
+      paddingTop: 90 * 46,
+      paddingBottom: (1000 - 1 - 121) * 46,
+    });
+  });
+
+  it("never returns negative bottom padding", () => {
+    expect(rangePadding({ start: 0, end: 999 }, 1000, 46).paddingBottom).toBe(0);
+  });
+});
+
+describe("keepIndicesInRange", () => {
+  it("expands the window to include a dragged row far below it", () => {
+    // a row dragged out of view must stay rendered so its drag source survives
+    expect(keepIndicesInRange({ start: 0, end: 30 }, [500])).toEqual({ start: 0, end: 500 });
+  });
+
+  it("expands the window to include a dragged row far above it", () => {
+    expect(keepIndicesInRange({ start: 400, end: 430 }, [5])).toEqual({ start: 5, end: 430 });
+  });
+
+  it("leaves the window unchanged when no rows are dragged", () => {
+    expect(keepIndicesInRange({ start: 0, end: 30 }, [])).toEqual({ start: 0, end: 30 });
+  });
+
+  it("leaves the window unchanged for a dragged row already inside it", () => {
+    expect(keepIndicesInRange({ start: 0, end: 30 }, [10])).toEqual({ start: 0, end: 30 });
+  });
+
+  it("ignores not-found indices", () => {
+    expect(keepIndicesInRange({ start: 10, end: 30 }, [-1])).toEqual({ start: 10, end: 30 });
+  });
+});

--- a/src/renderer/src/util/ListWindow.ts
+++ b/src/renderer/src/util/ListWindow.ts
@@ -1,0 +1,138 @@
+// rows rendered beyond each edge of the visible range
+const DEFAULT_OVERSCAN = 10;
+// row pitch (row height + list gap) assumed until measured from the DOM
+const DEFAULT_PITCH = 46;
+
+export interface IListWindowOptions {
+  // invoked when the visible range changes and the consumer needs to re-render
+  onChange: () => void;
+  overscan?: number;
+  defaultPitch?: number;
+}
+
+export interface IWindowRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Tracks which contiguous slice of a uniform-height list is scrolled into
+ * view, so a long list can render only the rows on screen. Follows the
+ * nearest scrollable ancestor and measures the row pitch from the DOM.
+ *
+ * The consumer wires it up by:
+ *  - passing the content element (whose first element child holds the rows)
+ *    to `setContent`, then calling `attach` once mounted;
+ *  - calling `measurePitch` and `update` from componentDidUpdate;
+ *  - reading `range`/`padding` during render;
+ *  - calling `detach` on unmount.
+ */
+export class ListWindow {
+  readonly #overscan: number;
+  readonly #onChange: () => void;
+  #pitch: number;
+  #content: HTMLElement | null = null;
+  #scrollParent: HTMLElement | null = null;
+  #resizeObserver: ResizeObserver | null = null;
+  // items reference the pitch was last measured for; measuring reads layout,
+  //  which forces a reflow, so it must not run on every re-render
+  #measuredFor: unknown = null;
+  #start = 0;
+  #end: number;
+
+  constructor(options: IListWindowOptions) {
+    this.#overscan = options.overscan ?? DEFAULT_OVERSCAN;
+    this.#pitch = options.defaultPitch ?? DEFAULT_PITCH;
+    this.#onChange = options.onChange;
+    // until the scroll parent is known, assume two viewport-heights of rows
+    this.#end = Math.ceil((2 * window.innerHeight) / this.#pitch);
+  }
+
+  // The scrollable content wrapper; its first element child holds the rows.
+  public setContent = (ref: HTMLElement | null): void => {
+    this.#content = ref;
+  };
+
+  // Start following the nearest scrollable ancestor. Idempotent.
+  public attach(): void {
+    if (this.#scrollParent !== null || this.#content === null) {
+      return;
+    }
+    let el = this.#content.parentElement;
+    while (el !== null && !["auto", "scroll"].includes(getComputedStyle(el).overflowY)) {
+      el = el.parentElement;
+    }
+    if (el === null) {
+      return;
+    }
+    this.#scrollParent = el;
+    el.addEventListener("scroll", this.update, { passive: true });
+    this.#resizeObserver = new ResizeObserver(this.update);
+    this.#resizeObserver.observe(el);
+    this.update();
+  }
+
+  public detach(): void {
+    this.#scrollParent?.removeEventListener("scroll", this.update);
+    this.#resizeObserver?.disconnect();
+    this.#scrollParent = null;
+    this.#resizeObserver = null;
+  }
+
+  // Measure the row pitch from the first two rendered rows, once per list
+  //  change. A differing pitch re-derives the visible range.
+  public measurePitch(itemsIdentity: unknown): void {
+    if (this.#measuredFor === itemsIdentity || this.#content === null) {
+      return;
+    }
+    const rows = this.#content.firstElementChild?.children;
+    if (rows === undefined || rows.length < 2) {
+      return;
+    }
+    this.#measuredFor = itemsIdentity;
+    const pitch = rows[1].getBoundingClientRect().top - rows[0].getBoundingClientRect().top;
+    if (pitch > 10 && Math.abs(pitch - this.#pitch) > 0.5) {
+      this.#pitch = pitch;
+      this.update();
+    }
+  }
+
+  // Recompute the visible range from the current scroll position, notifying
+  //  the consumer when it changes.
+  public update = (): void => {
+    if (this.#content === null || this.#scrollParent === null) {
+      return;
+    }
+    const contentTop = this.#content.getBoundingClientRect().top;
+    const parentRect = this.#scrollParent.getBoundingClientRect();
+    const visStart = parentRect.top - contentTop;
+    const start = Math.max(0, Math.floor(visStart / this.#pitch) - this.#overscan);
+    const end =
+      Math.ceil((visStart + this.#scrollParent.clientHeight) / this.#pitch) + this.#overscan;
+    if (start !== this.#start || end !== this.#end) {
+      this.#start = start;
+      this.#end = end;
+      this.#onChange();
+    }
+  };
+
+  // The clamped [start, end] slice of `itemCount` rows to render.
+  public range(itemCount: number): IWindowRange {
+    const maxIdx = Math.max(0, itemCount - 1);
+    const start = Math.min(Math.max(0, this.#start), maxIdx);
+    const end = Math.min(Math.max(start, this.#end), maxIdx);
+    return { start, end };
+  }
+
+  // Spacer padding standing in for the rows outside [start, end].
+  public padding(
+    start: number,
+    end: number,
+    itemCount: number,
+  ): { paddingTop: number; paddingBottom: number } {
+    return {
+      paddingTop: start * this.#pitch,
+      paddingBottom: Math.max(0, itemCount - 1 - end) * this.#pitch,
+    };
+  }
+}

--- a/src/renderer/src/util/ListWindow.ts
+++ b/src/renderer/src/util/ListWindow.ts
@@ -15,10 +15,64 @@ export interface IWindowRange {
   end: number;
 }
 
+export interface IWindowPadding {
+  paddingTop: number;
+  paddingBottom: number;
+}
+
+// The rows intersecting a viewport, padded by overscan. `visibleTop` is how far the content's top
+// has scrolled above the viewport top. Unclamped: end may exceed the row count.
+export function visibleRange(
+  visibleTop: number,
+  viewportHeight: number,
+  pitch: number,
+  overscan: number,
+): IWindowRange {
+  const start = Math.max(0, Math.floor(visibleTop / pitch) - overscan);
+  const end = Math.ceil((visibleTop + viewportHeight) / pitch) + overscan;
+  return { start, end };
+}
+
+// Clamp a raw range to a list of `itemCount` rows.
+export function clampRange(range: IWindowRange, itemCount: number): IWindowRange {
+  const maxIdx = Math.max(0, itemCount - 1);
+  const start = Math.min(Math.max(0, range.start), maxIdx);
+  const end = Math.min(Math.max(start, range.end), maxIdx);
+  return { start, end };
+}
+
+// Spacer padding standing in for the rows outside [start, end].
+export function rangePadding(
+  range: IWindowRange,
+  itemCount: number,
+  pitch: number,
+): IWindowPadding {
+  return {
+    paddingTop: range.start * pitch,
+    paddingBottom: Math.max(0, itemCount - 1 - range.end) * pitch,
+  };
+}
+
+// Widen a range so it also covers the given indices, keeping dragged rows
+// rendered while virtualized so their drag source stays mounted. Indices below
+// zero (not found) are ignored.
+export function keepIndicesInRange(range: IWindowRange, indices: number[]): IWindowRange {
+  let { start, end } = range;
+  for (const idx of indices) {
+    if (idx < 0) {
+      continue;
+    }
+    start = Math.min(start, idx);
+    end = Math.max(end, idx);
+  }
+  return { start, end };
+}
+
 /**
  * Tracks which contiguous slice of a uniform-height list is scrolled into
  * view, so a long list can render only the rows on screen. Follows the
- * nearest scrollable ancestor and measures the row pitch from the DOM.
+ * nearest scrollable ancestor and measures the row pitch from the DOM; the
+ * range math itself lives in the pure helpers above.
  *
  * The consumer wires it up by:
  *  - passing the content element (whose first element child holds the rows)
@@ -37,15 +91,14 @@ export class ListWindow {
   // items reference the pitch was last measured for; measuring reads layout,
   //  which forces a reflow, so it must not run on every re-render
   #measuredFor: unknown = null;
-  #start = 0;
-  #end: number;
+  #range: IWindowRange;
 
   constructor(options: IListWindowOptions) {
     this.#overscan = options.overscan ?? DEFAULT_OVERSCAN;
     this.#pitch = options.defaultPitch ?? DEFAULT_PITCH;
     this.#onChange = options.onChange;
     // until the scroll parent is known, assume two viewport-heights of rows
-    this.#end = Math.ceil((2 * window.innerHeight) / this.#pitch);
+    this.#range = { start: 0, end: Math.ceil((2 * window.innerHeight) / this.#pitch) };
   }
 
   // The scrollable content wrapper; its first element child holds the rows.
@@ -103,36 +156,27 @@ export class ListWindow {
     if (this.#content === null || this.#scrollParent === null) {
       return;
     }
-    const contentTop = this.#content.getBoundingClientRect().top;
-    const parentRect = this.#scrollParent.getBoundingClientRect();
-    const visStart = parentRect.top - contentTop;
-    const start = Math.max(0, Math.floor(visStart / this.#pitch) - this.#overscan);
-    const end =
-      Math.ceil((visStart + this.#scrollParent.clientHeight) / this.#pitch) + this.#overscan;
-    if (start !== this.#start || end !== this.#end) {
-      this.#start = start;
-      this.#end = end;
+    const visibleTop =
+      this.#scrollParent.getBoundingClientRect().top - this.#content.getBoundingClientRect().top;
+    const next = visibleRange(
+      visibleTop,
+      this.#scrollParent.clientHeight,
+      this.#pitch,
+      this.#overscan,
+    );
+    if (next.start !== this.#range.start || next.end !== this.#range.end) {
+      this.#range = next;
       this.#onChange();
     }
   };
 
   // The clamped [start, end] slice of `itemCount` rows to render.
   public range(itemCount: number): IWindowRange {
-    const maxIdx = Math.max(0, itemCount - 1);
-    const start = Math.min(Math.max(0, this.#start), maxIdx);
-    const end = Math.min(Math.max(start, this.#end), maxIdx);
-    return { start, end };
+    return clampRange(this.#range, itemCount);
   }
 
   // Spacer padding standing in for the rows outside [start, end].
-  public padding(
-    start: number,
-    end: number,
-    itemCount: number,
-  ): { paddingTop: number; paddingBottom: number } {
-    return {
-      paddingTop: start * this.#pitch,
-      paddingBottom: Math.max(0, itemCount - 1 - end) * this.#pitch,
-    };
+  public padding(range: IWindowRange, itemCount: number): IWindowPadding {
+    return rangePadding(range, itemCount, this.#pitch);
   }
 }

--- a/src/stylesheets/vortex/page-mod-load-order.scss
+++ b/src/stylesheets/vortex/page-mod-load-order.scss
@@ -57,6 +57,19 @@
         height: 100%;
         overflow: auto;
 
+        // uniform row height; the draggable list windows its rows based on
+        //  the measured height of the first row, so rows must not vary
+        &.fblo-uniform-row {
+            height: 42px;
+            overflow: hidden;
+
+            .load-order-name {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+
         margin: 0;
         border: 1px solid $border-color;
         border-radius: 4px;


### PR DESCRIPTION
Virtualize the file-based load order list (via a standalone ListWindow helper) and cut the per-drag work that made dragging unusable with 1000+ entries: stable react-dnd collector, memoized rows, precomputed row position/locked-count, id-indexed UpdateSet lookups.

Debounce the BG3 auto-export and heal stale pak-cache mod links so managed mods stop showing as "Not managed by Vortex". Add an opt-in uniformRowHeight flag for custom-renderer games to virtualize.

closes LAZ-717