### PR TITLE
Move spec URL consts into a shared constants.ts file

### DIFF
--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared constants for E2E specs — keep hard-coded URLs here (rather than as
+ * per-spec consts) so they're maintained in one place.
+ */
+
+export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";

--- a/packages/e2e/src/tests/mods-deploy.spec.ts
+++ b/packages/e2e/src/tests/mods-deploy.spec.ts
@@ -7,6 +7,7 @@
  * Deploy it from the Mods list. Runs for both free and premium.
  *
  */
+import { SDV_MOD_URL } from "../constants";
 import { test, expect, type NexusUser } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { Timeouts } from "../helpers/timeouts";
@@ -14,8 +15,6 @@ import { freeUser, premiumUser } from "../helpers/users";
 import { ModsPage } from "../selectors/modsPage";
 import { NavBar } from "../selectors/navbar";
 import { AUTOMATION_LABELS, SettingsPage } from "../selectors/settings";
-
-const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
 
 const TIERS = [
   { tier: "free", user: freeUser },

--- a/packages/e2e/src/tests/mods-manual.spec.ts
+++ b/packages/e2e/src/tests/mods-manual.spec.ts
@@ -7,6 +7,7 @@ import path from "node:path";
  * has no real launcher). Native file picker is bypassed by overriding
  * dialog.showOpenDialog from the test side.
  */
+import { SDV_MOD_URL } from "../constants";
 import { test, expect, type NexusUser } from "../fixtures/vortex-app";
 import { acceptConsent } from "../helpers/consent";
 import { Timeouts } from "../helpers/timeouts";
@@ -14,8 +15,6 @@ import { freeUser, premiumUser } from "../helpers/users";
 import { ModsPage } from "../selectors/modsPage";
 import { NavBar } from "../selectors/navbar";
 import { NexusModPage } from "../selectors/nexusModPage";
-
-const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
 
 const TIERS = [
   { tier: "free", user: freeUser },

--- a/packages/e2e/src/tests/mods.spec.ts
+++ b/packages/e2e/src/tests/mods.spec.ts
@@ -3,13 +3,12 @@
  * SMAPI (mods/2400) — picked because it has no further prerequisites, so the
  * install completes cleanly. Premium users skip the slow-download interstitial.
  */
+import { SDV_MOD_URL } from "../constants";
 import { test, expect, type NexusUser } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { NavBar } from "../selectors/navbar";
-
-const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
 
 const TIERS = [
   { tier: "free", user: freeUser },


### PR DESCRIPTION
The SDV_MOD_URL declared at the top of mods.spec.ts, mods-deploy.spec.ts and mods-manual.spec.ts is now exported from packages/e2e/src/constants.ts, so hard-coded URLs are maintained in one place. The specs import it instead of re-declaring it.

This is where we should store other URLS going forwards that will be consumed in the tests rather than declaring them at the start of each test