### PR TITLE
fix CP77 community game extension showing as official

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4614,9 +4614,6 @@ importers:
       '@types/xml2js':
         specifier: 'catalog:'
         version: 0.4.14
-      '@vortex/adaptor-cyberpunk2077':
-        specifier: workspace:*
-        version: link:../../packages/adaptors/cyberpunk2077
       '@welldone-software/why-did-you-render':
         specifier: 'catalog:'
         version: 10.0.1(react@16.14.0)

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -372,7 +372,6 @@
     "@types/write-file-atomic": "catalog:",
     "@types/ws": "catalog:",
     "@types/xml2js": "catalog:",
-    "@vortex/adaptor-cyberpunk2077": "workspace:*",
     "@welldone-software/why-did-you-render": "catalog:",
     "cross-env": "catalog:",
     "electron": "catalog:",

--- a/src/renderer/src/extensions/file_based_loadorder/gameSupport.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/gameSupport.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
-import { COMPANY_ID } from "../../util/constants";
 import * as fs from "../../util/fs";
+import { isContributed } from "../../util/isContributed";
 import { log } from "../../util/log";
 import type { ILoadOrderGameInfo, ILoadOrderGameInfoExt } from "./types/types";
 
@@ -37,7 +37,7 @@ export function addGameEntry(gameEntry: ILoadOrderGameInfo, extPath: string) {
 
   gameSupport.push({
     ...gameEntry,
-    isContributed: gameExtInfo.author !== COMPANY_ID,
+    isContributed: isContributed(gameExtInfo.author),
   });
 }
 

--- a/src/renderer/src/extensions/gamemode_management/index.ts
+++ b/src/renderer/src/extensions/gamemode_management/index.ts
@@ -26,10 +26,10 @@ import type { IGameStore } from "../../types/IGameStore";
 import type { NotificationDismiss } from "../../types/INotification";
 import type { IProfile, IRunningTool, IState } from "../../types/IState";
 import type { IEditChoice, ITableAttribute } from "../../types/ITableAttribute";
-import { COMPANY_ID, NEXUSMODS_EXT_ID } from "../../util/constants";
 import { DataInvalid, ProcessCanceled, SetupError, UserCanceled } from "../../util/CustomErrors";
 import * as fs from "../../util/fs";
 import GameStoreHelper from "../../util/GameStoreHelper";
+import { isContributed } from "../../util/isContributed";
 import local from "../../util/local";
 import { showError } from "../../util/message";
 import opn from "../../util/opn";
@@ -740,10 +740,7 @@ function init(context: IExtensionContext): boolean {
             encoding: "utf8",
           }),
         );
-        game.contributed =
-          gameExtInfo.author === COMPANY_ID || gameExtInfo.author === NEXUSMODS_EXT_ID
-            ? undefined
-            : gameExtInfo.author;
+        game.contributed = isContributed(gameExtInfo.author) ? gameExtInfo.author : undefined;
         game.final = semver.gte(gameExtInfo.version, "1.0.0");
         game.version = gameExtInfo.version;
       } else {

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -13,6 +13,7 @@ import { Picker } from "@/ui/components/picker/Picker";
 import { Pictogram } from "@/ui/components/pictogram/Pictogram";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
+import { isContributed } from "@/util/isContributed";
 import { getSafe } from "@/util/storeHelper";
 
 import { connect, translate } from "../../../controls/ComponentEx";
@@ -248,7 +249,7 @@ const GamePicker = ({
         imageURL: ext.image,
         requiredFiles: [],
         executable: undefined,
-        contributed: ext.author,
+        contributed: isContributed(ext.author) ? ext.author : undefined,
       }))
       .filter((ext) => showHidden || !(discoveredGames[ext.id]?.hidden ?? false)),
   );

--- a/src/renderer/src/util/errorHandling.test.ts
+++ b/src/renderer/src/util/errorHandling.test.ts
@@ -1,6 +1,8 @@
 import { recordErrorOnSpan } from "@vortex/shared/telemetry";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { IError } from "../types/IError";
+import { COMPANY_ID, NEXUSMODS_EXT_ID } from "./constants";
 import { genHash } from "./genHash";
 import { log } from "./log";
 
@@ -16,7 +18,7 @@ vi.mock("./genHash", () => ({ genHash: vi.fn() }));
 vi.mock("./application", () => ({ getApplication: () => ({ version: "1.2.3" }) }));
 vi.mock("@vortex/shared/telemetry", () => ({ recordErrorOnSpan: vi.fn() }));
 
-import { reportRenderError } from "./errorHandling";
+import { reportRenderError, resolveAllowReport } from "./errorHandling";
 
 const errorInfo = { componentStack: "\n    in Foo\n    in Bar" };
 
