### PR TITLE
Cover blurred images so portraits stay visible in landscape frames

### DIFF
--- a/src/renderer/src/ui/components/image/Image.demo.tsx
+++ b/src/renderer/src/ui/components/image/Image.demo.tsx
@@ -126,6 +126,47 @@ export const ImageDemo = () => (
 
     <div className="space-y-4">
       <Typography as="h3" typographyType="heading-xs">
+        Blurred fills the frame
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        A blurred image always covers its frame, whatever its{" "}
+        <span className="font-semibold">fit</span>. Otherwise a portrait source in a landscape frame
+        would blur down to a barely-visible letterboxed smear.
+      </Typography>
+
+      <div className="flex flex-wrap items-end gap-6">
+        <div className="flex flex-col items-center gap-2">
+          <Image
+            alt="Portrait source in a landscape frame, not blurred"
+            className="w-56"
+            imageType="mod"
+            src="https://picsum.photos/seed/portrait/300/500"
+          />
+
+          <Typography appearance="subdued" typographyType="body-xs">
+            Not blurred (contain, letterboxed)
+          </Typography>
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <Image
+            isBlurred
+            alt="Portrait source in a landscape frame, blurred"
+            className="w-56"
+            imageType="mod"
+            src="https://picsum.photos/seed/portrait/300/500"
+          />
+
+          <Typography appearance="subdued" typographyType="body-xs">
+            Blurred (covers the frame)
+          </Typography>
+        </div>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
         Adult-aware
       </Typography>
 

--- a/src/renderer/src/ui/components/image/Image.tsx
+++ b/src/renderer/src/ui/components/image/Image.tsx
@@ -58,7 +58,7 @@ export const Image = ({
           className={joinClasses(
             [
               "absolute z-1 rounded-[inherit]",
-              fit === "cover" ? "size-full object-cover" : "max-h-full",
+              isBlurred || fit === "cover" ? "size-full object-cover" : "max-h-full",
               imageClassName,
             ],
             {


### PR DESCRIPTION
A blurred image now always uses object-cover regardless of its fit, since a letterboxed portrait in a landscape frame blurs down to a barely-visible smear. AdultAwareImage inherits this via Image. Adds a demo section comparing a portrait source in a landscape frame, blurred vs not.

<img width="1044" height="267" alt="image" src="https://github.com/user-attachments/assets/8c7a9b2b-4efc-4553-a6a2-5e8b3d7481aa" />
