### PR TITLE
Fix stale Mod Requirements by switching to a session cache rather than persistent storage

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -18,7 +18,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @nexusmods/file-dependency-resolver | link:../../packages/file-dependency-resolver |
 | @nexusmods/fomod-installer-ipc | 0.13.3 |
 | @nexusmods/fomod-installer-native | 0.13.3 |
-| @nexusmods/nexus-api | 1.7.1 |
+| @nexusmods/nexus-api | 1.7.2 |
 | @opentelemetry/api | 1.9.1 |
 | @opentelemetry/context-async-hooks | 2.8.0 |
 | @opentelemetry/context-zone | 2.8.0 |

--- a/src/renderer/src/extensions/health_check/actions/session.ts
+++ b/src/renderer/src/extensions/health_check/actions/session.ts
@@ -1,6 +1,5 @@
 import safeCreateAction from "../../../actions/safeCreateAction";
 import type { IHealthCheckResult } from "../../../types/IHealthCheck";
-import type { IModFileInfo } from "../types";
 
 /**
  * Set the result of a health check
@@ -32,20 +31,4 @@ export const clearAllHealthCheckResults = safeCreateAction(
 export const setHealthCheckRunning = safeCreateAction(
   "SET_HEALTH_CHECK_RUNNING",
   (checkId: string, running: boolean) => ({ checkId, running }),
-);
-
-/**
- * Set mod files in cache
- */
-export const setModFiles = safeCreateAction(
-  "SET_MOD_FILES",
-  (modId: number, files: IModFileInfo[]) => ({ modId, files }),
-);
-
-/**
- * Set whether mod files are being loaded
- */
-export const setModFilesLoading = safeCreateAction(
-  "SET_MOD_FILES_LOADING",
-  (modId: number, loading: boolean) => ({ modId, loading }),
 );

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -442,6 +442,8 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
               fileId: "0",
               gameId: gameIdForStorage,
             }),
+            // Denormalized for the detail view; see IModRequirementExt.mainFile.
+            mainFile: mainFiles[0],
             requiredBy,
             modUrl:
               (req.url && req.url.trim()) ||

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -7,10 +7,14 @@ import type { IModRequirements } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 
 import { getModFilesWithCache } from "@/extensions/health_check/utils/modRequirements/modFiles";
-import { chunked } from "@/extensions/health_check/utils/shared/batchCache";
+import {
+  chunked,
+  createKeyedCache,
+  resolveCached,
+  type KeyedCache,
+} from "@/extensions/health_check/utils/shared/batchCache";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
 
