### PR TITLE
add launch_method to app_game_exited (LAZ-790)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -130,6 +130,7 @@ export class AppGameLaunchedEvent implements MixpanelEvent {
 export interface GameExitedProps {
   game_id: number | null;
   launch_method: GameLaunchMethod;
+  enabled_mod_count: number;
   launch_session_id: string;
   duration_ms: number;
   // Process exit code, when Vortex launched the process itself; null for store launches.
@@ -138,7 +139,8 @@ export interface GameExitedProps {
 
 /**
  * Sent when a launched game/tool process exits. `duration_ms` is the time since its launch;
- * `launch_method` and `launch_session_id` match the app_game_launched it pairs with.
+ * `launch_method`, `enabled_mod_count` and `launch_session_id` match the app_game_launched it
+ * pairs with (captured at launch, so they reflect state at launch time).
  */
 export class AppGameExitedEvent implements MixpanelEvent {
   readonly eventName = "app_game_exited";

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -129,6 +129,7 @@ export class AppGameLaunchedEvent implements MixpanelEvent {
 /** Fields on the app_game_exited event. */
 export interface GameExitedProps {
   game_id: number | null;
+  launch_method: GameLaunchMethod;
   launch_session_id: string;
   duration_ms: number;
   // Process exit code, when Vortex launched the process itself; null for store launches.
@@ -137,7 +138,7 @@ export interface GameExitedProps {
 
 /**
  * Sent when a launched game/tool process exits. `duration_ms` is the time since its launch;
- * `launch_session_id` matches the app_game_launched it pairs with.
+ * `launch_method` and `launch_session_id` match the app_game_launched it pairs with.
  */
 export class AppGameExitedEvent implements MixpanelEvent {
   readonly eventName = "app_game_exited";

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -54,8 +54,8 @@ describe("game launch analytics", () => {
     const h = harness();
     const info = makeStarterInfo({ exePath: "C:/g/exited.exe" });
     emitGameLaunched(h.api, info);
-    const sessionId = h.events.find((e) => e.eventName === "app_game_launched")?.properties
-      .launch_session_id;
+    const launched = h.events.find((e) => e.eventName === "app_game_launched");
+    const sessionId = launched?.properties.launch_session_id;
 
     emitExitsForStoppedTools(h.api, { [makeExeId(info.exePath)]: { started: 0 } }, {});
 
@@ -63,6 +63,7 @@ describe("game launch analytics", () => {
     expect(exited).toBeDefined();
     expect(exited?.properties.launch_session_id).toBe(sessionId);
     expect(exited?.properties.launch_method).toBe("direct_exe");
+    expect(exited?.properties.enabled_mod_count).toBe(launched?.properties.enabled_mod_count);
     expect(typeof exited?.properties.duration_ms).toBe("number");
     expect(exited?.properties.exit_code).toBeNull();
   });

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -62,6 +62,7 @@ describe("game launch analytics", () => {
     const exited = h.events.find((e) => e.eventName === "app_game_exited");
     expect(exited).toBeDefined();
     expect(exited?.properties.launch_session_id).toBe(sessionId);
+    expect(exited?.properties.launch_method).toBe("direct_exe");
     expect(typeof exited?.properties.duration_ms).toBe("number");
     expect(exited?.properties.exit_code).toBeNull();
   });

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -19,6 +19,7 @@ interface ILaunchRecord {
   sessionId: string;
   gameId: number | null;
   launchMethod: GameLaunchMethod;
+  enabledModCount: number;
   launchTime: number;
   // Set from runExecutable's exit for Vortex-spawned launches; stays null for store launches.
   exitCode: number | null;
@@ -67,6 +68,7 @@ export function emitExitsForStoppedTools(
       new AppGameExitedEvent({
         game_id: record.gameId,
         launch_method: record.launchMethod,
+        enabled_mod_count: record.enabledModCount,
         launch_session_id: record.sessionId,
         duration_ms: Date.now() - record.launchTime,
         exit_code: record.exitCode,
@@ -95,20 +97,22 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   const gameId = numericNexusGameId(info.gameId);
   const sessionId = shortid();
   const method = launchMethod(info);
+  const profileId = lastActiveProfileForGame(state, info.gameId);
+  const enabledModCount = enabledModCountForProfile(state, profileId);
   pendingLaunches.set(makeExeId(info.exePath), {
     sessionId,
     gameId,
     launchMethod: method,
+    enabledModCount,
     launchTime: Date.now(),
     exitCode: null,
   });
-  const profileId = lastActiveProfileForGame(state, info.gameId);
   api.events.emit(
     "analytics-track-mixpanel-event",
     new AppGameLaunchedEvent({
       game_id: gameId,
       launch_method: method,
-      enabled_mod_count: enabledModCountForProfile(state, profileId),
+      enabled_mod_count: enabledModCount,
       launch_session_id: sessionId,
     }),
   );

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -18,6 +18,7 @@ import type { IStarterInfo } from "./StarterInfo";
 interface ILaunchRecord {
   sessionId: string;
   gameId: number | null;
+  launchMethod: GameLaunchMethod;
   launchTime: number;
   // Set from runExecutable's exit for Vortex-spawned launches; stays null for store launches.
   exitCode: number | null;
@@ -65,6 +66,7 @@ export function emitExitsForStoppedTools(
       "analytics-track-mixpanel-event",
       new AppGameExitedEvent({
         game_id: record.gameId,
+        launch_method: record.launchMethod,
         launch_session_id: record.sessionId,
         duration_ms: Date.now() - record.launchTime,
         exit_code: record.exitCode,
@@ -92,9 +94,11 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   const state: IState = api.getState();
   const gameId = numericNexusGameId(info.gameId);
   const sessionId = shortid();
+  const method = launchMethod(info);
   pendingLaunches.set(makeExeId(info.exePath), {
     sessionId,
     gameId,
+    launchMethod: method,
     launchTime: Date.now(),
     exitCode: null,
   });
@@ -103,7 +107,7 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
     "analytics-track-mixpanel-event",
     new AppGameLaunchedEvent({
       game_id: gameId,
-      launch_method: launchMethod(info),
+      launch_method: method,
       enabled_mod_count: enabledModCountForProfile(state, profileId),
       launch_session_id: sessionId,
     }),


### PR DESCRIPTION
Store the launch method on the pending-launch record so the paired app_game_exited reports it, matching app_game_launched. Exits can be segmented by launch method without joining back on launch_session_id.

Also added enabled_mod_count to app_game_exit event for convenience.

closes LAZ-790