### PR TITLE
fix: missing thumbnails for downloaded files by hydrating them

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -80,7 +80,7 @@ function ref(fileUID: string, enabled = true, emitRequirements = true): IInstall
 }
 
 function downloadedRef(fileUID: string): IDownloadedFileRef {
-  return { fileUID, downloadId: `download-${fileUID}` };
+  return { fileUID, modUID: `moduid-${fileUID}`, downloadId: `download-${fileUID}` };
 }
 
 function installedFile(fileUID: string, enabled: boolean): IInstalledFile {

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "vitest";
+
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
+import type { IModDetails } from "@/extensions/health_check/types";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+
+import { makeDownloadedFileHydrator, type IDownloadedFileRef } from "./installedFiles";
+
+const REF: IDownloadedFileRef = { fileUID: "file-1", modUID: "mod-1", downloadId: "dl-1" };
+
+const DETAILS: IModDetails = {
+  modUID: "mod-1",
+  modName: "Details Name",
+  modSummary: "details summary",
+  thumbnailUrl: "http://img/details.png",
+  adultContent: true,
+};
+
+/** An api whose downloads store holds the given downloads keyed by id. */
+function apiWith(files: { [id: string]: Partial<IDownload> }): IExtensionApi {
+  return {
+    getState: () => ({ persistent: { downloads: { files } } }),
+  } as unknown as IExtensionApi;
+}
+
+/** A download carrying the given modInfo block, plus any extra download fields. */
+function download(modInfo: unknown, over: Partial<IDownload> = {}): Partial<IDownload> {
+  return { game: ["skyrimse"], modInfo, ...over };
+}
+
+/** Hydrate the single REF from a download and (optionally) its mod details. */
+function hydrate(dl: Partial<IDownload> | undefined, details?: IModDetails) {
+  const files = dl ? { "dl-1": dl } : {};
+  const map = details ? new Map([[details.modUID, details]]) : new Map<string, IModDetails>();
+  return makeDownloadedFileHydrator(apiWith(files), [REF], map)("file-1");
+}
+
+describe("makeDownloadedFileHydrator", () => {
+  test("returns undefined for a fileUID with no ref", () => {
+    const result = makeDownloadedFileHydrator(
+      apiWith({ "dl-1": download({}) }),
+      [REF],
+      new Map(),
+    )("unknown");
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when the download is gone from state", () => {
+    expect(hydrate(undefined)).toBeUndefined();
+  });
+
+  test("carries the ref identifiers straight through", () => {
+    expect(hydrate(download({ nexus: { ids: {} } }))).toMatchObject({
+      downloadId: "dl-1",
+      fileUID: "file-1",
+      modUID: "mod-1",
+    });
+  });
+
+  describe("thumbnail / summary / adult flag", () => {
+    test("prefers the download's own nexus.modInfo over mod details", () => {
+      const dl = download({
+        nexus: {
+          modInfo: {
+            summary: "own summary",
+            picture_url: "http://img/own.png",
+            contains_adult_content: true,
+          },
+        },
+      });
+      expect(hydrate(dl, DETAILS)).toMatchObject({
+        modSummary: "own summary",
+        thumbnailUrl: "http://img/own.png",
+        adultContent: true,
+      });
+    });
+
+    test("backfills from mod details when the download carries only nexus.ids", () => {
+      const dl = download({ nexus: { ids: { modId: 1, fileId: 2 } } });
+      expect(hydrate(dl, DETAILS)).toMatchObject({
+        modSummary: "details summary",
+        thumbnailUrl: "http://img/details.png",
+        adultContent: true,
+      });
+    });
+
+    test("keeps contains_adult_content:false over details:true (guards ?? vs ||)", () => {
+      const dl = download({ nexus: { modInfo: { contains_adult_content: false } } });
+      expect(hydrate(dl, DETAILS)?.adultContent).toBe(false);
+    });
+
+    test("leaves summary/thumbnail undefined and adult false when neither source supplies them", () => {
+      expect(hydrate(download({ nexus: { ids: {} } }))).toMatchObject({
+        modSummary: undefined,
+        thumbnailUrl: undefined,
+        adultContent: false,
+      });
+    });
+  });
+
+  describe("modName fallback chain", () => {
+    test("uses the download's own name first", () => {
+      const dl = download({ name: "Own Name", nexus: {} }, { localPath: "archive.zip" });
+      expect(hydrate(dl, DETAILS)?.modName).toBe("Own Name");
+    });
+
+    test("falls back to mod details when the download has no name", () => {
+      const dl = download({ nexus: {} }, { localPath: "archive.zip" });
+      expect(hydrate(dl, DETAILS)?.modName).toBe("Details Name");
+    });
+
+    test("falls back to localPath when neither name nor details apply", () => {
+      const dl = download({ nexus: {} }, { localPath: "archive.zip" });
+      expect(hydrate(dl)?.modName).toBe("archive.zip");
+    });
+
+    test("falls back to the download id as a last resort", () => {
+      expect(hydrate(download({ nexus: {} }))?.modName).toBe("dl-1");
+    });
+  });
+
+  describe("fileName and version", () => {
+    test("fileName prefers meta.fileName, then localPath, then modName", () => {
+      expect(
+        hydrate(download({ meta: { fileName: "file.7z" }, nexus: {} }, { localPath: "lp" }))
+          ?.fileName,
+      ).toBe("file.7z");
+      expect(hydrate(download({ nexus: {} }, { localPath: "lp" }))?.fileName).toBe("lp");
+      expect(hydrate(download({ name: "Own Name", nexus: {} }))?.fileName).toBe("Own Name");
+    });
+
+    test("version comes from meta.fileVersion and defaults to empty string", () => {
+      expect(hydrate(download({ meta: { fileVersion: "3.1" }, nexus: {} }))?.version).toBe("3.1");
+      expect(hydrate(download({ nexus: {} }))?.version).toBe("");
+    });
+  });
+});

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -1,4 +1,5 @@
 import type { IDownload } from "@/extensions/download_management/types/IDownload";
+import type { IModDetails } from "@/extensions/health_check/types";
 import type { IMod } from "@/extensions/mod_management/types/IMod";
 import { nexusGamesProm } from "@/extensions/nexus_integration/util";
 import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UIDs";
@@ -54,6 +55,13 @@ export interface IDownloadedFile {
   adultContent: boolean;
   /** Thumbnail URL if available */
   thumbnailUrl?: string;
+}
+
+/** The subset of a download's enriched `nexus.modInfo` block that we display. */
+interface INexusModDisplayInfo {
+  summary?: string;
+  picture_url?: string;
+  contains_adult_content?: boolean;
 }
 
 /** The subset of mod attributes the file-level gather/hydrate reads. */
@@ -174,6 +182,8 @@ export async function gatherInstalledFiles(api: IExtensionApi): Promise<IInstall
 export interface IDownloadedFileRef {
   /** Composite file version id for the resolver's uninstalledFileVersionUids set. */
   fileUID: string;
+  /** Composite mod UID, for hydrating display data from the Nexus mods endpoint. */
+  modUID: string;
   /** Download ID - passed directly to start-install-download as the archive ID. */
   downloadId: string;
 }
@@ -215,46 +225,50 @@ export async function gatherDownloadedFileRefs(api: IExtensionApi): Promise<IDow
     const fileUID = makeFileUID({ gameId: nexusGameId, fileId: String(nexusIds.fileId) });
     if (!fileUID) continue;
 
-    refs.push({ fileUID, downloadId });
+    const modUID =
+      makeModUID({ gameId: nexusGameId, modId: String(nexusIds.modId ?? ""), fileId: "0" }) ?? "";
+
+    refs.push({ fileUID, modUID, downloadId });
   }
 
   return refs;
 }
 
