### PR TITLE
Feature - Add filter to Version dropdown for mods with multiple versions

### DIFF
--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from "vitest";
+
+import { makeApiHarness, makeMod, makeProfile } from "../../../test-utils/builders";
+import type { IApiHarness } from "../../../test-utils/harnessTypes";
+import type { IMod, IModAttributes } from "../types/IMod";
+import VersionFilter from "./VersionFilter";
+
+const GAME_ID = "skyrimse";
+const OTHER_GAME_ID = "fallout4";
+const PROFILE_ID = "profile-skyrimse";
+const OTHER_PROFILE_ID = "profile-fallout4";
+
+/**
+ * A harness seeded with the mods each game has installed, active on GAME_ID.
+ * VersionFilter resolves the game through the active profile, so `activeProfileId` is
+ * what decides which mod list the counts come from.
+ */
+function seed(mods: Record<string, Record<string, IMod>>): IApiHarness {
+  const harness = makeApiHarness({
+    profiles: { [PROFILE_ID]: makeProfile({ id: PROFILE_ID, gameId: GAME_ID }) },
+    mods,
+  });
+  harness.setState((draft) => {
+    draft.settings.profiles.activeProfileId = PROFILE_ID;
+  });
+  return harness;
+}
+
+/**
+ * An installed mod that reports the given Nexus mod id. `modId` is typed loosely
+ * because ICommonModAttributes declares it a number while the store also holds the
+ * string form (from meta lookups) and the nullish forms these tests cover.
+ */
+function installed(id: string, modId: unknown): IMod {
+  return makeMod({ id, state: "installed", attributes: { modId } as IModAttributes });
+}
+
+function byId(...mods: IMod[]): Record<string, IMod> {
+  return Object.fromEntries(mods.map((mod) => [mod.id, mod]));
+}
+
+describe("VersionFilter", () => {
+  describe("isEmpty", () => {
+    it("treats a missing or empty selection as no filter", () => {
+      const filter = new VersionFilter();
+
+      expect(filter.isEmpty(undefined)).toBe(true);
+      expect(filter.isEmpty([])).toBe(true);
+      expect(filter.isEmpty(["multi-version"])).toBe(false);
+    });
+  });
+
+  describe("existing presets", () => {
+    // these presets decide on the row alone and never consult the store, so they all
+    // share one empty state rather than seeding mod lists the filter never reads
+    const state = seed({}).getState();
+
+    it("passes every row through when nothing is selected", () => {
+      const filter = new VersionFilter();
+      const mod = installed("a", 42);
+
+      expect(filter.matches([], mod, state)).toBe(true);
+      expect(filter.matches(undefined, mod, state)).toBe(true);
+    });
+
+    it("matches mods with no source on missing-meta", () => {
+      const filter = new VersionFilter();
+      const noSource = installed("a", 42);
+      const withSource = makeMod({
+        id: "b",
+        state: "installed",
+        attributes: { modId: 43, source: "nexus", fileId: 1 },
+      });
+
+      expect(filter.matches(["missing-meta"], noSource, state)).toBe(true);
+      expect(filter.matches(["missing-meta"], withSource, state)).toBe(false);
+    });
+
+    it("matches mods with a newer version available on has-update", () => {
+      const filter = new VersionFilter();
+      const outdated = makeMod({
+        id: "a",
+        attributes: { source: "nexus", version: "1.0.0", newestVersion: "1.1.0" },
+      });
+      const current = makeMod({
+        id: "b",
+        attributes: { source: "nexus", version: "1.1.0", newestVersion: "1.1.0" },
+      });
+
+      expect(filter.matches(["has-update"], outdated, state)).toBe(true);
+      expect(filter.matches(["has-update"], current, state)).toBe(false);
+    });
+
+    it("matches an explicitly picked version", () => {
+      const filter = new VersionFilter();
+      const mod = makeMod({ id: "a", attributes: { version: "1.0.0" } });
+      const noVersion = makeMod({ id: "b", attributes: {} });
+
+      expect(filter.matches(["v:1.0.0"], mod, state)).toBe(true);
+      expect(filter.matches(["v:2.0.0"], mod, state)).toBe(false);
+      expect(filter.matches(["v:1.0.0"], noVersion, state)).toBe(false);
+    });
+
+    it("returns undefined for a row with no value", () => {
+      const filter = new VersionFilter();
+
+      expect(filter.matches(["multi-version"], undefined, state)).toBeUndefined();
+    });
+  });
+
+  describe("multi-version", () => {
+    it("matches mods that have more than one version installed", () => {
+      const filter = new VersionFilter();
+      const v1 = installed("a", 42);
+      const v2 = installed("b", 42);
+      const { getState } = seed({ [GAME_ID]: byId(v1, v2) });
+
+      expect(filter.matches(["multi-version"], v1, getState())).toBe(true);
+      expect(filter.matches(["multi-version"], v2, getState())).toBe(true);
+    });
+
+    it("does not match a mod that only has one version installed", () => {
+      const filter = new VersionFilter();
+      const only = installed("a", 42);
+      const other = installed("b", 43);
+      const { getState } = seed({ [GAME_ID]: byId(only, other) });
+
+      expect(filter.matches(["multi-version"], only, getState())).toBe(false);
+    });
+
+    it("ignores versions that are only downloaded or still installing", () => {
+      const filter = new VersionFilter();
+      const current = installed("a", 42);
+      const archive = makeMod({ id: "b", state: "downloaded", attributes: { modId: 42 } });
+      const pending = makeMod({ id: "c", state: "installing", attributes: { modId: 42 } });
+      const { getState } = seed({ [GAME_ID]: byId(current, archive, pending) });
+
+      expect(filter.matches(["multi-version"], current, getState())).toBe(false);
+    });
+
+    it("never matches a row that isn't itself installed", () => {
+      const filter = new VersionFilter();
+      const v1 = installed("a", 42);
+      const v2 = installed("b", 42);
+      // the mods page lists finished downloads as rows too, and those carry the same
+      // modId; an archive is not one of the installed versions the filter is about
+      const archive = makeMod({ id: "c", state: "downloaded", attributes: { modId: 42 } });
+      const { getState } = seed({ [GAME_ID]: byId(v1, v2, archive) });
+
+      expect(filter.matches(["multi-version"], archive, getState())).toBe(false);
+    });
+
+    it.each<[string, unknown]>([
+      ["undefined", undefined],
+      ["null", null],
+      ["empty string", ""],
+      ["zero", 0],
+    ])("never groups mods whose mod id is %s", (_label, modId) => {
+      // manually installed mods have no modId at all, and the mods reducer only drops an
+      // attribute when it is set to undefined, so a failed meta lookup can leave a nullish
+      // or empty one behind. All of these mean "no mod id" - grouping on them reports
+      // unrelated mods as versions of each other
+      const filter = new VersionFilter();
+      const one = installed("a", modId);
+      const two = installed("b", modId);
+      const { getState } = seed({ [GAME_ID]: byId(one, two) });
+
+      expect(filter.matches(["multi-version"], one, getState())).toBe(false);
+      expect(filter.matches(["multi-version"], two, getState())).toBe(false);
+    });
+
+    it("counts numeric and string mod ids as the same mod", () => {
+      // modId arrives as a number from the api and as a string from some meta lookups;
+      // both have to land in the same bucket or a mod split across the two
+      // representations never registers as having multiple versions
+      const filter = new VersionFilter();
+      const numeric = installed("a", 42);
+      const text = installed("b", "42");
+      const { getState } = seed({ [GAME_ID]: byId(numeric, text) });
+
+      expect(filter.matches(["multi-version"], numeric, getState())).toBe(true);
+      expect(filter.matches(["multi-version"], text, getState())).toBe(true);
+    });
+
+    it("combines with the other presets as an or", () => {
+      const filter = new VersionFilter();
+      const single = makeMod({
+        id: "a",
+        state: "installed",
+        attributes: { modId: 42, source: "nexus", version: "1.0.0", newestVersion: "1.1.0" },
+      });
+      const { getState } = seed({ [GAME_ID]: byId(single) });
+
+      expect(filter.matches(["multi-version"], single, getState())).toBe(false);
+      expect(filter.matches(["multi-version", "has-update"], single, getState())).toBe(true);
+    });
+
+    it("survives a game with no mods at all", () => {
+      const filter = new VersionFilter();
+      const orphan = installed("a", 42);
+
+      expect(filter.matches(["multi-version"], orphan, seed({}).getState())).toBe(false);
+      expect(filter.matches(["multi-version"], orphan, seed({ [GAME_ID]: {} }).getState())).toBe(
+        false,
+      );
+    });
+
+    it("survives having no active profile", () => {
+      const filter = new VersionFilter();
+      const orphan = installed("a", 42);
+      const harness = seed({ [GAME_ID]: byId(orphan, installed("b", 42)) });
+      harness.setState((draft) => {
+        draft.settings.profiles.activeProfileId = undefined;
+      });
+
+      expect(filter.matches(["multi-version"], orphan, harness.getState())).toBe(false);
+    });
+  });
+
+  describe("count cache", () => {
+    it("walks the mod list once per pass rather than once per row", () => {
+      // the reason the cache exists: matches() runs for every row, so a rescan per row
+      // makes the filter quadratic in the size of the mod list
+      const filter = new VersionFilter();
+      // 100 mods with two installed versions each
+      const mods = byId(
+        ...Array.from({ length: 200 }, (_, idx) => installed(`m${idx}`, Math.floor(idx / 2) + 1)),
+      );
+
+      let scans = 0;
+      const counted = new Proxy(mods, {
+        ownKeys(target) {
+          scans += 1;
+          return Reflect.ownKeys(target);
+        },
+      });
+      const { getState } = seed({ [GAME_ID]: counted });
+
+      const matched = Object.values(mods).filter(
+        (mod) => filter.matches(["multi-version"], mod, getState()) === true,
+      );
+
+      expect(scans).toBe(1);
+      expect(matched).toHaveLength(200);
+    });
+
+    it("picks up an uninstall on the next pass", () => {
+      const filter = new VersionFilter();
+      const v1 = installed("a", 42);
+      const v2 = installed("b", 42);
+      const harness = seed({ [GAME_ID]: byId(v1, v2) });
+
+      expect(filter.matches(["multi-version"], v1, harness.getState())).toBe(true);
+
+      // the reducer replaces the slice on uninstall, and that replacement is what
+      // invalidates the cache
+      harness.setState((draft) => {
+        draft.persistent.mods[GAME_ID] = byId(v1);
+      });
+
+      expect(filter.matches(["multi-version"], v1, harness.getState())).toBe(false);
+    });
+
+    it("picks up a second version being installed on the next pass", () => {
+      const filter = new VersionFilter();
+      const v1 = installed("a", 42);
+      const v2 = installed("b", 42);
+      const harness = seed({ [GAME_ID]: byId(v1) });
+
+      expect(filter.matches(["multi-version"], v1, harness.getState())).toBe(false);
+
+      harness.setState((draft) => {
+        draft.persistent.mods[GAME_ID] = byId(v1, v2);
+      });
+
+      expect(filter.matches(["multi-version"], v1, harness.getState())).toBe(true);
+    });
+
+    it("does not carry counts across a game switch", () => {
+      // one filter instance serves the mods page for every game, so counts from the
+      // game the user came from must not decide what the next game shows
+      const filter = new VersionFilter();
+      const skyrimV1 = installed("a", 42);
+      const skyrimV2 = installed("b", 42);
+      const falloutOnly = installed("c", 42);
+      const harness = seed({
+        [GAME_ID]: byId(skyrimV1, skyrimV2),
+        [OTHER_GAME_ID]: byId(falloutOnly),
+      });
+
+      expect(filter.matches(["multi-version"], skyrimV1, harness.getState())).toBe(true);
+
+      harness.setState((draft) => {
+        draft.persistent.profiles[OTHER_PROFILE_ID] = makeProfile({
+          id: OTHER_PROFILE_ID,
+          gameId: OTHER_GAME_ID,
+        });
+        draft.settings.profiles.activeProfileId = OTHER_PROFILE_ID;
+      });
+      expect(filter.matches(["multi-version"], falloutOnly, harness.getState())).toBe(false);
+
+      harness.setState((draft) => {
+        draft.settings.profiles.activeProfileId = PROFILE_ID;
+      });
+      expect(filter.matches(["multi-version"], skyrimV1, harness.getState())).toBe(true);
+    });
+
+    it("keeps two filter instances independent", () => {
+      const one = new VersionFilter();
+      const two = new VersionFilter();
+      const v1 = installed("a", 42);
+      const v2 = installed("b", 42);
+
+      expect(one.matches(["multi-version"], v1, seed({ [GAME_ID]: byId(v1, v2) }).getState())).toBe(
+        true,
+      );
+      expect(two.matches(["multi-version"], v1, seed({ [GAME_ID]: byId(v1) }).getState())).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
@@ -12,6 +12,7 @@ import updateState, { isIdValid } from "./modUpdateState";
 const PRESET_OPTIONS = [
   { value: "has-update", label: "Update available" },
   { value: "missing-meta", label: "Missing Meta ID" },
+  { value: "multi-version", label: "Multiple versions installed" },
 ];
 
 interface IConnectedProps {
@@ -79,7 +80,7 @@ class VersionFilter implements ITableFilter {
   public raw = true;
   public dataId = "$";
 
-  public matches(filter: any, value: any): boolean {
+  public matches(filter: any, value: any, state: any): boolean {
     if (value === undefined) {
       return undefined;
     }
@@ -94,6 +95,20 @@ class VersionFilter implements ITableFilter {
 
     if (filter.includes("has-update") && updateState(value.attributes) !== "current") {
       return true;
+    }
+
+    if (filter.includes("multi-version")) {
+      const modId = getSafe(value, ["attributes", "modId"], undefined);
+      if (modId !== undefined) {
+        const gameId = activeGameId(state);
+        const mods = gameId !== undefined ? getSafe(state, ["persistent", "mods", gameId], {}) : {};
+        const count = Object.values(mods).filter(
+          (mod: IMod) => getSafe(mod, ["attributes", "modId"], undefined) === modId,
+        ).length;
+        if (count > 1) {
+          return true;
+        }
+      }
     }
 
     const versionFilters = filter

--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
@@ -48,12 +48,12 @@ class VersionFilterComponent extends React.Component<IProps, {}> {
     return (
       <Select
         multi
+        autosize={false}
         className="select-compact"
         options={options}
+        placeholder={t("Filter...")}
         value={filterArr}
         onChange={this.changeFilter}
-        autosize={false}
-        placeholder={t("Filter...")}
       />
     );
   }
@@ -79,12 +79,10 @@ class VersionFilter implements ITableFilter {
   public raw = true;
   public dataId = "$";
 
-  // number of versions per modId, cached so we don't rescan the entire mod and
-  // download lists for every row we're asked to match
-  private mCachedState: any;
-  private mCachedMods: { [id: string]: IMod };
-  private mCachedDownloads: { [archiveId: string]: any };
-  private mVersionCounts: { [modId: string]: number } = {};
+  // installed versions per Nexus mod id, cached so we don't rescan the mod
+  // list for every row we're asked to match
+  private mCachedMods: Record<string, IMod> | undefined;
+  private mVersionCounts: Record<string, number> = {};
 
   public matches(filter: any, value: any, state: any): boolean {
     if (value === undefined) {
@@ -129,59 +127,24 @@ class VersionFilter implements ITableFilter {
   }
 
   /**
-   * how many versions of each modId the user has had installed: the mods installed right
-   * now plus the archives of versions that were installed at some point in the past.
-   * Cached against the state object we last saw so a single filter pass only walks the
-   * lists once, and the counts themselves are only rebuilt when the mods or downloads
-   * they were derived from actually changed.
+   * how many versions of each mod are installed, keyed by Nexus mod id. Rebuilt only
+   * when the mod list it was derived from actually changed, so a single filter pass
+   * walks the list once rather than once per row.
    */
-  private versionCounts(state: any): { [modId: string]: number } {
-    if (state === this.mCachedState) {
-      return this.mVersionCounts;
-    }
-    this.mCachedState = state;
-
+  private versionCounts(state: IState): Record<string, number> {
     const gameId = activeGameId(state);
-    const mods: { [id: string]: IMod } =
-      (gameId !== undefined ? state.persistent.mods?.[gameId] : undefined) ?? {};
-    const downloads = state.persistent.downloads?.files ?? {};
+    const mods = state.persistent.mods?.[gameId] ?? {};
 
-    if (mods !== this.mCachedMods || downloads !== this.mCachedDownloads) {
+    if (mods !== this.mCachedMods) {
       this.mCachedMods = mods;
-      this.mCachedDownloads = downloads;
 
-      const counts: { [modId: string]: number } = {};
-      // an archive that is installed right now is already represented by its mod,
-      // counting it again would double up
-      const installedArchives = new Set<string>();
-
+      const counts: Record<string, number> = {};
       for (const mod of Object.values<IMod>(mods)) {
-        installedArchives.add(mod.archiveId);
         const modId = mod.attributes?.modId;
         if (mod.state === "installed" && modId !== undefined) {
           counts[modId] = (counts[modId] ?? 0) + 1;
         }
       }
-
-      for (const [archiveId, download] of Object.entries<any>(downloads)) {
-        // "installed" is set when an archive is installed and is not cleared on
-        // uninstall, so it marks the versions that were installed in the past
-        if (
-          download.state !== "finished" ||
-          download.installed?.gameId !== gameId ||
-          installedArchives.has(archiveId)
-        ) {
-          continue;
-        }
-        const modId =
-          download.modInfo?.ids?.modId ??
-          download.modInfo?.nexus?.ids?.modId ??
-          download.modInfo?.meta?.details?.modId;
-        if (modId !== undefined) {
-          counts[modId] = (counts[modId] ?? 0) + 1;
-        }
-      }
-
       this.mVersionCounts = counts;
     }
 

--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
@@ -4,7 +4,6 @@ import Select from "react-select";
 
 import type { IState } from "../../../types/IState";
 import type { IFilterProps, ITableFilter } from "../../../types/ITableAttribute";
-import { getSafe } from "../../../util/storeHelper";
 import { activeGameId } from "../../profile_management/selectors";
 import type { IMod } from "../types/IMod";
 import updateState, { isIdValid } from "./modUpdateState";
@@ -29,8 +28,8 @@ class VersionFilterComponent extends React.Component<IProps, {}> {
 
     const versions = new Set<string>();
     if (mods !== undefined) {
-      for (const mod of Object.values(mods)) {
-        const version = getSafe(mod, ["attributes", "version"], undefined);
+      for (const mod of Object.values<IMod>(mods)) {
+        const version = mod.attributes?.version;
         if (version !== undefined && version !== "") {
           versions.add(version);
         }
@@ -80,6 +79,12 @@ class VersionFilter implements ITableFilter {
   public raw = true;
   public dataId = "$";
 
+  // number of installed mods per modId, cached so we don't rescan the entire
+  // mod list for every row we're asked to match
+  private mCachedState: any;
+  private mCachedMods: { [id: string]: IMod };
+  private mInstallCounts: { [modId: string]: number } = {};
+
   public matches(filter: any, value: any, state: any): boolean {
     if (value === undefined) {
       return undefined;
@@ -97,17 +102,10 @@ class VersionFilter implements ITableFilter {
       return true;
     }
 
-    if (filter.includes("multi-version")) {
-      const modId = getSafe(value, ["attributes", "modId"], undefined);
-      if (modId !== undefined) {
-        const gameId = activeGameId(state);
-        const mods = gameId !== undefined ? getSafe(state, ["persistent", "mods", gameId], {}) : {};
-        const count = Object.values(mods).filter(
-          (mod: IMod) => getSafe(mod, ["attributes", "modId"], undefined) === modId,
-        ).length;
-        if (count > 1) {
-          return true;
-        }
+    if (filter.includes("multi-version") && value.state === "installed") {
+      const modId = value.attributes?.modId;
+      if (modId !== undefined && (this.installCounts(state)[modId] ?? 0) > 1) {
+        return true;
       }
     }
 
@@ -116,7 +114,7 @@ class VersionFilter implements ITableFilter {
       .map((f: string) => f.slice(2));
 
     if (versionFilters.length > 0) {
-      const version: string = getSafe(value, ["attributes", "version"], "") ?? "";
+      const version: string = value.attributes?.version ?? "";
       if (versionFilters.includes(version)) {
         return true;
       }
@@ -127,6 +125,38 @@ class VersionFilter implements ITableFilter {
 
   public isEmpty(filter: any): boolean {
     return !Array.isArray(filter) || filter.length === 0;
+  }
+
+  /**
+   * how many installed mods there are for each modId. Cached against the state object
+   * we last saw so a single filter pass only walks the mod list once, and the counts
+   * themselves are only rebuilt when the mod list actually changed.
+   */
+  private installCounts(state: any): { [modId: string]: number } {
+    if (state === this.mCachedState) {
+      return this.mInstallCounts;
+    }
+    this.mCachedState = state;
+
+    const gameId = activeGameId(state);
+    const mods: { [id: string]: IMod } =
+      (gameId !== undefined ? state.persistent.mods?.[gameId] : undefined) ?? {};
+
+    if (mods !== this.mCachedMods) {
+      this.mCachedMods = mods;
+      this.mInstallCounts = Object.values<IMod>(mods).reduce(
+        (prev: { [modId: string]: number }, mod: IMod) => {
+          const modId = mod.attributes?.modId;
+          if (mod.state === "installed" && modId !== undefined) {
+            prev[modId] = (prev[modId] ?? 0) + 1;
+          }
+          return prev;
+        },
+        {},
+      );
+    }
+
+    return this.mInstallCounts;
   }
 }
 

--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
@@ -79,11 +79,12 @@ class VersionFilter implements ITableFilter {
   public raw = true;
   public dataId = "$";
 
-  // number of installed mods per modId, cached so we don't rescan the entire
-  // mod list for every row we're asked to match
+  // number of versions per modId, cached so we don't rescan the entire mod and
+  // download lists for every row we're asked to match
   private mCachedState: any;
   private mCachedMods: { [id: string]: IMod };
-  private mInstallCounts: { [modId: string]: number } = {};
+  private mCachedDownloads: { [archiveId: string]: any };
+  private mVersionCounts: { [modId: string]: number } = {};
 
   public matches(filter: any, value: any, state: any): boolean {
     if (value === undefined) {
@@ -104,7 +105,7 @@ class VersionFilter implements ITableFilter {
 
     if (filter.includes("multi-version") && value.state === "installed") {
       const modId = value.attributes?.modId;
-      if (modId !== undefined && (this.installCounts(state)[modId] ?? 0) > 1) {
+      if (modId !== undefined && (this.versionCounts(state)[modId] ?? 0) > 1) {
         return true;
       }
     }
@@ -128,35 +129,63 @@ class VersionFilter implements ITableFilter {
   }
 
   /**
-   * how many installed mods there are for each modId. Cached against the state object
-   * we last saw so a single filter pass only walks the mod list once, and the counts
-   * themselves are only rebuilt when the mod list actually changed.
+   * how many versions of each modId the user has had installed: the mods installed right
+   * now plus the archives of versions that were installed at some point in the past.
+   * Cached against the state object we last saw so a single filter pass only walks the
+   * lists once, and the counts themselves are only rebuilt when the mods or downloads
+   * they were derived from actually changed.
    */
-  private installCounts(state: any): { [modId: string]: number } {
+  private versionCounts(state: any): { [modId: string]: number } {
     if (state === this.mCachedState) {
-      return this.mInstallCounts;
+      return this.mVersionCounts;
     }
     this.mCachedState = state;
 
     const gameId = activeGameId(state);
     const mods: { [id: string]: IMod } =
       (gameId !== undefined ? state.persistent.mods?.[gameId] : undefined) ?? {};
+    const downloads = state.persistent.downloads?.files ?? {};
 
-    if (mods !== this.mCachedMods) {
+    if (mods !== this.mCachedMods || downloads !== this.mCachedDownloads) {
       this.mCachedMods = mods;
-      this.mInstallCounts = Object.values<IMod>(mods).reduce(
-        (prev: { [modId: string]: number }, mod: IMod) => {
-          const modId = mod.attributes?.modId;
-          if (mod.state === "installed" && modId !== undefined) {
-            prev[modId] = (prev[modId] ?? 0) + 1;
-          }
-          return prev;
-        },
-        {},
-      );
+      this.mCachedDownloads = downloads;
+
+      const counts: { [modId: string]: number } = {};
+      // an archive that is installed right now is already represented by its mod,
+      // counting it again would double up
+      const installedArchives = new Set<string>();
+
+      for (const mod of Object.values<IMod>(mods)) {
+        installedArchives.add(mod.archiveId);
+        const modId = mod.attributes?.modId;
+        if (mod.state === "installed" && modId !== undefined) {
+          counts[modId] = (counts[modId] ?? 0) + 1;
+        }
+      }
+
+      for (const [archiveId, download] of Object.entries<any>(downloads)) {
+        // "installed" is set when an archive is installed and is not cleared on
+        // uninstall, so it marks the versions that were installed in the past
+        if (
+          download.state !== "finished" ||
+          download.installed?.gameId !== gameId ||
+          installedArchives.has(archiveId)
+        ) {
+          continue;
+        }
+        const modId =
+          download.modInfo?.ids?.modId ??
+          download.modInfo?.nexus?.ids?.modId ??
+          download.modInfo?.meta?.details?.modId;
+        if (modId !== undefined) {
+          counts[modId] = (counts[modId] ?? 0) + 1;
+        }
+      }
+
+      this.mVersionCounts = counts;
     }
 
-    return this.mInstallCounts;
+    return this.mVersionCounts;
   }
 }
 

--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.tsx
@@ -15,7 +15,8 @@ const PRESET_OPTIONS = [
 ];
 
 interface IConnectedProps {
-  mods: { [modId: string]: IMod };
+  // the active game's installed mods, keyed by mod id. Undefined until a game is active
+  mods: Record<string, IMod> | undefined;
 }
 
 type IProps = IFilterProps & IConnectedProps;
@@ -66,9 +67,8 @@ class VersionFilterComponent extends React.Component<IProps, {}> {
 }
 
 function mapStateToProps(state: IState): IConnectedProps {
-  const gameId = activeGameId(state);
   return {
-    mods: gameId !== undefined ? state.persistent.mods[gameId] : undefined,
+    mods: state.persistent.mods?.[activeGameId(state)],
   };
 }
 
@@ -84,7 +84,7 @@ class VersionFilter implements ITableFilter {
   private mCachedMods: Record<string, IMod> | undefined;
   private mVersionCounts: Record<string, number> = {};
 
-  public matches(filter: any, value: any, state: any): boolean {
+  public matches(filter: any, value: any, state: IState): boolean {
     if (value === undefined) {
       return undefined;
     }
@@ -101,11 +101,12 @@ class VersionFilter implements ITableFilter {
       return true;
     }
 
-    if (filter.includes("multi-version") && value.state === "installed") {
-      const modId = value.attributes?.modId;
-      if (modId !== undefined && (this.versionCounts(state)[modId] ?? 0) > 1) {
-        return true;
-      }
+    if (
+      filter.includes("multi-version") &&
+      value.state === "installed" &&
+      (this.versionCounts(state)[value.attributes?.modId] ?? 0) > 1
+    ) {
+      return true;
     }
 
     const versionFilters = filter
@@ -132,16 +133,16 @@ class VersionFilter implements ITableFilter {
    * walks the list once rather than once per row.
    */
   private versionCounts(state: IState): Record<string, number> {
-    const gameId = activeGameId(state);
-    const mods = state.persistent.mods?.[gameId] ?? {};
+    const mods = state.persistent.mods?.[activeGameId(state)];
 
     if (mods !== this.mCachedMods) {
       this.mCachedMods = mods;
 
       const counts: Record<string, number> = {};
-      for (const mod of Object.values<IMod>(mods)) {
+      for (const mod of Object.values<IMod>(mods ?? {})) {
         const modId = mod.attributes?.modId;
-        if (mod.state === "installed" && modId !== undefined) {
+        // a nullish or empty modId is "no mod id", not an id every such mod shares
+        if (mod.state === "installed" && modId) {
           counts[modId] = (counts[modId] ?? 0) + 1;
         }
       }


### PR DESCRIPTION
Add filter to Version dropdown to only show mods with multiple versions in Vortex.

## Summary

Adds a new preset option, "Multiple versions installed", to the Version column
filter on the mods page. When selected, the table shows only mods that have
more than one version installed at the same time (i.e. multiple entries
sharing the same Nexus mod ID, such as when a mod is installed as separate
variants instead of being upgraded in place).

## Changes

File: `src/renderer/src/extensions/mod_management/util/VersionFilter.tsx`

1. Added a new entry to `PRESET_OPTIONS`:
   ```ts
   { value: "multi-version", label: "Multiple versions installed" }
   ```

2. Extended `VersionFilter.matches()` to accept the `state` parameter (already
   supported by the `ITableFilter` interface but previously unused here), and
   added a `multi-version` branch: it reads the row's `attributes.modId`,
   looks up all mods for the active game in `state.persistent.mods`, and
   counts how many share that `modId`. If more than one match, the row passes
   the filter.