### PR TITLE
heal persisted state keys with invalid UTF-8 bytes (LAZ-788)

### DIFF
--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -35,6 +35,7 @@ import MainWindow from "./MainWindow";
 import SplashScreen from "./SplashScreen";
 import DuckDBSingleton from "./store/DuckDBSingleton";
 import { flattenState } from "./store/flattenState";
+import { healInvalidKeys } from "./store/healInvalidKeys";
 import LevelPersist, { DatabaseLocked, DatabaseOpenError } from "./store/LevelPersist";
 import {
   initMainPersistence,
@@ -971,6 +972,18 @@ class Application {
         await this.importBackup(finalPersistor, this.mArgs.restore, true);
       } else if (this.mArgs.merge !== undefined) {
         await this.importBackup(finalPersistor, this.mArgs.merge, false);
+      }
+
+      // 5b. Self-heal keys clobbered into non-UTF-8 bytes (LAZ-788). Such keys
+      // are unremovable through the normal delete path and otherwise re-trigger
+      // the state-corruption dialog on every launch. Do this before hydration so
+      // the renderer never sees them. Best-effort — never block startup on it.
+      try {
+        await healInvalidKeys(finalPersistor);
+      } catch (err) {
+        log("warn", "state heal failed", {
+          error: getErrorMessageOrDefault(err),
+        });
       }
 
       // 6. Initialize the IPC-based persistence system

--- a/src/main/src/store/LevelPersist.corruption.test.integration.ts
+++ b/src/main/src/store/LevelPersist.corruption.test.integration.ts
@@ -1,0 +1,139 @@
+/**
+ * Reproduces the unremovable-key defect (LAZ-788): a persisted key whose bytes
+ * are not valid UTF-8 cannot be deleted through the normal key-based path. The
+ * key is stored VARCHAR, so it reads back lossily as U+FFFD and a delete built
+ * from that decoded string no longer matches the bytes on disk.
+ *
+ * Runs against the real level_pivot extension over a real LevelDB store; the
+ * corrupt key is injected at the byte level with `leveldown`, then read and
+ * deleted through `LevelPersist` as the persistence layer does.
+ *
+ * Requires the extension binary: `pnpm --filter @vortex/main run
+ * download-duckdb-extensions`.
+ */
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import DuckDBSingleton from "./DuckDBSingleton";
+import LevelPersist from "./LevelPersist";
+
+const require = createRequire(import.meta.url);
+// leveldown ships no reliable ESM types; treat as a raw LevelDB byte store.
+const leveldown = require("leveldown") as (dbPath: string) => LevelDown;
+
+interface LevelDown {
+  open(opts: { createIfMissing: boolean }, cb: (err?: Error) => void): void;
+  put(key: Buffer, value: Buffer, cb: (err?: Error) => void): void;
+  close(cb: (err?: Error) => void): void;
+}
+
+const EXT_DIR = path.resolve(import.meta.dirname, "../../build/duckdb-extensions");
+const PLATFORM = process.platform === "win32" ? "windows_amd64" : "linux_amd64";
+
+// A download key with its middle bytes mangled: 0xFF bytes (never valid UTF-8
+// lead bytes) decode to U+FFFD on a VARCHAR read, so re-encoding the read-back
+// string no longer matches the stored bytes.
+const FILES_PREFIX = "persistent###downloads###files###";
+const HEALTHY_ID = "Y-To2XJTA";
+const CORRUPT_KEY = Buffer.concat([
+  Buffer.from(`${FILES_PREFIX}Y-T`),
+  Buffer.from([0xff, 0xff, 0xff, 0xff]),
+  Buffer.from("TA###size"),
+]);
+const HEALTHY_KEY = Buffer.from(`${FILES_PREFIX}${HEALTHY_ID}###size`);
+const VALUE = Buffer.from("112105");
+
+function injectRawKeys(dbPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const db = leveldown(dbPath);
+    db.open({ createIfMissing: true }, (openErr) => {
+      if (openErr) return reject(openErr);
+      db.put(HEALTHY_KEY, VALUE, (e1) => {
+        if (e1) return reject(e1);
+        db.put(CORRUPT_KEY, VALUE, (e2) => {
+          if (e2) return reject(e2);
+          db.close((e3) => (e3 ? reject(e3) : resolve()));
+        });
+      });
+    });
+  });
+}
+
+describe("LevelPersist corrupt-key removal (LAZ-788)", () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = mkdtempSync(path.join(tmpdir(), "lp788-"));
+  });
+
+  afterEach(() => {
+    DuckDBSingleton.getInstance().close();
+    try {
+      rmSync(dbPath, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  async function openPersist(): Promise<LevelPersist> {
+    const singleton = DuckDBSingleton.getInstance();
+    await singleton.initialize(EXT_DIR);
+    const alias = singleton.nextAlias();
+    const conn = await singleton.attachDatabase(dbPath, alias);
+    return new LevelPersist(conn, alias);
+  }
+
+  const fileEntries = (kvs: Array<{ key: string[]; value: string }>) =>
+    kvs.filter((kv) => kv.key.length === 5 && kv.key[2] === "files");
+
+  it("extension binary is present", () => {
+    expect(existsSync(path.join(EXT_DIR, "v1.5.1", PLATFORM, "level_pivot.duckdb_extension"))).toBe(
+      true,
+    );
+  });
+
+  it("reads an invalid-UTF-8 key lossily, so it no longer matches the bytes on disk", async () => {
+    await injectRawKeys(dbPath);
+    const persist = await openPersist();
+
+    const files = fileEntries(await persist.getAllKVs());
+    expect(files.map((kv) => kv.key[3])).toContain(HEALTHY_ID);
+
+    const corrupt = files.find((kv) => kv.key[3] !== HEALTHY_ID);
+    expect(corrupt, "corrupt download entry should be visible").toBeDefined();
+
+    const readBackKey = corrupt!.key.join("###");
+    // Lossy: the string we read back, re-encoded to UTF-8, is NOT the on-disk bytes.
+    expect(Buffer.from(readBackKey, "utf-8").equals(CORRUPT_KEY)).toBe(false);
+    // The invalid bytes came back as replacement characters.
+    expect(corrupt!.key[3]).toContain("�");
+  });
+
+  it("does NOT remove the corrupt key via key-based removeItem (repro)", async () => {
+    await injectRawKeys(dbPath);
+    const persist = await openPersist();
+
+    const corrupt = fileEntries(await persist.getAllKVs()).find((kv) => kv.key[3] !== HEALTHY_ID);
+    expect(corrupt).toBeDefined();
+
+    // Vortex's repair path: read the key back, then removeItem(it).
+    await persist.removeItem(corrupt!.key);
+
+    const afterFiles = fileEntries(await persist.getAllKVs());
+    // BUG: the corrupt row survives — its stored bytes don't match the re-encoded key.
+    expect(afterFiles.some((kv) => kv.key[3] !== HEALTHY_ID)).toBe(true);
+    // Control: a healthy key IS removable via the same path.
+    await persist.removeItem([...FILES_PREFIX.split("###").filter(Boolean), HEALTHY_ID, "size"]);
+    expect(fileEntries(await persist.getAllKVs()).some((kv) => kv.key[3] === HEALTHY_ID)).toBe(
+      false,
+    );
+  });
+
+  // The raw key-based delete inherently cannot remove this key (its bytes don't
+  // round-trip). The fix does not change removeItem — it heals at a clean prefix
+  // in the main process before hydration; see healInvalidKeys.test.integration.ts.
+});

--- a/src/main/src/store/healInvalidKeys.test.integration.ts
+++ b/src/main/src/store/healInvalidKeys.test.integration.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests `healInvalidKeys` (LAZ-788) against the real level_pivot extension over
+ * a real LevelDB store, with corrupt keys injected at the byte level via
+ * `leveldown`.
+ *
+ * The hive-safety case is critical: a heal must never be able to wipe a whole
+ * hive, which would destroy the user's modding environment.
+ *
+ * Requires the extension binary: `pnpm --filter @vortex/main run
+ * download-duckdb-extensions`.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import DuckDBSingleton from "./DuckDBSingleton";
+import { healInvalidKeys } from "./healInvalidKeys";
+import LevelPersist from "./LevelPersist";
+
+const require = createRequire(import.meta.url);
+const leveldown = require("leveldown") as (dbPath: string) => LevelDown;
+
+interface LevelDown {
+  open(opts: { createIfMissing: boolean }, cb: (err?: Error) => void): void;
+  put(key: Buffer, value: Buffer, cb: (err?: Error) => void): void;
+  close(cb: (err?: Error) => void): void;
+}
+
+const EXT_DIR = path.resolve(import.meta.dirname, "../../build/duckdb-extensions");
+const BAD = Buffer.from([0xff, 0xff, 0xff, 0xff]); // never valid UTF-8 -> U+FFFD on read
+const CTRL = Buffer.from([0x01, 0x02]); // C0 control chars, also "clobbered"
+const val = (s: string) => Buffer.from(s);
+
+/** Inject raw key/value byte pairs directly into the LevelDB store. */
+function inject(dbPath: string, pairs: Array<[Buffer, Buffer]>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const db = leveldown(dbPath);
+    db.open({ createIfMissing: true }, (openErr) => {
+      if (openErr) return reject(openErr);
+      const step = (i: number): void => {
+        if (i >= pairs.length) return db.close((e) => (e ? reject(e) : resolve()));
+        const [k, v] = pairs[i]!;
+        db.put(k, v, (e) => (e ? reject(e) : step(i + 1)));
+      };
+      step(0);
+    });
+  });
+}
+
+describe("healInvalidKeys (LAZ-788 fix)", () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = mkdtempSync(path.join(tmpdir(), "heal788-"));
+  });
+
+  afterEach(() => {
+    DuckDBSingleton.getInstance().close();
+    try {
+      rmSync(dbPath, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  async function open(): Promise<LevelPersist> {
+    const s = DuckDBSingleton.getInstance();
+    await s.initialize(EXT_DIR);
+    const alias = s.nextAlias();
+    const conn = await s.attachDatabase(dbPath, alias);
+    return new LevelPersist(conn, alias);
+  }
+
+  const joined = (persist: LevelPersist) =>
+    persist.getAllKeys().then((keys) => keys.map((k) => k.join("###")));
+  const anyClobbered = (persist: LevelPersist) =>
+    persist.getAllKeys().then((keys) => keys.some((k) => k.some((seg) => seg.includes("�"))));
+
+  it("removes a deep clobbered key; preserves valid siblings and other hives", async () => {
+    await inject(dbPath, [
+      [Buffer.from("persistent###downloads###files###Y-To2XJTA###size"), val("112105")],
+      [
+        Buffer.concat([
+          Buffer.from("persistent###downloads###files###Y-T"),
+          BAD,
+          Buffer.from("TA###size"),
+        ]),
+        val("112105"),
+      ],
+      [Buffer.from("settings###window###width"), val("800")],
+    ]);
+    const persist = await open();
+
+    const res = await healInvalidKeys(persist);
+
+    expect(res.removed).toBe(1);
+    expect(res.rewritten).toBe(1); // the healthy sibling
+    expect(res.prefixes).toEqual(["persistent.downloads.files"]);
+    expect(await anyClobbered(persist)).toBe(false);
+
+    const keys = await joined(persist);
+    expect(keys).toContain("persistent###downloads###files###Y-To2XJTA###size"); // healthy kept
+    expect(keys).toContain("settings###window###width"); // other hive untouched
+  });
+
+  it("also detects control-char clobbering (not just U+FFFD)", async () => {
+    await inject(dbPath, [
+      [Buffer.from("persistent###mods###skyrimse###goodmod###installationPath"), val('"goodmod"')],
+      [
+        Buffer.concat([
+          Buffer.from("persistent###mods###skyrimse###bad"),
+          CTRL,
+          Buffer.from("mod###installationPath"),
+        ]),
+        val('"x"'),
+      ],
+    ]);
+    const persist = await open();
+
+    const res = await healInvalidKeys(persist);
+
+    expect(res.removed).toBe(1);
+    expect(res.prefixes).toEqual(["persistent.mods.skyrimse"]);
+    const keys = await joined(persist);
+    expect(keys).toContain("persistent###mods###skyrimse###goodmod###installationPath");
+  });
+
+  // A heal must never be able to wipe an entire hive.
+  it("NEVER deletes a whole hive when corruption is at hive-child depth", async () => {
+    // A key clobbered at index 1 -> the only clean prefix is ["persistent"],
+    // i.e. the whole hive. Alongside it, a realistic modding environment.
+    await inject(dbPath, [
+      [Buffer.from("persistent###mods###skyrimse###modA###installationPath"), val('"modA"')],
+      [Buffer.from("persistent###mods###skyrimse###modB###installationPath"), val('"modB"')],
+      [Buffer.from("persistent###downloads###files###dl1###size"), val("42")],
+      [Buffer.from("persistent###profiles###p1###gameId"), val('"skyrimse"')],
+      // clobbered SECOND segment -> clean prefix would be the whole `persistent` hive
+      [Buffer.concat([Buffer.from("persistent###"), BAD, Buffer.from("###orphan")]), val("x")],
+      [Buffer.from("settings###window###width"), val("800")],
+    ]);
+    const persist = await open();
+
+    const before = await joined(persist);
+    const res = await healInvalidKeys(persist);
+
+    // Refused, not healed.
+    expect(res.removed).toBe(0);
+    expect(res.rewritten).toBe(0);
+    expect(res.prefixes).toEqual([]);
+    expect(res.skipped.length).toBe(1);
+
+    // The entire hive — and every other key — is exactly as it was. Nothing wiped.
+    const after = await joined(persist);
+    expect(new Set(after)).toEqual(new Set(before));
+    expect(after).toContain("persistent###mods###skyrimse###modA###installationPath");
+    expect(after).toContain("persistent###mods###skyrimse###modB###installationPath");
+    expect(after).toContain("persistent###profiles###p1###gameId");
+    expect(after).toContain("settings###window###width");
+  });
+
+  it("is a no-op and idempotent when there is no corruption", async () => {
+    await inject(dbPath, [
+      [Buffer.from("persistent###downloads###files###dl1###size"), val("1")],
+      [Buffer.from("settings###window###width"), val("800")],
+    ]);
+    const persist = await open();
+
+    const res1 = await healInvalidKeys(persist);
+    expect(res1.removed).toBe(0);
+    expect(res1.rewritten).toBe(0);
+
+    const res2 = await healInvalidKeys(persist);
+    expect(res2).toEqual(res1);
+    expect((await joined(persist)).sort()).toEqual(
+      ["persistent###downloads###files###dl1###size", "settings###window###width"].sort(),
+    );
+  });
+});

--- a/src/main/src/store/healInvalidKeys.ts
+++ b/src/main/src/store/healInvalidKeys.ts
@@ -1,0 +1,119 @@
+import { getErrorMessageOrDefault } from "@vortex/shared";
+import { isClobberedKeySegment } from "@vortex/shared/state";
+
+import { log } from "../logging";
+import type LevelPersist from "./LevelPersist";
+
+const isCorrupt = (key: string[]): boolean => key.some(isClobberedKeySegment);
+
+// The shallowest prefix we will ever delete. A depth-1 prefix is a whole hive
+// (e.g. `persistent`), so deleting it — even with a re-insert of the survivors —
+// would put the entire modding environment through a destructive rebuild. If the
+// only clean prefix we can form is that shallow, refuse and leave the key: a
+// lingering corrupt key is recoverable, a wiped hive is not.
+const MIN_HEAL_PREFIX_DEPTH = 2;
+
+export interface HealResult {
+  /** number of corrupt (clobbered) keys dropped */
+  removed: number;
+  /** number of valid sibling rows rewritten to preserve them */
+  rewritten: number;
+  /** the clean prefixes whose subtree was rebuilt (dotted, for logging) */
+  prefixes: string[];
+  /** corrupt keys we refused to heal because the only clean prefix was too shallow */
+  skipped: string[][];
+}
+
+/**
+ * Remove persisted keys whose bytes are not valid UTF-8.
+ *
+ * Such a key reads back through the VARCHAR key column as a lossy,
+ * U+FFFD/control-char string; re-encoding that string yields different bytes
+ * than are on disk, so an exact-key delete can never match it and it lingers,
+ * re-triggering state repair on every launch.
+ *
+ * It can still be removed via a delete keyed on a CLEAN prefix (the segments
+ * before the first clobbered one), which matches the key's intact leading bytes
+ * at the byte level. The corrupt key shares that prefix with its valid siblings,
+ * so we drop the subtree and re-insert the siblings, losing only the corrupt one.
+ *
+ * Safety: never deletes a prefix shallower than `MIN_HEAL_PREFIX_DEPTH`, so a
+ * heal can never wipe a whole hive; wrapped in a transaction so a failure rolls
+ * back rather than leaving a half-cleared subtree.
+ *
+ * Runs in the main process before hydration, so the renderer never sees the
+ * corruption. Best-effort: callers must not let a failure here block startup.
+ * (LAZ-788)
+ */
+export async function healInvalidKeys(persist: LevelPersist): Promise<HealResult> {
+  const result: HealResult = { removed: 0, rewritten: 0, prefixes: [], skipped: [] };
+
+  const corruptKeys = (await persist.getAllKeys()).filter(isCorrupt);
+  if (corruptKeys.length === 0) {
+    return result;
+  }
+
+  // The clean prefix is the segments before the first clobbered one, so its
+  // length equals that segment's index. Dedupe: sibling corrupt keys share it.
+  const prefixes = new Map<string, string[]>();
+  for (const key of corruptKeys) {
+    const idx = key.findIndex(isClobberedKeySegment);
+    if (idx < MIN_HEAL_PREFIX_DEPTH) {
+      result.skipped.push(key);
+      continue;
+    }
+    const prefix = key.slice(0, idx);
+    prefixes.set(JSON.stringify(prefix), prefix);
+  }
+
+  if (result.skipped.length > 0) {
+    log(
+      "warn",
+      "state heal: refusing to heal corrupt key(s) — clean prefix would be a whole hive",
+      {
+        count: result.skipped.length,
+        // segment 0 is safe to log — it is the intact hive name
+        hives: [...new Set(result.skipped.map((k) => k[0]))],
+      },
+    );
+  }
+
+  if (prefixes.size === 0) {
+    return result;
+  }
+
+  // Load values once so the valid siblings can be re-inserted after the drop.
+  const allKVs = await persist.getAllKVs();
+
+  await persist.beginTransaction();
+  try {
+    for (const prefix of prefixes.values()) {
+      const underPrefix = allKVs.filter(
+        (kv) => kv.key.length > prefix.length && prefix.every((seg, i) => kv.key[i] === seg),
+      );
+      const good = underPrefix.filter((kv) => !isCorrupt(kv.key));
+
+      await persist.removeItem(prefix);
+      if (good.length > 0) {
+        await persist.bulkSetItem(good);
+      }
+
+      result.removed += underPrefix.length - good.length;
+      result.rewritten += good.length;
+      result.prefixes.push(prefix.join("."));
+    }
+    await persist.commitTransaction();
+  } catch (err) {
+    await persist.rollbackTransaction();
+    throw new Error(`state heal failed: ${getErrorMessageOrDefault(err)}`, { cause: err });
+  }
+
+  log("info", "state heal: removed unrepairable keys", {
+    removed: result.removed,
+    rewritten: result.rewritten,
+    prefixes: result.prefixes,
+    skipped: result.skipped.length,
+  });
+
+  return result;
+}

--- a/src/renderer/src/extensions/mod_management/reducers/mods.ts
+++ b/src/renderer/src/extensions/mod_management/reducers/mods.ts
@@ -1,3 +1,4 @@
+import { isClobberedKeySegment } from "@vortex/shared/state";
 import * as _ from "lodash";
 import type { IRule } from "modmeta-db";
 
@@ -17,19 +18,12 @@ import * as actions from "../actions/mods";
 import type { IMod } from "../types/IMod";
 import { referenceEqual } from "../util/testModReference";
 
-// A modId is unusable as a staging-folder name if it was corrupted by an
-// external state clobber - the installationPath self-heal uses this to tell a
-// recoverable key from rubbish. U+FFFD is what a UTF-8 decode
-// of clobbered key bytes yields; anything below U+0020 is a C0 control char.
-// Either means the key can't name a real folder on disk.
+// A modId is unusable as a staging-folder name if it was clobbered by a bad
+// state write: the installationPath self-heal uses this to tell a recoverable
+// key from rubbish. Shares the "clobbered key" predicate with the main-process
+// heal (healInvalidKeys) so both agree on what's recoverable.
 function isUnusableModId(modId: string): boolean {
-  for (let i = 0; i < modId.length; ++i) {
-    const code = modId.charCodeAt(i);
-    if (code === 0xfffd || code < 0x20) {
-      return true;
-    }
-  }
-  return false;
+  return isClobberedKeySegment(modId);
 }
 
 function reduceRule(input: IRule): IRule {

--- a/src/shared/src/types/state.test.ts
+++ b/src/shared/src/types/state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isClobberedKeySegment } from "./state";
+
+describe("isClobberedKeySegment", () => {
+  it("accepts normal key segments", () => {
+    for (const s of ["persistent", "downloads", "Y-To2XJTA", "skyrimse", "a1b2-c3", "size", ""]) {
+      expect(isClobberedKeySegment(s)).toBe(false);
+    }
+  });
+
+  it("flags U+FFFD (replacement char from an invalid-UTF-8 decode)", () => {
+    expect(isClobberedKeySegment("Y-T��TA")).toBe(true);
+    expect(isClobberedKeySegment("�")).toBe(true);
+  });
+
+  it("flags C0 control chars (< U+0020)", () => {
+    expect(isClobberedKeySegment("bad\x01mod")).toBe(true);
+    expect(isClobberedKeySegment("\x1ffoo")).toBe(true);
+    expect(isClobberedKeySegment("tab\there")).toBe(true); // \t is 0x09
+  });
+
+  it("does not flag ordinary punctuation, spaces, or valid multi-byte text", () => {
+    expect(isClobberedKeySegment("a b.c_d-e (f)")).toBe(false);
+    expect(isClobberedKeySegment("café")).toBe(false);
+  });
+});

--- a/src/shared/src/types/state.ts
+++ b/src/shared/src/types/state.ts
@@ -84,3 +84,26 @@ export interface IWindow {
 }
 
 export const currentStatePath = "state.v2";
+
+/**
+ * True if a persisted-key segment was clobbered by a partial write or bit-rot.
+ *
+ * When a key's bytes on disk are not valid UTF-8, a UTF-8 decode yields U+FFFD
+ * (REPLACEMENT CHARACTER); C0 control chars (< U+0020) likewise never appear in
+ * a legitimate hive path or id. Such a key does not round-trip — reading it back
+ * through the VARCHAR key column and re-encoding produces different bytes than
+ * are stored — so it can never be matched by an exact-key delete and must be
+ * scrubbed at the byte level (see the main-process `healInvalidKeys`).
+ *
+ * Shared so the main-process heal and the renderer's mods reducer agree on
+ * exactly what "clobbered" means.
+ */
+export function isClobberedKeySegment(segment: string): boolean {
+  for (let i = 0; i < segment.length; ++i) {
+    const code = segment.charCodeAt(i);
+    if (code === 0xfffd || code < 0x20) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
A key with non-UTF-8 bytes reads back lossily as U+FFFD, so an exact-key delete can't match it: it's unremovable and re-triggers the state-corruption dialog every launch.

Add a main-process heal (pre-hydration) that deletes such keys via their clean prefix and re-inserts the valid siblings. It never deletes shallower than a sub-container, so it can't wipe a hive, and runs in a transaction. The "clobbered key" predicate moves to @vortex/shared/state, shared with the mods reducer's self-heal. Covered by integration tests against the real extension, including a hive-safety test.

closes LAZ-788
supersedes LAZ-674