### PR TITLE
fire `app_game_exited` when the game closes, not when the loader exits (LAZ-803)

### DIFF
--- a/src/renderer/src/reducers/session.ts
+++ b/src/renderer/src/reducers/session.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 
 import * as actions from "../actions/session";
 import type { IReducerSpec } from "../types/IExtensionContext";
+import type { IRunningTool } from "../types/IState";
 import { addUniqueSafe, deleteOrNop, pushSafe, removeValue, setSafe } from "../util/storeHelper";
 
 export function makeExeId(exePath: string): string {
@@ -11,6 +12,32 @@ export function makeExeId(exePath: string): string {
   // On the flipside, if we _don't_ use the basename, lookup will be more complicated and
   // thus slower.
   return path.basename(exePath).toLowerCase();
+}
+
+/** True when the exe with this id (from makeExeId) appears in a session.base.toolsRunning map. */
+export function isExeIdRunning(
+  toolsRunning: Readonly<Record<string, unknown>>,
+  exeId: string,
+): boolean {
+  return toolsRunning[exeId] !== undefined;
+}
+
+/** True when the exe at this path is running (its basename appears in toolsRunning). */
+export function isExeRunning(
+  toolsRunning: Readonly<Record<string, unknown>>,
+  exePath: string,
+): boolean {
+  if (!exePath) {
+    return false;
+  }
+  return isExeIdRunning(toolsRunning, makeExeId(exePath));
+}
+
+/** True when any running tool holds the exclusive lock (which blocks other launches). */
+export function hasExclusiveToolRunning(
+  toolsRunning: Readonly<Record<string, IRunningTool>>,
+): boolean {
+  return Object.values(toolsRunning).some((tool) => tool.exclusive);
 }
 
 /**

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -2,7 +2,7 @@
  * Tests for the game launch/exit analytics: app_game_launched carries the launch method and a
  * session id, and app_game_exited pairs with it (same launch_session_id) with an elapsed duration.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   GameLaunchMethod,
@@ -84,5 +84,98 @@ describe("game launch analytics", () => {
     const h = harness();
     emitExitsForStoppedTools(h.api, { "unrelated.exe": { started: 0 } }, {});
     expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+  });
+});
+
+describe("exit detection for launches that hand off to the game", () => {
+  // A harness whose active game (skyrimse) has a discovered executable, so the launch code can
+  // resolve the real game process to watch.
+  function gameHarness() {
+    const h = harness();
+    const state = h.api.getState() as unknown as {
+      settings: { gameMode: { discovered: Record<string, unknown> } };
+    };
+    state.settings.gameMode.discovered.skyrimse = {
+      executable: "SkyrimSE.exe",
+      path: "C:/games/skyrimse",
+    };
+    return h;
+  }
+
+  const running = (...exeIds: string[]): Record<string, unknown> =>
+    Object.fromEntries(exeIds.map((id) => [id, { pid: 1, started: 0, exclusive: false }]));
+
+  const gameExeId = makeExeId("SkyrimSE.exe");
+
+  it("ties a script-extender launch's exit to the game process, not the loader", () => {
+    const h = gameHarness();
+    const info = makeStarterInfo({
+      isGame: false,
+      defaultPrimary: true,
+      id: "skse64",
+      exePath: "C:/games/skyrimse/skse64_loader.exe",
+    });
+    emitGameLaunched(h.api, info);
+    const sessionId = h.events.find((e) => e.eventName === "app_game_launched")?.properties
+      .launch_session_id;
+    const loaderId = makeExeId(info.exePath);
+
+    // the loader exits during the handoff - must NOT end the session
+    emitExitsForStoppedTools(h.api, running(loaderId), running());
+    expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+
+    // the game process comes up; still running, no exit yet
+    emitExitsForStoppedTools(h.api, running(), running(gameExeId));
+    expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+
+    // the game process stops - now the session ends, once, paired with the launch
+    emitExitsForStoppedTools(h.api, running(gameExeId), running());
+    const exited = h.events.filter((e) => e.eventName === "app_game_exited");
+    expect(exited).toHaveLength(1);
+    expect(exited[0].properties.launch_session_id).toBe(sessionId);
+    expect(typeof exited[0].properties.duration_ms).toBe("number");
+  });
+
+  it("keeps watching its own process for a plain utility tool", () => {
+    const h = gameHarness();
+    const info = makeStarterInfo({
+      isGame: false,
+      defaultPrimary: false,
+      id: "nifskope",
+      exePath: "C:/tools/nifskope.exe",
+    });
+    emitGameLaunched(h.api, info);
+
+    // the game process appearing/stopping is irrelevant to a utility tool
+    emitExitsForStoppedTools(h.api, running(gameExeId), running());
+    expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+
+    // the tool's own process stopping ends its session
+    emitExitsForStoppedTools(h.api, running(makeExeId(info.exePath)), running());
+    expect(h.events.filter((e) => e.eventName === "app_game_exited")).toHaveLength(1);
+  });
+
+  it("emits a best-effort exit with the loader's exit code if the game never appears", () => {
+    vi.useFakeTimers();
+    try {
+      const h = gameHarness();
+      const info = makeStarterInfo({
+        isGame: false,
+        defaultPrimary: true,
+        id: "f4se",
+        exePath: "C:/games/fallout4/f4se_loader.exe",
+      });
+      emitGameLaunched(h.api, info);
+      recordLaunchExit(info.exePath, 1);
+
+      expect(h.events.some((e) => e.eventName === "app_game_exited")).toBe(false);
+      vi.advanceTimersByTime(5 * 60 * 1000);
+
+      const exited = h.events.filter((e) => e.eventName === "app_game_exited");
+      expect(exited).toHaveLength(1);
+      expect(exited[0].properties.exit_code).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -6,6 +6,7 @@ import {
   type GameLaunchMethod,
 } from "../extensions/analytics/mixpanel/MixpanelEvents";
 import { numericNexusGameId } from "../extensions/analytics/mixpanel/numericGameId";
+import { getGame } from "../extensions/gamemode_management/util/getGame";
 import {
   enabledModCountForProfile,
   lastActiveProfileForGame,
@@ -15,6 +16,12 @@ import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IState } from "../types/IState";
 import type { IStarterInfo } from "./StarterInfo";
 
+// A launch that hands off to the game (script extender / mod loader) exits its launcher within
+// seconds while the game keeps running, so we wait for the game process to appear. If it never
+// does (failed or undetected launch) emit a best-effort exit after this long. Generous so a game
+// behind a store launcher or shader compile isn't cut off early.
+const GAME_START_TIMEOUT_MS = 5 * 60 * 1000;
+
 interface ILaunchRecord {
   sessionId: string;
   gameId: number | null;
@@ -23,9 +30,17 @@ interface ILaunchRecord {
   launchTime: number;
   // Set from runExecutable's exit for Vortex-spawned launches; stays null for store launches.
   exitCode: number | null;
+  // Exe id whose stop ends the play session. For a script-extender / mod-loader launch this is the
+  // game's own executable, not the launched loader (which exits during the handoff).
+  watchExeId: string;
+  // Whether watchExeId has been seen running. A handoff launch starts false until the game process
+  // appears; other launches start true because the launched exe is already running.
+  started: boolean;
+  // Fires a best-effort exit if the game process never appears. Cleared once the game is seen.
+  startTimer: ReturnType<typeof setTimeout> | undefined;
 }
 
-// Recorded launches awaiting their exit, keyed by exe id (makeExeId).
+// Recorded launches awaiting their exit, keyed by the launched exe id (makeExeId of info.exePath).
 const pendingLaunches = new Map<string, ILaunchRecord>();
 let exitWatcherInstalled = false;
 
@@ -35,6 +50,65 @@ function launchMethod(info: IStarterInfo): GameLaunchMethod {
   }
   // Extensions flag script-extender tools (skse64, f4se, ...) with defaultPrimary.
   return info.defaultPrimary ? "script_extender" : "tool";
+}
+
+/**
+ * True when a launch actually starts the game, as opposed to a plain utility tool. That means the
+ * game itself, the extension's defaultPrimary launcher (script extenders, and mod loaders like
+ * SMAPI), or a tool the user has bound as the game's primary launcher. A utility tool run from the
+ * tools dashlet is none of these, so its session stays tied to its own process.
+ */
+function launchRunsGame(info: IStarterInfo, state: IState): boolean {
+  if (info.isGame || (info.defaultPrimary ?? false)) {
+    return true;
+  }
+  // A user can bind a non-defaultPrimary tool as the launcher. primaryTool is an extension-added
+  // slice, not part of the base IState type.
+  const primaryTool = (state.settings?.interface as { primaryTool?: Record<string, string> })
+    ?.primaryTool?.[info.gameId];
+  return primaryTool === info.id;
+}
+
+/** Resolves the game's executable id (normalized basename) for a game id, or undefined. */
+function gameExecutableId(state: IState, gameId: string): string | undefined {
+  const discovered = state.settings?.gameMode?.discovered?.[gameId];
+  const discoveredExe = discovered?.executable;
+  if (typeof discoveredExe === "string" && discoveredExe.length > 0) {
+    return makeExeId(discoveredExe);
+  }
+  const game = getGame(gameId);
+  if (game !== undefined && typeof game.executable === "function") {
+    try {
+      const exe = game.executable(discovered?.path);
+      if (typeof exe === "string" && exe.length > 0) {
+        return makeExeId(exe);
+      }
+    } catch {
+      // dynamic executable() that needs a discovery path we don't have; fall through
+    }
+  }
+  return undefined;
+}
+
+function clearStartTimer(record: ILaunchRecord): void {
+  if (record.startTimer !== undefined) {
+    clearTimeout(record.startTimer);
+    record.startTimer = undefined;
+  }
+}
+
+function emitExited(api: IExtensionApi, record: ILaunchRecord): void {
+  api.events.emit(
+    "analytics-track-mixpanel-event",
+    new AppGameExitedEvent({
+      game_id: record.gameId,
+      launch_method: record.launchMethod,
+      enabled_mod_count: record.enabledModCount,
+      launch_session_id: record.sessionId,
+      duration_ms: Date.now() - record.launchTime,
+      exit_code: record.exitCode,
+    }),
+  );
 }
 
 /**
@@ -48,32 +122,32 @@ export function recordLaunchExit(exePath: string, code: number | null): void {
   }
 }
 
-/** Emits app_game_exited for each recorded launch whose exe is in `previous` but absent from `current`. */
+/**
+ * Emits app_game_exited for tracked launches whose watched process has stopped. Each launch watches
+ * either its own exe (direct/store/tool) or, for a script-extender / mod-loader handoff, the game's
+ * executable. A handoff launch only counts as exited once the game process has been seen running
+ * and then disappears.
+ */
 export function emitExitsForStoppedTools(
   api: IExtensionApi,
   previous: Record<string, unknown>,
   current: Record<string, unknown>,
 ): void {
-  for (const exeId of Object.keys(previous ?? {})) {
-    if (current?.[exeId] !== undefined) {
-      continue;
+  for (const [key, record] of [...pendingLaunches.entries()]) {
+    const wasRunning = previous?.[record.watchExeId] !== undefined;
+    const isRunning = current?.[record.watchExeId] !== undefined;
+
+    if (!record.started && isRunning) {
+      // The watched (game) process has come up; from here its disappearance ends the session.
+      record.started = true;
+      clearStartTimer(record);
     }
-    const record = pendingLaunches.get(exeId);
-    if (record === undefined) {
-      continue;
+
+    if (record.started && wasRunning && !isRunning) {
+      clearStartTimer(record);
+      pendingLaunches.delete(key);
+      emitExited(api, record);
     }
-    pendingLaunches.delete(exeId);
-    api.events.emit(
-      "analytics-track-mixpanel-event",
-      new AppGameExitedEvent({
-        game_id: record.gameId,
-        launch_method: record.launchMethod,
-        enabled_mod_count: record.enabledModCount,
-        launch_session_id: record.sessionId,
-        duration_ms: Date.now() - record.launchTime,
-        exit_code: record.exitCode,
-      }),
-    );
   }
 }
 
@@ -99,14 +173,41 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   const method = launchMethod(info);
   const profileId = lastActiveProfileForGame(state, info.gameId);
   const enabledModCount = enabledModCountForProfile(state, profileId);
-  pendingLaunches.set(makeExeId(info.exePath), {
+  const launchedExeId = makeExeId(info.exePath);
+
+  // A launch that hands the game off to a separate process (script extender / mod loader) watches
+  // the game executable; every other launch watches the exe it started. A handoff waits for the
+  // game process to appear, so it is only "started" once that process is running.
+  const gameExeId = launchRunsGame(info, state) ? gameExecutableId(state, info.gameId) : undefined;
+  let watchExeId = launchedExeId;
+  let started = true;
+  if (gameExeId !== undefined && gameExeId !== launchedExeId) {
+    watchExeId = gameExeId;
+    started = state.session?.base?.toolsRunning?.[gameExeId] !== undefined;
+  }
+
+  const record: ILaunchRecord = {
     sessionId,
     gameId,
     launchMethod: method,
     enabledModCount,
     launchTime: Date.now(),
     exitCode: null,
-  });
+    watchExeId,
+    started,
+    startTimer: undefined,
+  };
+  pendingLaunches.set(launchedExeId, record);
+
+  if (!started) {
+    record.startTimer = setTimeout(() => {
+      if (pendingLaunches.get(launchedExeId) === record && !record.started) {
+        pendingLaunches.delete(launchedExeId);
+        emitExited(api, record);
+      }
+    }, GAME_START_TIMEOUT_MS);
+  }
+
   api.events.emit(
     "analytics-track-mixpanel-event",
     new AppGameLaunchedEvent({

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -11,7 +11,7 @@ import {
   enabledModCountForProfile,
   lastActiveProfileForGame,
 } from "../extensions/profile_management/selectors";
-import { makeExeId } from "../reducers/session";
+import { isExeIdRunning, makeExeId } from "../reducers/session";
 import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IState } from "../types/IState";
 import type { IStarterInfo } from "./StarterInfo";
@@ -134,8 +134,8 @@ export function emitExitsForStoppedTools(
   current: Record<string, unknown>,
 ): void {
   for (const [key, record] of [...pendingLaunches.entries()]) {
-    const wasRunning = previous?.[record.watchExeId] !== undefined;
-    const isRunning = current?.[record.watchExeId] !== undefined;
+    const wasRunning = isExeIdRunning(previous, record.watchExeId);
+    const isRunning = isExeIdRunning(current, record.watchExeId);
 
     if (!record.started && isRunning) {
       // The watched (game) process has come up; from here its disappearance ends the session.
@@ -183,7 +183,7 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
   let started = true;
   if (gameExeId !== undefined && gameExeId !== launchedExeId) {
     watchExeId = gameExeId;
-    started = state.session?.base?.toolsRunning?.[gameExeId] !== undefined;
+    started = isExeIdRunning(state.session?.base?.toolsRunning ?? {}, gameExeId);
   }
 
   const record: ILaunchRecord = {

--- a/src/renderer/src/views/QuickLauncher.tsx
+++ b/src/renderer/src/views/QuickLauncher.tsx
@@ -11,7 +11,7 @@ import Spinner from "../controls/Spinner";
 import { IconButton } from "../controls/TooltipControls";
 import { useExtensionContext } from "../ExtensionProvider";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
-import { makeExeId } from "../reducers/session";
+import { hasExclusiveToolRunning, isExeRunning } from "../reducers/session";
 import type { IState } from "../types/IState";
 import Debouncer from "../util/Debouncer";
 import { log } from "../util/log";
@@ -291,11 +291,8 @@ export const QuickLauncher: React.FC = () => {
     return null;
   }
 
-  const exclusiveRunning =
-    Object.keys(toolsRunning).find((exeId) => toolsRunning[exeId].exclusive) !== undefined;
-  const primaryRunning =
-    truthy(starter.exePath) &&
-    Object.keys(toolsRunning).find((exeId) => exeId === makeExeId(starter.exePath)) !== undefined;
+  const exclusiveRunning = hasExclusiveToolRunning(toolsRunning);
+  const primaryRunning = isExeRunning(toolsRunning, starter.exePath);
 
   return (
     <div className="container-quicklaunch">

--- a/src/renderer/src/views/components/Menu/useToolsRunning.ts
+++ b/src/renderer/src/views/components/Menu/useToolsRunning.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 
-import { makeExeId } from "../../../reducers/session";
+import { hasExclusiveToolRunning, isExeRunning } from "../../../reducers/session";
 import type { IState } from "../../../types/IState";
 
 export interface UseToolsRunningResult {
@@ -16,17 +16,12 @@ export interface UseToolsRunningResult {
 export const useToolsRunning = (): UseToolsRunningResult => {
   const toolsRunning = useSelector((state: IState) => state.session.base.toolsRunning);
 
-  const exclusiveRunning = useMemo(() => {
-    return Object.keys(toolsRunning).some((exeId) => toolsRunning[exeId].exclusive);
-  }, [toolsRunning]);
+  const exclusiveRunning = useMemo(() => hasExclusiveToolRunning(toolsRunning), [toolsRunning]);
 
-  const isToolRunning = useMemo(() => {
-    return (toolExePath: string): boolean => {
-      if (!toolExePath) return false;
-      const exeId = makeExeId(toolExePath);
-      return toolsRunning[exeId] !== undefined;
-    };
-  }, [toolsRunning]);
+  const isToolRunning = useMemo(
+    () => (toolExePath: string) => isExeRunning(toolsRunning, toolExePath),
+    [toolsRunning],
+  );
 
   return { exclusiveRunning, isToolRunning };
 };


### PR DESCRIPTION
For a launch that hands off to the game through a script extender or mod loader (SKSE, F4SE, SMAPI), the launched loader exits within a second or two of spawning the game, so app_game_exited reported a few-second session while the game was still running.

Such launches now watch the game's own executable in session.base.toolsRunning (which ProcessMonitor already tracks) rather than the loader, and emit app_game_exited when the game process ends, with a duration reflecting real play time. A launch counts as running the game when it is the game itself, a defaultPrimary launcher, or the user's configured primary tool; a plain utility tool keeps watching its own process. When the game process never appears, a bounded timeout emits a best-effort exit.

closes LAZ-803