-/** Build the display shape for one downloaded-but-not-installed archive. */
+/**
+ * Build the display shape for one downloaded-but-not-installed archive. The
+ * mod name, summary, thumbnail and adult flag live in the download's
+ * `nexus.modInfo` block, which is missing on unenriched archives; fall back to
+ * the fetched mod details for those fields.
+ */
 function toDownloadedFile(
-  downloadId: string,
+  ref: IDownloadedFileRef,
   download: IDownload,
-  fileUID: string,
+  details: IModDetails | undefined,
 ): IDownloadedFile {
-  const nexusIds = download.modInfo?.nexus?.ids;
-  const nexusGameId = nexusIds?.gameId ?? download.game[0] ?? "";
-  const modUID =
-    makeModUID({
-      gameId: nexusGameId,
-      modId: String(nexusIds?.modId ?? ""),
-      fileId: String(nexusIds?.fileId ?? ""),
-    }) ?? "";
-  const modName = download.modInfo?.name ?? download.localPath ?? downloadId;
+  const modInfo = (download.modInfo?.nexus?.modInfo ?? {}) as INexusModDisplayInfo;
+  const modName =
+    download.modInfo?.name ?? details?.modName ?? download.localPath ?? ref.downloadId;
   return {
-    downloadId,
-    fileUID,
-    modUID,
+    downloadId: ref.downloadId,
+    fileUID: ref.fileUID,
+    modUID: ref.modUID,
     modName,
-    modSummary: download.modInfo?.nexus?.modInfo?.summary ?? undefined,
+    modSummary: modInfo.summary ?? details?.modSummary ?? undefined,
     fileName: download.modInfo?.meta?.fileName ?? download.localPath ?? modName,
     version: download.modInfo?.meta?.fileVersion ?? "",
-    thumbnailUrl: download.modInfo?.nexus?.modInfo?.picture_url ?? undefined,
-    adultContent: download.modInfo?.nexus?.modInfo?.contains_adult_content ?? false,
+    thumbnailUrl: modInfo.picture_url ?? details?.thumbnailUrl ?? undefined,
+    adultContent: modInfo.contains_adult_content ?? details?.adultContent ?? false,
   };
 }
 
 /**
  * A fileUID -> IDownloadedFile hydrator over downloaded-but-not-installed refs.
+ * `modDetailsByUID` backfills display fields missing from unenriched downloads.
  */
 export function makeDownloadedFileHydrator(
   api: IExtensionApi,
   refs: IDownloadedFileRef[],
+  modDetailsByUID: Map<string, IModDetails>,
 ): (fileUID: string) => IDownloadedFile | undefined {
   const state = api.getState();
   const downloads: { [dlId: string]: IDownload } = state.persistent.downloads?.files ?? {};
@@ -265,7 +279,7 @@ export function makeDownloadedFileHydrator(
     if (!ref) return undefined;
     const download = downloads[ref.downloadId];
     if (!download) return undefined;
-    return toDownloadedFile(ref.downloadId, download, fileUID);
+    return toDownloadedFile(ref, download, modDetailsByUID.get(ref.modUID));
   };
 }
 
