### PR TITLE
fixed collection cards displaying archive name instead of col name

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -626,14 +626,24 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
     const nexusCollectionInfo: IRevision =
       info?.revisionInfo ?? input.download?.modInfo?.nexus?.revisionInfo;
 
+    // collections are identified by their revision info, not a downloaded file. Their
+    // display name is the collection name; the archive on disk is not a meaningful name.
+    const isCollection = nexusCollectionInfo !== undefined;
+    const collectionName = nexusCollectionInfo?.collection?.name;
+
     // never accept a CDN storage path as a name (LAZ-807); `?? undefined`
     // normalizes an explicit null, which would otherwise make decodeHTML
     // return "" and defeat the fuzz-ratio guard below
-    const rawModName = nexusModInfo?.name ?? input.download?.modInfo?.name ?? undefined;
+    const rawModName =
+      nexusModInfo?.name ?? collectionName ?? input.download?.modInfo?.name ?? undefined;
     const modName = decodeHTML(isStoragePathName(rawModName) ? undefined : rawModName);
-    const fileName = decodeHTML(
-      nexusFileInfo?.name ?? input.download?.localPath ?? input.meta?.fileName,
-    );
+    // for collections the "file name" is the collection name, never the archive/localPath:
+    // deriving logicalFileName/customFileName from the archive is what surfaced archive
+    // and storage-path names on collection cards
+    const rawFileName = isCollection
+      ? (collectionName ?? input.download?.modInfo?.name)
+      : (nexusFileInfo?.name ?? input.download?.localPath ?? input.meta?.fileName);
+    const fileName = decodeHTML(isStoragePathName(rawFileName) ? undefined : rawFileName);
     const fuzzRatio =
       modName !== undefined && fileName !== undefined ? fuzz.ratio(modName, fileName) : 100;
 


### PR DESCRIPTION
The nexus attribute extractor derives logicalFileName and customFileName from the resolved file name, which for collections falls through to the download localPath (the archive on disk) because collections carry no fileInfo. The extractor is not modType-aware, so it stamps the archive name onto collection mods, and it surfaces on the collection card.

Make processAttributes collection-aware: for a collection (identified by its revision info) take the name from revisionInfo.collection.name rather than the archive, and reject a CDN storage path as the resolved file name.

closes LAZ-812