### PR TITLE
chore: update dependencies/materialized endpoint to new /ranges/ rout…

### DIFF
--- a/packages/nexus-api-v3/schema/openapi.yaml
+++ b/packages/nexus-api-v3/schema/openapi.yaml
@@ -589,7 +589,7 @@ paths:
             application/problem+json:
               schema:
                 "$ref": "#/components/schemas/ProblemDetails"
-  "/mod-file-versions/dependencies/materialized/batch":
+  "/mod-file-versions/dependencies/ranges/materialized/batch":
     post:
       tags:
         - mods
@@ -609,7 +609,7 @@ paths:
 
         `meta.total_count` is only meaningful on a non-empty page; a page past the end returns no
         candidates and `total_count` 0.
-      operationId: getModFileVersionDependencyCandidatesBatch
+      operationId: getModFileVersionDependencyRangesMaterializedBatch
       x-badges:
         - name: Experimental
           color: orange

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -121,7 +121,7 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
       meta: components["schemas"]["PaginationMeta"];
     }> {
       const { data, error, response } = await client.POST(
-        "/mod-file-versions/dependencies/materialized/batch",
+        "/mod-file-versions/dependencies/ranges/materialized/batch",
         { body: { version_ids: [...versionIds], page, page_size: pageSize } },
       );
       if (error) throw toV3Error(error, response);


### PR DESCRIPTION
…e path

Closes LAZ-821

We updated the route of the dependencies endpoint on the backend, updating here as well. Previous route was deprecated.