### PR TITLE
Set skipDisabledRequirements based on feature flag

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -80,7 +80,7 @@ import {
   FULL_COLLECTION_INFO,
   FULL_REVISION_INFO,
   COLLECTION_SEARCH_QUERY,
-  MOD_REQUIREMENTS_INFO,
+  getModRequirementsInfo,
   MY_COLLECTIONS_SEARCH_QUERY,
 } from "./util/graphQueries";
 import submitFeedback from "./util/submitFeedback";
@@ -945,7 +945,7 @@ export function onGetModRequirements(
         return nexus.modsByUid(
           {
             modId: true,
-            modRequirements: MOD_REQUIREMENTS_INFO,
+            modRequirements: getModRequirementsInfo(),
             uid: true,
             thumbnailUrl: true,
           },

--- a/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
@@ -5,6 +5,8 @@ import type {
   IModFileQuery,
 } from "@nexusmods/nexus-api";
 
+import { FlagService } from "@/FlagService";
+
 const revisionInfo: IRevisionQuery = {
   id: true,
   revisionNumber: true,
@@ -230,31 +232,44 @@ export const MOD_FILE_INFO: Partial<IModFileQuery> = {
   version: true,
 };
 
-export const MOD_REQUIREMENTS_INFO: IModRequirementsQuery = {
-  // Prevents pulling in mod to mod requirements when they are
-  // disabled by file to file requirements.
-  $filter: { skipDisabledRequirements: true },
-  dlcRequirements: {
-    gameExpansion: { id: true, name: true },
-    notes: true,
-  },
-  nexusRequirements: {
-    nodes: {
-      id: true,
-      gameId: true,
-      modId: true,
-      modName: true,
+/**
+ * Get the mod requirements query object. The $filter property is only included
+ * when the file-level requirements feature flag is enabled, to prevent pulling in
+ * mod-to-mod requirements when they are disabled by file-to-file requirements.
+ */
+export function getModRequirementsInfo(): IModRequirementsQuery {
+  const flagEnabled =
+    FlagService.instance?.getFlag("vortex-file-requirements-health-check") !== undefined;
+
+  const baseQuery: IModRequirementsQuery = {
+    dlcRequirements: {
+      gameExpansion: { id: true, name: true },
       notes: true,
-      url: true,
-      externalRequirement: true,
     },
-    totalCount: true,
-  },
-  modsRequiringThisMod: {
-    nodes: { id: true, modId: true, modName: true },
-    totalCount: true,
-  },
-};
+    nexusRequirements: {
+      nodes: {
+        id: true,
+        gameId: true,
+        modId: true,
+        modName: true,
+        notes: true,
+        url: true,
+        externalRequirement: true,
+      },
+      totalCount: true,
+    },
+    modsRequiringThisMod: {
+      nodes: { id: true, modId: true, modName: true },
+      totalCount: true,
+    },
+  };
+
+  if (flagEnabled) {
+    baseQuery.$filter = { skipDisabledRequirements: true };
+  }
+
+  return baseQuery;
+}
 
 export const MY_COLLECTIONS_SEARCH_QUERY: ICollectionQuery = {
   revisions: {


### PR DESCRIPTION
Fix for LAZ-680. The filter should only be set based on the feature flag, otherwise mod requirements don't show up for mods that have both mod-to-mod and file-to-file requirements.