### PR TITLE
restore downloads from mega.nz / Google Drive (LAZ-808)

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.adopt.test.ts
+++ b/src/renderer/src/IPCDownloadAdapter.adopt.test.ts
@@ -1,0 +1,77 @@
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
+
+// getVortexPath reads electron's userData/temp dirs, which aren't wired up in tests, so (like
+// migrate.test.ts and the main adapter suite) it's mocked. It points at a real temp dir here so
+// adoption's file copy/hash/cleanup run against a real filesystem rather than mocks.
+const paths = vi.hoisted(() => ({ root: "" }));
+vi.mock("./util/getVortexPath", () => ({ default: () => paths.root }));
+
+import { finishDownload } from "./extensions/download_management/actions/state";
+import { downloadPathForGame } from "./extensions/download_management/selectors";
+import { test } from "./test-utils/downloadAdapterTest";
+
+// browse-for-download encodes a completed blob as "<url>|<fileName><<referer>".
+const BLOB = "blob:https://mega.nz/uuid|Cool Mod.7z<https://mega.nz/file/uuid";
+
+describe("blob adoption", () => {
+  beforeEach(async () => {
+    paths.root = await mkdtemp(path.join(tmpdir(), "vortex-adopt-"));
+  });
+
+  afterEach(async () => {
+    await rm(paths.root, { recursive: true, force: true });
+  });
+
+  test("adopts a browser blob (already saved to temp) as a finished download on disk", async ({
+    makeDownloadAdapter,
+  }) => {
+    // the embedded browser saved the file to <temp>/<fileName>.tmp before handing back the blob url
+    await writeFile(path.join(paths.root, "Cool Mod.7z.tmp"), "the mod bytes");
+
+    const h = makeDownloadAdapter();
+    const finished = vi.fn();
+    h.events.on("did-finish-download", finished);
+
+    const result = await new Promise<{ err: Error | null; id?: string }>((resolve) => {
+      h.events.emit("start-download", [BLOB], { game: "skyrimse" }, undefined, (err, id) =>
+        resolve({ err, id }),
+      );
+    });
+
+    // adopted as a finished download; the blob was never handed to the network downloader
+    expect(result.err).toBeNull();
+    expect(result.id).toBeTruthy();
+    expect(h.start).not.toHaveBeenCalled();
+    expect(finished).toHaveBeenCalledWith(result.id, "finished");
+    expect(h.dispatched).toContainEqual(finishDownload(result.id!, "finished", null));
+
+    // the file really landed in the game's download folder under its parsed name, and the temp blob
+    // was cleaned up
+    const dlPath = downloadPathForGame(h.getState(), "skyrimse");
+    await expect(access(path.join(dlPath, "Cool Mod.7z"))).resolves.toBeUndefined();
+    await expect(access(path.join(paths.root, "Cool Mod.7z.tmp"))).rejects.toThrow();
+  });
+
+  test("reports an error for a blob with no file name and no hint", async ({
+    makeDownloadAdapter,
+  }) => {
+    const h = makeDownloadAdapter();
+
+    const result = await new Promise<{ err: Error | null }>((resolve) => {
+      h.events.emit(
+        "start-download",
+        ["blob:https://mega.nz/uuid<https://mega.nz/file/uuid"],
+        { game: "skyrimse" },
+        undefined,
+        (err) => resolve({ err }),
+      );
+    });
+
+    expect(result.err).toBeInstanceOf(Error);
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -1,6 +1,6 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { access, mkdir, rename, rm } from "node:fs/promises";
+import { access, copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
 
@@ -41,7 +41,10 @@ import {
 } from "./extensions/download_management/actions/state";
 import { downloadPathForGame } from "./extensions/download_management/selectors";
 import type { IDownload } from "./extensions/download_management/types/IDownload";
-import { TEMP_DOWNLOAD_PREFIX } from "./extensions/download_management/util/downloadNames";
+import {
+  freeDownloadName,
+  TEMP_DOWNLOAD_PREFIX,
+} from "./extensions/download_management/util/downloadNames";
 import { knownGames } from "./extensions/gamemode_management/selectors";
 import type { IGameStored } from "./extensions/gamemode_management/types/IGameStored";
 import { nxmUrlFromDownload } from "./extensions/nexus_integration/NXMUrl";
@@ -50,6 +53,8 @@ import { convertGameIdReverse } from "./extensions/nexus_integration/util/conver
 import { activeGameId } from "./extensions/profile_management/selectors";
 import { log } from "./logging";
 import type { IExtensionApi } from "./types/IExtensionContext";
+import type { IState } from "./types/IState";
+import getVortexPath from "./util/getVortexPath";
 import { batchDispatch, flatten } from "./util/util";
 
 function rehydrateDownloadError(state: WireDownloadState): Error | null {
@@ -509,21 +514,19 @@ export class IPCDownloadAdapter {
     // TODO: decide how to handle multiple URL inputs
     const rawUrl = rawUrls[0];
 
+    // A blob: url can't be fetched - the embedded browser already downloaded the file to the temp
+    // folder (see MainWindow's will-download handler). Adopt that file as a finished download rather
+    // than routing it through the network path. Pasted urls, collection browse dependencies, and
+    // community extensions all feed the browse-for-download result into start-download, so handling
+    // it here covers every caller.
+    if (rawUrl.toString().startsWith("blob:")) {
+      await this.#adoptBrowserDownload(rawUrls, modInfo, fileName, callback, options);
+      return;
+    }
+
     const encodedUrl = parseEncodedUrl(rawUrl.toString());
 
-    const state = this.#api.getState();
-    const gameId = toInternalGameId(this.#api, modInfo.game ?? activeGameId(state));
-    const dlPath = downloadPathForGame(state, gameId);
-
-    // Include games that can consume this download (e.g. Skyrim VR <- skyrimse) so
-    // the install handler targets the actively managed game rather than the base
-    // game. See expandCompatibleGameIds.
-    const gameIds = expandCompatibleGameIds(knownGames(state), gameId);
-
-    // The per-game subfolder may not exist yet - ensureDownloadsDirectory only
-    // creates the active game's folder, but downloads can target any game
-    // (SITE_ID extension downloads, compatible domains, collection downloads, etc.).
-    await mkdir(dlPath, { recursive: true });
+    const { state, dlPath, gameIds } = await this.#resolveDownloadTarget(modInfo);
 
     // Check for an existing file using the caller-supplied name before queuing.
     // We can only do this when a name is provided; temp-named downloads are always new.
@@ -630,6 +633,82 @@ export class IPCDownloadAdapter {
       }
     } catch (err) {
       this.#resolvedMeta.delete(collationId);
+      callback?.(unknownToError(err));
+    }
+  }
+
+  // Resolves where a download for the given modInfo goes: the game's download folder (created if
+  // missing) and the set of games that can consume it (e.g. Skyrim VR <- skyrimse, so the install
+  // handler targets the actively managed game rather than the base game). Shared by the network
+  // download path and the browser-adoption path.
+  async #resolveDownloadTarget(
+    modInfo: ModInfo,
+  ): Promise<{ state: IState; dlPath: string; gameIds: Array<string | undefined> }> {
+    const state = this.#api.getState();
+    const gameId = toInternalGameId(this.#api, modInfo.game ?? activeGameId(state));
+    const dlPath = downloadPathForGame(state, gameId);
+    const gameIds = expandCompatibleGameIds(knownGames(state), gameId);
+    await mkdir(dlPath, { recursive: true });
+    return { state, dlPath, gameIds };
+  }
+
+  // Adopts a file the embedded browser already downloaded (a blob) as a finished download. The main
+  // process saved it to <temp>/<fileName>.tmp; this moves it into the download folder under a free
+  // name and hands off to #completeDownload, so it takes the exact same finish/hash/callback/install
+  // path as a network download (and emits did-finish-download, which collections and auto-install
+  // wait on). browse-for-download encodes its result as "<url>|<fileName><<referer>".
+  async #adoptBrowserDownload(
+    rawUrls: string[],
+    modInfo: ModInfo,
+    fileNameHint: string | undefined,
+    callback?: (err: Error | null, id?: string) => void,
+    options?: { allowInstall?: boolean | "force" },
+  ): Promise<void> {
+    try {
+      const [urlPart] = rawUrls[0].toString().split("<");
+      const [, encodedName] = urlPart.split("|");
+      const fileName = encodedName !== undefined && encodedName !== "" ? encodedName : fileNameHint;
+      if (fileName === undefined || fileName === "") {
+        throw new Error("browser download has no file name to adopt");
+      }
+
+      const { dlPath, gameIds } = await this.#resolveDownloadTarget(modInfo);
+
+      const blobPath = path.join(getVortexPath("temp"), `${fileName}.tmp`);
+      const finalName = await freeDownloadName(dlPath, fileName);
+      const finalPath = path.join(dlPath, finalName);
+      await copyFile(blobPath, finalPath);
+      const { size } = await stat(finalPath);
+      // The file is already safely in the download folder; a failed temp cleanup must not fail the
+      // adoption (a lingering temp file is harmless).
+      await rm(blobPath, { force: true }).catch(() => undefined);
+
+      // Register the record already at its final name, so #completeDownload skips the rename and
+      // just hashes, marks it finished, fires the callback, and triggers install. A blob url isn't
+      // fetchable, so the record stores no source urls.
+      const id = randomUUID();
+      this.#api.store.dispatch(initDownload(id, [], modInfo, gameIds));
+      this.#api.store.dispatch(setDownloadFilePath(id, finalName));
+      this.#api.store.dispatch(downloadProgress(id, size, size, undefined));
+
+      const wireState: WireDownloadState = {
+        status: "completed",
+        error: null,
+        bytesReceived: size,
+        bytesWritten: size,
+        size,
+        fileName: finalName,
+        isChunked: false,
+      };
+      await this.#completeDownload(id, wireState, {
+        callback,
+        fileNameHint,
+        allowInstall: normalizeAllowInstall(options?.allowInstall),
+        lastBytesReceived: size,
+        lastProgressDispatch: 0,
+        startedEventEmitted: true,
+      });
+    } catch (err) {
       callback?.(unknownToError(err));
     }
   }

--- a/src/renderer/src/extensions/download_management/index.ts
+++ b/src/renderer/src/extensions/download_management/index.ts
@@ -9,6 +9,7 @@ import type * as Redux from "redux";
 import { generate as shortid } from "shortid";
 import winapi from "winapi-bindings";
 
+import { log } from "../../logging";
 import ReduxProp from "../../ReduxProp";
 import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
@@ -20,7 +21,6 @@ import { setErrorContext } from "../../util/errorHandling";
 import * as fs from "../../util/fs";
 import type { Normalize } from "../../util/getNormalizeFunc";
 import getNormalizeFunc from "../../util/getNormalizeFunc";
-import { log } from "../../util/log";
 import * as selectors from "../../util/selectors";
 import { knownGames } from "../../util/selectors";
 import { getSafe } from "../../util/storeHelper";
@@ -646,6 +646,32 @@ function genImportDownloadsHandler(api: IExtensionApi) {
   };
 }
 
+/**
+ * Opens a url in the embedded browser and downloads whatever it resolves to. Pasted urls can't be
+ * fetched reliably up front: some sites (mega.nz, google drive, ...) assemble the file client-side
+ * and hand it over as a blob, others sit behind a challenge/login page. The browser resolves to
+ * either a blob (the main process saves it to temp; the download adapter adopts it) or a direct
+ * link; both are handed to start-download, which routes a blob to adoption and everything else to
+ * the network downloader.
+ */
+async function browseAndDownload(
+  api: IExtensionApi,
+  navUrl: string,
+  onComplete?: (err: Error | null, dlId?: string) => void,
+): Promise<void> {
+  const instructions = api.translate(
+    "This site delivers the file through your browser. Start the download on the page and " +
+      "Vortex will pick it up automatically.",
+  );
+  const results: string[] = await api.emitAndAwait("browse-for-download", navUrl, instructions);
+  const raw = (results ?? []).find(truthy);
+  // No/err result means the user closed or canceled the browser.
+  if (raw === undefined || raw.startsWith("err:")) {
+    return;
+  }
+  api.events.emit("start-download", [raw], {}, undefined, onComplete ?? (() => null));
+}
+
 function checkPendingTransfer(api: IExtensionApi): PromiseBB<ITestResult> {
   let result: ITestResult;
   const state = api.store.getState();
@@ -1179,6 +1205,17 @@ function init(context: IExtensionContext): boolean {
     });
 
     context.api.events.on("import-downloads", genImportDownloadsHandler(context.api));
+
+    context.api.events.on(
+      "browse-download-url",
+      (navUrl: string, onComplete?: (err: Error | null, dlId?: string) => void) => {
+        // browse-for-download surfaces its own browse-level failures and treats cancel as a no-op;
+        // download failures reach onComplete. This catch is only unhandled-rejection hygiene.
+        browseAndDownload(context.api, navUrl, onComplete).catch((err) => {
+          log("error", "browse-download-url failed", { err });
+        });
+      },
+    );
 
     context.api.onAsync(
       "set-download-games",

--- a/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
 
 import { makeFileInfo } from "../../../test-utils/builders";
 import type { IDownload } from "../types/IDownload";
 import {
   TEMP_DOWNLOAD_PREFIX,
+  freeDownloadName,
   friendlyDownloadName,
   isTempDownloadName,
   nameFromUrl,
@@ -136,5 +141,38 @@ describe("friendlyDownloadName", () => {
       }),
     );
     expect(result).toBe("Cool Mod");
+  });
+});
+
+describe("freeDownloadName", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "vortex-dl-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns the name unchanged when nothing collides", async () => {
+    expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.7z");
+  });
+
+  it("appends .1 before the extension on the first collision", async () => {
+    await writeFile(path.join(dir, "Mod.7z"), "x");
+    expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.1.7z");
+  });
+
+  it("increments the counter until a free name is found", async () => {
+    await writeFile(path.join(dir, "Mod.7z"), "x");
+    await writeFile(path.join(dir, "Mod.1.7z"), "x");
+    await writeFile(path.join(dir, "Mod.2.7z"), "x");
+    expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.3.7z");
+  });
+
+  it("handles a name with no extension", async () => {
+    await writeFile(path.join(dir, "README"), "x");
+    expect(await freeDownloadName(dir, "README")).toBe("README.1");
   });
 });

