### PR TITLE
Health check QA polish LAZ-676

### DIFF
--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -76,7 +76,6 @@
       "current_version": "Current version",
       "required_version": "Required version:",
       "enable_required": "Enable required version",
-      "view_in_loadout": "View in loadout",
       "view_in_mods": "View in Mods",
       "enable_this_version": "Enable this version",
       "install_uninstalled": "Install (downloaded)"

--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -4,7 +4,15 @@
   },
   "shared": {
     "requires_files": "Requires {{ count }} additional mod file to be installed to work correctly:",
-    "requires_files_plural": "Requires {{ count }} additional mod files to be installed to work correctly:"
+    "requires_files_plural": "Requires {{ count }} additional mod files to be installed to work correctly:",
+    "requires_pick": "Requires {{ count }} additional mod file to be picked to work correctly:",
+    "requires_pick_plural": "Requires {{ count }} additional mod files to be picked to work correctly:",
+    "wrong_version_installed": "Requires installing a different version of this existing mod file to work correctly:",
+    "wrong_version_installed_plural": "Requires installing a different version of {{ count }} existing mod files to work correctly:",
+    "wrong_version_enabled": "Requires enabling a different version of this installed mod file to work correctly:",
+    "wrong_version_enabled_plural": "Requires enabling a different version of {{ count }} installed mod files to work correctly:",
+    "correct_version_uninstalled": "Requires installing this previously downloaded mod file to work correctly:",
+    "correct_version_uninstalled_plural": "Requires installing {{ count }} previously downloaded mod files to work correctly:"
   },
   "listing": {
     "title": "Health Check",
@@ -16,8 +24,6 @@
       "more_count": "+{{ count }} more",
       "missing_for": "Missing required mod for: {{modName}}",
       "missing_for_plural": "Missing required mods for: {{modName}}",
-      "requires_pick": "Requires {{ count }} mod to be picked:",
-      "requires_pick_plural": "Requires {{ count }} mods to be picked:",
       "or_join": "or"
     },
     "no_results_active": {
@@ -66,16 +72,13 @@
       "installing": "Installing...",
       "pick_one": "Pick one of these",
       "install_required": "Install required",
-      "wrong_version_installed": "A different version of an installed file is required. Only one version can be enabled at a time.",
       "different_version_required": "Different version install required",
       "current_version": "Current version",
       "required_version": "Required version:",
-      "wrong_version_enabled": "The correct version is installed but a different version is enabled. Only one version can be enabled at a time.",
-      "enabled_version": "Currently enabled version:",
+      "enable_required": "Enable required version",
       "view_in_loadout": "View in loadout",
       "view_in_mods": "View in Mods",
       "enable_this_version": "Enable this version",
-      "correct_version_downloaded": "The required version is downloaded but not installed.",
       "install_uninstalled": "Install (downloaded)"
     },
     "feedback_modal": {

--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -2,6 +2,10 @@
   "actions": {
     "install_all": "1-click install all ({{count}})"
   },
+  "shared": {
+    "requires_files": "Requires {{ count }} additional mod file to be installed to work correctly:",
+    "requires_files_plural": "Requires {{ count }} additional mod files to be installed to work correctly:"
+  },
   "listing": {
     "title": "Health Check",
     "subtitle": "Review your Loadout for any issues and learn how to resolve them if needed.",
@@ -12,8 +16,6 @@
       "more_count": "+{{ count }} more",
       "missing_for": "Missing required mod for: {{modName}}",
       "missing_for_plural": "Missing required mods for: {{modName}}",
-      "requires_count": "Requires {{ count }} mod:",
-      "requires_count_plural": "Requires {{ count }} mods:",
       "requires_pick": "Requires {{ count }} mod to be picked:",
       "requires_pick_plural": "Requires {{ count }} mods to be picked:",
       "or_join": "or"
@@ -58,8 +60,6 @@
       "confirm_install": "Confirm install",
       "missing_for": "Missing required mod for: <modLink>{{modName}}</modLink>",
       "missing_for_plural": "Missing required mods for: <modLink>{{modName}}</modLink>",
-      "requires_files": "Requires {{ count }} mod file to be installed to work correctly.",
-      "requires_files_plural": "Requires {{ count }} mod files to be installed to work correctly.",
       "install_via_mod_page": "Install via mod page",
       "install_one_click": "1-click install",
       "downloading": "Downloading...",

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -10,17 +10,14 @@ import type { IState } from "@/types/IState";
 import { Listing } from "@/ui/components/listing/Listing";
 import { Pagination } from "@/ui/components/pagination/Pagination";
 import { Picker } from "@/ui/components/picker/Picker";
-import { Pictogram } from "@/ui/components/pictogram/Pictogram";
-import { Typography } from "@/ui/components/typography/Typography";
-import { joinClasses } from "@/ui/utils/joinClasses";
 import { isContributed } from "@/util/isContributed";
 import { getSafe } from "@/util/storeHelper";
+import { Page } from "@/views/components/Page/Page";
+import { PageHeader } from "@/views/components/Page/PageHeader";
+import { PageScroll } from "@/views/components/Page/PageScroll";
 
 import { connect, translate } from "../../../controls/ComponentEx";
 import { activeGameId } from "../../../util/selectors";
-import { Page } from "../../../views/components/Page/Page";
-import { PageHeader } from "../../../views/components/Page/PageHeader";
-import { PageScroll } from "../../../views/components/Page/PageScroll";
 import { nexusGameId } from "../../nexus_integration/util/convertGameId";
 import type { IProfile } from "../../profile_management/types/IProfile";
 import { setPickerLayout, setSortManaged, setSortUnmanaged } from "../actions/settings";
@@ -79,7 +76,7 @@ type IProps = IBaseProps & IConnectedProps & IActionProps & WithTranslation;
 // "Final Fantasy 7 Remake" vs "Final Fantasy VII Remake" are 91 similar
 const SIMILARITY_RATIO = 90;
 // The unmanaged list can be large, so it's paginated this many games per page.
-const UNMANAGED_PAGE_SIZE = 50;
+const UNMANAGED_PAGE_SIZE = 49;
 
 /**
  * picker/configuration for game modes

--- a/src/renderer/src/extensions/health_check/components/beta_badge/BetaBadge.tsx
+++ b/src/renderer/src/extensions/health_check/components/beta_badge/BetaBadge.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Typography } from "@/ui/components/typography/Typography";
+
+/** Small "Beta" pill shown next to the health check page titles. */
+export const BetaBadge = () => {
+  const { t } = useTranslation(["health_check", "common"]);
+
+  return (
+    <Typography
+      as="div"
+      className="flex min-h-4 items-center justify-center rounded-sm border border-neutral-strong px-1"
+      typographyType="title-xs"
+    >
+      {t("common:::beta")}
+    </Typography>
+  );
+};

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
@@ -1,4 +1,4 @@
-import { mdiEye, mdiEyeOff, mdiThumbDownOutline, mdiThumbUpOutline } from "@mdi/js";
+import { mdiEyeOutline, mdiEyeOffOutline, mdiThumbDownOutline, mdiThumbUpOutline } from "@mdi/js";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -80,7 +80,7 @@ export function EntryActions({
       <Button
         appearance={appearance}
         brand="neutral"
-        leftIconPath={isHidden ? mdiEye : mdiEyeOff}
+        leftIconPath={isHidden ? mdiEyeOutline : mdiEyeOffOutline}
         size="sm"
         title={isHidden ? t("common:::unhide") : t("common:::hide")}
         onClick={handle(onToggleHide)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import {
@@ -7,7 +7,6 @@ import {
   openModPage,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
-import type { IFileRequirementCandidate } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 import { severityStyleMap } from "@/extensions/health_check/utils/shared/severityStyles";
 import type { IState } from "@/types/IState";
 import { Icon } from "@/ui/components/icon/Icon";
@@ -18,16 +17,17 @@ import { joinClasses } from "@/ui/utils/joinClasses";
 import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { setFileRequirementHidden } from "../../actions/persistent";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
+import { useReportCopy } from "../../hooks/useReportCopy";
 import { isFileEntryHidden } from "../../views/content/fileRequirementEntries";
 import type { IDetailViewProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { RequirementBody } from "./RequirementBody";
 
 export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
-  const { t } = useTranslation(["health_check", "common"]);
   const report = entry.data as IFileRequirementReport;
   const severityStyle = severityStyleMap[entry.severity];
   const count = report.requirements.length;
+  const { summary } = useReportCopy(report);
 
   const isHidden = useSelector((state: IState) => isFileEntryHidden(state, entry));
   const toggleHideEntry = () => {
@@ -45,18 +45,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   // file-level feedback is persisted only, it does not emit a Mixpanel event yet
   // (HealthCheckFeedbackEvent is mod-shaped).
   const { givenFeedback, markFeedback } = useFileRequirementFeedback(api, report.sourceFileUID);
-
-  // Report-level intro line, mirroring the per-category detail copy.
-  const subtitle =
-    report.category === "toggle"
-      ? t("detail::item::wrong_version_enabled")
-      : report.category === "download-replace"
-        ? t("detail::item::wrong_version_installed")
-        : report.category === "install-uninstalled"
-          ? t("detail::item::correct_version_downloaded")
-          : t(count > 1 ? "shared::requires_files_plural" : "shared::requires_files", {
-              count,
-            });
 
   return (
     <div className="rounded-lg border border-stroke-weak">
@@ -104,7 +92,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
 
       <div className="pt-4 pb-6">
         <Typography appearance="subdued" className="mb-4 px-6">
-          {subtitle}
+          {summary}
         </Typography>
 
         <div className="space-y-4">

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -54,7 +54,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
         ? t("detail::item::wrong_version_installed")
         : report.category === "install-uninstalled"
           ? t("detail::item::correct_version_downloaded")
-          : t(count > 1 ? "detail::item::requires_files_plural" : "detail::item::requires_files", {
+          : t(count > 1 ? "shared::requires_files_plural" : "shared::requires_files", {
               count,
             });
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
@@ -117,9 +117,13 @@ export function FileRequirement({
             <div className="truncate">{file.fileName}</div>
           )}
 
-          <Bullet />
+          {!!file.fileVersion && (
+            <>
+              <Bullet />
 
-          <div className="shrink-0">{file.fileVersion}</div>
+              <div className="shrink-0">{file.fileVersion}</div>
+            </>
+          )}
         </Typography>
 
         <div className="flex items-center gap-x-2">

--- a/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
@@ -92,7 +92,7 @@ export function FileRequirement({
 
       <div
         className={joinClasses([
-          "flex items-center justify-between gap-x-2 bg-surface-mid px-4 py-3",
+          "flex items-center justify-between gap-x-12 bg-surface-mid px-4 py-3",
           showMod ? "rounded-b-sm" : "rounded-sm",
         ])}
       >
@@ -107,16 +107,17 @@ export function FileRequirement({
           {onOpenFile ? (
             <TypographyLink
               appearance="subdued"
-              className="truncate"
+              className="min-w-0"
+              customContent={<span className="truncate">{file.fileName}</span>}
               typographyType="inherit"
               variant="secondary"
               onClick={onOpenFile}
-            >
-              {file.fileName}
-            </TypographyLink>
+            />
           ) : (
             <div className="truncate">{file.fileName}</div>
           )}
+
+          <Bullet />
 
           <div className="shrink-0">{file.fileVersion}</div>
         </Typography>
@@ -133,10 +134,10 @@ export function FileRequirement({
               ) : (
                 <Pill iconPath={mdiCloseCircleOutline}>Disabled</Pill>
               )}
+
+              {!!actions && <div className="w-px self-stretch bg-stroke-weak" />}
             </>
           )}
-
-          {!!actions && <div className="w-px self-stretch bg-stroke-weak" />}
 
           {actions}
         </div>

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -1,10 +1,4 @@
-import {
-  mdiCallSplit,
-  mdiCheck,
-  mdiChevronRight,
-  mdiSwapHorizontal,
-  mdiTrayArrowDown,
-} from "@mdi/js";
+import { mdiCallSplit, mdiCheck, mdiSwapHorizontal, mdiTrayArrowDown } from "@mdi/js";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -23,24 +17,20 @@ import {
   uninstalledFiles,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
-import { severityStyleMap } from "@/extensions/health_check/utils/shared/severityStyles";
 import { Button } from "@/ui/components/button/Button";
-import { Icon } from "@/ui/components/icon/Icon";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
-import { Typography } from "@/ui/components/typography/Typography";
-import { joinClasses } from "@/ui/utils/joinClasses";
 
 import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
 import { useReportCopy } from "../../hooks/useReportCopy";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
+import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
 import { PremiumModal } from "../premium_modal/PremiumModal";
 
 export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IListingRowProps) => {
   const { t } = useTranslation(["health_check", "common"]);
   const report = entry.data as IFileRequirementReport;
-  const severityStyle = severityStyleMap[entry.severity];
   const { title, summary } = useReportCopy(report);
 
   const showPremiumAd = useSelector(shouldShowPremiumAd);
@@ -48,7 +38,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   const { givenFeedback, markFeedback } = useFileRequirementFeedback(api, report.sourceFileUID);
 
   const candidates = downloadCandidates(report.requirements);
-  const quickInstall = canQuickInstall(report.category) && candidates.length > 0;
+  const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
   const toInstall = uninstalledFiles(report.requirements);
   const orJoin = ` ${t("listing::item::or_join")} `;
@@ -72,106 +62,81 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
   return (
     <>
-      <div
-        className="group hover-overlay-weak flex w-full cursor-pointer items-start gap-x-4 rounded-sm bg-surface-mid px-4 py-3 shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info-subdued"
-        role="button"
-        tabIndex={0}
-        onClick={onOpen}
-        onKeyDown={(e) => {
-          if (["Enter", " "].includes(e.key)) {
-            e.preventDefault();
-            onOpen();
-          }
-        }}
-      >
-        <Icon
-          className={joinClasses(["shrink-0", severityStyle.textClassName])}
-          path={severityStyle.iconPath}
-        />
-
-        <div className="min-w-0 grow text-left">
-          <div className="flex items-start justify-between gap-x-4">
-            <div className="min-w-0">
-              <Typography brand="neutral-translucent" className="truncate">
-                {title}
-              </Typography>
-
-              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
-                {summary}
-              </Typography>
-
-              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
-                {namesLine}
-              </Typography>
-            </div>
-
-            <EntryActions
-              givenFeedback={givenFeedback}
-              isHidden={isHidden}
-              variant="listing"
-              onHelpful={markFeedback}
-              onNotHelpful={markFeedback}
-              onToggleHide={onToggleHide}
-            />
-          </div>
-        </div>
-
-        {quickInstall ? (
-          <Button
-            appearance="moderate"
-            brand="neutral"
-            leftIconPath={mdiTrayArrowDown}
-            rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
-            size="sm"
-            onClick={doQuickInstall}
-          >
-            {candidates.length === 1
-              ? t("detail::item::install_one_click")
-              : t("listing::install_one_click", { count: candidates.length })}
-          </Button>
-        ) : report.category === "or" ? (
-          <Button
-            appearance="moderate"
-            brand="neutral"
-            leftIconPath={mdiCallSplit}
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpen();
-            }}
-          >
-            {t("listing::pick_mod_install")}
-          </Button>
-        ) : report.category === "toggle" && switches.length > 0 ? (
-          <Button
-            appearance="moderate"
-            brand="neutral"
-            leftIconPath={mdiSwapHorizontal}
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              switchActiveVersions(api, switches);
-            }}
-          >
-            {t("detail::item::enable_this_version")}
-          </Button>
-        ) : report.category === "install-uninstalled" && toInstall.length > 0 ? (
-          <Button
-            appearance="moderate"
-            brand="neutral"
-            leftIconPath={mdiCheck}
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              toInstall.forEach((req) => void installDownloadedFile(api, req.uninstalledFile));
-            }}
-          >
-            {t("listing::install_uninstalled")}
-          </Button>
-        ) : null}
-
-        <Icon className="shrink-0 text-translucent-moderate" path={mdiChevronRight} size="lg" />
-      </div>
+      <ListingRowShell
+        action={
+          quickInstall ? (
+            <Button
+              appearance="moderate"
+              brand="neutral"
+              leftIconPath={mdiTrayArrowDown}
+              rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
+              size="sm"
+              onClick={doQuickInstall}
+            >
+              {candidates.length === 1
+                ? t("detail::item::install_one_click")
+                : t("listing::install_one_click", { count: candidates.length })}
+            </Button>
+          ) : report.category === "or" ? (
+            <Button
+              appearance="moderate"
+              brand="neutral"
+              leftIconPath={mdiCallSplit}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpen();
+              }}
+            >
+              {t("listing::pick_mod_install")}
+            </Button>
+          ) : report.category === "toggle" && !!switches.length ? (
+            <Button
+              appearance="moderate"
+              brand="neutral"
+              leftIconPath={mdiSwapHorizontal}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                switchActiveVersions(api, switches);
+              }}
+            >
+              {t("detail::item::enable_this_version")}
+            </Button>
+          ) : (
+            report.category === "install-uninstalled" &&
+            !!toInstall.length && (
+              <Button
+                appearance="moderate"
+                brand="neutral"
+                leftIconPath={mdiCheck}
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toInstall.forEach((req) => void installDownloadedFile(api, req.uninstalledFile));
+                }}
+              >
+                {t("listing::install_uninstalled")}
+              </Button>
+            )
+          )
+        }
+        detail={namesLine}
+        entryActions={
+          <EntryActions
+            givenFeedback={givenFeedback}
+            isHidden={isHidden}
+            variant="listing"
+            onHelpful={markFeedback}
+            onNotHelpful={markFeedback}
+            onToggleHide={onToggleHide}
+          />
+        }
+        severity={entry.severity}
+        summary={summary}
+        title={title}
+        onOpen={onOpen}
+      />
 
       <PremiumModal
         downloadScope={candidates.length === 1 ? "single" : "all"}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -1,4 +1,10 @@
-import { mdiCallSplit, mdiChevronRight, mdiSwapHorizontal, mdiTrayArrowDown } from "@mdi/js";
+import {
+  mdiCallSplit,
+  mdiCheck,
+  mdiChevronRight,
+  mdiSwapHorizontal,
+  mdiTrayArrowDown,
+} from "@mdi/js";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -86,9 +92,11 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
         <div className="min-w-0 grow text-left">
           <div className="flex items-start justify-between gap-x-4">
             <div className="min-w-0">
-              <Typography className="truncate">{title}</Typography>
+              <Typography brand="neutral-translucent" className="truncate">
+                {title}
+              </Typography>
 
-              <Typography appearance="subdued" as="div" typographyType="body-sm">
+              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
                 {summary}
               </Typography>
 
@@ -151,6 +159,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
           <Button
             appearance="moderate"
             brand="neutral"
+            leftIconPath={mdiCheck}
             size="sm"
             onClick={(e) => {
               e.stopPropagation();

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -35,7 +35,7 @@ const groupTitleKey = (category: FileRequirementCategory): string => {
     case "download-replace":
       return "detail::item::different_version_required";
     case "toggle":
-      return "detail::item::enabled_version";
+      return "detail::item::enable_required";
     case "or":
       return "detail::item::pick_one";
   }

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -30,7 +30,9 @@ export const CandidateCard = ({
     () => ctx.requestDownload(candidate),
     ctx.showPremiumAd,
   );
+
   const loading = isLoading || !!ctx.isDownloadingAll;
+
   return (
     <FileRequirement
       actions={

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
@@ -1,4 +1,4 @@
-import { mdiSwapHorizontal } from "@mdi/js";
+import { mdiCheck } from "@mdi/js";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -14,6 +14,7 @@ import {
 import type { IInstalledFile } from "@/extensions/health_check/utils/fileRequirements/installedFiles";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
+import { nxmModOutline } from "@/ui/icon-paths";
 
 import { FileRequirement } from "../FileRequirement";
 
@@ -39,6 +40,7 @@ export const EnableCard = ({
           <Button
             appearance="subdued"
             brand="neutral"
+            leftIconPath={nxmModOutline}
             size="sm"
             onClick={() => viewInLoadout(api, correctFile)}
           >
@@ -48,7 +50,7 @@ export const EnableCard = ({
           <Button
             appearance="strong"
             brand="neutral"
-            leftIconPath={mdiSwapHorizontal}
+            leftIconPath={mdiCheck}
             size="sm"
             onClick={() =>
               enabledFile

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
@@ -1,4 +1,4 @@
-import { mdiCheck } from "@mdi/js";
+import { mdiSwapHorizontal } from "@mdi/js";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -44,13 +44,13 @@ export const EnableCard = ({
             size="sm"
             onClick={() => viewInLoadout(api, correctFile)}
           >
-            {t("detail::item::view_in_loadout")}
+            {t("detail::item::view_in_mods")}
           </Button>
 
           <Button
             appearance="strong"
             brand="neutral"
-            leftIconPath={mdiCheck}
+            leftIconPath={mdiSwapHorizontal}
             size="sm"
             onClick={() =>
               enabledFile

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
@@ -1,3 +1,4 @@
+import { mdiCheck } from "@mdi/js";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -12,6 +13,7 @@ import {
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
+import { nxmModOutline } from "@/ui/icon-paths";
 
 import { useInstallButton } from "../../../hooks/useInstallButton";
 import { FileRequirement } from "../FileRequirement";
@@ -35,6 +37,7 @@ export const InstallUninstalledRows = ({
           <Button
             appearance="subdued"
             brand="neutral"
+            leftIconPath={nxmModOutline}
             size="sm"
             onClick={() => viewDownloadInMods(api, requirement.uninstalledFile)}
           >
@@ -45,6 +48,7 @@ export const InstallUninstalledRows = ({
             appearance="strong"
             brand="neutral"
             isLoading={isLoading}
+            leftIconPath={mdiCheck}
             size="sm"
             onClick={onClick}
           >

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -9,6 +9,7 @@ import { viewInLoadout } from "@/extensions/health_check/utils/fileRequirements/
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
+import { nxmModOutline } from "@/ui/icon-paths";
 
 import { CandidateCard } from "../cards/CandidateCard";
 import { FileRequirement } from "../FileRequirement";
@@ -42,6 +43,7 @@ export const ReplaceRows = ({
             <Button
               appearance="subdued"
               brand="neutral"
+              leftIconPath={nxmModOutline}
               size="sm"
               onClick={() => viewInLoadout(ctx.api, requirement.installedFile)}
             >

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -47,7 +47,7 @@ export const ReplaceRows = ({
               size="sm"
               onClick={() => viewInLoadout(ctx.api, requirement.installedFile)}
             >
-              {t("detail::item::view_in_loadout")}
+              {t("detail::item::view_in_mods")}
             </Button>
           }
           file={installedToFileData(requirement.installedFile)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
@@ -49,7 +49,7 @@ export const ToggleRows = ({
               size="sm"
               onClick={() => viewInLoadout(api, requirement.enabledFile)}
             >
-              {t("detail::item::view_in_loadout")}
+              {t("detail::item::view_in_mods")}
             </Button>
           }
           file={installedToFileData(requirement.enabledFile)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
@@ -7,6 +7,7 @@ import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequi
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
+import { nxmModOutline } from "@/ui/icon-paths";
 
 import { EnableCard } from "../cards/EnableCard";
 import { FileRequirement } from "../FileRequirement";
@@ -44,6 +45,7 @@ export const ToggleRows = ({
             <Button
               appearance="subdued"
               brand="neutral"
+              leftIconPath={nxmModOutline}
               size="sm"
               onClick={() => viewInLoadout(api, requirement.enabledFile)}
             >

--- a/src/renderer/src/extensions/health_check/components/listing_row/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/listing_row/ListingRow.tsx
@@ -1,0 +1,76 @@
+import { mdiChevronRight } from "@mdi/js";
+import React, { type KeyboardEvent, type ReactNode } from "react";
+
+import {
+  type Severity,
+  severityStyleMap,
+} from "@/extensions/health_check/utils/shared/severityStyles";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+interface IListingRowProps {
+  severity: Severity;
+  title: ReactNode;
+  summary: ReactNode;
+  detail: ReactNode;
+  entryActions: ReactNode;
+  action?: ReactNode;
+  onOpen: () => void;
+}
+
+export const ListingRow = ({
+  severity,
+  title,
+  summary,
+  detail,
+  entryActions,
+  action,
+  onOpen,
+}: IListingRowProps) => {
+  const severityStyle = severityStyleMap[severity];
+
+  return (
+    <div
+      className="group hover-overlay-weak flex w-full cursor-pointer items-start gap-x-4 rounded-sm bg-surface-mid px-4 py-3 shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info-subdued"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (["Enter", " "].includes(e.key)) {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      <Icon
+        className={joinClasses(["shrink-0", severityStyle.textClassName])}
+        path={severityStyle.iconPath}
+      />
+
+      <div className="min-w-0 grow text-left">
+        <div className="flex items-start justify-between gap-x-4">
+          <div className="min-w-0">
+            <Typography brand="neutral-translucent" className="truncate">
+              {title}
+            </Typography>
+
+            <Typography appearance="subdued" className="truncate" typographyType="body-sm">
+              {summary}
+            </Typography>
+
+            <Typography appearance="subdued" className="truncate" typographyType="body-sm">
+              {detail}
+            </Typography>
+          </div>
+
+          {entryActions}
+        </div>
+      </div>
+
+      {action}
+
+      <Icon className="shrink-0 text-translucent-moderate" path={mdiChevronRight} size="lg" />
+    </div>
+  );
+};

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -1,4 +1,4 @@
-import { mdiCheck, mdiDownload, mdiHelpCircleOutline, mdiOpenInNew } from "@mdi/js";
+import { mdiCheck, mdiHelpCircleOutline, mdiMonitorArrowDownVariant, mdiOpenInNew } from "@mdi/js";
 import React, { useCallback, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -125,7 +125,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                   <Button
                     appearance="strong"
                     brand="neutral"
-                    leftIconPath={mdiDownload}
+                    leftIconPath={mdiMonitorArrowDownVariant}
                     rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
                     size="sm"
                     onClick={() => void installInApp()}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -1,24 +1,20 @@
-import { mdiChevronRight, mdiMonitorArrowDownVariant } from "@mdi/js";
-import React, { type KeyboardEvent } from "react";
+import { mdiMonitorArrowDownVariant } from "@mdi/js";
+import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { severityStyleMap } from "@/extensions/health_check/utils/shared/severityStyles";
 import { Button } from "@/ui/components/button/Button";
-import { Icon } from "@/ui/components/icon/Icon";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
-import { Typography } from "@/ui/components/typography/Typography";
-import { joinClasses } from "@/ui/utils/joinClasses";
 
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import type { IModRequirementExt } from "../../types";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
+import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
 import { PremiumModal } from "../premium_modal/PremiumModal";
 
 export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IListingRowProps) => {
   const { t } = useTranslation(["health_check", "common"]);
   const mod = entry.data as IModRequirementExt;
-  const severityStyle = severityStyleMap[entry.severity];
 
   const {
     givenFeedback,
@@ -33,71 +29,44 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
   return (
     <>
-      <div
-        className="group hover-overlay-weak flex w-full cursor-pointer items-center gap-x-4 rounded-sm bg-surface-mid px-4 py-3 shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info-subdued"
-        role="button"
-        tabIndex={0}
-        onClick={onOpen}
-        onKeyDown={(e: KeyboardEvent) => {
-          if (["Enter", " "].includes(e.key)) {
-            e.preventDefault();
-            onOpen();
-          }
-        }}
-      >
-        <Icon
-          className={joinClasses(["shrink-0", severityStyle.textClassName])}
-          path={severityStyle.iconPath}
-        />
-
-        <div className="min-w-0 grow text-left">
-          <div className="flex items-start justify-between gap-x-4">
-            <div className="min-w-0">
-              <Typography brand="neutral-translucent" className="truncate">
-                {t("listing::item::title", { modName: mod.requiredBy.modName })}
-              </Typography>
-
-              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
-                {mod.notes
-                  ? t("detail::item::author_note", { note: mod.notes })
-                  : t("detail::item::may_require_file")}
-              </Typography>
-
-              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
-                {t("listing::item::description", {
-                  dependencyModName: mod.modName || mod.modUrl || mod.notes,
-                })}
-              </Typography>
-            </div>
-
-            <EntryActions
-              givenFeedback={givenFeedback}
-              isHidden={isHidden}
-              variant="listing"
-              onHelpful={handlePositiveFeedback}
-              onNotHelpful={handleFeedbackSuccess}
-              onToggleHide={onToggleHide}
-            />
-          </div>
-        </div>
-
-        <Button
-          appearance="moderate"
-          brand="neutral"
-          className="shrink-0 self-center"
-          leftIconPath={mdiMonitorArrowDownVariant}
-          rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            void installInApp();
-          }}
-        >
-          {t("detail::item::install_one_click")}
-        </Button>
-
-        <Icon className="shrink-0 text-translucent-moderate" path={mdiChevronRight} size="lg" />
-      </div>
+      <ListingRowShell
+        action={
+          <Button
+            appearance="moderate"
+            brand="neutral"
+            leftIconPath={mdiMonitorArrowDownVariant}
+            rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              void installInApp();
+            }}
+          >
+            {t("detail::item::install_one_click")}
+          </Button>
+        }
+        detail={t("listing::item::description", {
+          dependencyModName: mod.modName || mod.modUrl || mod.notes,
+        })}
+        entryActions={
+          <EntryActions
+            givenFeedback={givenFeedback}
+            isHidden={isHidden}
+            variant="listing"
+            onHelpful={handlePositiveFeedback}
+            onNotHelpful={handleFeedbackSuccess}
+            onToggleHide={onToggleHide}
+          />
+        }
+        severity={entry.severity}
+        summary={
+          mod.notes
+            ? t("detail::item::author_note", { note: mod.notes })
+            : t("detail::item::may_require_file")
+        }
+        title={t("listing::item::title", { modName: mod.requiredBy.modName })}
+        onOpen={onOpen}
+      />
 
       <PremiumModal
         isOpen={showPremiumModal}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -1,4 +1,4 @@
-import { mdiChevronRight, mdiDownload } from "@mdi/js";
+import { mdiChevronRight, mdiMonitorArrowDownVariant } from "@mdi/js";
 import React, { type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -53,8 +53,14 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
         <div className="min-w-0 grow text-left">
           <div className="flex items-start justify-between gap-x-4">
             <div className="min-w-0">
-              <Typography className="truncate">
+              <Typography brand="neutral-translucent" className="truncate">
                 {t("listing::item::title", { modName: mod.requiredBy.modName })}
+              </Typography>
+
+              <Typography appearance="subdued" className="truncate" typographyType="body-sm">
+                {mod.notes
+                  ? t("detail::item::author_note", { note: mod.notes })
+                  : t("detail::item::may_require_file")}
               </Typography>
 
               <Typography appearance="subdued" className="truncate" typographyType="body-sm">
@@ -79,7 +85,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
           appearance="moderate"
           brand="neutral"
           className="shrink-0 self-center"
-          leftIconPath={mdiDownload}
+          leftIconPath={mdiMonitorArrowDownVariant}
           rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
           size="sm"
           onClick={(e) => {

--- a/src/renderer/src/extensions/health_check/hooks/useReportCopy.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useReportCopy.ts
@@ -1,21 +1,30 @@
 import { useTranslation } from "react-i18next";
 
-import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
+import type {
+  FileRequirementCategory,
+  IFileRequirementReport,
+} from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
+
+/** Shared-namespace summary key per report category. Pluralised via `_plural`. */
+const summaryKeyByCategory: Record<FileRequirementCategory, string> = {
+  download: "shared::requires_files",
+  "download-replace": "shared::wrong_version_installed",
+  "install-uninstalled": "shared::correct_version_uninstalled",
+  toggle: "shared::wrong_version_enabled",
+  or: "shared::requires_pick",
+};
 
 /** The localized title and summary for a report, by category and entry count. */
 export const useReportCopy = (report: IFileRequirementReport) => {
   const { t } = useTranslation(["health_check", "common"]);
+
   const count = report.requirements.length;
-  const title = t(count > 1 ? "listing::item::missing_for_plural" : "listing::item::missing_for", {
-    modName: report.sourceModName,
-  });
-  const summary =
-    report.category === "or"
-      ? t(count > 1 ? "listing::item::requires_pick_plural" : "listing::item::requires_pick", {
-          count,
-        })
-      : t(count > 1 ? "shared::requires_files_plural" : "shared::requires_files", {
-          count,
-        });
-  return { title, summary };
+  const summaryKey = summaryKeyByCategory[report.category];
+
+  return {
+    title: t(count > 1 ? "listing::item::missing_for_plural" : "listing::item::missing_for", {
+      modName: report.sourceModName,
+    }),
+    summary: t(count > 1 ? `${summaryKey}_plural` : summaryKey, { count }),
+  };
 };

--- a/src/renderer/src/extensions/health_check/hooks/useReportCopy.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useReportCopy.ts
@@ -14,7 +14,7 @@ export const useReportCopy = (report: IFileRequirementReport) => {
       ? t(count > 1 ? "listing::item::requires_pick_plural" : "listing::item::requires_pick", {
           count,
         })
-      : t(count > 1 ? "listing::item::requires_count_plural" : "listing::item::requires_count", {
+      : t(count > 1 ? "shared::requires_files_plural" : "shared::requires_files", {
           count,
         });
   return { title, summary };

--- a/src/renderer/src/extensions/health_check/index.ts
+++ b/src/renderer/src/extensions/health_check/index.ts
@@ -34,6 +34,16 @@ function init(context: IExtensionContext): boolean {
   // through it — no buffering, no two-phase setup.
   registry = new HealthCheckRegistry(context.api);
 
+  // Bridge so clicking the "Health check" menu item while already on the page
+  // returns to the listing. HealthCheckPage registers its "back to listing"
+  // handler here; the Menu calls onReset (below) only when the page is already
+  // active. When navigating in from elsewhere the page stays mounted, so its
+  // selected-detail state is preserved and the last-viewed check is restored.
+  let resetHealthCheckPage: (() => void) | undefined;
+  const registerReset = (cb: () => void) => {
+    resetHealthCheckPage = cb;
+  };
+
   context.registerHealthCheck = (hc: IHealthCheck | IModHealthCheck) => {
     registry.register(hc);
   };
@@ -58,7 +68,9 @@ function init(context: IExtensionContext): boolean {
     props: () => ({
       api: context.api,
       onRefresh: () => healthCheckApi?.runChecksByTrigger?.(HealthCheckTrigger.Manual),
+      registerReset,
     }),
+    onReset: () => resetHealthCheckPage?.(),
   });
 
   context.once(() => {

--- a/src/renderer/src/extensions/health_check/utils/shared/severityStyles.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/severityStyles.ts
@@ -7,18 +7,18 @@ export const severityStyleMap: Record<
   { backgroundClassName: string; iconPath: string; textClassName: string }
 > = {
   error: {
-    backgroundClassName: "bg-danger-strong",
+    backgroundClassName: "bg-danger-moderate",
     iconPath: mdiAlertOctagonOutline,
     textClassName: "text-danger-strong",
   },
   suggestion: {
     backgroundClassName: "bg-info-moderate",
     iconPath: mdiInformationOutline,
-    textClassName: "text-info-moderate",
+    textClassName: "text-info-strong",
   },
   warning: {
     backgroundClassName: "bg-warning-moderate",
     iconPath: mdiAlertOutline,
-    textClassName: "text-warning-moderate",
+    textClassName: "text-warning-strong",
   },
 };

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -10,6 +10,7 @@ import { Page } from "@/views/components/Page/Page";
 import { PageHeader } from "@/views/components/Page/PageHeader";
 import { PageScroll } from "@/views/components/Page/PageScroll";
 
+import { BetaBadge } from "../components/beta_badge/BetaBadge";
 import { PremiumBanner } from "../components/premium_banner/PremiumBanner";
 import {
   fileRequirementsCheckResult,
@@ -75,13 +76,7 @@ function HealthCheckDetailPage({
               {t(`detail::title::${shownEntry.severity}`)}
             </Typography>
 
-            <Typography
-              as="div"
-              className="flex min-h-4 items-center justify-center rounded-sm border border-neutral-strong px-1"
-              typographyType="title-xs"
-            >
-              {t("common:::beta")}
-            </Typography>
+            <BetaBadge />
           </div>
         }
         pictogramName="health-check"

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -6,7 +6,7 @@ import {
   mdiEyeOff,
   mdiRefresh,
 } from "@mdi/js";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -49,6 +49,8 @@ interface IHealthCheckPageProps {
   api: IExtensionApi;
   onRefresh?: () => void;
   active?: boolean;
+  /** Registers a handler the Menu calls when Health check is clicked while already active. */
+  registerReset?: (cb: () => void) => void;
 }
 
 /**
@@ -85,11 +87,18 @@ function collectInstallAllItems(state: IState, api: IExtensionApi): IBulkInstall
   return out;
 }
 
-function HealthCheckPage({ api, onRefresh, active }: IHealthCheckPageProps) {
+function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheckPageProps) {
   const { t } = useTranslation(["health_check", "common"]);
   const dispatch = useDispatch();
   const [selected, setSelected] = useState<IListedEntry | null>(null);
   const [selectedTab, setSelectedTab] = useState("active");
+
+  // Clicking the Health check menu item while already on the page returns to
+  // the listing (closes any open detail). setSelected is stable, so registering
+  // once on mount is enough.
+  useEffect(() => {
+    registerReset?.(() => setSelected(null));
+  }, [registerReset]);
 
   // Subscribe only to the slices the listing + install-all derive from, so the
   // frequent unrelated dispatches during a check run (mod-file and mod-attribute

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -67,7 +67,7 @@ function LastUpdated() {
     return null;
   }
   return (
-    <Typography appearance="moderate" typographyType="body-sm">
+    <Typography appearance="subdued" brand="neutral-translucent" typographyType="body-sm">
       {t("listing::last_updated", { time })}
     </Typography>
   );

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -30,6 +30,7 @@ import { PageHeader } from "@/views/components/Page/PageHeader";
 import { PageScroll } from "@/views/components/Page/PageScroll";
 
 import { shouldShowPremiumAd } from "../../nexus_integration/selectors";
+import { BetaBadge } from "../components/beta_badge/BetaBadge";
 import { PremiumBanner } from "../components/premium_banner/PremiumBanner";
 import { PremiumModal } from "../components/premium_modal/PremiumModal";
 import {
@@ -203,9 +204,17 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
   return (
     <Page active={active} id="health-check-page" scrollable={false}>
       <PageHeader
+        customTitle={
+          <div className="flex items-center gap-x-1.5">
+            <Typography appearance="moderate" as="h2" typographyType="heading-xs">
+              {t("listing::title")}
+            </Typography>
+
+            <BetaBadge />
+          </div>
+        }
         pictogramName="health-check"
         subtitle={t("listing::subtitle")}
-        title={t("listing::title")}
       >
         <div className="flex shrink-0 items-center gap-x-2">
           <LastUpdated />

--- a/src/renderer/src/views/components/iconMap.ts
+++ b/src/renderer/src/views/components/iconMap.ts
@@ -5,7 +5,6 @@ import {
   mdiDownload,
   mdiEye,
   mdiGamepadSquare,
-  mdiPulse,
   mdiHelpCircle,
   mdiInformationOutline,
   mdiMenu,
@@ -19,6 +18,11 @@ import {
   mdiWrench,
 } from "@mdi/js";
 
+// Material Symbols "heart-pulse" (outlined), transformed from the 0 -960 960 960
+// viewBox to MDI's 0 0 24 24 space so it renders through the shared Icon component.
+const heartPulseOutline =
+  "M7.5 3q1.3 0 2.475 0.55t2.025 1.55q0.85 -1 2.025 -1.55t2.475 -0.55q2.35 0 3.925 1.575t1.575 3.925q0 0.125 -0.013 0.25t-0.013 0.25h-2q0.025 -0.125 0.025 -0.25v-0.25q0 -1.5 -1 -2.5t-2.5 -1q-1.175 0 -2.175 0.663T12.95 7.35h-1.9q-0.375 -1.025 -1.375 -1.688T7.5 5q-1.5 0 -2.5 1t-1 2.5v0.25q0 0.125 0.025 0.25H2.025q0 -0.125 -0.013 -0.25t-0.013 -0.25q0 -2.35 1.575 -3.925t3.925 -1.575Zm-2.2 12h2.8q0.8 0.775 1.75 1.675t2.15 1.975q1.2 -1.075 2.15 -1.975t1.75 -1.675h2.825q-0.95 1.05 -2.25 2.275T13.45 20.05l-1.45 1.3l-1.45 -1.3q-1.725 -1.55 -3.013 -2.775T5.3 15Zm5.75 1q0.325 0 0.562 -0.188T11.95 15.325l1.35 -4.075l0.875 1.3q0.125 0.2 0.35 0.325t0.475 0.125h8v-2H15.575l-1.725 -2.55q-0.15 -0.225 -0.388 -0.338T12.95 8q-0.325 0 -0.562 0.188T12.05 8.675l-1.35 4.05l-0.85 -1.275q-0.125 -0.2 -0.35 -0.325t-0.475 -0.125H1v2h7.425l1.725 2.55q0.15 0.225 0.388 0.338T11.05 16Zm0.95 -4.175Z";
+
 // Map legacy icon names to MDI paths
 const iconMap: Record<string, string> = {
   dashboard: mdiViewDashboard,
@@ -26,7 +30,7 @@ const iconMap: Record<string, string> = {
   settings: mdiCog,
   download: mdiDownload,
   game: mdiGamepadSquare,
-  health: mdiPulse,
+  health: heartPulseOutline,
   support: mdiHelpCircle,
   about: mdiInformationOutline,
   menu: mdiMenu,


### PR DESCRIPTION
### Changes
- Menu item resets to the listing — clicking Health check in the menu while already on the page closes any open detail and returns to the listing; navigating in from another page restores the last-viewed detail.
- Unified file-requirement copy — the listing card and detail view now render identical, category-accurate intro text from a single source (useReportCopy), with the per-category strings living in the shared locale namespace. Removed the now-unused requires_count strings and renamed the toggle group's enabled_version key to enable_required.
- Requirement UI polish — swapped action-button icons, tidied listing-row typography, added a summary line to mod-requirement rows, adjusted FileRequirement spacing/separators, and softened the severity colors.
- BetaBadge component — extracted the duplicated "Beta" pill shared by the listing and detail headers.
- Menu icon — Health check now uses an outlined heart-pulse icon.