### PR TITLE
Add health check severity badge to left menu item (LAZ-347)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -3041,6 +3041,7 @@ interface IMainPageOptions {
     isModernOnly?: boolean;
     // (undocumented)
     mdi?: string;
+    menuBadge?: React_2.ComponentType;
     newLayout?: boolean;
     // (undocumented)
     onReset?: () => void;

--- a/src/renderer/src/extensions/health_check/components/menu_badge/HealthCheckMenuBadge.tsx
+++ b/src/renderer/src/extensions/health_check/components/menu_badge/HealthCheckMenuBadge.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { useSelector } from "react-redux";
+
+import { useWindowContext } from "@/contexts";
+import type { IState } from "@/types/IState";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+import { selectListedEntries } from "../../utils/shared/listedEntries";
+import { type Severity, severityStyleMap } from "../../utils/shared/severityStyles";
+
+const SEVERITY_RANK: Record<Severity, number> = { suggestion: 0, warning: 1, error: 2 };
+
+const highestActiveSeverity = (state: IState): Severity | undefined => {
+  let worst: Severity | undefined;
+
+  for (const { entry, hidden } of selectListedEntries(state)) {
+    if (hidden) {
+      continue;
+    }
+
+    if (worst === undefined || SEVERITY_RANK[entry.severity] > SEVERITY_RANK[worst]) {
+      worst = entry.severity;
+    }
+  }
+
+  return worst;
+};
+
+export const HealthCheckMenuBadge = () => {
+  const { menuIsCollapsed } = useWindowContext();
+  const severity = useSelector(highestActiveSeverity);
+
+  if (!severity) {
+    return null;
+  }
+
+  return (
+    <span
+      className={joinClasses(
+        ["size-1.5 shrink-0 rounded-full", severityStyleMap[severity].backgroundClassName],
+        { "absolute top-1.5 right-1.5": menuIsCollapsed },
+      )}
+    />
+  );
+};

--- a/src/renderer/src/extensions/health_check/index.ts
+++ b/src/renderer/src/extensions/health_check/index.ts
@@ -4,10 +4,10 @@
  */
 
 import { FlagService } from "@/FlagService";
+import type { IExtensionContext } from "@/types/IExtensionContext";
+import type { IHealthCheck, IModHealthCheck } from "@/types/IHealthCheck";
+import { HealthCheckTrigger } from "@/types/IHealthCheck";
 
-import type { IExtensionContext } from "../../types/IExtensionContext";
-import type { IHealthCheck, IModHealthCheck } from "../../types/IHealthCheck";
-import { HealthCheckTrigger } from "../../types/IHealthCheck";
 import { activeGameId } from "../../util/selectors";
 import { createHealthCheckApi } from "./api";
 import { setupAutomaticTriggers } from "./api/triggers";
@@ -16,6 +16,7 @@ import {
   FILE_REQUIREMENTS_FLAG,
 } from "./checks/fileRequirementsCheck";
 import { modRequirementsHealthCheck } from "./checks/modRequirementsCheck";
+import { HealthCheckMenuBadge } from "./components/menu_badge/HealthCheckMenuBadge";
 import { HealthCheckRegistry } from "./core/HealthCheckRegistry";
 import { LegacyTestAdapter } from "./core/LegacyTestAdapter";
 import { persistentReducer } from "./reducers/persistent";
@@ -53,6 +54,7 @@ function init(context: IExtensionContext): boolean {
     group: "per-game",
     newLayout: true,
     visible: () => activeGameId(context.api.getState()) !== undefined,
+    menuBadge: HealthCheckMenuBadge,
     props: () => ({
       api: context.api,
       onRefresh: () => healthCheckApi?.runChecksByTrigger?.(HealthCheckTrigger.Manual),

--- a/src/renderer/src/extensions/health_check/utils/shared/listedEntries.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/listedEntries.ts
@@ -1,0 +1,25 @@
+import type { IState } from "@/types/IState";
+
+import { healthCheckContent } from "../../views/content/registry";
+import type { IHealthCheckContent, IHealthCheckEntry } from "../../views/content/types";
+
+/** One listing entry paired with the content provider that owns it. */
+export interface IListedEntry {
+  entry: IHealthCheckEntry;
+  content: IHealthCheckContent;
+  hidden: boolean;
+}
+
+/** Gather entries from every registered health-check content provider. */
+export const selectListedEntries = (state: IState): IListedEntry[] => {
+  const items: IListedEntry[] = [];
+  for (const content of Object.values(healthCheckContent)) {
+    if (!content) {
+      continue;
+    }
+    for (const entry of content.selectEntries(state)) {
+      items.push({ entry, content, hidden: content.isHidden?.(state, entry) ?? false });
+    }
+  }
+  return items;
+};

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -40,34 +40,15 @@ import {
   lastHealthCheckRun,
   modRequirementsCheckResult,
 } from "../selectors";
+import { type IListedEntry, selectListedEntries } from "../utils/shared/listedEntries";
 import { healthCheckContent } from "./content/registry";
-import type { IBulkInstallItem, IHealthCheckContent, IHealthCheckEntry } from "./content/types";
+import type { IBulkInstallItem } from "./content/types";
 import HealthCheckDetailPage from "./HealthCheckDetailPage";
 
 interface IHealthCheckPageProps {
   api: IExtensionApi;
   onRefresh?: () => void;
   active?: boolean;
-}
-
-interface IListedEntry {
-  entry: IHealthCheckEntry;
-  content: IHealthCheckContent;
-  hidden: boolean;
-}
-
-/** Gather entries from every registered health-check content provider. */
-function selectListedEntries(state: IState): IListedEntry[] {
-  const items: IListedEntry[] = [];
-  for (const content of Object.values(healthCheckContent)) {
-    if (!content) {
-      continue;
-    }
-    for (const entry of content.selectEntries(state)) {
-      items.push({ entry, content, hidden: content.isHidden?.(state, entry) ?? false });
-    }
-  }
-  return items;
 }
 
 /**

--- a/src/renderer/src/hooks/useMainPages.ts
+++ b/src/renderer/src/hooks/useMainPages.ts
@@ -31,6 +31,7 @@ const registerMainPage = (
     newLayout: options.newLayout,
     badge: options.badge,
     activity: options.activity,
+    menuBadge: options.menuBadge,
     priority: options.priority !== undefined ? options.priority : 100,
     onReset: options.onReset,
     namespace: extInfo.namespace,

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -216,6 +216,8 @@ export interface IMainPageOptions {
   activity?: ReduxProp<boolean>;
   onReset?: () => void;
   mdi?: string;
+  /** Self-subscribing status badge shown on this page's left-menu item. */
+  menuBadge?: React.ComponentType;
 }
 
 export type RegisterMainPage = (

--- a/src/renderer/src/types/IMainPage.ts
+++ b/src/renderer/src/types/IMainPage.ts
@@ -33,4 +33,5 @@ export interface IMainPage {
   activity?: ReduxProp<boolean>;
   namespace?: string;
   onReset?: () => void;
+  menuBadge?: React.ComponentType;
 }

--- a/src/renderer/src/views/components/Menu/MenuButton.tsx
+++ b/src/renderer/src/views/components/Menu/MenuButton.tsx
@@ -1,4 +1,4 @@
-import React, { type ButtonHTMLAttributes, type FC } from "react";
+import React, { type ButtonHTMLAttributes, type ComponentType, type FC } from "react";
 
 import { useWindowContext } from "@/contexts";
 import { Icon } from "@/ui/components/icon/Icon";
@@ -9,9 +9,16 @@ interface MenuButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: string;
   iconPath: string;
   isActive?: boolean;
+  Badge?: ComponentType;
 }
 
-export const MenuButton: FC<MenuButtonProps> = ({ children, iconPath, isActive, ...props }) => {
+export const MenuButton: FC<MenuButtonProps> = ({
+  children,
+  iconPath,
+  isActive,
+  Badge,
+  ...props
+}) => {
   const { menuIsCollapsed } = useWindowContext();
 
   return (
@@ -35,17 +42,7 @@ export const MenuButton: FC<MenuButtonProps> = ({ children, iconPath, isActive, 
         {children}
       </Typography>
 
-      {/* todo show only when there is a health check item, and pick the
-       * severity from the worst item rather than hardcoding warning
-       * <span
-       *  className={joinClasses([
-       *    "size-1.5 shrink-0 rounded-full",
-       *    severityStyleMap.warning.backgroundClassName,
-       *  ], {
-       *    'absolute top-1.5 right-1.5': menuIsCollapsed,
-       *  })}
-       * />
-       */}
+      {Badge && <Badge />}
     </button>
   );
 };

--- a/src/renderer/src/views/components/Menu/index.tsx
+++ b/src/renderer/src/views/components/Menu/index.tsx
@@ -75,6 +75,7 @@ const MenuContent: FC = () => {
           ) : (
             visiblePages.map((page) => (
               <MenuButton
+                Badge={page.menuBadge}
                 iconPath={page.mdi ?? getIconPath(page.icon)}
                 isActive={mainPage === page.id}
                 key={page.id}


### PR DESCRIPTION
Shows a coloured dot on the Health check left-menu item reflecting the highest-severity diagnostic currently present:
                                                                           
- 🔵 Suggestion · 🟡 Warning · 🔴 Critical
- Only the worst severity is shown at a time
- Clears automatically once every item is resolved or hidden
                                                                           
### Approach                                                                 

Rather than teaching the core menu about health checks, this adds a generic menuBadge?: React.ComponentType slot to the page contract (registerMainPage). MenuButton just renders whatever badge a page provides. The health check extension owns everything about its own badge - colours, and a small self-subscribing HealthCheckMenuBadge component so only the dot re-renders on the frequent dispatches during a check run, not the whole menu.                                                      

###  Changes
- menuBadge slot: IMainPage / IMainPageOptions, useMainPages, MenuButton, Menu
- HealthCheckMenuBadge component + shared selectListedEntries util; registered on the health page                                            
- Regenerated etc/vortex.api.md