### PR TITLE
heal names polluted by the 2.4.0-beta.1 storage-path regression (LAZ-807)

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -115,6 +115,7 @@ import {
 import { checkModVersion } from "./util/checkModsVersion";
 import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
 import { fillNexusIdByMD5, guessFromFileName, queryResetSource } from "./util/guessModID";
+import { isStoragePathName } from "./util/healStoragePathNames";
 import retrieveCategoryList from "./util/retrieveCategories";
 import Tracking from "./util/tracking";
 import { makeFileUID } from "./util/UIDs";
@@ -525,17 +526,6 @@ const ATTRIBUTES_CACHE_DURATION = 10 * 60 * 1000; // 10 minutes
 function processAttributes(state: IState, input: any, quick: boolean): PromiseBB<any> {
   const nexusChangelog = input.nexus?.fileInfo?.changelog_html;
 
-  const modName = decodeHTML(
-    input.download?.modInfo?.nexus?.modInfo?.name ?? input.download?.modInfo?.name,
-  );
-  const fileName = decodeHTML(
-    input.download?.modInfo?.nexus?.fileInfo?.name ??
-      input.download?.localPath ??
-      input.meta?.fileName,
-  );
-  const fuzzRatio =
-    modName !== undefined && fileName !== undefined ? fuzz.ratio(modName, fileName) : 100;
-
   let fetchPromise: PromiseBB<IRemoteInfo> = PromiseBB.resolve(undefined);
 
   let gameId = input.download?.modInfo?.game || input.download?.modInfo?.nexus?.ids?.gameId;
@@ -636,6 +626,17 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
     const nexusCollectionInfo: IRevision =
       info?.revisionInfo ?? input.download?.modInfo?.nexus?.revisionInfo;
 
+    // never accept a CDN storage path as a name (LAZ-807); `?? undefined`
+    // normalizes an explicit null, which would otherwise make decodeHTML
+    // return "" and defeat the fuzz-ratio guard below
+    const rawModName = nexusModInfo?.name ?? input.download?.modInfo?.name ?? undefined;
+    const modName = decodeHTML(isStoragePathName(rawModName) ? undefined : rawModName);
+    const fileName = decodeHTML(
+      nexusFileInfo?.name ?? input.download?.localPath ?? input.meta?.fileName,
+    );
+    const fuzzRatio =
+      modName !== undefined && fileName !== undefined ? fuzz.ratio(modName, fileName) : 100;
+
     const gameMode = activeGameId(state);
     const category = remapCategory(state, nexusModInfo?.category_id, gameId, gameMode);
 
@@ -646,7 +647,7 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
       collectionId:
         input.download?.modInfo?.nexus?.ids?.collectionId ?? nexusCollectionInfo?.collection?.id,
       revisionId: input.download?.modInfo?.nexus?.ids?.revisionId ?? nexusCollectionInfo?.id,
-      collectionSlug: nexusIds?.collectionSlug ?? nexusCollectionInfo?.collection["slug"],
+      collectionSlug: nexusIds?.collectionSlug ?? nexusCollectionInfo?.collection?.["slug"],
       revisionNumber: nexusIds?.revisionNumber ?? nexusCollectionInfo?.revisionNumber,
       author: nexusModInfo?.author ?? nexusCollectionInfo?.collection?.user?.name,
       uploader: nexusModInfo?.uploaded_by ?? nexusCollectionInfo?.collection?.user?.name,

--- a/src/renderer/src/extensions/nexus_integration/util/healStoragePathNames.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/healStoragePathNames.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import type { IState } from "../../../types/IState";
+import { setDownloadModInfo } from "../../download_management/actions/state";
+import { setModAttribute } from "../../mod_management/actions/mods";
+import {
+  healStoragePathNameActions,
+  isStoragePathName,
+  stripStoragePathPrefix,
+} from "./healStoragePathNames";
+
+const STORAGE_PATH = "5c/d3/1f/5cd31ffe-41b5-4520-8ac2-cc796226941e";
+
+function makeState(input: { downloads?: any; mods?: any }): IState {
+  return {
+    persistent: {
+      downloads: { files: input.downloads ?? {} },
+      mods: input.mods ?? {},
+    },
+  } as unknown as IState;
+}
+
+describe("isStoragePathName", () => {
+  it("detects CDN storage paths", () => {
+    expect(isStoragePathName(STORAGE_PATH)).toBe(true);
+    expect(isStoragePathName(`${STORAGE_PATH} - Fix Flickering Particles`)).toBe(true);
+  });
+
+  it("leaves ordinary names alone", () => {
+    expect(isStoragePathName("Fix Flickering Particles")).toBe(false);
+    expect(isStoragePathName("Mods/Textures HD")).toBe(false);
+    expect(isStoragePathName(undefined)).toBe(false);
+  });
+});
+
+describe("stripStoragePathPrefix", () => {
+  it("strips the storage-path prefix from a customFileName", () => {
+    expect(stripStoragePathPrefix(`${STORAGE_PATH} - Fix Flickering Particles`)).toBe(
+      "Fix Flickering Particles",
+    );
+  });
+
+  it("keeps separators inside the friendly part", () => {
+    expect(stripStoragePathPrefix(`${STORAGE_PATH} - SMIM - Special Edition`)).toBe(
+      "SMIM - Special Edition",
+    );
+  });
+
+  it("returns undefined when there is nothing to strip", () => {
+    expect(stripStoragePathPrefix("Fix Flickering Particles")).toBeUndefined();
+    expect(stripStoragePathPrefix(STORAGE_PATH)).toBeUndefined();
+  });
+});
+
+describe("healStoragePathNameActions", () => {
+  it("replaces a polluted download name with the friendly file name", () => {
+    const state = makeState({
+      downloads: {
+        dl1: {
+          modInfo: {
+            name: STORAGE_PATH,
+            nexus: { fileInfo: { name: "Fix Flickering Particles" } },
+          },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([
+      setDownloadModInfo("dl1", "name", "Fix Flickering Particles"),
+    ]);
+  });
+
+  it("leaves a polluted download alone when no friendly name is available", () => {
+    const state = makeState({
+      downloads: { dl1: { modInfo: { name: STORAGE_PATH } } },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([]);
+  });
+
+  it("strips the prefix from a polluted customFileName", () => {
+    const state = makeState({
+      mods: {
+        skyrimse: {
+          mod1: {
+            attributes: { customFileName: `${STORAGE_PATH} - Fix Flickering Particles` },
+          },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([
+      setModAttribute("skyrimse", "mod1", "customFileName", "Fix Flickering Particles"),
+    ]);
+  });
+
+  it("repairs logicalFileName and modName from the mod's download", () => {
+    const state = makeState({
+      downloads: {
+        dl1: {
+          modInfo: {
+            nexus: {
+              fileInfo: { name: "Fix Flickering Particles" },
+              modInfo: { name: "Flickering Particles Fix" },
+            },
+          },
+        },
+      },
+      mods: {
+        skyrimse: {
+          mod1: {
+            archiveId: "dl1",
+            attributes: { logicalFileName: STORAGE_PATH, modName: STORAGE_PATH },
+          },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([
+      setModAttribute("skyrimse", "mod1", "logicalFileName", "Fix Flickering Particles"),
+      setModAttribute("skyrimse", "mod1", "modName", "Flickering Particles Fix"),
+    ]);
+  });
+
+  it("heals modName from the file name when the mod name is missing (2.4.0-beta.1 cohort)", () => {
+    // the 2.4.0-beta.1 GraphQL query never populated nexus.modInfo.name; the file
+    // name is the only friendly name available
+    const state = makeState({
+      downloads: {
+        dl1: {
+          modInfo: {
+            nexus: { fileInfo: { name: "Fix Flickering Particles" }, modInfo: {} },
+          },
+        },
+      },
+      mods: {
+        skyrimse: {
+          mod1: { archiveId: "dl1", attributes: { modName: STORAGE_PATH } },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([
+      setModAttribute("skyrimse", "mod1", "modName", "Fix Flickering Particles"),
+    ]);
+  });
+
+  it("heals an archiveless mod from the name recovered out of customFileName", () => {
+    const state = makeState({
+      mods: {
+        skyrimse: {
+          mod1: {
+            attributes: {
+              customFileName: `${STORAGE_PATH} - Fix Flickering Particles`,
+              logicalFileName: STORAGE_PATH,
+              modName: STORAGE_PATH,
+            },
+          },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([
+      setModAttribute("skyrimse", "mod1", "customFileName", "Fix Flickering Particles"),
+      setModAttribute("skyrimse", "mod1", "logicalFileName", "Fix Flickering Particles"),
+      setModAttribute("skyrimse", "mod1", "modName", "Fix Flickering Particles"),
+    ]);
+  });
+
+  it("does nothing for healthy state (idempotent)", () => {
+    const state = makeState({
+      downloads: {
+        dl1: {
+          modInfo: {
+            name: "Fix Flickering Particles",
+            nexus: { fileInfo: { name: "Fix Flickering Particles" } },
+          },
+        },
+      },
+      mods: {
+        skyrimse: {
+          mod1: {
+            archiveId: "dl1",
+            attributes: {
+              customFileName: "Fix Flickering Particles",
+              logicalFileName: "Fix Flickering Particles",
+            },
+          },
+        },
+      },
+    });
+    expect(healStoragePathNameActions(state)).toEqual([]);
+  });
+});

--- a/src/renderer/src/extensions/nexus_integration/util/healStoragePathNames.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/healStoragePathNames.ts
@@ -1,0 +1,79 @@
+import type * as Redux from "redux";
+
+import type { IState } from "../../../types/IState";
+import { setDownloadModInfo } from "../../download_management/actions/state";
+import { setModAttribute } from "../../mod_management/actions/mods";
+
+// CDN storage paths ("5c/d3/1f/<guid>") leaked into name attributes on
+// 2.4.0-beta.1 (LAZ-807). The "xx/yy/zz/" prefix is enough to identify them;
+// no legitimate name starts with that.
+const STORAGE_PATH_PREFIX = /^[0-9a-f]{2}\/[0-9a-f]{2}\/[0-9a-f]{2}\//i;
+
+export function isStoragePathName(name: unknown): name is string {
+  return typeof name === "string" && STORAGE_PATH_PREFIX.test(name);
+}
+
+// "5c/d3/1f/<guid> - Friendly Name" -> "Friendly Name", undefined if not polluted
+export function stripStoragePathPrefix(name: string): string | undefined {
+  if (!isStoragePathName(name)) {
+    return undefined;
+  }
+  const sep = name.indexOf(" - ");
+  return sep !== -1 ? name.slice(sep + 3) : undefined;
+}
+
+/**
+ * Repair names polluted by the 2.4.0-beta.1 storage-path regression (LAZ-807).
+ * Idempotent; applied once via the healStoragePathNames_2_4 migration.
+ */
+export function healStoragePathNameActions(state: IState): Redux.Action[] {
+  const actions: Redux.Action[] = [];
+  const downloads = state.persistent.downloads?.files ?? {};
+
+  for (const [dlId, download] of Object.entries(downloads)) {
+    if (isStoragePathName(download.modInfo?.name)) {
+      const friendly = download.modInfo?.nexus?.fileInfo?.name;
+      if (friendly) {
+        actions.push(setDownloadModInfo(dlId, "name", friendly));
+      }
+    }
+  }
+
+  for (const [gameId, gameMods] of Object.entries(state.persistent.mods ?? {})) {
+    for (const [modId, mod] of Object.entries(gameMods)) {
+      const attributes = mod.attributes ?? {};
+      const download = mod.archiveId !== undefined ? downloads[mod.archiveId] : undefined;
+
+      const stripped =
+        typeof attributes.customFileName === "string"
+          ? stripStoragePathPrefix(attributes.customFileName)
+          : undefined;
+      if (stripped !== undefined) {
+        actions.push(setModAttribute(gameId, modId, "customFileName", stripped));
+      }
+
+      // modInfo.name is missing on the polluted downloads, so fall back to the
+      // file name, then to the name recovered from customFileName (covers mods
+      // whose archive was deleted)
+      const fileName = download?.modInfo?.nexus?.fileInfo?.name;
+
+      if (isStoragePathName(attributes.logicalFileName)) {
+        const friendlyFile = fileName ?? stripped;
+        if (friendlyFile) {
+          actions.push(setModAttribute(gameId, modId, "logicalFileName", friendlyFile));
+        }
+      }
+
+      if (isStoragePathName(attributes.modName)) {
+        const friendlyMod = (download?.modInfo?.nexus?.modInfo?.name ??
+          fileName ??
+          stripped) as string;
+        if (friendlyMod) {
+          actions.push(setModAttribute(gameId, modId, "modName", friendlyMod));
+        }
+      }
+    }
+  }
+
+  return actions;
+}

--- a/src/renderer/src/util/migrate.test.ts
+++ b/src/renderer/src/util/migrate.test.ts
@@ -331,7 +331,9 @@ describe("moveDomainFolders_2_1 migration", () => {
     const { downloadsRoot, store, dispatch } = await buildScenario({
       downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
       knownGames: [skyrimseGame],
-      migrations: ["moveDomainFolders_2_1"],
+      // healStoragePathNames_2_4 included so the strict no-dispatch assertion
+      // below stays scoped to moveDomainFolders_2_1
+      migrations: ["moveDomainFolders_2_1", "healStoragePathNames_2_4"],
     });
     const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
     await fs.mkdir(fromDir, { recursive: true });
@@ -347,6 +349,9 @@ describe("moveDomainFolders_2_1 migration", () => {
     const { downloadsRoot, store, dispatch } = await buildScenario({
       downloads: { dl1: { localPath: "MyMod.7z", game: ["skyrimspecialedition"] } },
       knownGames: [skyrimseGame],
+      // this test gates on semver only; mark later migrations as applied so
+      // the strict no-dispatch assertion stays scoped to moveDomainFolders_2_1
+      migrations: ["healStoragePathNames_2_4"],
     });
     const fromDir = path.join(downloadsRoot, "skyrimspecialedition");
     await fs.mkdir(fromDir, { recursive: true });
@@ -371,5 +376,57 @@ describe("moveDomainFolders_2_1 migration", () => {
     await migrate(store, "2.1.0-beta.4");
 
     expect((await fs.stat(path.join(toDir, "MyMod.7z"))).isFile()).toBe(true);
+  });
+});
+
+describe("healStoragePathNames_2_4 migration", () => {
+  const STORAGE_PATH = "5c/d3/1f/5cd31ffe-41b5-4520-8ac2-cc796226941e";
+
+  it("fires for users upgrading from the affected 2.4.0-beta.1 to the fix in 2.4.0-beta.2", async () => {
+    const { store, dispatch } = await buildScenario({
+      downloads: {
+        dl1: {
+          localPath: "MyMod.7z",
+          game: ["skyrimse"],
+          modInfo: {
+            name: STORAGE_PATH,
+            nexus: { fileInfo: { name: "Friendly Name" } },
+          },
+        } as Partial<IDownload>,
+      },
+      knownGames: [skyrimseGame],
+    });
+
+    await migrate(store, "2.4.0-beta.1");
+
+    const actions = unwrapDispatched(dispatch);
+    const healed = actions.find(
+      (a) => a?.type === "SET_DOWNLOAD_MODINFO" && a.payload?.value === "Friendly Name",
+    );
+    expect(healed).toBeDefined();
+    const completed = actions.find(
+      (a) => a?.type === "COMPLETE_MIGRATION" && a.payload === "healStoragePathNames_2_4",
+    );
+    expect(completed).toBeDefined();
+  });
+
+  it("does not run when oldVersion is already >= 2.4.0-beta.2", async () => {
+    const { store, dispatch } = await buildScenario({
+      downloads: {
+        dl1: {
+          localPath: "MyMod.7z",
+          game: ["skyrimse"],
+          modInfo: {
+            name: STORAGE_PATH,
+            nexus: { fileInfo: { name: "Friendly Name" } },
+          },
+        } as Partial<IDownload>,
+      },
+      knownGames: [skyrimseGame],
+    });
+
+    await migrate(store, "2.4.0-beta.2");
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/util/migrate.ts
+++ b/src/renderer/src/util/migrate.ts
@@ -25,6 +25,7 @@ import { knownGames } from "../extensions/gamemode_management/selectors";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import resolvePath, { pathDefaults } from "../extensions/mod_management/util/resolvePath";
 import { convertGameIdReverse } from "../extensions/nexus_integration/util/convertGameId";
+import { healStoragePathNameActions } from "../extensions/nexus_integration/util/healStoragePathNames";
 import { activeGameId } from "../extensions/profile_management/selectors";
 import { log } from "../logging";
 import type { IState } from "../types/IState";
@@ -367,6 +368,17 @@ async function moveDomainFolders_2_1(store: Redux.Store<IState>): Promise<void> 
   });
 }
 
+function healStoragePathNames_2_4(store: Redux.Store<IState>): PromiseBB<void> {
+  const actions = healStoragePathNameActions(store.getState());
+  if (actions.length > 0) {
+    log("info", "migration: healing storage-path polluted names", {
+      count: actions.length,
+    });
+    batchDispatch(store, actions);
+  }
+  return PromiseBB.resolve();
+}
+
 const migrations: IMigration[] = [
   {
     id: "move-downloads-0.16",
@@ -414,6 +426,18 @@ const migrations: IMigration[] = [
       "Move downloads saved under Nexus domain folders (e.g. skyrimspecialedition) " +
       "to the internal-id folder (skyrimse) used by the rest of Vortex.",
     apply: moveDomainFolders_2_1,
+  },
+  {
+    id: "healStoragePathNames_2_4",
+    // Bug shipped in 2.4.0-beta.1 (LAZ-807); fix lands in 2.4.0-beta.2.
+    // Targeting the fix version covers the entire affected cohort.
+    minVersion: "2.4.0-beta.2",
+    maySkip: false,
+    doQuery: false,
+    description:
+      "Repair mod and download names polluted with CDN storage paths " +
+      '("5c/d3/1f/<guid>") by 2.4.0-beta.1.',
+    apply: healStoragePathNames_2_4,
   },
 ];
 


### PR DESCRIPTION
LAZ-807 left CDN storage paths ("5c/d3/1f/<guid>") persisted in download names and mod attributes (customFileName/logicalFileName/modName). The fix in #23726 only stopped new pollution; this repairs existing state:

- healStoragePathNames_2_4 one-shot migration (minVersion 2.4.0-beta.2) restores friendly names from nexus.fileInfo.name, falling back to the name recovered from customFileName for mods whose archive is gone
- processAttributes now rejects storage paths as mod names, normalizes explicit-null names before decodeHTML, and guards the collection slug access that could throw away all nexus attributes on install

closes LAZ-807