-import { setModAttribute } from "../../../actions";
 import { log } from "../../../logging";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import {
@@ -22,7 +26,6 @@ import {
 } from "../../../types/IHealthCheck";
 import { getGame, nexusGameId, renderModName } from "../../../util/api";
 import { getSafe } from "../../../util/storeHelper";
-import { batchDispatch } from "../../../util/util";
 import type { IMod } from "../../mod_management/types/IMod";
 import { isLoggedIn } from "../../nexus_integration/selectors";
 import { numericGameIdToDomainName } from "../../nexus_integration/util";
@@ -34,7 +37,6 @@ import type {
   IModFileInfo,
   IModRequirementsCheckMetadata,
   IModMissingRequirements,
-  IModRequirementsCheckParams,
   IModRequirementExt,
 } from "../types";
 
@@ -42,6 +44,13 @@ export const MOD_REQUIREMENTS_CHECK_ID = "check-nexus-mod-requirements";
 
 // Per-mod file-list lookups have no batch endpoint; fan them out this many at a time.
 const FILE_LOOKUP_CONCURRENCY = 20;
+
+// Mod requirements rarely change between runs; cache them in memory for a while
+// so re-runs (e.g. on ModsChanged) refetch at most once per TTL and always
+// refetch after a restart
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const modRequirementsCache: KeyedCache<Partial<IModRequirements>> = createKeyedCache(CACHE_TTL_MS);
 
 /**
  * Create a result object for the mod requirements check
@@ -141,13 +150,28 @@ function resolveRequirementTarget(
 }
 
 /**
+ * Resolve a mod's Nexus mod UID (the game id + game-scoped mod id composite)
+ * Returns undefined when the mod has no usable Nexus mod id.
+ */
+function resolveModUID(mod: IMod, gameId: string): string | undefined {
+  const modId = mod.attributes?.modId;
+  if (modId === undefined) {
+    return undefined;
+  }
+  return (
+    makeModUID({
+      gameId: mod.attributes?.downloadGame ?? gameId,
+      modId: String(modId),
+      fileId: "0",
+    }) ?? undefined
+  );
+}
+
+/**
  * Check Nexus mod requirements
  * Fetches requirements from Nexus API and checks if they are satisfied
  */
-export async function checkModRequirements(
-  api: IExtensionApi,
-  params?: IModRequirementsCheckParams,
-): Promise<IHealthCheckResult> {
+export async function checkModRequirements(api: IExtensionApi): Promise<IHealthCheckResult> {
   const startTime = Date.now();
   try {
     const state = api.getState();
@@ -171,8 +195,6 @@ export async function checkModRequirements(
       );
     }
 
-    const useCachedOnly = params?.cachedOnly === true;
-
     const enabledMods = getEnabledMods(api, gameId).filter(
       (mod: IMod) =>
         mod.type !== "collection" &&
@@ -187,13 +209,10 @@ export async function checkModRequirements(
 
     // Build lookup structures for O(1) access
     const installedModIds = new Set<number>();
-    const modsByNexusId = new Map<number, IMod>();
-
     for (const mod of enabledMods) {
       const nexusModId = mod.attributes?.modId;
       if (nexusModId) {
         installedModIds.add(nexusModId);
-        modsByNexusId.set(nexusModId, mod);
       }
     }
 
@@ -206,71 +225,77 @@ export async function checkModRequirements(
       errors: [],
     };
 
-    const modLimit = params?.limit ?? enabledMods.length;
-    const modsToCheck = enabledMods.slice(0, modLimit);
-
-    // Build a map of requirements: first from cache, then fetch missing ones
-    const requirementsMap: {
-      [modId: number]: Partial<IModRequirements> | undefined;
-    } = {};
-    const modsNeedingFetch: number[] = [];
-
-    // First pass: collect cached requirements and identify mods needing fetch
-    for (const mod of modsToCheck) {
-      const modId = mod.attributes?.modId;
-      if (!modId) continue;
-
-      const cachedRequirements = mod.attributes?.requirements as
-        | Partial<IModRequirements>
-        | undefined;
-
-      if (cachedRequirements) {
-        requirementsMap[modId] = cachedRequirements;
-      } else if (!useCachedOnly) {
-        modsNeedingFetch.push(modId);
+    // Key the session cache by mod UID. Installed mods sharing uid resolve
+    // to one UID and share a single cache entry.
+    const modsByUid = new Map<string, IMod>();
+    for (const mod of enabledMods) {
+      const uid = resolveModUID(mod, gameId);
+      if (uid) {
+        modsByUid.set(uid, mod);
       }
     }
 
-    // Batch fetch requirements for mods that don't have cached data
-    if (modsNeedingFetch.length > 0) {
-      try {
-        const nexusGetModRequirements = api.ext.nexusGetModRequirements as
-          | ((
-              gameId: string,
-              modIds: number[],
-            ) => Promise<{ [modId: number]: Partial<IModRequirements> }>)
-          | undefined;
+    const nexusGetModRequirements = api.ext.nexusGetModRequirements as
+      | ((
+          gameId: string,
+          modIds: number[],
+        ) => Promise<{ [modId: number]: Partial<IModRequirements> }>)
+      | undefined;
 
-        if (!nexusGetModRequirements) {
-          throw new Error("Nexus API not available");
-        }
+    // Resolve requirements through the timed session cache, fetching only the
+    // misses. resolveCached returns entries keyed by UID; re-key by mod id for
+    // the rest of the check, which works in numeric mod ids.
+    const requirementsMap: {
+      [modId: number]: Partial<IModRequirements> | undefined;
+    } = {};
 
-        const fetchedRequirements = await nexusGetModRequirements(gameId, modsNeedingFetch);
+    try {
+      const resolved = await resolveCached(
+        [...modsByUid.keys()],
+        modRequirementsCache,
+        async (missingUids): Promise<Map<string, Partial<IModRequirements>>> => {
+          const byUid = new Map<string, Partial<IModRequirements>>();
+          if (!nexusGetModRequirements) {
+            throw new Error("Nexus API not available");
+          }
+          // The endpoint is game-scoped and keyed by numeric mod id, so group
+          // the misses by each mod's own game (as their UIDs were), then map the
+          // per-game response back onto the UID it came from.
+          const missesByGame = new Map<string, Map<number, string>>();
+          for (const uid of missingUids) {
+            const attributes = modsByUid.get(uid)?.attributes;
+            if (attributes?.modId === undefined) continue;
+            const modGameId = attributes.downloadGame ?? gameId;
+            const uidByModId = missesByGame.get(modGameId) ?? new Map<number, string>();
+            uidByModId.set(attributes.modId, uid);
+            missesByGame.set(modGameId, uidByModId);
+          }
 
-        if (fetchedRequirements) {
-          const cacheActions: ReturnType<typeof setModAttribute>[] = [];
-
-          for (const [modIdStr, requirements] of Object.entries(fetchedRequirements)) {
-            const modId = parseInt(modIdStr, 10);
-            requirementsMap[modId] = requirements;
-            metadata.modsFetched++;
-
-            const mod = modsByNexusId.get(modId);
-            if (mod && requirements) {
-              cacheActions.push(setModAttribute(gameId, mod.id, "requirements", requirements));
+          for (const [modGameId, uidByModId] of missesByGame) {
+            const fetched = await nexusGetModRequirements(modGameId, [...uidByModId.keys()]);
+            for (const [modIdStr, requirements] of Object.entries(fetched ?? {})) {
+              const uid = uidByModId.get(parseInt(modIdStr, 10));
+              if (uid && requirements) {
+                byUid.set(uid, requirements);
+              }
             }
           }
+          metadata.modsFetched += byUid.size;
+          return byUid;
+        },
+      );
 
-          if (cacheActions.length > 0 && api.store) {
-            batchDispatch(api.store.dispatch, cacheActions);
-          }
+      for (const [uid, requirements] of resolved) {
+        const modId = modsByUid.get(uid)?.attributes?.modId;
+        if (modId !== undefined) {
+          requirementsMap[modId] = requirements;
         }
-      } catch (err) {
-        log("warn", "Failed to fetch mod requirements", {
-          error: (err as Error).message,
-        });
-        metadata.errors.push(`Failed to fetch requirements: ${(err as Error).message}`);
       }
+    } catch (err) {
+      log("warn", "Failed to fetch mod requirements", {
+        error: (err as Error).message,
+      });
+      metadata.errors.push(`Failed to fetch requirements: ${(err as Error).message}`);
     }
 
     // Pre-fetch, batched and in parallel, the per-required-mod data the second pass
@@ -279,7 +304,7 @@ export async function checkModRequirements(
     // rule. Files have no batch endpoint, so fan out with a concurrency cap. The
     // second pass then reads both from cache instead of awaiting one mod at a time.
     const requiredTargets = new Map<number, { gameId: string; uid: string | undefined }>();
-    for (const mod of modsToCheck) {
+    for (const mod of enabledMods) {
       const requiringModId = mod.attributes?.modId;
       const sourceGameId = mod.attributes?.downloadGame;
       if (!requiringModId || !sourceGameId) {
@@ -331,7 +356,7 @@ export async function checkModRequirements(
     }
 
     // Second pass: process requirements and check for missing dependencies
-    for (const mod of modsToCheck) {
+    for (const mod of enabledMods) {
       const modId = mod.attributes?.modId;
       if (!modId) continue;
       const gameId = mod.attributes.downloadGame;

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -1,14 +1,10 @@
 import { mdiCheck, mdiDownload, mdiHelpCircleOutline, mdiOpenInNew } from "@mdi/js";
-import { unknownToError } from "@vortex/shared";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import { getModFilesWithCache } from "@/extensions/health_check/utils/modRequirements/modFiles";
 import { modToFileData } from "@/extensions/health_check/utils/modRequirements/modRequirementData";
 import { severityStyleMap } from "@/extensions/health_check/utils/shared/severityStyles";
-import { log } from "@/logging";
-import type { IState } from "@/types/IState";
 import { Button } from "@/ui/components/button/Button";
 import { Icon } from "@/ui/components/icon/Icon";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
@@ -18,7 +14,7 @@ import { opn } from "@/util/api";
 
 import { setModRequirementHidden } from "../../actions/persistent";
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
-import { getModFiles, hiddenModRequirements } from "../../selectors";
+import { hiddenModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
 import type { IDetailViewProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -40,24 +36,11 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     handleFeedbackSuccess,
   } = useModRequirementActions(api, mod, onBack);
 
-  const modFiles = useSelector((state: IState) => getModFiles(state, mod.modId));
-
   const hiddenRequirementMap = useSelector(hiddenModRequirements);
   const isHidden = useMemo(
     () => (hiddenRequirementMap[mod.requiredBy.modId] ?? []).includes(mod.id),
     [hiddenRequirementMap, mod.requiredBy.modId, mod.id],
   );
-
-  // Fetch the required mod's files for the preview/version; skipped for external
-  // requirements, which have no Nexus files.
-  useEffect(() => {
-    if (mod.externalRequirement) {
-      return;
-    }
-    getModFilesWithCache(api, mod.gameId, mod.modId).catch((err: unknown) => {
-      log("warn", "health check: failed to fetch requirement mod files", unknownToError(err));
-    });
-  }, [api, mod.gameId, mod.modId, mod.externalRequirement]);
 
   const openRequiringModPage = useCallback(() => {
     if (mod.requiredBy.modUrl) {
@@ -77,7 +60,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     onBack();
   }, [api, mod.requiredBy.modId, mod.id, onBack]);
 
-  const fileData = modToFileData(mod, modFiles?.[0]);
+  // mainFile is denormalized by the check, so no fetch is needed here.
+  const fileData = modToFileData(mod, mod.mainFile);
   const severityStyle = severityStyleMap[entry.severity];
 
   return (

--- a/src/renderer/src/extensions/health_check/reducers/session.ts
+++ b/src/renderer/src/extensions/health_check/reducers/session.ts
@@ -2,7 +2,6 @@ import type { IReducerSpec } from "../../../types/IExtensionContext";
 import type { IHealthCheckResult } from "../../../types/IHealthCheck";
 import { deleteOrNop, setSafe } from "../../../util/storeHelper";
 import * as actions from "../actions/session";
-import type { IModFileInfo } from "../types";
 import { reducerFor } from "./reducerFor";
 
 export interface IHealthCheckSessionState {
@@ -12,10 +11,6 @@ export interface IHealthCheckSessionState {
   runningChecks: string[];
   /** Timestamp of the last full health check run */
   lastFullRun?: number;
-  /** Cached mod files keyed by mod ID */
-  modFiles: Record<number, IModFileInfo[]>;
-  /** Mod IDs currently being fetched */
-  loadingModFiles: number[];
 }
 
 const on = reducerFor<IHealthCheckSessionState>();
@@ -50,31 +45,10 @@ export const sessionReducer: IReducerSpec<IHealthCheckSessionState> = {
       }
       return state;
     }),
-    on(actions.setModFiles, (state, payload) => {
-      const { modId, files } = payload;
-      return setSafe(state, ["modFiles", modId], files);
-    }),
-    on(actions.setModFilesLoading, (state, payload) => {
-      const { modId, loading } = payload;
-      const currentLoading = state.loadingModFiles || [];
-
-      if (loading && !currentLoading.includes(modId)) {
-        return setSafe(state, ["loadingModFiles"], [...currentLoading, modId]);
-      } else if (!loading && currentLoading.includes(modId)) {
-        return setSafe(
-          state,
-          ["loadingModFiles"],
-          currentLoading.filter((id) => id !== modId),
-        );
-      }
-      return state;
-    }),
   ]),
   defaults: {
     results: {},
     runningChecks: [],
     lastFullRun: 0,
-    modFiles: {},
-    loadingModFiles: [],
   },
 };

--- a/src/renderer/src/extensions/health_check/selectors.ts
+++ b/src/renderer/src/extensions/health_check/selectors.ts
@@ -7,7 +7,6 @@ import type {
   IModMissingRequirements,
   IModRequirementsCheckMetadata,
   IModRequirementExt,
-  IModFileInfo,
 } from "./types";
 import type {
   IFileLevelRequirements,
@@ -23,8 +22,6 @@ export const healthCheckState = (state: IState): IHealthCheckSessionState =>
   state.session?.healthCheck ?? {
     results: {},
     runningChecks: [],
-    modFiles: {},
-    loadingModFiles: [],
   };
 
 /**
@@ -193,15 +190,3 @@ export const getModHiddenRequirements = (state: IState, modId: number): string[]
  */
 export const feedbackGivenMap = (state: IState): { [modId: number]: string[] } =>
   healthCheckPersistentState(state).feedbackGiven ?? {};
-
-/**
- * Get cached mod files for a specific mod
- */
-export const getModFiles = (state: IState, modId: number): IModFileInfo[] | undefined =>
-  healthCheckState(state).modFiles?.[modId];
-
-/**
- * Check if mod files are currently being loaded
- */
-export const isModFilesLoading = (state: IState, modId: number): boolean =>
-  healthCheckState(state).loadingModFiles?.includes(modId) ?? false;

--- a/src/renderer/src/extensions/health_check/types.ts
+++ b/src/renderer/src/extensions/health_check/types.ts
@@ -133,16 +133,6 @@ export interface IModMissingRequirements {
 }
 
 /**
- * Parameters for the check-nexus-mod-requirements check
- */
-export interface IModRequirementsCheckParams {
-  /** Skip API calls and only use cached requirements data */
-  cachedOnly?: boolean;
-  /** Limit the number of mods to check */
-  limit?: number;
-}
-
-/**
  * Metadata for the mod requirements health check result
  */
 export interface IModRequirementsCheckMetadata {

--- a/src/renderer/src/extensions/health_check/types.ts
+++ b/src/renderer/src/extensions/health_check/types.ts
@@ -35,6 +35,11 @@ export interface IModRequirementExt extends Omit<IModRequirement, "modId" | "gam
   gameId: string;
   /** Url to view mod information; undefined if no URL could be derived (e.g., game has no Nexus domain mapping) */
   modUrl?: string;
+  /**
+   * The required mod's single main file, denormalized by the check so the detail
+   * view needs no separate fetch. Undefined for external requirements.
+   */
+  mainFile?: IModFileInfo;
 }
 
 /**

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/modFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/modFiles.ts
@@ -1,6 +1,8 @@
-import { setModFiles, setModFilesLoading } from "@/extensions/health_check/actions/session";
-import { getModFiles as getModFilesSelector } from "@/extensions/health_check/selectors";
 import type { IModDetails, IModFileInfo } from "@/extensions/health_check/types";
+import {
+  createKeyedCache,
+  type KeyedCache,
+} from "@/extensions/health_check/utils/shared/batchCache";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
 import { makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import type { IExtensionApi } from "@/types/IExtensionContext";
@@ -60,34 +62,29 @@ async function fetchModFilesFromApi(
     });
 }
 
+// Mod file lists rarely change between runs; cache in memory with a TTL so re-runs
+// refetch at most once per TTL. Mirrors the mod-requirements and mod-details caches.
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+// Keyed by game + mod id so the same mod id across games does not collide.
+const modFilesCache: KeyedCache<IModFileInfo[]> = createKeyedCache(CACHE_TTL_MS);
+
 /**
- * Get mod files with caching
- * Checks cache first, fetches from API if needed, and stores in Redux
+ * Get a mod's main files, cached in memory with a TTL. Fetches from the API only
+ * on a cache miss.
  */
 export async function getModFilesWithCache(
   api: IExtensionApi,
   gameId: string,
   modId: number,
 ): Promise<IModFileInfo[]> {
-  // Check if already cached
-  const cached = getModFilesSelector(api.getState(), modId);
-  if (cached) {
+  const cacheKey = `${gameId}:${modId}`;
+  const cached = modFilesCache.get(cacheKey);
+  if (cached !== undefined) {
     return cached;
   }
 
-  // Mark as loading
-  api.store?.dispatch(setModFilesLoading(modId, true));
-
-  try {
-    // Fetch from API
-    const files = await fetchModFilesFromApi(api, gameId, modId);
-
-    // Store in cache
-    api.store?.dispatch(setModFiles(modId, files));
-
-    return files;
-  } finally {
-    // Mark as not loading
-    api.store?.dispatch(setModFilesLoading(modId, false));
-  }
+  const files = await fetchModFilesFromApi(api, gameId, modId);
+  modFilesCache.set(cacheKey, files);
+  return files;
 }

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -948,7 +948,6 @@ export function onGetModRequirements(
             modId: true,
             modRequirements: getModRequirementsInfo(),
             uid: true,
-            thumbnailUrl: true,
           },
           validUids,
         );

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -707,7 +707,6 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
       newestVersion:
         nexusCollectionInfo?.collection?.latestPublishedRevision?.revisionNumber?.toString?.(),
       rating: nexusCollectionInfo?.rating,
-      requirements: nexusModInfo?.requirements,
     };
   });
 }

--- a/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
@@ -247,6 +247,9 @@ export function getModRequirementsInfo(): IModRequirementsQuery {
       notes: true,
     },
     nexusRequirements: {
+      // count caps the page and multiplies its inner selection for complexity, so a
+      // low cap keeps the query cheap; mods realistically never have 10+ requirements.
+      $filter: { count: 10 },
       nodes: {
         id: true,
         gameId: true,

--- a/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
@@ -258,10 +258,6 @@ export function getModRequirementsInfo(): IModRequirementsQuery {
       },
       totalCount: true,
     },
-    modsRequiringThisMod: {
-      nodes: { id: true, modId: true, modName: true },
-      totalCount: true,
-    },
   };
 
   if (flagEnabled) {


### PR DESCRIPTION
Closes LAZ-810

- Switch mod requirements to a session cache: moves mod-requirement data out of persisted Redux state (where it was never invalidated, causing stale data) into a session/memory cache.
- Store mod files data in the memory cache rather than Redux state, removing the associated session actions, reducers, and selectors. This also seems to have improved performance.
- Skip fetching unused data
- Reduce modsByUid query complexity by limiting the requirements page size in the GraphQL query.
- Removed now-dead health-check session plumbing (actions/reducers/selectors) and updated DetailView/types accordingly.
- Fix missing Mod Requirements fetches due to query cap by upgrading node-nexus-api https://github.com/Nexus-Mods/node-nexus-api/pull/41