### PR TITLE
flag whether app_game_exited duration is reliable (LAZ-791)

### DIFF
--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -133,6 +133,10 @@ export interface GameExitedProps {
   enabled_mod_count: number;
   launch_session_id: string;
   duration_ms: number;
+  // True when duration_ms reflects the real session: the watched process was seen running and then
+  // stopped. False for a best-effort exit emitted because the game process never appeared (e.g. a
+  // failed or undetected script-extender / mod-loader handoff), so its duration_ms is not trusted.
+  duration_reliable: boolean;
   // Process exit code, when Vortex launched the process itself; null for store launches.
   exit_code: number | null;
 }

--- a/src/renderer/src/util/gameLaunchAnalytics.test.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.test.ts
@@ -65,6 +65,7 @@ describe("game launch analytics", () => {
     expect(exited?.properties.launch_method).toBe("direct_exe");
     expect(exited?.properties.enabled_mod_count).toBe(launched?.properties.enabled_mod_count);
     expect(typeof exited?.properties.duration_ms).toBe("number");
+    expect(exited?.properties.duration_reliable).toBe(true);
     expect(exited?.properties.exit_code).toBeNull();
   });
 
@@ -134,6 +135,8 @@ describe("exit detection for launches that hand off to the game", () => {
     expect(exited).toHaveLength(1);
     expect(exited[0].properties.launch_session_id).toBe(sessionId);
     expect(typeof exited[0].properties.duration_ms).toBe("number");
+    // the game was seen running and then stopped, so this duration is trusted
+    expect(exited[0].properties.duration_reliable).toBe(true);
   });
 
   it("keeps watching its own process for a plain utility tool", () => {
@@ -174,6 +177,8 @@ describe("exit detection for launches that hand off to the game", () => {
       const exited = h.events.filter((e) => e.eventName === "app_game_exited");
       expect(exited).toHaveLength(1);
       expect(exited[0].properties.exit_code).toBe(1);
+      // the game process never appeared, so this is a best-effort exit with an untrusted duration
+      expect(exited[0].properties.duration_reliable).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/renderer/src/util/gameLaunchAnalytics.ts
+++ b/src/renderer/src/util/gameLaunchAnalytics.ts
@@ -97,7 +97,9 @@ function clearStartTimer(record: ILaunchRecord): void {
   }
 }
 
-function emitExited(api: IExtensionApi, record: ILaunchRecord): void {
+// reliable is true when the watched process was observed running and then stopped, so duration_ms
+// is the real session; false for a best-effort exit fired because the game process never appeared.
+function emitExited(api: IExtensionApi, record: ILaunchRecord, reliable: boolean): void {
   api.events.emit(
     "analytics-track-mixpanel-event",
     new AppGameExitedEvent({
@@ -106,6 +108,7 @@ function emitExited(api: IExtensionApi, record: ILaunchRecord): void {
       enabled_mod_count: record.enabledModCount,
       launch_session_id: record.sessionId,
       duration_ms: Date.now() - record.launchTime,
+      duration_reliable: reliable,
       exit_code: record.exitCode,
     }),
   );
@@ -146,7 +149,7 @@ export function emitExitsForStoppedTools(
     if (record.started && wasRunning && !isRunning) {
       clearStartTimer(record);
       pendingLaunches.delete(key);
-      emitExited(api, record);
+      emitExited(api, record, true);
     }
   }
 }
@@ -203,7 +206,7 @@ export function emitGameLaunched(api: IExtensionApi, info: IStarterInfo): void {
     record.startTimer = setTimeout(() => {
       if (pendingLaunches.get(launchedExeId) === record && !record.started) {
         pendingLaunches.delete(launchedExeId);
-        emitExited(api, record);
+        emitExited(api, record, false);
       }
     }, GAME_START_TIMEOUT_MS);
   }


### PR DESCRIPTION
Add duration_reliable to app_game_exited. It is true when the watched process was seen running and then stopped, so duration_ms is the real session, and false for the best-effort exit emitted when a script-extender or mod-loader handoff never brings the game process up, whose duration_ms reflects the timeout window instead. Analysis can filter out best-effort exits rather than skewing play-time aggregates with them.

closes LAZ-791