### PR TITLE
hash files on a main-process worker pool (LAZ-774)

### DIFF
--- a/src/main/build.mjs
+++ b/src/main/build.mjs
@@ -29,21 +29,33 @@ const bootstrapConfig = createConfig(BOOTSTRAP_INPUT, BOOTSTRAP_OUTPUT, "esm", [
 const bootstrapBundle = await rolldown(bootstrapConfig);
 await bootstrapBundle.write(bootstrapConfig.output);
 
-// bsdiff patch worker: bundled as a standalone CJS entry next to main.cjs and
-// spawned as a worker_thread by src/main/src/bsdiff/host.ts. hdiff.wasm is
-// copied alongside so the worker reads it by a path relative to itself.
-const BSDIFF_WORKER_INPUT = path.resolve(import.meta.dirname, "./src/bsdiff/worker.ts");
-const BSDIFF_WORKER_OUTPUT = path.join(mainOutputDirectory, "bsdiff-worker.cjs");
+// Each worker_thread bundles to a standalone CJS entry next to main.cjs, spawned
+// by its host. They share one external policy: bundle relative/local sources,
+// leave node built-ins and dependencies external.
+async function bundleWorker(inputRelPath, outputName) {
+  const config = createConfig(
+    path.resolve(import.meta.dirname, inputRelPath),
+    path.join(mainOutputDirectory, outputName),
+    "cjs",
+    [],
+    (id) => {
+      if (id.startsWith(".")) return false;
+      if (path.isAbsolute(id)) return false;
 
-const bsdiffConfig = createConfig(BSDIFF_WORKER_INPUT, BSDIFF_WORKER_OUTPUT, "cjs", [], (id) => {
-  if (id.startsWith(".")) return false;
-  if (path.isAbsolute(id)) return false;
+      return true;
+    },
+  );
+  const bundle = await rolldown(config);
+  await bundle.write(config.output);
+}
 
-  return true;
-});
+// bsdiff patch worker (src/main/src/bsdiff/host.ts). hdiff.wasm is copied
+// alongside below so the worker reads it by a path relative to itself.
+await bundleWorker("./src/bsdiff/worker.ts", "bsdiff-worker.cjs");
 
-const bsdiffBundle = await rolldown(bsdiffConfig);
-await bsdiffBundle.write(bsdiffConfig.output);
+// hash worker (src/main/src/hash/host.ts). Uses node's crypto, so there is
+// nothing extra to copy alongside it.
+await bundleWorker("./src/hash/worker.ts", "hash-worker.cjs");
 
 const require = createRequire(import.meta.url);
 const wasmPackageDir = path.resolve(require.resolve("@hot-updater/bsdiff"), "..", "..");

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -23,6 +23,7 @@ import uuidpkg from "uuid";
 const { v4: uuidv4 } = uuidpkg;
 import winapi from "winapi-bindings";
 
+import { shutdownBsdiffWorker } from "./bsdiff/host";
 import { parseCommandline, updateStartupSettings } from "./cli";
 import { installDevelExtensions } from "./devel";
 import { terminate, terminateAsync } from "./errorHandling";
@@ -30,6 +31,7 @@ import { disableErrorReporting, reportCrash } from "./errorReporting";
 import { setupMainExtensions } from "./extensions";
 import { validateFiles } from "./fileValidation";
 import { getVortexPath, setVortexPath } from "./getVortexPath";
+import { shutdownHashWorker } from "./hash/host";
 import { log, setupLogging, changeLogPath } from "./logging";
 import MainWindow from "./MainWindow";
 import SplashScreen from "./SplashScreen";
@@ -205,6 +207,9 @@ class Application {
           log("info", "clean application end");
           DuckDBSingleton.getInstance().close();
           this.mTray?.close();
+          // Terminate the worker_thread pools so no idle worker lingers past quit.
+          void shutdownHashWorker();
+          void shutdownBsdiffWorker();
           if (process.platform !== "darwin") {
             app.quit();
           }

--- a/src/main/src/hash/compute.ts
+++ b/src/main/src/hash/compute.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure file-hashing core, kept separate from worker.ts (a worker_thread entry
+ * point with parentPort side effects) so it can be unit-tested directly.
+ */
+
+import { createHash, getHashes } from "node:crypto";
+import * as fs from "node:fs";
+
+const supportedAlgorithms = new Set(getHashes());
+
+/** True if the algorithm name is one crypto.createHash accepts on this build. */
+export function isSupportedAlgorithm(algorithm: string): boolean {
+  return supportedAlgorithms.has(algorithm);
+}
+
+/**
+ * Stream a file and compute its hex digest. Rejects on an unsupported algorithm
+ * or any read error. numBytes is the number of bytes hashed (the file size).
+ */
+export function hashFileStream(
+  algorithm: string,
+  filePath: string,
+): Promise<{ hash: string; numBytes: number }> {
+  return new Promise((resolve, reject) => {
+    if (!isSupportedAlgorithm(algorithm)) {
+      reject(new Error(`unsupported hash algorithm: ${algorithm}`));
+      return;
+    }
+    const hash = createHash(algorithm);
+    let numBytes = 0;
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk: string | Buffer) => {
+      hash.update(chunk);
+      numBytes += chunk.length;
+    });
+    stream.on("end", () => resolve({ hash: hash.digest("hex"), numBytes }));
+    stream.on("error", reject);
+  });
+}

--- a/src/main/src/hash/compute.ts
+++ b/src/main/src/hash/compute.ts
@@ -4,7 +4,8 @@
  */
 
 import { createHash, getHashes } from "node:crypto";
-import * as fs from "node:fs";
+import { createReadStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
 
 const supportedAlgorithms = new Set(getHashes());
 
@@ -17,23 +18,15 @@ export function isSupportedAlgorithm(algorithm: string): boolean {
  * Stream a file and compute its hex digest. Rejects on an unsupported algorithm
  * or any read error. numBytes is the number of bytes hashed (the file size).
  */
-export function hashFileStream(
+export async function hashFileStream(
   algorithm: string,
   filePath: string,
 ): Promise<{ hash: string; numBytes: number }> {
-  return new Promise((resolve, reject) => {
-    if (!isSupportedAlgorithm(algorithm)) {
-      reject(new Error(`unsupported hash algorithm: ${algorithm}`));
-      return;
-    }
-    const hash = createHash(algorithm);
-    let numBytes = 0;
-    const stream = fs.createReadStream(filePath);
-    stream.on("data", (chunk: string | Buffer) => {
-      hash.update(chunk);
-      numBytes += chunk.length;
-    });
-    stream.on("end", () => resolve({ hash: hash.digest("hex"), numBytes }));
-    stream.on("error", reject);
-  });
+  if (!isSupportedAlgorithm(algorithm)) {
+    throw new Error(`unsupported hash algorithm: ${algorithm}`);
+  }
+  const hash = createHash(algorithm);
+  const source = createReadStream(filePath);
+  await pipeline(source, hash);
+  return { hash: hash.digest("hex"), numBytes: source.bytesRead };
 }

--- a/src/main/src/hash/hash.test.ts
+++ b/src/main/src/hash/hash.test.ts
@@ -1,0 +1,79 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { hashFileStream, isSupportedAlgorithm } from "./compute";
+
+// deterministic pseudo-random bytes so digests are reproducible across runs
+function generateBytes(size: number, seed: number): Buffer {
+  const buf = Buffer.alloc(size);
+  let state = seed;
+  for (let i = 0; i < size; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    buf[i] = state & 0xff;
+  }
+  return buf;
+}
+
+function reference(algorithm: string, buf: Buffer): string {
+  return crypto.createHash(algorithm).update(buf).digest("hex");
+}
+
+const SIZES = [
+  { name: "empty", size: 0, seed: 1 },
+  { name: "1kb", size: 1024, seed: 42 },
+  { name: "100kb", size: 102400, seed: 200 },
+  // larger than the default 64kb read highWaterMark, so multiple chunks stream
+  { name: "1mb", size: 1048576, seed: 300 },
+];
+
+const ALGORITHMS = ["md5", "sha1", "sha256"];
+
+let tmpDir: string;
+const filePathFor = (name: string) => path.join(tmpDir, `${name}.bin`);
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hash-test-"));
+  for (const tc of SIZES) {
+    fs.writeFileSync(filePathFor(tc.name), generateBytes(tc.size, tc.seed));
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("hashFileStream - correctness", () => {
+  for (const algorithm of ALGORITHMS) {
+    for (const tc of SIZES) {
+      it(`${algorithm} matches crypto for ${tc.name}`, async () => {
+        const buf = generateBytes(tc.size, tc.seed);
+        const { hash, numBytes } = await hashFileStream(algorithm, filePathFor(tc.name));
+        expect(hash).toBe(reference(algorithm, buf));
+        expect(numBytes).toBe(tc.size);
+      });
+    }
+  }
+});
+
+describe("hashFileStream - error handling", () => {
+  it("rejects an unsupported algorithm", async () => {
+    await expect(hashFileStream("not-a-real-hash", filePathFor("1kb"))).rejects.toThrow(
+      /unsupported hash algorithm/,
+    );
+  });
+
+  it("rejects when the file does not exist", async () => {
+    await expect(hashFileStream("md5", path.join(tmpDir, "missing.bin"))).rejects.toThrow();
+  });
+});
+
+describe("isSupportedAlgorithm", () => {
+  it("accepts md5 and rejects nonsense", () => {
+    expect(isSupportedAlgorithm("md5")).toBe(true);
+    expect(isSupportedAlgorithm("not-a-real-hash")).toBe(false);
+  });
+});

--- a/src/main/src/hash/host.test.ts
+++ b/src/main/src/hash/host.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+
+import { HashWorkerPool } from "./host";
+import type { HashWorker } from "./host";
+import type { HashJob, HashResult } from "./protocol";
+
+// A worker stand-in whose responses the test drives explicitly. postMessage
+// records the job; the emit* helpers fire the events the pool listens for.
+class FakeWorker implements HashWorker {
+  readonly posted: HashJob[] = [];
+  terminated = false;
+  readonly #messageListeners: Array<(result: HashResult) => void> = [];
+  readonly #errorListeners: Array<(err: Error) => void> = [];
+  readonly #exitListeners: Array<(code: number) => void> = [];
+
+  postMessage(message: HashJob): void {
+    this.posted.push(message);
+  }
+
+  on(event: "message", listener: (result: HashResult) => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  on(event: "exit", listener: (code: number) => void): void;
+  on(
+    event: "message" | "error" | "exit",
+    listener: ((result: HashResult) => void) | ((err: Error) => void) | ((code: number) => void),
+  ): void {
+    if (event === "message") {
+      this.#messageListeners.push(listener as (result: HashResult) => void);
+    } else if (event === "error") {
+      this.#errorListeners.push(listener as (err: Error) => void);
+    } else {
+      this.#exitListeners.push(listener as (code: number) => void);
+    }
+  }
+
+  terminate(): Promise<number> {
+    this.terminated = true;
+    return Promise.resolve(0);
+  }
+
+  unref(): void {
+    // no-op: nothing to unref for a fake
+  }
+
+  emitMessage(result: HashResult): void {
+    for (const listener of this.#messageListeners) {
+      listener(result);
+    }
+  }
+
+  emitError(err: Error): void {
+    for (const listener of this.#errorListeners) {
+      listener(err);
+    }
+  }
+
+  get lastJob(): HashJob {
+    return this.jobAt(this.posted.length - 1);
+  }
+
+  jobAt(index: number): HashJob {
+    const job = this.posted[index];
+    if (job === undefined) {
+      throw new Error(`worker has no job at index ${index}`);
+    }
+    return job;
+  }
+}
+
+function nthWorker(workers: FakeWorker[], index: number): FakeWorker {
+  const worker = workers[index];
+  if (worker === undefined) {
+    throw new Error(`no worker at index ${index}`);
+  }
+  return worker;
+}
+
+function trackingFactory(): { factory: () => HashWorker; workers: FakeWorker[] } {
+  const workers: FakeWorker[] = [];
+  return {
+    workers,
+    factory: () => {
+      const worker = new FakeWorker();
+      workers.push(worker);
+      return worker;
+    },
+  };
+}
+
+describe("HashWorkerPool", () => {
+  it("spawns the pool lazily and resolves a job with the worker's result", async () => {
+    const { factory, workers } = trackingFactory();
+    const pool = new HashWorkerPool(factory, 2);
+
+    const result = pool.hashFile("md5", "/a");
+    expect(workers).toHaveLength(2);
+
+    const worker = nthWorker(workers, 0);
+    worker.emitMessage({ id: worker.lastJob.id, hash: "abc", numBytes: 10 });
+
+    await expect(result).resolves.toEqual({ hash: "abc", numBytes: 10 });
+  });
+
+  it("queues jobs beyond the pool size and dispatches them as workers free up", async () => {
+    const { factory, workers } = trackingFactory();
+    const pool = new HashWorkerPool(factory, 2);
+
+    const p1 = pool.hashFile("md5", "/1");
+    const p2 = pool.hashFile("md5", "/2");
+    const p3 = pool.hashFile("md5", "/3");
+
+    // Two workers, three jobs: two dispatched, one queued.
+    expect(workers.flatMap((w) => w.posted)).toHaveLength(2);
+
+    const w0 = nthWorker(workers, 0);
+    const w1 = nthWorker(workers, 1);
+    w0.emitMessage({ id: w0.lastJob.id, hash: "h1", numBytes: 1 });
+    // Freeing w0 pulls the queued third job onto it.
+    expect(w0.posted).toHaveLength(2);
+    expect(w0.jobAt(1).filePath).toBe("/3");
+
+    w0.emitMessage({ id: w0.lastJob.id, hash: "h3", numBytes: 3 });
+    w1.emitMessage({ id: w1.lastJob.id, hash: "h2", numBytes: 2 });
+
+    await expect(p1).resolves.toEqual({ hash: "h1", numBytes: 1 });
+    await expect(p2).resolves.toEqual({ hash: "h2", numBytes: 2 });
+    await expect(p3).resolves.toEqual({ hash: "h3", numBytes: 3 });
+  });
+
+  it("rejects only the crashed worker's job and replaces the worker", async () => {
+    const { factory, workers } = trackingFactory();
+    const pool = new HashWorkerPool(factory, 2);
+
+    const p1 = pool.hashFile("md5", "/1");
+    const p2 = pool.hashFile("md5", "/2");
+
+    const w0 = nthWorker(workers, 0);
+    const w1 = nthWorker(workers, 1);
+    w0.emitError(new Error("boom"));
+
+    await expect(p1).rejects.toThrow("boom");
+    // A replacement worker was spawned to restore the pool.
+    expect(workers).toHaveLength(3);
+
+    // The other in-flight job is unaffected.
+    w1.emitMessage({ id: w1.lastJob.id, hash: "h2", numBytes: 2 });
+    await expect(p2).resolves.toEqual({ hash: "h2", numBytes: 2 });
+  });
+
+  it("rejects the job and drops it from the queue when a worker cannot be spawned", async () => {
+    const workers: FakeWorker[] = [];
+    let calls = 0;
+    const factory = (): HashWorker => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("spawn failed");
+      }
+      const worker = new FakeWorker();
+      workers.push(worker);
+      return worker;
+    };
+    const pool = new HashWorkerPool(factory, 1);
+
+    await expect(pool.hashFile("md5", "/first")).rejects.toThrow("spawn failed");
+
+    // The second call spawns successfully; the first job must not linger in the
+    // queue and run on this worker, or it would hash for an already-rejected
+    // promise.
+    const p2 = pool.hashFile("md5", "/second");
+    const worker = nthWorker(workers, 0);
+    expect(worker.posted).toHaveLength(1);
+    expect(worker.jobAt(0).filePath).toBe("/second");
+
+    worker.emitMessage({ id: worker.lastJob.id, hash: "ok", numBytes: 1 });
+    await expect(p2).resolves.toEqual({ hash: "ok", numBytes: 1 });
+  });
+
+  it("does not park a worker when a message arrives with an unexpected id", async () => {
+    const { factory, workers } = trackingFactory();
+    const pool = new HashWorkerPool(factory, 1);
+
+    const p1 = pool.hashFile("md5", "/1");
+    const p2 = pool.hashFile("md5", "/2");
+
+    const worker = nthWorker(workers, 0);
+    expect(worker.posted).toHaveLength(1);
+
+    // A stray message whose id matches no outstanding job must still free the
+    // slot so the queued job is picked up.
+    worker.emitMessage({ id: worker.lastJob.id + 999, hash: "stray", numBytes: 0 });
+    expect(worker.posted).toHaveLength(2);
+    expect(worker.jobAt(1).filePath).toBe("/2");
+
+    worker.emitMessage({ id: worker.lastJob.id, hash: "ok", numBytes: 5 });
+    await expect(p2).resolves.toEqual({ hash: "ok", numBytes: 5 });
+
+    // p1's job was abandoned by the protocol violation; it stays pending.
+    void p1;
+  });
+
+  it("terminates every worker on shutdown", async () => {
+    const { factory, workers } = trackingFactory();
+    const pool = new HashWorkerPool(factory, 3);
+
+    void pool.hashFile("md5", "/1");
+    expect(workers).toHaveLength(3);
+
+    await pool.shutdown();
+    expect(workers.every((w) => w.terminated)).toBe(true);
+  });
+});

--- a/src/main/src/hash/host.ts
+++ b/src/main/src/hash/host.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { Worker } from "node:worker_threads";
 
 import { getErrorMessageOrDefault, VortexError } from "@vortex/shared";
+import type { HashAlgorithm } from "@vortex/shared/ipc";
 
 import type { HashJob, HashResult } from "./protocol";
 
@@ -45,7 +46,7 @@ export interface HashWorker {
 
 interface Job {
   id: number;
-  algorithm: string;
+  algorithm: HashAlgorithm;
   filePath: string;
   resolve: (result: HashFileResult) => void;
   reject: (err: Error) => void;
@@ -80,11 +81,10 @@ export class HashWorkerPool {
   }
 
   /**
-   * Compute the hex digest of a file off-thread. algorithm is any name accepted
-   * by crypto.createHash / listed by crypto.getHashes(). Concurrent calls run in
+   * Compute the hex digest of a file off-thread. Concurrent calls run in
    * parallel up to the pool size; the rest queue.
    */
-  hashFile(algorithm: string, filePath: string): Promise<HashFileResult> {
+  hashFile(algorithm: HashAlgorithm, filePath: string): Promise<HashFileResult> {
     return new Promise<HashFileResult>((resolve, reject) => {
       const job: Job = { id: this.#nextId++, algorithm, filePath, resolve, reject };
       this.#queue.push(job);
@@ -195,11 +195,8 @@ export class HashWorkerPool {
 
 const defaultPool = new HashWorkerPool();
 
-/**
- * Compute the hex digest of a file off-thread on the shared pool. algorithm is
- * any name accepted by crypto.createHash / listed by crypto.getHashes().
- */
-export function hashFile(algorithm: string, filePath: string): Promise<HashFileResult> {
+/** Compute the hex digest of a file off-thread on the shared pool. */
+export function hashFile(algorithm: HashAlgorithm, filePath: string): Promise<HashFileResult> {
   return defaultPool.hashFile(algorithm, filePath);
 }
 

--- a/src/main/src/hash/host.ts
+++ b/src/main/src/hash/host.ts
@@ -1,0 +1,209 @@
+/**
+ * Owns a small pool of hash worker_threads for the main process and exposes a
+ * promise-returning file-hash operation. Workers are spawned lazily on the first
+ * job; each worker processes one job at a time and jobs beyond the pool size
+ * queue until a worker frees up. This keeps concurrent download finalizations
+ * from serializing on a single thread. A crashed worker rejects only the job it
+ * was running and is replaced on the next dispatch.
+ *
+ * The pool is a class parameterized by a worker factory so the scheduling logic
+ * can be unit-tested with a fake worker; the process shares one default instance
+ * exposed via hashFile / shutdownHashWorker.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { Worker } from "node:worker_threads";
+
+import { getErrorMessageOrDefault, VortexError } from "@vortex/shared";
+
+import type { HashJob, HashResult } from "./protocol";
+
+const WORKER_SCRIPT = path.join(__dirname, "hash-worker.cjs");
+
+// Hashing is largely disk-bound, so a small pool is enough to stop concurrent
+// finalizations serializing without thrashing the disk with too many readers.
+const POOL_SIZE = Math.max(2, Math.min(4, os.cpus().length - 1));
+
+export interface HashFileResult {
+  hash: string;
+  numBytes: number;
+}
+
+/**
+ * The subset of worker_threads.Worker the pool depends on. Kept minimal so a
+ * fake worker can stand in during tests.
+ */
+export interface HashWorker {
+  postMessage(message: HashJob): void;
+  on(event: "message", listener: (result: HashResult) => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  on(event: "exit", listener: (code: number) => void): void;
+  terminate(): Promise<unknown>;
+  unref(): void;
+}
+
+interface Job {
+  id: number;
+  algorithm: string;
+  filePath: string;
+  resolve: (result: HashFileResult) => void;
+  reject: (err: Error) => void;
+}
+
+interface PoolWorker {
+  worker: HashWorker;
+  job: Job | undefined;
+}
+
+function defaultCreateWorker(): HashWorker {
+  return new Worker(WORKER_SCRIPT);
+}
+
+// Surface pool failures as VortexError so the reworked error system classifies
+// them by data.kind; prototype identity is lost across the worker/IPC boundaries.
+function hashWorkerError(message: string, cause?: unknown): VortexError {
+  return new VortexError(message, { kind: "setup-error", component: "hash-worker" }, { cause });
+}
+
+export class HashWorkerPool {
+  readonly #createWorker: () => HashWorker;
+  readonly #size: number;
+  readonly #pool: PoolWorker[] = [];
+  readonly #queue: Job[] = [];
+  #nextId = 0;
+  #shuttingDown = false;
+
+  constructor(createWorker: () => HashWorker = defaultCreateWorker, size: number = POOL_SIZE) {
+    this.#createWorker = createWorker;
+    this.#size = Math.max(1, size);
+  }
+
+  /**
+   * Compute the hex digest of a file off-thread. algorithm is any name accepted
+   * by crypto.createHash / listed by crypto.getHashes(). Concurrent calls run in
+   * parallel up to the pool size; the rest queue.
+   */
+  hashFile(algorithm: string, filePath: string): Promise<HashFileResult> {
+    return new Promise<HashFileResult>((resolve, reject) => {
+      const job: Job = { id: this.#nextId++, algorithm, filePath, resolve, reject };
+      this.#queue.push(job);
+      try {
+        this.#ensurePool();
+      } catch (err) {
+        // Spawning a worker failed (e.g. the bundled worker script is missing).
+        // Drop the job we just queued so a later spawn can't run it for an
+        // already-rejected promise, then surface the failure.
+        const idx = this.#queue.indexOf(job);
+        if (idx !== -1) {
+          this.#queue.splice(idx, 1);
+        }
+        reject(hashWorkerError(getErrorMessageOrDefault(err), err));
+        return;
+      }
+      this.#drain();
+    });
+  }
+
+  /** Terminate all workers. Call during app shutdown. */
+  async shutdown(): Promise<void> {
+    this.#shuttingDown = true;
+    const workers = this.#pool.splice(0, this.#pool.length);
+    await Promise.all(workers.map((pw) => pw.worker.terminate()));
+  }
+
+  // Assign the next queued job to a now-idle worker, or leave it idle.
+  #assignNext(pw: PoolWorker): void {
+    const next = this.#queue.shift();
+    pw.job = next;
+    if (next !== undefined) {
+      pw.worker.postMessage({
+        id: next.id,
+        algorithm: next.algorithm,
+        filePath: next.filePath,
+      } satisfies HashJob);
+    }
+  }
+
+  #handleFailure(pw: PoolWorker, err: Error): void {
+    const idx = this.#pool.indexOf(pw);
+    if (idx !== -1) {
+      this.#pool.splice(idx, 1);
+    }
+    const job = pw.job;
+    pw.job = undefined;
+    if (job !== undefined) {
+      job.reject(err);
+    }
+    if (this.#shuttingDown) {
+      return;
+    }
+    this.#ensurePool();
+    this.#drain();
+  }
+
+  #spawnWorker(): void {
+    const worker = this.#createWorker();
+    const pw: PoolWorker = { worker, job: undefined };
+    worker.on("message", (result: HashResult) => {
+      const job = pw.job;
+      if (job !== undefined && job.id === result.id) {
+        if (result.error !== undefined) {
+          job.reject(hashWorkerError(result.error));
+        } else {
+          job.resolve({ hash: result.hash ?? "", numBytes: result.numBytes ?? 0 });
+        }
+      }
+      // A worker answers each job with exactly one message, so any message means
+      // it is now idle. Hand it the next job even if the id was unexpected, so a
+      // stray message can never permanently park this pool slot.
+      this.#assignNext(pw);
+    });
+    worker.on("error", (err: Error) => this.#handleFailure(pw, hashWorkerError(err.message, err)));
+    worker.on("exit", (code: number) => {
+      if (code !== 0) {
+        this.#handleFailure(
+          pw,
+          hashWorkerError(`hash worker stopped unexpectedly (exit code ${code})`),
+        );
+      }
+    });
+    // Don't let idle workers keep the main process alive at shutdown; any
+    // in-flight job at quit time is abandoned, which is acceptable.
+    worker.unref();
+    this.#pool.push(pw);
+  }
+
+  #ensurePool(): void {
+    for (let i = this.#pool.length; i < this.#size; i += 1) {
+      this.#spawnWorker();
+    }
+  }
+
+  // Hand queued jobs to any idle workers.
+  #drain(): void {
+    for (const pw of this.#pool) {
+      if (this.#queue.length === 0) {
+        break;
+      }
+      if (pw.job === undefined) {
+        this.#assignNext(pw);
+      }
+    }
+  }
+}
+
+const defaultPool = new HashWorkerPool();
+
+/**
+ * Compute the hex digest of a file off-thread on the shared pool. algorithm is
+ * any name accepted by crypto.createHash / listed by crypto.getHashes().
+ */
+export function hashFile(algorithm: string, filePath: string): Promise<HashFileResult> {
+  return defaultPool.hashFile(algorithm, filePath);
+}
+
+/** Terminate the shared pool's workers. Call during app shutdown. */
+export async function shutdownHashWorker(): Promise<void> {
+  await defaultPool.shutdown();
+}

--- a/src/main/src/hash/protocol.ts
+++ b/src/main/src/hash/protocol.ts
@@ -1,0 +1,20 @@
+/**
+ * Message protocol between the hash host (main thread) and the hash worker
+ * (worker_thread). Jobs carry a file path and an algorithm name; the worker
+ * streams the file itself, so only the path crosses the boundary, never the
+ * file contents.
+ */
+
+export interface HashJob {
+  id: number;
+  // any algorithm name accepted by crypto.createHash / listed by crypto.getHashes()
+  algorithm: string;
+  filePath: string;
+}
+
+export interface HashResult {
+  id: number;
+  hash?: string;
+  numBytes?: number;
+  error?: string;
+}

--- a/src/main/src/hash/protocol.ts
+++ b/src/main/src/hash/protocol.ts
@@ -5,10 +5,11 @@
  * file contents.
  */
 
+import type { HashAlgorithm } from "@vortex/shared/ipc";
+
 export interface HashJob {
   id: number;
-  // any algorithm name accepted by crypto.createHash / listed by crypto.getHashes()
-  algorithm: string;
+  algorithm: HashAlgorithm;
   filePath: string;
 }
 

--- a/src/main/src/hash/worker.ts
+++ b/src/main/src/hash/worker.ts
@@ -1,0 +1,35 @@
+/**
+ * File-hash worker. Runs on a main-process worker_thread so streaming a large
+ * file and computing its digest stays off both the renderer UI thread and the
+ * main event loop. The host posts one job per message and every job is answered
+ * with exactly one response carrying the same id, so a caller never hangs. The
+ * worker reads the file itself (see compute.ts), so only the path crosses the
+ * boundary, never the contents.
+ */
+
+import { parentPort } from "node:worker_threads";
+
+import { getErrorMessageOrDefault } from "@vortex/shared";
+
+import { hashFileStream } from "./compute";
+import type { HashJob, HashResult } from "./protocol";
+
+if (parentPort === null) {
+  throw new Error("hash worker must run as a worker_thread");
+}
+const port = parentPort;
+
+async function handleJob(job: HashJob): Promise<void> {
+  let result: HashResult;
+  try {
+    const { hash, numBytes } = await hashFileStream(job.algorithm, job.filePath);
+    result = { id: job.id, hash, numBytes };
+  } catch (err) {
+    result = { id: job.id, error: getErrorMessageOrDefault(err) };
+  }
+  port.postMessage(result);
+}
+
+port.on("message", (job: HashJob) => {
+  void handleJob(job);
+});

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -7,7 +7,7 @@ import { appendFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import type { VortexPaths } from "@vortex/shared/ipc";
+import type { HashAlgorithm, VortexPaths } from "@vortex/shared/ipc";
 import type { SerializableMenuItem } from "@vortex/shared/preload";
 import type {
   IpcMainInvokeEvent,
@@ -651,7 +651,7 @@ export function init() {
 
   betterIpcMain.handle(
     "hash:compute",
-    (_event: IpcMainInvokeEvent, algorithm: string, filePath: string) =>
+    (_event: IpcMainInvokeEvent, algorithm: HashAlgorithm, filePath: string) =>
       hashFile(algorithm, filePath),
   );
 }

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -33,6 +33,7 @@ import {
 import { diffFiles as bsdiffDiff, patchFiles as bsdiffPatch } from "./bsdiff/host";
 import { relaunch } from "./cli";
 import { getVortexPath } from "./getVortexPath";
+import { hashFile } from "./hash/host";
 import { betterIpcMain } from "./ipc";
 import { openUrl, openFile } from "./open";
 import { extraWebViews } from "./webview";
@@ -642,5 +643,15 @@ export function init() {
     "bsdiff:apply",
     (_event: IpcMainInvokeEvent, oldPath: string, patchPath: string, outputPath: string) =>
       bsdiffPatch(oldPath, outputPath, patchPath),
+  );
+
+  // ============================================================================
+  // file hashing (delegated to a worker_thread, off the main and renderer loops)
+  // ============================================================================
+
+  betterIpcMain.handle(
+    "hash:compute",
+    (_event: IpcMainInvokeEvent, algorithm: string, filePath: string) =>
+      hashFile(algorithm, filePath),
   );
 }

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -283,6 +283,11 @@ try {
         betterIpcRenderer.invoke("bsdiff:apply", oldPath, patchPath, outputPath),
     },
 
+    hash: {
+      compute: (algorithm, filePath) =>
+        betterIpcRenderer.invoke("hash:compute", algorithm, filePath),
+    },
+
     diag: {
       // Raw ipcRenderer because betterIpcRenderer has no sendSync helper.
       fatal: (message: string) => {

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -1,8 +1,6 @@
-import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { access, copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
 import * as path from "node:path";
-import { pipeline } from "node:stream/promises";
 
 import { unknownToError, wireToDownloadError } from "@vortex/shared";
 import { AlreadyDownloaded, UserCanceled } from "@vortex/shared/errors";
@@ -467,13 +465,11 @@ export class IPCDownloadAdapter {
       }
 
       try {
-        // TODO: move hashing into main process
-
-        // MD5 is used as a fallback identifier for collection rule matching and
-        // reverse ModDB lookups for files that lack Nexus IDs (e.g. non-NXM downloads).
-        const hash = createHash("md5");
-        await pipeline(createReadStream(finalPath), hash);
-        this.#api.store.dispatch(setDownloadHash(downloadId, hash.digest("hex")));
+        // MD5 is a fallback identifier for collection rule matching and reverse
+        // ModDB lookups for files that lack Nexus IDs (e.g. non-NXM downloads).
+        // Hash on a main-process worker_thread so a large file doesn't block the renderer.
+        const { hash } = await window.api.hash.compute("md5", finalPath);
+        this.#api.store.dispatch(setDownloadHash(downloadId, hash));
       } catch (err) {
         log("warn", "failed to compute MD5 for download", { downloadId, err });
       }

--- a/src/renderer/src/util/checksum.test.ts
+++ b/src/renderer/src/util/checksum.test.ts
@@ -1,8 +1,3 @@
-import { createHash } from "crypto";
-import * as os from "os";
-import * as path from "path";
-
-import * as fsExtra from "fs-extra";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { checksum, fileMD5 } from "./checksum";
@@ -26,6 +21,7 @@ describe("checksum", () => {
 });
 
 describe("fileMD5", () => {
+  // Buffers are hashed in the renderer (see checksum.ts), so these need no mock.
   it("produces correct MD5 for Buffer inputs", async () => {
     for (const [input, expected] of MD5_VECTORS) {
       const buf = Buffer.from(input, "utf-8");
@@ -41,70 +37,39 @@ describe("fileMD5", () => {
     expect(progress).toHaveBeenCalledWith(buf.length, buf.length);
   });
 
-  describe("file-based hashing", () => {
-    let tmpDir: string;
-    let tmpFile: string;
+  // File paths are delegated to the main-process hash worker over the preload
+  // API; the digest correctness itself is covered by src/main/src/hash/hash.test.ts.
+  // Here we only assert fileMD5 delegates and surfaces the result correctly.
+  describe("file-based hashing (delegates to the hash worker)", () => {
+    const compute = vi.fn();
 
-    beforeEach(async () => {
-      tmpDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), "checksum-test-"));
-      tmpFile = path.join(tmpDir, "test.bin");
+    beforeEach(() => {
+      vi.stubGlobal("window", { api: { hash: { compute } } });
     });
 
-    afterEach(async () => {
-      await fsExtra.remove(tmpDir);
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      compute.mockReset();
     });
 
-    it("produces correct MD5 for a file with known content", async () => {
-      const content = "The quick brown fox jumps over the lazy dog";
-      const expected = createHash("md5").update(content).digest("hex");
-      await fsExtra.writeFile(tmpFile, content);
-
-      const result = await fileMD5(tmpFile);
-      expect(result).toBe(expected);
+    it("passes the algorithm and path to the worker and returns its digest", async () => {
+      compute.mockResolvedValue({ hash: "deadbeef", numBytes: 42 });
+      const result = await fileMD5("/some/archive.bin");
+      expect(compute).toHaveBeenCalledWith("md5", "/some/archive.bin");
+      expect(result).toBe("deadbeef");
     });
 
-    it("produces correct MD5 for an empty file", async () => {
-      await fsExtra.writeFile(tmpFile, "");
-      const result = await fileMD5(tmpFile);
-      expect(result).toBe("d41d8cd98f00b204e9800998ecf8427e");
-    });
-
-    it("produces correct MD5 for binary data", async () => {
-      const buf = Buffer.alloc(256);
-      for (let i = 0; i < 256; i++) buf[i] = i;
-      const expected = createHash("md5").update(buf).digest("hex");
-      await fsExtra.writeFile(tmpFile, buf);
-
-      const result = await fileMD5(tmpFile);
-      expect(result).toBe(expected);
-    });
-
-    it("produces correct MD5 for a large file (1MB)", async () => {
-      const buf = Buffer.alloc(1024 * 1024);
-      for (let i = 0; i < buf.length; i++) buf[i] = i % 256;
-      const expected = createHash("md5").update(buf).digest("hex");
-      await fsExtra.writeFile(tmpFile, buf);
-
-      const result = await fileMD5(tmpFile);
-      expect(result).toBe(expected);
-    });
-
-    it("reports progress for file hashing", async () => {
-      const buf = Buffer.alloc(256 * 1024); // 256KB
-      await fsExtra.writeFile(tmpFile, buf);
+    it("reports completion progress once with the hashed byte count", async () => {
+      compute.mockResolvedValue({ hash: "deadbeef", numBytes: 256 * 1024 });
       const progress = vi.fn();
-
-      await fileMD5(tmpFile, progress);
-
-      expect(progress).toHaveBeenCalled();
-      // Last call should report total bytes equal to file size
-      const lastCall = progress.mock.calls[progress.mock.calls.length - 1];
-      expect(lastCall[0]).toBe(buf.length); // bytesProcessed
-      expect(lastCall[1]).toBe(buf.length); // totalBytes
+      await fileMD5("/some/archive.bin", progress);
+      expect(progress).toHaveBeenCalledTimes(1);
+      expect(progress).toHaveBeenCalledWith(256 * 1024, 256 * 1024);
     });
 
-    it("rejects for non-existent file", async () => {
-      await expect(fileMD5(path.join(tmpDir, "nope.bin"))).rejects.toThrow();
+    it("propagates a worker rejection (e.g. missing file)", async () => {
+      compute.mockRejectedValue(new Error("ENOENT: no such file"));
+      await expect(fileMD5("/nope.bin")).rejects.toThrow("ENOENT");
     });
   });
 });

--- a/src/renderer/src/util/checksum.ts
+++ b/src/renderer/src/util/checksum.ts
@@ -1,7 +1,5 @@
 import { createHash } from "crypto";
 
-import * as fs from "./fs";
-
 export function checksum(input: Buffer): string {
   return createHash("md5").update(input).digest("hex");
 }
@@ -10,28 +8,20 @@ export async function fileMD5(
   input: string | Buffer,
   progress?: (bytesProcessed: number, totalBytes: number) => void,
 ): Promise<string> {
+  // A Buffer is already in renderer memory, so hash it here rather than over IPC:
+  // the renderer<->main boundary is structured-clone, so offloading would copy the
+  // whole buffer across for no gain. Only file paths go to the worker, where the
+  // bytes are read worker-side and never cross the boundary.
   if (Buffer.isBuffer(input)) {
     const hex = createHash("md5").update(input).digest("hex");
     progress?.(input.length, input.length);
     return hex;
   }
 
-  // Only stat the file when a progress callback is provided. The stat is
-  // needed to report (bytesProcessed, totalBytes), but is a wasted syscall
-  // when nobody is listening.
-  const totalSize = progress ? await fs.statAsync(input).then((s) => s.size) : 0;
-
-  return new Promise<string>((resolve, reject) => {
-    const hash = createHash("md5");
-    let bytesRead = 0;
-
-    const stream = fs.createReadStream(input);
-    stream.on("data", (data: Buffer) => {
-      hash.update(data);
-      bytesRead += data.length;
-      progress?.(bytesRead, totalSize);
-    });
-    stream.on("end", () => resolve(hash.digest("hex")));
-    stream.on("error", reject);
-  });
+  // Hash the file on a main-process worker_thread so a large file doesn't block
+  // the renderer. Progress is not streamed back over IPC, so report completion
+  // once when the digest returns.
+  const { hash, numBytes } = await window.api.hash.compute("md5", input);
+  progress?.(numBytes, numBytes);
+  return hash;
 }

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -278,6 +278,12 @@ export interface InvokeChannels {
   "bsdiff:create": (oldPath: string, newPath: string, patchPath: string) => Promise<void>;
   "bsdiff:apply": (oldPath: string, patchPath: string, outputPath: string) => Promise<void>;
 
+  // file hashing, run on a main-process worker_thread (only the path crosses IPC)
+  "hash:compute": (
+    algorithm: string,
+    filePath: string,
+  ) => Promise<{ hash: string; numBytes: number }>;
+
   // Persistence: Get all hydration data at startup (called once during init)
   "persist:get-hydration": () => Promise<Partial<PersistedState>>;
 

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -267,6 +267,9 @@ export interface FlagMetricsBucket {
   toggles: Record<string, { yes: number; no: number; variants?: Record<string, number> }>;
 }
 
+/** Hash algorithms the app requests over `hash:compute`. Closed set; extend as callers need. */
+export type HashAlgorithm = "md5";
+
 /** Type containing all known channels used by renderer processes to send to and receive messages from the main process */
 export interface InvokeChannels {
   // NOTE(erri120): Parameters must be serializable and return values must be Promises resolving serializable content.
@@ -280,7 +283,7 @@ export interface InvokeChannels {
 
   // file hashing, run on a main-process worker_thread (only the path crosses IPC)
   "hash:compute": (
-    algorithm: string,
+    algorithm: HashAlgorithm,
     filePath: string,
   ) => Promise<{ hash: string; numBytes: number }>;
 

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -21,6 +21,7 @@ import type { FlagContext, FlagMetricsBucket } from "./ipc";
 import type {
   DiffOperation,
   AppInitMetadata,
+  HashAlgorithm,
   Serializable,
   UpdateStatus,
   VortexPaths,
@@ -518,11 +519,8 @@ export interface BsdiffApi {
 }
 
 export interface HashApi {
-  /**
-   * Compute the hex digest of a file off the renderer thread. algorithm is any
-   * name accepted by crypto.createHash / listed by crypto.getHashes().
-   */
-  compute(algorithm: string, filePath: string): Promise<{ hash: string; numBytes: number }>;
+  /** Compute the hex digest of a file off the renderer thread. */
+  compute(algorithm: HashAlgorithm, filePath: string): Promise<{ hash: string; numBytes: number }>;
 }
 
 /** API for receiving feature flag updates pushed from the main process */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -103,6 +103,9 @@ export interface Api {
   /** bsdiff binary patching APIs (run on a main-process worker_thread) */
   bsdiff: BsdiffApi;
 
+  /** file hashing API (run on a main-process worker_thread) */
+  hash: HashApi;
+
   /** Diagnostic APIs */
   diag: Diag;
 
@@ -512,6 +515,14 @@ export interface BsdiffApi {
 
   /** Apply a BSDIFF40 patch file to oldPath, writing the result to outputPath. */
   patch(oldPath: string, outputPath: string, patchPath: string): Promise<void>;
+}
+
+export interface HashApi {
+  /**
+   * Compute the hex digest of a file off the renderer thread. algorithm is any
+   * name accepted by crypto.createHash / listed by crypto.getHashes().
+   */
+  compute(algorithm: string, filePath: string): Promise<{ hash: string; numBytes: number }>;
 }
 
 /** API for receiving feature flag updates pushed from the main process */


### PR DESCRIPTION
Move MD5 file hashing off the renderer thread so finalizing a large download no longer blocks the UI.

Add a hash worker service (src/main/src/hash): a worker_thread pool that streams a file and returns its hex digest over a hash:compute IPC channel (window.api.hash.compute). It spawns lazily, runs pool-size jobs in parallel, isolates a crashed worker, and surfaces failures as VortexError. Route the download-finalize hash and checksum.fileMD5 / genMd5Hash through it; a Buffer already in renderer memory stays local.

Verified in a dev build: a 836 MB download finalizes off-thread in ~6.7s during peak collection installation which thrashes the disk (downloading/extracting/etc) with the UI fully interactable/responsive. Previously it would stutter/freeze + finalizing downloads would queue up to 40 minutes at times, affecting collection installation speed.

Also fixed bsdiff worker shutdown not being called on app quit.

closes LAZ-774