@@ -325,7 +339,13 @@ export function makeInstalledFileHydrator(
       return undefined;
     }
     const download = mod.archiveId ? downloads[mod.archiveId] : undefined;
-    const adultContent = download?.modInfo?.nexus?.modInfo?.contains_adult_content ?? false;
-    return toInstalledFile(mod, fileUID, ref.enabled, gameId, adultContent);
+    const modInfo = (download?.modInfo?.nexus?.modInfo ?? {}) as INexusModDisplayInfo;
+    return toInstalledFile(
+      mod,
+      fileUID,
+      ref.enabled,
+      gameId,
+      modInfo.contains_adult_content ?? false,
+    );
   };
 }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -6,8 +6,9 @@ import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UID
 import { activeProfile } from "@/extensions/profile_management/selectors";
 import type { IProfile } from "@/extensions/profile_management/types/IProfile";
 import type { IExtensionApi } from "@/types/IExtensionContext";
-import { renderModName } from "@/util/api";
 import { getSafe } from "@/util/storeHelper";
+
+import renderModName from "../../../mod_management/util/modName";
 
 /**
  * A file the user already has installed (a Vortex mod)

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -6,6 +6,8 @@ import {
 import { activeProfile } from "@/extensions/profile_management/selectors";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
+import type { IModDetails } from "../../types";
+import { getModDetails } from "../shared/modDetails";
 import { createResolverPorts } from "./fileDependencyPorts";
 import {
   gatherDownloadedFileRefs,
@@ -14,10 +16,23 @@ import {
   makeInstalledFileHydrator,
 } from "./installedFiles";
 import {
-  type HydratedFile,
+  type HydrateFile,
   type IFileRequirementsCheckMetadata,
   mapRequirementsReport,
 } from "./mapRequirementsReport";
+
+/** Mod UIDs of the downloaded-but-not-installed archives the check surfaces. */
+function surfacedDownloadModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
+  const uids = new Set<string>();
+  for (const fileReq of Object.values(metadata.fileRequirements)) {
+    for (const req of fileReq.requirements) {
+      if (req.kind === "correct-version-uninstalled" && req.uninstalledFile.modUID) {
+        uids.add(req.uninstalledFile.modUID);
+      }
+    }
+  }
+  return [...uids];
+}
 
 /**
  * Resolve the active game's file-level requirements: gather installed and
@@ -51,18 +66,31 @@ export async function runFileLevelRequirements(
   });
 
   const hydrateInstalled = makeInstalledFileHydrator(api, installedRefs);
-  const hydrateDownloaded = makeDownloadedFileHydrator(api, downloadedRefs);
-  const hydrate = (fileUID: string): HydratedFile | undefined => {
-    const installed = hydrateInstalled(fileUID);
-    if (installed) return { kind: "installed", file: installed };
-    const downloaded = hydrateDownloaded(fileUID);
-    if (downloaded) return { kind: "downloaded", file: downloaded };
-    return undefined;
+  const buildHydrate = (modDetailsByUID: Map<string, IModDetails>): HydrateFile => {
+    const hydrateDownloaded = makeDownloadedFileHydrator(api, downloadedRefs, modDetailsByUID);
+    return (fileUID) => {
+      const installed = hydrateInstalled(fileUID);
+      if (installed) return { kind: "installed", file: installed };
+      const downloaded = hydrateDownloaded(fileUID);
+      if (downloaded) return { kind: "downloaded", file: downloaded };
+      return undefined;
+    };
   };
 
-  return mapRequirementsReport(report, hydrate, {
-    gameId,
-    modsChecked: installedRefs.length,
-    errors: [],
-  });
+  const context = { gameId, modsChecked: installedRefs.length, errors: [] };
+
+  // First pass without mod details reveals which downloaded archives the check
+  // actually surfaces, so we only fetch details for those.
+  const initial = mapRequirementsReport(report, buildHydrate(new Map()), context);
+  const modUIDs = surfacedDownloadModUIDs(initial);
+  if (modUIDs.length === 0) {
+    return initial;
+  }
+
+  // Backfill display data (thumbnail, summary, adult flag) missing from those
+  // unenriched downloads via the batched, cached mod-details endpoint, then
+  // re-map with it. See toDownloadedFile.
+  const details = await getModDetails(api, modUIDs).catch((): IModDetails[] => []);
+  const modDetailsByUID = new Map(details.map((detail) => [detail.modUID, detail]));
+  return mapRequirementsReport(report, buildHydrate(modDetailsByUID), context);
 }


### PR DESCRIPTION
The thumbnails could be missing for newly downloaded mods since the mod info would be populated, but not the thumbnails.
This makes sure the thumbnails data is hydrated when generating the health checks.