### PR TITLE
Fixed display filename

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.naming.test.ts
+++ b/src/renderer/src/IPCDownloadAdapter.naming.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, vi } from "vitest";
+
+import { initDownload, setDownloadModInfo } from "./extensions/download_management/actions/state";
+import { test } from "./test-utils/downloadAdapterTest";
+
+// Keep the download off disk. access must reject so the "already downloaded" probe
+// treats the file as absent and the download proceeds to the seed path.
+vi.mock(import("node:fs/promises"), async (importOriginal) => ({
+  ...(await importOriginal()),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  rename: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+// let the fired-and-forgotten start-download handler run to completion
+const flush = async () => {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+};
+
+const modInfoAction = (
+  h: { dispatched: Array<{ type: string; payload?: unknown }> },
+  key: string,
+) =>
+  h.dispatched.filter(
+    (a) =>
+      a.type === setDownloadModInfo("", "", "").type && (a.payload as { key: string }).key === key,
+  );
+
+describe("start-download name seeding (GH #23718)", () => {
+  test("does not overwrite a modInfo name already provided by the caller", async ({
+    makeDownloadAdapter,
+  }) => {
+    const h = makeDownloadAdapter();
+    const storagePathHint = "5c/d3/1f/5cd31ffe-41b5-4520-8ac2-cc796226941e";
+
+    h.events.emit(
+      "start-download",
+      ["https://cdn.example/file.bin"],
+      { game: "skyrimse", source: "nexus", name: "Fix Flickering Particles" },
+      storagePathHint,
+      () => undefined,
+    );
+    await h.started.promise;
+    await flush();
+
+    const inits = h.dispatched.filter((a) => a.type === initDownload("", [], {}, []).type);
+    expect(inits).toHaveLength(1);
+    expect((inits[0].payload as { modInfo: { name: string } }).modInfo.name).toBe(
+      "Fix Flickering Particles",
+    );
+    expect(modInfoAction(h, "name")).toHaveLength(0);
+  });
+
+  test("still seeds the hint when the caller provided no name", async ({ makeDownloadAdapter }) => {
+    const h = makeDownloadAdapter();
+
+    h.events.emit(
+      "start-download",
+      ["https://cdn.example/file.bin"],
+      { game: "skyrimse" },
+      "MyMod-1234.zip",
+      () => undefined,
+    );
+    await h.started.promise;
+    await flush();
+
+    const nameSeeds = modInfoAction(h, "name");
+    expect(nameSeeds).toHaveLength(1);
+    expect((nameSeeds[0].payload as { value: string }).value).toBe("MyMod-1234.zip");
+  });
+});

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -604,9 +604,9 @@ export class IPCDownloadAdapter {
       this.#api.store.dispatch(initDownload(downloadId, rawUrls, modInfo, gameIds));
       // Set localPath to the temp name so the UI has something to display.
       this.#api.store.dispatch(setDownloadFilePath(downloadId, tempName));
-      // Seed a friendly name from the caller's hint so the UI shows it instead of
-      // the temp name; nxm downloads without a hint fall back to enriched metadata.
-      if (fileName !== undefined) {
+      // Fall back to the filename hint for the display name only when the caller didn't
+      // provide a semantic name in modInfo, so the hint can't override it.
+      if (fileName !== undefined && !modInfo?.name) {
         this.#api.store.dispatch(setDownloadModInfo(downloadId, "name", fileName));
       }
       // All IPC downloads support pause via checkpoint. DownloadView checks

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -549,6 +549,7 @@ export function getInfoGraphQL(
         id: true,
         name: true,
       },
+      name: true, // required, else modInfo.name is undefined
       pictureUrl: true,
       status: true,
       uid: true,
@@ -669,7 +670,7 @@ function transformGraphQLFileToIFileInfo(file: Partial<IModFile>): IFileInfo {
     uploaded_timestamp: file.mod?.updatedAt ? new Date(file.mod.updatedAt).getTime() : file.date,
     uploaded_time: file.mod?.updatedAt || new Date(file.date).toString(),
     changelog_html: null, // Changelog HTML is not included in the GraphQL response
-    file_name: file.uri,
+    file_name: file.uri, // file.uri is the CDN storage path ("5c/d3/1f/<guid>")
     description: file.description || "",
     content_preview_link: "", // Default value
     external_virus_scan_url: "", // Default value
@@ -775,7 +776,7 @@ function startDownloadMod(
               fileInfo,
             },
           },
-          fileName ?? nexusFileInfo.file_name,
+          fileName ?? nexusFileInfo.name,
           (err, downloadId) => (truthy(err) ? reject(contextify(err)) : resolve(downloadId)),
           redownload,
           { allowInstall },
@@ -816,12 +817,7 @@ function startDownloadMod(
                   undefined,
                   (err: any, id: string) => {
                     if (err) {
-                      processInstallError(
-                        api,
-                        err,
-                        downloadId,
-                        fileName ?? nexusFileInfo.file_name,
-                      );
+                      processInstallError(api, err, downloadId, fileName ?? nexusFileInfo.name);
                     }
                   },
                 );


### PR DESCRIPTION
We were showing the CDN's "name" if the file, which isn't correct. Using nexusFileInfo.name should yeld a better result

Fixes #23718
Closes LAZ-807