### PR TITLE
Fix PageHeader collapse jitter on barely-scrollable pages

### DIFF
--- a/src/renderer/src/views/components/Page/Page.context.tsx
+++ b/src/renderer/src/views/components/Page/Page.context.tsx
@@ -1,15 +1,18 @@
 import { createContext, useContext } from "react";
 
-export interface IPageScrollContext {
+export interface IPageState {
   scrolled: boolean;
-  setScrolled: (scrolled: boolean) => void;
+  collapsed: boolean;
 }
 
-export const PageScrollContext = createContext<IPageScrollContext | null>(null);
+export interface IPageContext extends IPageState {
+  setPageState: (state: IPageState) => void;
+}
 
-/**
- * Whether the page's `PageScroll` region has been scrolled away from the top.
- * Returns false outside a `Page`. Use it in descendants of a `PageHeader` /
- * `PageScroll` to drive scroll-linked transitions.
- */
-export const usePageScrolled = (): boolean => useContext(PageScrollContext)?.scrolled ?? false;
+export const PageContext = createContext<IPageContext>({
+  scrolled: false,
+  collapsed: false,
+  setPageState: () => {},
+});
+
+export const usePageContext = (): IPageContext => useContext(PageContext);

--- a/src/renderer/src/views/components/Page/Page.tsx
+++ b/src/renderer/src/views/components/Page/Page.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, type HTMLAttributes, useCallback, useMemo, useState 
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-import { type IPageScrollContext, PageScrollContext } from "./Page.context";
+import { type IPageContext, type IPageState, PageContext } from "./Page.context";
 import { PageContent } from "./PageContent";
 
 export interface IPageProps extends HTMLAttributes<HTMLDivElement> {
@@ -51,11 +51,9 @@ export const Page = forwardRef<HTMLDivElement, IPageProps>(
     },
     ref,
   ) => {
-    const [scrolled, setScrolled] = useState(false);
-    const scrollContext = useMemo<IPageScrollContext>(
-      () => ({ scrolled, setScrolled }),
-      [scrolled],
-    );
+    const [pageState, setPageState] = useState<IPageState>({ scrolled: false, collapsed: false });
+
+    const pageContext = useMemo<IPageContext>(() => ({ ...pageState, setPageState }), [pageState]);
 
     const setRef = useCallback(
       (element: HTMLDivElement | null) => {
@@ -72,7 +70,7 @@ export const Page = forwardRef<HTMLDivElement, IPageProps>(
     );
 
     return (
-      <PageScrollContext.Provider value={scrollContext}>
+      <PageContext.Provider value={pageContext}>
         <div
           className={joinClasses([
             "my-0.5 mr-0.5 flex flex-1 flex-col transition-opacity",
@@ -92,7 +90,7 @@ export const Page = forwardRef<HTMLDivElement, IPageProps>(
             {children}
           </PageContent>
         </div>
-      </PageScrollContext.Provider>
+      </PageContext.Provider>
     );
   },
 );

--- a/src/renderer/src/views/components/Page/PageHeader.tsx
+++ b/src/renderer/src/views/components/Page/PageHeader.tsx
@@ -5,7 +5,7 @@ import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import type { XOr } from "@/ui/utils/types";
 
-import { usePageScrolled } from "./Page.context";
+import { usePageContext } from "./Page.context";
 import { PageContent } from "./PageContent";
 
 export type IPageHeaderProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
@@ -36,13 +36,14 @@ export const PageHeader = ({
   subtitle,
   ...rest
 }: IPageHeaderProps) => {
-  const scrolled = usePageScrolled();
+  const { scrolled, collapsed } = usePageContext();
 
   return (
     <div
       className={joinClasses([
-        "relative z-10 w-full pb-3 transition-[padding]",
-        scrolled ? "pt-3 shadow-md" : "border-b border-stroke-weak pt-6",
+        "relative z-10 w-full border-b pb-3 transition-[padding]",
+        collapsed ? "pt-3" : "pt-6",
+        scrolled ? "border-transparent shadow-md" : "border-stroke-weak",
         className,
       ])}
       {...rest}
@@ -53,7 +54,7 @@ export const PageHeader = ({
             <Pictogram
               className={joinClasses([
                 "transition-[width,height]",
-                scrolled ? "size-7" : "size-14",
+                collapsed ? "size-7" : "size-14",
               ])}
               name={pictogramName}
               size="none"
@@ -68,7 +69,7 @@ export const PageHeader = ({
             )}
 
             {!!subtitle && (
-              <Typography appearance="subdued" className={joinClasses({ hidden: scrolled })}>
+              <Typography appearance="subdued" className={joinClasses({ hidden: collapsed })}>
                 {subtitle}
               </Typography>
             )}

--- a/src/renderer/src/views/components/Page/PageScroll.tsx
+++ b/src/renderer/src/views/components/Page/PageScroll.tsx
@@ -1,17 +1,7 @@
-import React, {
-  forwardRef,
-  type HTMLAttributes,
-  type UIEvent,
-  useCallback,
-  useContext,
-} from "react";
+import React, { forwardRef, type HTMLAttributes, type UIEvent, useCallback } from "react";
 
-import { PageScrollContext } from "./Page.context";
+import { usePageContext } from "./Page.context";
 import { PageContent } from "./PageContent";
-
-export type IPageScrollProps = HTMLAttributes<HTMLDivElement> & {
-  isFullWidth?: boolean;
-};
 
 /**
  * Scrolling region for a non-scrolling `Page`. Fills the remaining space and
@@ -27,13 +17,31 @@ export type IPageScrollProps = HTMLAttributes<HTMLDivElement> & {
  * Only use inside a `Page` with `scrollable={false}`; nesting it in a scrollable
  * `Page` stacks two scroll containers (double scrollbars).
  */
+
+const COLLAPSE_OVERFLOW_THRESHOLD = 64;
+
+export type IPageScrollProps = HTMLAttributes<HTMLDivElement> & {
+  isFullWidth?: boolean;
+};
+
 export const PageScroll = forwardRef<HTMLDivElement, IPageScrollProps>(
   ({ children, className, isFullWidth = false, onScroll, ...rest }, ref) => {
-    const context = useContext(PageScrollContext);
+    const context = usePageContext();
 
     const handleScroll = useCallback(
       (event: UIEvent<HTMLDivElement>) => {
-        context?.setScrolled(event.currentTarget.scrollTop > 0);
+        const el = event.currentTarget;
+        const atTop = el.scrollTop <= 0;
+        const overflow = el.scrollHeight - el.clientHeight;
+        const scrolled = !atTop;
+        const collapsed = context.collapsed
+          ? !atTop
+          : !atTop && overflow > COLLAPSE_OVERFLOW_THRESHOLD;
+
+        if (scrolled !== context.scrolled || collapsed !== context.collapsed) {
+          context.setPageState({ scrolled, collapsed });
+        }
+
         onScroll?.(event);
       },
       [context, onScroll],


### PR DESCRIPTION
Collapsing the header freed vertical space in the PageScroll region, so on content that only just overflowed the collapse removed the overflow, the browser reset scrollTop to 0, the header re-expanded, and it oscillated.

Decouple the header shadow (any scroll) from the collapse (size reduction): the shadow no longer changes layout height (border is always 1px, colour- swapped), and the collapse is gated by hysteresis + an overflow threshold so it only engages when there's room to sustain it. Merge the two flags behind a single generic page context (IPageState / usePageContext) for future use.