### PR TITLE
Handle external mod requirements in health check (LAZ-828)

### DIFF
--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -2,6 +2,10 @@
   "actions": {
     "install_all": "1-click install all ({{count}})"
   },
+  "divider": {
+    "and": "And",
+    "or": "Or"
+  },
   "shared": {
     "requires_files": "Requires {{ count }} additional mod file to be installed to work correctly:",
     "requires_files_plural": "Requires {{ count }} additional mod files to be installed to work correctly:",
@@ -33,6 +37,7 @@
     "no_results_hidden": {
       "title": "No hidden items"
     },
+    "external_mod_install": "External mod install",
     "install_one_click": "1-click install ({{count}})",
     "install_uninstalled": "Install (downloaded)",
     "pick_mod_install": "Pick mod install",
@@ -62,6 +67,7 @@
       "author_note": "Author note: {{note}}",
       "mod_page_source_note": "This requirement was identified from the mod page rather than the file-level requirement system, so it may not be required for your specific configuration. <modLink>View the mod page to get full details</modLink>.",
       "open_external_mod_page": "Open external mod page",
+      "external_hosted_note": "This mod is hosted outside Nexus Mods. Check the description before installing.",
       "after_installing": "After installing, click Confirm install. We can’t automatically detect external mod installations.",
       "confirm_install": "Confirm install",
       "missing_for": "Missing required mod for: <modLink>{{modName}}</modLink>",

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -385,17 +385,14 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
         };
 
         for (const req of requirements.nexusRequirements.nodes) {
-          // External requirements (e.g. tools from GitHub) don't have valid
-          // Nexus mod IDs — report them as missing but skip the API lookup
+          // External (non-Nexus) requirements are temporarily suppressed because there
+          // is no way to invalidate them. They can't be auto-detected, so the only way
+          // to clear one is for the user to confirm it's installed — which just hides
+          // it permanently, with no path back if they later uninstall it. Skip them
+          // until that lifecycle is handled. Restore the push below (see git history /
+          // commit 015dfa493) to re-enable the "External mod install" listing + detail
+          // UI, which is left in place for that.
           if (req.externalRequirement) {
-            getModEntry().missingMods.push({
-              ...req,
-              modId: 0,
-              gameId,
-              uid: `external-${req.id}`,
-              requiredBy,
-              modUrl: req.url,
-            });
             continue;
           }
 

--- a/src/renderer/src/extensions/health_check/components/divider/Divider.tsx
+++ b/src/renderer/src/extensions/health_check/components/divider/Divider.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+interface IDividerProps {
+  variant: "and" | "or";
+  className?: string;
+}
+
+export const Divider = ({ variant, className }: IDividerProps) => {
+  const { t } = useTranslation("health_check");
+
+  return (
+    <div aria-hidden className={joinClasses(["flex items-center gap-x-3", className])}>
+      <div className="h-px w-3 bg-surface-mid" />
+
+      <Typography as="div" className="font-semibold">
+        {t(`divider::${variant}`)}
+      </Typography>
+
+      <div className="h-px grow bg-surface-mid" />
+    </div>
+  );
+};

--- a/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
@@ -15,21 +15,24 @@ import { TypographyLink } from "@/ui/components/typography/TypographyLink";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
 import type { IFileRequirementData } from "../../utils/fileRequirements/cardHelpers";
+import { Divider } from "../divider/Divider";
 
 interface IFileRequirementProps {
   actions?: ReactNode;
   file: IFileRequirementData;
+  fileIconPath?: string;
+  hideImage?: boolean;
   isOr?: boolean;
   showMod?: boolean;
-  /** Open the mod page (web). When set, the thumbnail and mod name become links. */
   onOpenMod?: () => void;
-  /** Open the file page (web). When set, the file name becomes a link. */
   onOpenFile?: () => void;
 }
 
 export function FileRequirement({
   actions,
   file,
+  fileIconPath = mdiFileOutline,
+  hideImage = false,
   isOr,
   showMod = true,
   onOpenMod,
@@ -53,14 +56,20 @@ export function FileRequirement({
       ])}
     >
       {showMod && (
-        <div className="mb-px flex items-center gap-x-4 rounded-t-sm bg-surface-mid p-2">
-          {onOpenMod ? (
-            <button className="shrink-0" type="button" onClick={onOpenMod}>
-              {modImage}
-            </button>
-          ) : (
-            modImage
-          )}
+        <div
+          className={joinClasses([
+            "mb-px flex items-center gap-x-4 rounded-t-sm bg-surface-mid",
+            hideImage ? "p-4" : "p-2",
+          ])}
+        >
+          {!hideImage &&
+            (onOpenMod ? (
+              <button className="shrink-0" type="button" onClick={onOpenMod}>
+                {modImage}
+              </button>
+            ) : (
+              modImage
+            ))}
 
           <div className="max-w-xl space-y-0.5">
             <div className="flex items-center gap-x-2">
@@ -102,7 +111,7 @@ export function FileRequirement({
           className="flex min-w-0 items-center gap-x-1.5"
           typographyType="body-sm"
         >
-          <Icon path={mdiFileOutline} size="sm" />
+          <Icon path={fileIconPath} size="sm" />
 
           {onOpenFile ? (
             <TypographyLink
@@ -148,18 +157,7 @@ export function FileRequirement({
       </div>
 
       {isOr && (
-        <div
-          aria-hidden
-          className="absolute inset-x-0 -bottom-2 flex h-5 items-center gap-x-3 group-last/file:hidden"
-        >
-          <div className="h-px w-3 bg-surface-mid" />
-
-          <Typography as="div" className="font-semibold">
-            Or
-          </Typography>
-
-          <div className="h-px grow bg-surface-mid" />
-        </div>
+        <Divider className="absolute inset-x-0 -bottom-2 h-5 group-last/file:hidden" variant="or" />
       )}
     </div>
   );

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -1,4 +1,10 @@
-import { mdiCheck, mdiHelpCircleOutline, mdiMonitorArrowDownVariant, mdiOpenInNew } from "@mdi/js";
+import {
+  mdiCheck,
+  mdiHelpCircleOutline,
+  mdiMonitorArrowDownVariant,
+  mdiOpenInNew,
+  mdiWeb,
+} from "@mdi/js";
 import React, { useCallback, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -17,6 +23,7 @@ import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import { hiddenModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
 import type { IDetailViewProps } from "../../views/content/types";
+import { Divider } from "../divider/Divider";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { FileRequirement } from "../file_requirement/FileRequirement";
 import { PremiumModal } from "../premium_modal/PremiumModal";
@@ -60,8 +67,17 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     onBack();
   }, [api, mod.requiredBy.modId, mod.id, onBack]);
 
-  // mainFile is denormalized by the check, so no fetch is needed here.
-  const fileData = modToFileData(mod, mod.mainFile);
+  // mainFile is denormalized by the check, so no fetch is needed here. External
+  // requirements aren't hosted on Nexus, so surface the URL and a caution note
+  // in place of the file name and mod summary.
+  const fileData = mod.externalRequirement
+    ? {
+        ...modToFileData(mod, mod.mainFile),
+        modDescription: t("detail::item::external_hosted_note"),
+        fileName: mod.modUrl ?? "",
+        fileVersion: "",
+      }
+    : modToFileData(mod, mod.mainFile);
   const severityStyle = severityStyleMap[entry.severity];
 
   return (
@@ -136,24 +152,36 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               )
             }
             file={fileData}
+            {...(mod.externalRequirement
+              ? { fileIconPath: mdiWeb, hideImage: true, onOpenFile: openModPage }
+              : {})}
           />
 
           {mod.externalRequirement && (
-            <div className="flex items-center gap-x-3 rounded-sm bg-info-weak/20 p-3">
-              <Typography appearance="moderate" as="div" className="grow" typographyType="body-sm">
-                {t("detail::item::after_installing")}
-              </Typography>
+            <>
+              <Divider variant="and" />
 
-              <Button
-                appearance="moderate"
-                brand="neutral"
-                leftIconPath={mdiCheck}
-                size="sm"
-                onClick={handleConfirmInstall}
-              >
-                {t("detail::item::confirm_install")}
-              </Button>
-            </div>
+              <div className="mx-6 flex items-center gap-x-3 rounded-sm bg-info-weak/20 p-3">
+                <Typography
+                  appearance="moderate"
+                  as="div"
+                  className="grow"
+                  typographyType="body-sm"
+                >
+                  {t("detail::item::after_installing")}
+                </Typography>
+
+                <Button
+                  appearance="moderate"
+                  brand="neutral"
+                  leftIconPath={mdiCheck}
+                  size="sm"
+                  onClick={handleConfirmInstall}
+                >
+                  {t("detail::item::confirm_install")}
+                </Button>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -31,19 +31,33 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     <>
       <ListingRowShell
         action={
-          <Button
-            appearance="moderate"
-            brand="neutral"
-            leftIconPath={mdiMonitorArrowDownVariant}
-            rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              void installInApp();
-            }}
-          >
-            {t("detail::item::install_one_click")}
-          </Button>
+          mod.externalRequirement ? (
+            <Button
+              appearance="moderate"
+              brand="neutral"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpen();
+              }}
+            >
+              {t("listing::external_mod_install")}
+            </Button>
+          ) : (
+            <Button
+              appearance="moderate"
+              brand="neutral"
+              leftIconPath={mdiMonitorArrowDownVariant}
+              rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                void installInApp();
+              }}
+            >
+              {t("detail::item::install_one_click")}
+            </Button>
+          )
         }
         detail={t("listing::item::description", {
           dependencyModName: mod.modName || mod.modUrl || mod.notes,


### PR DESCRIPTION
External (non-Nexus) requirements can't be installed in-app, so the listing now shows an "External mod install" button that opens the detail instead of a 1-click install, and the detail view hides the thumbnail, shows a caution note, and surfaces the clickable external URL (web icon) in place of the file name. Also extract the shared and/or separator into a translated Divider component.