@@ -87,5 +89,31 @@ describe("reportRenderError", () => {
       error: error.stack,
       componentStack: undefined,
     });
+  });
+});
+
+describe("resolveAllowReport", () => {
+  const err = (extra: Partial<IError>): IError => ({ message: "boom", ...extra }) as IError;
+
+  it("keeps an explicit caller decision regardless of the extension", () => {
+    expect(resolveAllowReport(err({ extension: "SomeModder" }), true)).toBe(true);
+    expect(resolveAllowReport(err({ extension: COMPANY_ID }), false)).toBe(false);
+  });
+
+  it("suppresses reporting when the error opts out", () => {
+    expect(resolveAllowReport(err({ allowReport: false }))).toBe(false);
+  });
+
+  it("allows reporting for crashes in a first-party extension", () => {
+    expect(resolveAllowReport(err({ extension: COMPANY_ID }))).toBe(true);
+    expect(resolveAllowReport(err({ extension: NEXUSMODS_EXT_ID }))).toBe(true);
+  });
+
+  it("suppresses reporting for crashes in a community extension", () => {
+    expect(resolveAllowReport(err({ extension: "SomeModder" }))).toBe(false);
+  });
+
+  it("leaves the decision undefined when nothing determines it", () => {
+    expect(resolveAllowReport(err({}))).toBeUndefined();
   });
 });

--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -18,11 +18,11 @@ import { isTelemetryEnabled } from "../telemetry/selectors";
 import type { IErrorOptions, IExtensionApi, IState } from "../types/api";
 import type { IError } from "../types/IError";
 import { getApplication } from "./application";
-import { COMPANY_ID } from "./constants";
 import { UserCanceled } from "./CustomErrors";
 import { genHash } from "./genHash";
 import getVortexPath from "./getVortexPath";
 import { fallbackTFunc } from "./i18n";
+import { isContributed } from "./isContributed";
 import { log } from "./log";
 import { flatten, getAllPropertyNames, spawnSelf } from "./util";
 
@@ -206,6 +206,24 @@ async function showTerminateError(
 }
 
 /**
+ * Decides whether a terminating error may be reported. An explicit caller
+ * value wins; otherwise an error that opts out isn't reportable, and a crash
+ * from a first-party extension is reportable while a community one is not.
+ */
+export function resolveAllowReport(error: IError, allowReport?: boolean): boolean | undefined {
+  if (allowReport !== undefined) {
+    return allowReport;
+  }
+  if (error.allowReport === false) {
+    return false;
+  }
+  if (error.extension !== undefined) {
+    return !isContributed(error.extension);
+  }
+  return undefined;
+}
+
+/**
  * display an error message and quit the application
  * on confirmation.
  * Use this whenever the application state is unknown and thus
@@ -220,13 +238,7 @@ export function terminate(
   allowReport?: boolean,
   source?: string,
 ) {
-  if (allowReport === undefined && error.allowReport === false) {
-    allowReport = false;
-  }
-
-  if (allowReport === undefined && error.extension !== undefined) {
-    allowReport = error.extension === COMPANY_ID;
-  }
+  allowReport = resolveAllowReport(error, allowReport);
 
   log("error", "unrecoverable error", { error, process: process.type });
 

--- a/src/renderer/src/util/isContributed.ts
+++ b/src/renderer/src/util/isContributed.ts
@@ -1,0 +1,14 @@
+import { COMPANY_ID, NEXUSMODS_EXT_ID } from "./constants";
+
+// Lives here rather than in the extension manager util, which is mid-rework.
+// TODO: adopt this in ExtensionManager's two `author !== COMPANY_ID` checks and
+// move it into the extension manager util.
+
+const OFFICIAL_AUTHORS = [COMPANY_ID, NEXUSMODS_EXT_ID];
+
+// True when the extension is community-contributed rather than official.
+// First-party authors (Nexus Mods / Black Tree Gaming Ltd.) and empty values
+// are treated as official.
+export function isContributed(author: string | undefined): boolean {
+  return !!author && !OFFICIAL_AUTHORS.includes(author);
+}


### PR DESCRIPTION
Our GDL implementation of Cyberpunk 2077 is unreleased and unused, so bundling it only pollutes the environment (code is left untouched in case we decide to restore this eventually). Removing it also stops the game reading as official instead of community in the game picker.

Also folds the official-author checks into an isContributed helper and tests resolveAllowReport. The crash-report gate previously recognised only Black Tree Gaming Ltd. as official, diverging from the other checks, so crashes in Nexus Mods-authored extensions were likely never reported; they now are.

closes LAZ-825