--- a/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.test.ts
@@ -159,20 +159,16 @@ describe("freeDownloadName", () => {
     expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.7z");
   });
 
-  it("appends .1 before the extension on the first collision", async () => {
+  it("inserts a timestamp before the extension when the name is taken", async () => {
     await writeFile(path.join(dir, "Mod.7z"), "x");
-    expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.1.7z");
+    const name = await freeDownloadName(dir, "Mod.7z");
+    expect(name).not.toBe("Mod.7z");
+    expect(name).toMatch(/^Mod\.\d+\.7z$/);
   });
 
-  it("increments the counter until a free name is found", async () => {
-    await writeFile(path.join(dir, "Mod.7z"), "x");
-    await writeFile(path.join(dir, "Mod.1.7z"), "x");
-    await writeFile(path.join(dir, "Mod.2.7z"), "x");
-    expect(await freeDownloadName(dir, "Mod.7z")).toBe("Mod.3.7z");
-  });
-
-  it("handles a name with no extension", async () => {
+  it("appends the timestamp when a name has no extension", async () => {
     await writeFile(path.join(dir, "README"), "x");
-    expect(await freeDownloadName(dir, "README")).toBe("README.1");
+    const name = await freeDownloadName(dir, "README");
+    expect(name).toMatch(/^README\.\d+$/);
   });
 });

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -50,22 +50,18 @@ export function friendlyDownloadName(download: IDownload): string | undefined {
 }
 
 /**
- * Returns fileName, or the first "name.n.ext" variant not already present in dlPath, so an existing
- * download is never overwritten.
+ * Returns fileName if it is free in dlPath, otherwise a timestamped variant ("name.<ms>.ext"), so an
+ * existing download is never overwritten.
  */
 export async function freeDownloadName(dlPath: string, fileName: string): Promise<string> {
+  const taken = await access(path.join(dlPath, fileName)).then(
+    () => true,
+    () => false,
+  );
+  if (!taken) {
+    return fileName;
+  }
   const ext = path.extname(fileName);
   const base = path.basename(fileName, ext);
-  let candidate = fileName;
-  let counter = 0;
-  while (
-    await access(path.join(dlPath, candidate)).then(
-      () => true,
-      () => false,
-    )
-  ) {
-    counter += 1;
-    candidate = `${base}.${counter}${ext}`;
-  }
-  return candidate;
+  return `${base}.${Date.now()}${ext}`;
 }

--- a/src/renderer/src/extensions/download_management/util/downloadNames.ts
+++ b/src/renderer/src/extensions/download_management/util/downloadNames.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises";
 import * as path from "path";
 
 import type { IDownload } from "../types/IDownload";
@@ -46,4 +47,25 @@ export function friendlyDownloadName(download: IDownload): string | undefined {
 
   // Fall back to the temp name so sort/filter stay stable before metadata resolves.
   return friendly ?? localPath;
+}
+
+/**
+ * Returns fileName, or the first "name.n.ext" variant not already present in dlPath, so an existing
+ * download is never overwritten.
+ */
+export async function freeDownloadName(dlPath: string, fileName: string): Promise<string> {
+  const ext = path.extname(fileName);
+  const base = path.basename(fileName, ext);
+  let candidate = fileName;
+  let counter = 0;
+  while (
+    await access(path.join(dlPath, candidate)).then(
+      () => true,
+      () => false,
+    )
+  ) {
+    counter += 1;
+    candidate = `${base}.${counter}${ext}`;
+  }
+  return candidate;
 }

--- a/src/renderer/src/extensions/download_management/views/DownloadView.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadView.tsx
@@ -823,10 +823,15 @@ class DownloadView extends ComponentEx<IDownloadViewProps, IComponentState> {
 
   private dropDownload = (type: DropType, dlPaths: string[]) => {
     if (type === "urls") {
+      // A pasted url can't be fetched reliably without a browser: some sites (mega.nz, google
+      // drive, ...) deliver the file through client-side JavaScript as a blob, others sit behind a
+      // challenge/login page. There's no dependable way to tell those apart from a plain download
+      // link up front, so every pasted url goes through the embedded browser. A direct file link
+      // resolves and closes it near-instantly; anything else lets the user complete the download.
       dlPaths.forEach((url) =>
-        this.context.api.events.emit("start-download", [url], {}, undefined, (err: Error) => {
-          this.reportDownloadError(err, false);
-        }),
+        this.context.api.events.emit("browse-download-url", url, (err: Error) =>
+          this.reportDownloadError(err, false),
+        ),
       );
     } else {
       this.context.api.events.emit("import-downloads", dlPaths);


### PR DESCRIPTION
Pasted download URLs are routed through the embedded browser. When the browser hands back a blob (the file it has already saved to the temp folder), the IPC download adapter adopts it as a finished download: it moves the file into the game's download folder under a free name, hashes it, and registers it, taking the same completion path as a network download so it emits did-finish-download, fires the start-download callback, and triggers install.

This makes collection installs and manual downloads work for hosts that deliver files through client-side JavaScript rather than a fetchable URL (mega.nz, Google Drive, and similar), covering manual pastes, collection browse dependencies, and community extensions alike.

Sorry @erri120 - tried not to inflate the adapter any further but it's the only location that caters for all blob style downloads regardless of path.

closes LAZ-808