### PR TITLE
fix renderer memory leak crashing installs on large mod libraries (LAZ-834)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -1602,8 +1602,8 @@ enum HealthCheckCategory {
 // @public (undocumented)
 type HealthCheckFixFunction = (api: IExtensionApi) => Promise<void>;
 
-// @public (undocumented)
-type HealthCheckFunction = (api: IExtensionApi) => Promise<IHealthCheckResult>;
+// @public
+type HealthCheckFunction = (api: IExtensionApi, signal?: AbortSignal) => Promise<IHealthCheckResult>;
 
 // @public (undocumented)
 enum HealthCheckSeverity {
@@ -2698,6 +2698,7 @@ interface IHealthCheck {
     extensionName?: string;
     // (undocumented)
     fix?: HealthCheckFixFunction;
+    gameId?: string;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -4941,7 +4942,7 @@ paused: boolean;
 type PayloadT<Type> = Type extends ComplexActionCreator<infer X> ? X : never;
 
 // @public (undocumented)
-type PerModCheckFunction = (api: IExtensionApi, mod: IModCheckContext) => Promise<IHealthCheckResult>;
+type PerModCheckFunction = (api: IExtensionApi, mod: IModCheckContext, signal?: AbortSignal) => Promise<IHealthCheckResult>;
 
 // @public
 type PersistingType = "global" | "game" | "profile";

--- a/extensions/games/game-xrebirth/src/diagnostic.ts
+++ b/extensions/games/game-xrebirth/src/diagnostic.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 
 import { types, util } from "@nexusmods/vortex-api";
 
-import { XREBIRTH_MOD_TYPES } from "./installers";
+import { XREBIRTH_GAME_ID, XREBIRTH_MOD_TYPES } from "./installers";
 import { XREBIRTH_STOP_PATTERNS } from "./stopPatterns";
 
 const TAGGED_NON_CONTENT_XML = new Set<string>([
@@ -63,6 +63,7 @@ function warning(
  */
 const modHasFilesCheck: types.IModHealthCheck = {
   id: "xrebirth-mod-has-files",
+  gameId: XREBIRTH_GAME_ID,
   name: "X Rebirth — mod has files",
   description: "Verifies that the installer produced at least one file.",
   category: CATEGORY,
@@ -89,6 +90,7 @@ const modHasFilesCheck: types.IModHealthCheck = {
  */
 const contentXmlCustomFileNameCheck: types.IModHealthCheck = {
   id: "xrebirth-content-xml-customFileName",
+  gameId: XREBIRTH_GAME_ID,
   name: "X Rebirth — content.xml carries customFileName",
   description: "Verifies that content.xml mods record their declared name.",
   category: CATEGORY,
@@ -128,6 +130,7 @@ const contentXmlCustomFileNameCheck: types.IModHealthCheck = {
  */
 const modShapeRecognisedCheck: types.IModHealthCheck = {
   id: "xrebirth-mod-shape-recognised",
+  gameId: XREBIRTH_GAME_ID,
   name: "X Rebirth — mod has a recognisable shape",
   description:
     "Verifies the install output is content.xml, matches stopPatterns, or is tagged with a known modType.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5005,6 +5005,9 @@ importers:
       numeral:
         specifier: 'catalog:'
         version: 2.0.6
+      p-queue:
+        specifier: 'catalog:'
+        version: 9.3.0
       packery:
         specifier: 'catalog:'
         version: 2.1.2

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -157,6 +157,7 @@
     "node-7z": "catalog:",
     "normalize-url": "catalog:",
     "numeral": "catalog:",
+    "p-queue": "catalog:",
     "packery": "catalog:",
     "permissions": "catalog:",
     "prop-types": "catalog:",

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, vi } from "vitest";
+
+import { makeHealthCheckResult } from "../../../test-utils/builders";
+import { test } from "../../../test-utils/healthCheckTest";
+import * as perModRunner from "./perModRunner";
+
+// Budget for a parked body to notice its abort and return. Sized for a loaded CI box, not the
+// ~10ms it normally takes: a stuck body burns the budget once instead of failing at random.
+const SETTLE = { timeout: 10000, interval: 10 };
+
+/** What the registry does with a check whose body outlives the run's timeout (GH#23776). */
+describe("HealthCheckRegistry timeout handling", () => {
+  test("stops the check body once the run has timed out", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck();
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });
+
+    const result = await harness.run(parked.id);
+    expect(result?.status).toBe("error");
+    expect(result?.message).toMatch(/timed out/);
+
+    // Nothing but the abort ends this body before teardown, so settling proves it was delivered.
+    await vi.waitFor(() => expect(parked.hasSettled()).toBe(true), SETTLE);
+    expect(parked.ticks()).toBeGreaterThan(0);
+  });
+
+  test("holds the concurrency guard until the abandoned body settles", async ({
+    makeHealthCheck,
+  }) => {
+    const harness = makeHealthCheck();
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50, respectAbort: false });
+
+    await harness.run(parked.id);
+    expect(parked.starts()).toBe(1);
+
+    // The first body is still in flight, so a re-trigger must be refused.
+    await harness.run(parked.id);
+    expect(parked.starts()).toBe(1);
+  });
+
+  test("keeps refusing re-triggers for as long as the body runs", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck();
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50, respectAbort: false });
+
+    for (let i = 0; i < 4; i += 1) {
+      await harness.run(parked.id);
+    }
+
+    expect(parked.starts()).toBe(1);
+  });
+
+  test("runs again once the abandoned body has finished", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck();
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });
+
+    await harness.run(parked.id);
+    expect(parked.starts()).toBe(1);
+
+    // Holding the slot for the body's lifetime must not wedge the check shut.
+    await vi.waitFor(() => expect(parked.hasSettled()).toBe(true), SETTLE);
+    await harness.run(parked.id);
+    expect(parked.starts()).toBe(2);
+  });
+});
+
+/** Which game's mods a per-mod check is allowed to reach (GH#23776). */
+describe("HealthCheckRegistry game gating", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const stubRunner = () =>
+    vi
+      .spyOn(perModRunner, "runPerModCheck")
+      .mockResolvedValue(makeHealthCheckResult({ checkId: "stub" }));
+
+  test("skips a per-mod check registered for another game", async ({ makeHealthCheck }) => {
+    const runner = stubRunner();
+    const harness = makeHealthCheck({ gameId: "skyrimse" });
+    const id = harness.registerModCheck({ id: "xrebirth-mod-has-files", gameId: "xrebirth" });
+
+    await harness.run(id);
+
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test("runs a per-mod check registered for the active game", async ({ makeHealthCheck }) => {
+    const runner = stubRunner();
+    const harness = makeHealthCheck({ gameId: "xrebirth" });
+    const id = harness.registerModCheck({ id: "xrebirth-mod-has-files", gameId: "xrebirth" });
+
+    await harness.run(id);
+
+    expect(runner).toHaveBeenCalledOnce();
+  });
+
+  test("drops a stored result once its game is no longer active", async ({ makeHealthCheck }) => {
+    stubRunner();
+    const harness = makeHealthCheck({ gameId: "xrebirth" });
+    const id = harness.registerModCheck({ id: "xrebirth-mod-has-files", gameId: "xrebirth" });
+
+    await harness.run(id);
+    expect(harness.resultFor(id)).toBeDefined();
+
+    harness.setState((draft) => {
+      draft.persistent.profiles["profile-1"].gameId = "skyrimse";
+    });
+    await harness.run(id);
+
+    // An xrebirth result has no meaning on the Skyrim health check page.
+    expect(harness.resultFor(id)).toBeUndefined();
+  });
+
+  test("drops the result of a run whose game went away mid-flight", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck({ gameId: "xrebirth" });
+    const id = harness.registerModCheck({ id: "xrebirth-mod-has-files", gameId: "xrebirth" });
+
+    // The switch lands while the check is running, so the gate at the top of the run cannot
+    // catch it; only the check made before the result is stored.
+    vi.spyOn(perModRunner, "runPerModCheck").mockImplementation(async () => {
+      harness.setState((draft) => {
+        draft.persistent.profiles["profile-1"].gameId = "skyrimse";
+      });
+      return makeHealthCheckResult({ checkId: id });
+    });
+
+    expect(await harness.run(id)).toBeUndefined();
+    expect(harness.resultFor(id)).toBeUndefined();
+  });
+
+  test("runs a per-mod check that claims no game", async ({ makeHealthCheck }) => {
+    const runner = stubRunner();
+    const harness = makeHealthCheck({ gameId: "skyrimse" });
+    const id = harness.registerModCheck({ id: "generic-mod-check" });
+
+    await harness.run(id);
+
+    expect(runner).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
@@ -13,7 +13,8 @@ import {
   isModHealthCheck,
 } from "../../../types/IHealthCheck";
 import { log } from "../../../util/log";
-import { setHealthCheckResult } from "../actions/session";
+import { activeGameId } from "../../../util/selectors";
+import { clearHealthCheckResult, setHealthCheckResult } from "../actions/session";
 import type { HealthCheckId } from "../types";
 import { runPerModCheck } from "./perModRunner";
 
@@ -146,6 +147,17 @@ export class HealthCheckRegistry {
       return undefined;
     }
 
+    // The per-mod runner enumerates mods for whatever game is ACTIVE, so a check that names a
+    // game has to be held to it here.
+    if (!this.appliesToActiveGame(entry, api)) {
+      this.discardResult(entry, checkId);
+      log("debug", "Health check skipped, belongs to another game", {
+        id: checkId,
+        gameId: entry.healthCheck.gameId,
+      });
+      return undefined;
+    }
+
     // Check if result is cached (unless force is true)
     if (!force && entry.cachedUntil && entry.lastResult && new Date() < entry.cachedUntil) {
       log("debug", "Using cached result for health check", { id: checkId });
@@ -160,34 +172,54 @@ export class HealthCheckRegistry {
 
     this.mExecutionQueue.add(checkId);
     const startTime = Date.now();
+    let timedOut = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     try {
       const timeout = entry.healthCheck.timeout || 30000;
       log("debug", "Executing health check", { id: checkId, timeout });
 
+      // Abort stops the body, not just the promise this awaits.
+      const abort = new AbortController();
       const timeoutPromise = new Promise<IHealthCheckResult>((_, reject) => {
-        setTimeout(() => reject(new Error(`Health check timed out after ${timeout}ms`)), timeout);
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          abort.abort();
+          reject(new Error(`Health check timed out after ${timeout}ms`));
+        }, timeout);
       });
 
       const hc = entry.healthCheck;
-      const checkPromise = isModHealthCheck(hc) ? runPerModCheck(hc, api) : hc.check(api);
+      const checkPromise = isModHealthCheck(hc)
+        ? runPerModCheck(hc, api, { signal: abort.signal })
+        : hc.check(api, abort.signal);
+
+      // The slot belongs to the body, not the race: one that cannot observe the abort promptly
+      // (mid-readdir, mid-request) still holds resources, so the next trigger waits for it.
+      void checkPromise
+        .catch(() => undefined)
+        .finally(() => {
+          if (timedOut) {
+            log("debug", "Abandoned health check finished", {
+              id: checkId,
+              afterMs: Date.now() - startTime,
+            });
+          }
+          this.mExecutionQueue.delete(checkId);
+        });
+
       const result = await Promise.race([checkPromise, timeoutPromise]);
 
       result.checkId = checkId;
       result.timestamp = new Date();
       result.executionTime = Date.now() - startTime;
 
-      if (entry.healthCheck.cacheDuration && entry.healthCheck.cacheDuration > 0) {
-        entry.cachedUntil = new Date(Date.now() + entry.healthCheck.cacheDuration);
+      if (!this.recordResult(entry, checkId, result, api)) {
+        return undefined;
       }
 
-      entry.lastResult = result;
-      entry.lastExecuted = new Date();
-      this.mResults.set(checkId, result);
-
-      // Dispatch result to Redux so UI can access it
-      if (this.mApi.store) {
-        this.mApi.store.dispatch(setHealthCheckResult(checkId, result));
+      if (entry.healthCheck.cacheDuration && entry.healthCheck.cacheDuration > 0) {
+        entry.cachedUntil = new Date(Date.now() + entry.healthCheck.cacheDuration);
       }
 
       log("debug", "Health check completed", {
@@ -211,13 +243,8 @@ export class HealthCheckRegistry {
         isLegacyTest: "isLegacyTest" in entry.healthCheck,
       };
 
-      entry.lastResult = errorResult;
-      entry.lastExecuted = new Date();
-      this.mResults.set(checkId, errorResult);
-
-      // Dispatch error result to Redux so UI can access it
-      if (this.mApi.store) {
-        this.mApi.store.dispatch(setHealthCheckResult(checkId, errorResult));
+      if (!this.recordResult(entry, checkId, errorResult, api)) {
+        return undefined;
       }
 
       log("warn", "Health check failed", {
@@ -227,8 +254,54 @@ export class HealthCheckRegistry {
 
       return errorResult;
     } finally {
-      this.mExecutionQueue.delete(checkId);
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
+      // On timeout the body runs on and releases the slot from its settle handler; any other
+      // exit means it is done.
+      if (!timedOut) {
+        this.mExecutionQueue.delete(checkId);
+      }
     }
+  }
+
+  /** Whether this check names a game other than the active one. */
+  private appliesToActiveGame(entry: IHealthCheckEntry, api: IExtensionApi): boolean {
+    const checkGameId = entry.healthCheck.gameId;
+    return checkGameId === undefined || checkGameId === activeGameId(api.getState());
+  }
+
+  /** Forget a stored result, so nothing reports it against the game the user is now on. */
+  private discardResult(entry: IHealthCheckEntry, checkId: HealthCheckId): void {
+    if (entry.lastResult === undefined) {
+      return;
+    }
+    entry.lastResult = undefined;
+    entry.cachedUntil = undefined;
+    this.mResults.delete(checkId);
+    this.mApi.store?.dispatch(clearHealthCheckResult(checkId));
+  }
+
+  /**
+   * Store a result and publish it, unless the game moved on while the check was running. Returns
+   * whether it was kept.
+   */
+  private recordResult(
+    entry: IHealthCheckEntry,
+    checkId: HealthCheckId,
+    result: IHealthCheckResult,
+    api: IExtensionApi,
+  ): boolean {
+    if (!this.appliesToActiveGame(entry, api)) {
+      log("debug", "Health check result dropped, game changed while it ran", { id: checkId });
+      this.discardResult(entry, checkId);
+      return false;
+    }
+    entry.lastResult = result;
+    entry.lastExecuted = new Date();
+    this.mResults.set(checkId, result);
+    this.mApi.store?.dispatch(setHealthCheckResult(checkId, result));
+    return true;
   }
 
   /**

--- a/src/renderer/src/extensions/health_check/core/perModRunner.test.ts
+++ b/src/renderer/src/extensions/health_check/core/perModRunner.test.ts
@@ -2,15 +2,21 @@ import * as fs from "fs";
 
 import { afterEach, describe, test, expect, vi } from "vitest";
 
-import type { IExtensionApi } from "../../../types/IExtensionContext";
 import {
-  HealthCheckCategory,
-  HealthCheckSeverity,
-  HealthCheckTrigger,
-  type IModCheckContext,
-  type IModHealthCheck,
-} from "../../../types/IHealthCheck";
-import { aggregateResults, buildModCheckContext, runPerModCheck } from "./perModRunner";
+  makeConcurrencyProbe,
+  makeHealthCheckResult,
+  makeModCheckContext,
+  makeModHealthCheck,
+} from "../../../test-utils/builders";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { HealthCheckSeverity } from "../../../types/IHealthCheck";
+import type { IInstalledModEntry } from "./perModRunner";
+import {
+  aggregateResults,
+  buildModCheckContext,
+  MOD_WALK_CONCURRENCY,
+  runPerModCheck,
+} from "./perModRunner";
 
 const baseResult = (
   status: "passed" | "failed" | "warning" | "error",
@@ -88,29 +94,13 @@ describe("aggregateResults", () => {
 
 describe("runPerModCheck error handling", () => {
   const fakeApi = {} as IExtensionApi;
-
-  const makeCheck = (
-    checkMod: (api: IExtensionApi, mod: IModCheckContext) => Promise<any>,
-  ): IModHealthCheck => ({
-    id: "test-check",
-    name: "Test",
-    description: "",
-    category: HealthCheckCategory.Mods,
-    severity: HealthCheckSeverity.Warning,
-    triggers: [HealthCheckTrigger.Manual],
-    checkMod,
-  });
-
-  const emptyContext: IModCheckContext = {
-    modId: "m1",
-    files: [],
-    readFile: async () => Buffer.alloc(0),
-    attributes: {},
-  };
+  const emptyContext = makeModCheckContext({ modId: "m1" });
 
   test("checkMod throw is converted to an error-status result (not propagated)", async () => {
-    const hc = makeCheck(async () => {
-      throw new Error("boom in extension code");
+    const hc = makeModHealthCheck({
+      checkMod: async () => {
+        throw new Error("boom in extension code");
+      },
     });
     const result = await runPerModCheck(hc, fakeApi, {
       enumerate: () => [{ modId: "m1", stagingPath: "/fake", attributes: {} }],
@@ -121,29 +111,50 @@ describe("runPerModCheck error handling", () => {
     expect(result.details).toMatch(/checkMod threw for m1.*boom/);
   });
 
-  test("buildModCheckContext throw propagates (harness bug, not extension)", async () => {
-    const hc = makeCheck(async () => ({
-      checkId: "test-check",
-      status: "passed" as const,
-      severity: HealthCheckSeverity.Info,
-      message: "ok",
-      executionTime: 0,
-      timestamp: new Date(),
-    }));
+  test("buildModCheckContext throw is reported against its mod (not propagated)", async () => {
+    const hc = makeModHealthCheck();
 
-    await expect(
-      runPerModCheck(hc, fakeApi, {
-        enumerate: () => [{ modId: "m1", stagingPath: "/fake", attributes: {} }],
-        buildContext: async () => {
-          throw new Error("EACCES walking staging dir");
-        },
-      }),
-    ).rejects.toThrow(/EACCES/);
+    const result = await runPerModCheck(hc, fakeApi, {
+      enumerate: () => [{ modId: "m1", stagingPath: "/fake", attributes: {} }],
+      buildContext: async () => {
+        throw new Error("EACCES walking staging dir");
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.severity).toBe(HealthCheckSeverity.Error);
+    expect(result.details).toMatch(/Could not read staging folder for m1.*EACCES/);
+  });
+
+  test("one unreadable mod does not discard the rest of the wave", async () => {
+    const hc = makeModHealthCheck({
+      checkMod: async (_api, mod) => makeHealthCheckResult({ message: `checked ${mod.modId}` }),
+    });
+
+    const result = await runPerModCheck(hc, fakeApi, {
+      enumerate: () =>
+        ["m1", "locked", "m3"].map((modId) => ({
+          modId,
+          stagingPath: `/fake/${modId}`,
+          attributes: {},
+        })),
+      buildContext: async (entry) => {
+        if (entry.modId === "locked") {
+          throw new Error("EPERM: file is locked");
+        }
+        return makeModCheckContext({ modId: entry.modId });
+      },
+    });
+
+    expect(result.message).toContain("1 failed / 0 warned of 3 mods");
+    expect(result.details).toMatch(/Could not read staging folder for locked.*EPERM/);
   });
 
   test("no mods → passed/info short-circuit", async () => {
-    const hc = makeCheck(async () => {
-      throw new Error("should not run");
+    const hc = makeModHealthCheck({
+      checkMod: async () => {
+        throw new Error("should not run");
+      },
     });
     const result = await runPerModCheck(hc, fakeApi, {
       enumerate: () => [],
@@ -151,6 +162,85 @@ describe("runPerModCheck error handling", () => {
     });
     expect(result.status).toBe("passed");
     expect(result.severity).toBe(HealthCheckSeverity.Info);
+  });
+});
+
+/** How wide the runner goes on a large library (GH#23776). */
+describe("runPerModCheck fan-out", () => {
+  const fakeApi = {} as IExtensionApi;
+
+  // Loose enough to survive retuning MOD_WALK_CONCURRENCY, tight enough that an unbounded walk
+  // of the libraries below blows through it.
+  const CONCURRENCY_CEILING = 64;
+
+  // A microtask, not a timer: enough to make a wave's callbacks overlap, which is all the probe
+  // measures, and off the timer queue so CI load cannot change the result.
+  const tick = () => Promise.resolve();
+
+  const entries = (count: number): IInstalledModEntry[] =>
+    Array.from({ length: count }, (_, i) => ({
+      modId: `mod-${i}`,
+      stagingPath: `/staging/mod-${i}`,
+      attributes: {},
+    }));
+
+  // Peak contexts built but not yet released by checkMod. Each holds one mod's full file list,
+  // so this is the shape of the runner's memory footprint.
+  const peakLiveContexts = async (modCount: number): Promise<number> => {
+    const probe = makeConcurrencyProbe();
+
+    const hc = makeModHealthCheck({
+      checkMod: async () => {
+        await tick();
+        probe.leave();
+        return makeHealthCheckResult();
+      },
+    });
+
+    await runPerModCheck(hc, fakeApi, {
+      enumerate: () => entries(modCount),
+      buildContext: async (entry) => {
+        await tick();
+        probe.enter();
+        return makeModCheckContext({ modId: entry.modId });
+      },
+    });
+
+    return probe.peak();
+  };
+
+  test("walks a bounded number of mods at a time", async () => {
+    expect(await peakLiveContexts(400)).toBeLessThanOrEqual(CONCURRENCY_CEILING);
+  });
+
+  test("stops walking once the run is aborted", async () => {
+    const abort = new AbortController();
+    let walked = 0;
+
+    const result = await runPerModCheck(makeModHealthCheck(), fakeApi, {
+      signal: abort.signal,
+      enumerate: () => entries(400),
+      buildContext: async (entry) => {
+        walked += 1;
+        // Abort part-way through the first wave, where the registry's timeout would land.
+        if (walked === MOD_WALK_CONCURRENCY) {
+          abort.abort();
+        }
+        await tick();
+        return makeModCheckContext({ modId: entry.modId });
+      },
+    });
+
+    // The in-flight wave finishes; the rest of the library is left unwalked.
+    expect(walked).toBe(MOD_WALK_CONCURRENCY);
+    // A partial walk must not read as a clean bill of health for the whole library.
+    expect(result.message).toContain(`stopped after ${MOD_WALK_CONCURRENCY} of 400 mods`);
+  });
+
+  test("peak does not grow with the size of the library", async () => {
+    const small = await peakLiveContexts(200);
+    const large = await peakLiveContexts(800);
+    expect(large).toBe(small);
   });
 });
 

--- a/src/renderer/src/extensions/health_check/core/perModRunner.test.ts
+++ b/src/renderer/src/extensions/health_check/core/perModRunner.test.ts
@@ -126,7 +126,7 @@ describe("runPerModCheck error handling", () => {
     expect(result.details).toMatch(/Could not read staging folder for m1.*EACCES/);
   });
 
-  test("one unreadable mod does not discard the rest of the wave", async () => {
+  test("one unreadable mod does not discard the rest of the run", async () => {
     const hc = makeModHealthCheck({
       checkMod: async (_api, mod) => makeHealthCheckResult({ message: `checked ${mod.modId}` }),
     });
@@ -173,7 +173,7 @@ describe("runPerModCheck fan-out", () => {
   // of the libraries below blows through it.
   const CONCURRENCY_CEILING = 64;
 
-  // A microtask, not a timer: enough to make a wave's callbacks overlap, which is all the probe
+  // A microtask, not a timer: enough to make the pool's tasks overlap, which is all the probe
   // measures, and off the timer queue so CI load cannot change the result.
   const tick = () => Promise.resolve();
 
@@ -222,7 +222,7 @@ describe("runPerModCheck fan-out", () => {
       enumerate: () => entries(400),
       buildContext: async (entry) => {
         walked += 1;
-        // Abort part-way through the first wave, where the registry's timeout would land.
+        // Abort once the pool is saturated, where the registry's timeout would land.
         if (walked === MOD_WALK_CONCURRENCY) {
           abort.abort();
         }
@@ -231,10 +231,11 @@ describe("runPerModCheck fan-out", () => {
       },
     });
 
-    // The in-flight wave finishes; the rest of the library is left unwalked.
-    expect(walked).toBe(MOD_WALK_CONCURRENCY);
+    // How many tasks are in flight when the abort lands is p-queue's to decide; the bound is
+    // what matters.
+    expect(walked).toBeLessThanOrEqual(MOD_WALK_CONCURRENCY);
     // A partial walk must not read as a clean bill of health for the whole library.
-    expect(result.message).toContain(`stopped after ${MOD_WALK_CONCURRENCY} of 400 mods`);
+    expect(result.message).toMatch(/stopped after \d+ of 400 mods/);
   });
 
   test("peak does not grow with the size of the library", async () => {

--- a/src/renderer/src/extensions/health_check/core/perModRunner.ts
+++ b/src/renderer/src/extensions/health_check/core/perModRunner.ts
@@ -13,6 +13,7 @@ import { HealthCheckSeverity } from "../../../types/IHealthCheck";
 import { log } from "../../../util/log";
 import { activeGameId } from "../../../util/selectors";
 import { installPathForGame } from "../../mod_management/selectors";
+import { chunked } from "../utils/shared/batchCache";
 
 /** Map an installed mod's redux state row to an IModCheckContext. */
 export interface IInstalledModEntry {
@@ -85,13 +86,25 @@ async function walkRelative(root: string): Promise<string[]> {
 }
 
 /**
+ * How many mods are walked at a time. Each in-flight mod holds its whole file list in memory for
+ * as long as `checkMod` runs. The walk is filesystem-bound, so wider waves buy no measurable
+ * speedup.
+ */
+export const MOD_WALK_CONCURRENCY = 16;
+
+/** How many failing mod ids the summary log names before it stops listing them. */
+const LOGGED_MOD_SAMPLE = 10;
+
+/**
  * Run a per-mod healthcheck across all installed mods for the active game and
  * fold the per-mod results into a single IHealthCheckResult (worst severity
  * wins; per-mod messages are concatenated into `details`).
  *
- * `deps` is a seam for unit tests; production callers pass nothing.
+ * On `signal`, the walk stops at the next wave boundary and aggregates what it has.
+ * `enumerate` / `buildContext` are a seam for unit tests; production callers pass neither.
  */
-export interface IPerModCheckDeps {
+export interface IPerModCheckOpts {
+  signal?: AbortSignal;
   enumerate?: typeof enumerateInstalledMods;
   buildContext?: typeof buildModCheckContext;
 }
@@ -99,10 +112,11 @@ export interface IPerModCheckDeps {
 export async function runPerModCheck(
   hc: IModHealthCheck,
   api: IExtensionApi,
-  deps: IPerModCheckDeps = {},
+  opts: IPerModCheckOpts = {},
 ): Promise<IHealthCheckResult> {
-  const enumerate = deps.enumerate ?? enumerateInstalledMods;
-  const buildContext = deps.buildContext ?? buildModCheckContext;
+  const enumerate = opts.enumerate ?? enumerateInstalledMods;
+  const buildContext = opts.buildContext ?? buildModCheckContext;
+  const signal = opts.signal;
   const startedAt = Date.now();
   const mods = enumerate(api);
   if (mods.length === 0) {
@@ -115,28 +129,75 @@ export async function runPerModCheck(
       timestamp: new Date(),
     };
   }
-  const perMod = await Promise.all(
-    mods.map(async (entry): Promise<IHealthCheckResult> => {
-      // Context construction (FS walk, state lookup) is harness-controlled — if
-      // it throws, that's a bug in this module, not the extension's check.
-      // Let it propagate so the registry sees the real stack. Only wrap the
-      // extension-supplied `checkMod` call.
-      const ctx = await buildContext(entry);
-      try {
-        return await hc.checkMod(api, ctx);
-      } catch (err: unknown) {
-        return {
-          checkId: hc.id,
-          status: "error",
-          severity: HealthCheckSeverity.Error,
-          message: `checkMod threw for ${entry.modId}: ${unknownToError(err).message || "unknown error"}`,
-          executionTime: 0,
-          timestamp: new Date(),
-        };
+
+  const errorFor = (modId: string, prefix: string, err: unknown): IHealthCheckResult => {
+    const error = unknownToError(err);
+    return {
+      checkId: hc.id,
+      status: "error",
+      severity: HealthCheckSeverity.Error,
+      message: `${prefix} ${modId}: ${error.message || "unknown error"}`,
+      details: error.stack,
+      executionTime: 0,
+      timestamp: new Date(),
+    };
+  };
+
+  const checkOne = async (entry: IInstalledModEntry): Promise<IHealthCheckResult> => {
+    // A throw from buildContext is a fault in this module or the staging folder, not in the
+    // extension's check; the rejected branch below attributes it to this mod.
+    const ctx = await buildContext(entry);
+    try {
+      return await hc.checkMod(api, ctx, signal);
+    } catch (err: unknown) {
+      return errorFor(entry.modId, "checkMod threw for", err);
+    }
+  };
+
+  const perMod: IHealthCheckResult[] = [];
+  const unreadable: string[] = [];
+  let abandoned = false;
+
+  for (const wave of chunked(mods, MOD_WALK_CONCURRENCY)) {
+    if (signal?.aborted) {
+      abandoned = true;
+      break;
+    }
+    // An unreadable staging folder (scanner lock, mod removed mid-walk) fails that mod alone.
+    const waveResults = await Promise.allSettled(wave.map(checkOne));
+    for (let i = 0; i < waveResults.length; i += 1) {
+      const settled = waveResults[i];
+      if (settled.status === "fulfilled") {
+        perMod.push(settled.value);
+        continue;
       }
-    }),
-  );
-  return aggregateResults(hc.id, perMod, startedAt);
+      const modId = wave[i].modId;
+      unreadable.push(modId);
+      perMod.push(errorFor(modId, "Could not read staging folder for", settled.reason));
+    }
+  }
+
+  // One line per run, not per mod: a staging drive that has gone away would flood the log. Each
+  // failure is spelled out in the aggregate's `details`.
+  if (unreadable.length > 0) {
+    log("error", "per-mod check could not read some mods", {
+      id: hc.id,
+      count: unreadable.length,
+      mods: unreadable.slice(0, LOGGED_MOD_SAMPLE),
+    });
+  }
+
+  const result = aggregateResults(hc.id, perMod, startedAt);
+  if (abandoned) {
+    log("debug", "per-mod check abandoned mid-walk", {
+      id: hc.id,
+      checked: perMod.length,
+      total: mods.length,
+    });
+    // A partial walk is not a clean bill of health for the library.
+    result.message = `${result.message} (stopped after ${perMod.length} of ${mods.length} mods)`;
+  }
+  return result;
 }
 
 export function aggregateResults(

--- a/src/renderer/src/extensions/health_check/core/perModRunner.ts
+++ b/src/renderer/src/extensions/health_check/core/perModRunner.ts
@@ -13,7 +13,6 @@ import { HealthCheckSeverity } from "../../../types/IHealthCheck";
 import { log } from "../../../util/log";
 import { activeGameId } from "../../../util/selectors";
 import { installPathForGame } from "../../mod_management/selectors";
-import { chunked } from "../utils/shared/batchCache";
 
 /** Map an installed mod's redux state row to an IModCheckContext. */
 export interface IInstalledModEntry {
@@ -86,9 +85,8 @@ async function walkRelative(root: string): Promise<string[]> {
 }
 
 /**
- * How many mods are walked at a time. Each in-flight mod holds its whole file list in memory for
- * as long as `checkMod` runs. The walk is filesystem-bound, so wider waves buy no measurable
- * speedup.
+ * How many mods are walked at a time. Each in-flight mod holds its whole file list for as long as
+ * `checkMod` runs, and the walk is filesystem-bound, so a wider pool buys no measurable speedup.
  */
 export const MOD_WALK_CONCURRENCY = 16;
 
@@ -100,7 +98,7 @@ const LOGGED_MOD_SAMPLE = 10;
  * fold the per-mod results into a single IHealthCheckResult (worst severity
  * wins; per-mod messages are concatenated into `details`).
  *
- * On `signal`, the walk stops at the next wave boundary and aggregates what it has.
+ * On `signal`, mods not yet started are skipped and the aggregate covers what did run.
  * `enumerate` / `buildContext` are a seam for unit tests; production callers pass neither.
  */
 export interface IPerModCheckOpts {
@@ -144,8 +142,8 @@ export async function runPerModCheck(
   };
 
   const checkOne = async (entry: IInstalledModEntry): Promise<IHealthCheckResult> => {
-    // A throw from buildContext is a fault in this module or the staging folder, not in the
-    // extension's check; the rejected branch below attributes it to this mod.
+    // A buildContext throw is a fault in this module or the staging folder, not in the
+    // extension's check. The catch below attributes it to this mod.
     const ctx = await buildContext(entry);
     try {
       return await hc.checkMod(api, ctx, signal);
@@ -154,31 +152,40 @@ export async function runPerModCheck(
     }
   };
 
-  const perMod: IHealthCheckResult[] = [];
+  // ESM-only against a CommonJS renderer, so a static import fails typecheck (TS1479). webpack
+  // externalises this back to `require()`, which Node serves via require(esm): p-queue must stay
+  // free of top-level await.
+  const { default: PQueue } = await import("p-queue");
+  const queue = new PQueue({ concurrency: MOD_WALK_CONCURRENCY });
+
+  // Indexed by mod, so the aggregate reads in library order however the pool interleaves. A
+  // skipped mod leaves its slot empty.
+  const slots = new Array<IHealthCheckResult | undefined>(mods.length);
   const unreadable: string[] = [];
-  let abandoned = false;
 
-  for (const wave of chunked(mods, MOD_WALK_CONCURRENCY)) {
-    if (signal?.aborted) {
-      abandoned = true;
-      break;
-    }
-    // An unreadable staging folder (scanner lock, mod removed mid-walk) fails that mod alone.
-    const waveResults = await Promise.allSettled(wave.map(checkOne));
-    for (let i = 0; i < waveResults.length; i += 1) {
-      const settled = waveResults[i];
-      if (settled.status === "fulfilled") {
-        perMod.push(settled.value);
-        continue;
-      }
-      const modId = wave[i].modId;
-      unreadable.push(modId);
-      perMod.push(errorFor(modId, "Could not read staging folder for", settled.reason));
-    }
-  }
+  await Promise.all(
+    mods.map((entry, index) =>
+      queue.add(async () => {
+        if (signal?.aborted) {
+          return;
+        }
+        try {
+          slots[index] = await checkOne(entry);
+        } catch (err: unknown) {
+          // An unreadable staging folder (scanner lock, mod removed mid-walk) fails that mod
+          // alone.
+          unreadable.push(entry.modId);
+          slots[index] = errorFor(entry.modId, "Could not read staging folder for", err);
+        }
+      }),
+    ),
+  );
 
-  // One line per run, not per mod: a staging drive that has gone away would flood the log. Each
-  // failure is spelled out in the aggregate's `details`.
+  const perMod = slots.filter((result): result is IHealthCheckResult => result !== undefined);
+  const abandoned = perMod.length < mods.length;
+
+  // One line per run, not per mod: a staging drive that has gone away would flood the log. Every
+  // failure is still in the aggregate's `details`.
   if (unreadable.length > 0) {
     log("error", "per-mod check could not read some mods", {
       id: hc.id,

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -40,6 +40,8 @@ import type { IDownload, IModInfo } from "../extensions/download_management/type
 import type { ILoadOrderEntry } from "../extensions/file_based_loadorder/types/types";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
+import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
+import type { HealthCheckId } from "../extensions/health_check/types";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import { modsReducer } from "../extensions/mod_management/reducers/mods";
@@ -65,20 +67,32 @@ import type {
 import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../types/IDialog";
 import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IGame } from "../types/IGame";
+import type { IHealthCheckResult, IModCheckContext, IModHealthCheck } from "../types/IHealthCheck";
+import {
+  HealthCheckCategory,
+  HealthCheckSeverity,
+  HealthCheckTrigger,
+} from "../types/IHealthCheck";
 import type { IState } from "../types/IState";
 import local from "../util/local";
 import type { IStarterInfo } from "../util/StarterInfo";
 import type {
   IApiHarness,
+  IConcurrencyProbe,
   IDownloadAdapterHarness,
   IDownloadAdapterOpts,
   IDriverHarness,
   IDriverHarnessState,
   IFbloHarness,
   IFbloHarnessOpts,
+  IHealthCheckHarness,
+  IHealthCheckHarnessOpts,
   IInstallContextHarness,
   IInstallManagerHarness,
+  IModCheckOpts,
   IModChangeHarness,
+  IParkCheckOpts,
+  IParkedCheck,
   IRevisionFixture,
   IRevisionMemberSpec,
   ITrackedAction,
@@ -306,6 +320,46 @@ export function makeFileListItem(overrides: Partial<IFileListItem> = {}): IFileL
 
 export function makeModInfo(overrides: Partial<IModInfo> = {}): IModInfo {
   return { ...overrides };
+}
+
+export function makeHealthCheckResult(
+  overrides: Partial<IHealthCheckResult> = {},
+): IHealthCheckResult {
+  return {
+    checkId: "test-check",
+    status: "passed",
+    severity: HealthCheckSeverity.Info,
+    message: "ok",
+    executionTime: 0,
+    timestamp: new Date(0),
+    ...overrides,
+  };
+}
+
+// a per-mod health check; `gameId` scopes it to one game, and omitting it runs for every game
+export function makeModHealthCheck(
+  overrides: Partial<IModHealthCheck & { gameId: string }> = {},
+): IModHealthCheck & { gameId?: string } {
+  return {
+    id: "test-check",
+    name: "Test",
+    description: "",
+    category: HealthCheckCategory.Mods,
+    severity: HealthCheckSeverity.Warning,
+    triggers: [HealthCheckTrigger.Manual],
+    checkMod: async () => makeHealthCheckResult(),
+    ...overrides,
+  };
+}
+
+export function makeModCheckContext(overrides: Partial<IModCheckContext> = {}): IModCheckContext {
+  return {
+    modId: "mod-1",
+    files: [],
+    readFile: async () => Buffer.alloc(0),
+    attributes: {},
+    ...overrides,
+  };
 }
 
 /**
@@ -693,6 +747,135 @@ export function makeInstallContextHarness(
   const mixpanelEvents = collectMixpanelEvents(base.api);
   const ctx = new ContextCtor(gameId, base.api, opts.silent ?? false);
   return { ctx, mixpanelEvents, ...base };
+}
+
+/**
+ * Records the high-water mark of concurrent operations. Bracket each holder's window with
+ * enter()/leave(): a bounded fan-out peaks at its cap, an unbounded one at the item count.
+ */
+export function makeConcurrencyProbe(): IConcurrencyProbe {
+  let live = 0;
+  let peak = 0;
+  return {
+    enter: () => {
+      live += 1;
+      peak = Math.max(peak, live);
+    },
+    leave: () => {
+      live -= 1;
+    },
+    peak: () => peak,
+  };
+}
+
+/**
+ * Harness for HealthCheckRegistry scheduling tests. Constructs the REAL registry against the fake
+ * api (makeApiHarness) with an active profile, so activeGameId resolves and the registry routes
+ * per-mod checks the way it does in the app. The ctor is passed in (like makeDriverHarness) to keep
+ * the registry import out of builders.
+ *
+ * `parkCheck` registers a body that works until released, so a test can observe what the registry
+ * does with a run it has given up on. Every parked body must be released, so suites go through the
+ * healthCheckTest fixture rather than constructing this directly.
+ */
+export function makeHealthCheckHarness(
+  RegistryCtor: new (api: IExtensionApi) => HealthCheckRegistry,
+  opts: IHealthCheckHarnessOpts = {},
+): IHealthCheckHarness {
+  const gameId = opts.gameId ?? "skyrimse";
+  const profileId = opts.profileId ?? "profile-1";
+  const base = makeApiHarness({
+    profiles: { [profileId]: makeProfile({ id: profileId, gameId }) },
+  });
+  base.setState((draft) => {
+    draft.settings.profiles.activeProfileId = profileId;
+    draft.settings.profiles.lastActiveProfile = { [gameId]: profileId };
+  });
+
+  const registry = new RegistryCtor(base.api);
+  const releases: Array<() => void> = [];
+  // one entry per body invocation, resolved when that body returns
+  const bodies: Array<Promise<void>> = [];
+
+  const parkCheck = ({
+    id,
+    timeout,
+    tickMs = 10,
+    respectAbort = true,
+  }: IParkCheckOpts): IParkedCheck => {
+    let starts = 0;
+    let ticks = 0;
+    let inFlight = 0;
+    let parked = true;
+    releases.push(() => {
+      parked = false;
+    });
+
+    registry.register({
+      id,
+      name: id,
+      description: "",
+      category: HealthCheckCategory.System,
+      severity: HealthCheckSeverity.Info,
+      triggers: [HealthCheckTrigger.Manual],
+      timeout,
+      check: async (_api, signal) => {
+        starts += 1;
+        inFlight += 1;
+        let done!: () => void;
+        bodies.push(
+          new Promise<void>((resolve) => {
+            done = resolve;
+          }),
+        );
+        try {
+          while (parked && !(respectAbort && signal?.aborted === true)) {
+            ticks += 1;
+            await new Promise<void>((resolve) => setTimeout(resolve, tickMs));
+          }
+          return makeHealthCheckResult({ checkId: id, message: "released" });
+        } finally {
+          inFlight -= 1;
+          done();
+        }
+      },
+    });
+
+    return {
+      id,
+      starts: () => starts,
+      ticks: () => ticks,
+      hasSettled: () => starts > 0 && inFlight === 0,
+    };
+  };
+
+  const registerModCheck = ({ id, gameId: checkGameId }: IModCheckOpts): string => {
+    registry.register(
+      makeModHealthCheck({
+        id,
+        gameId: checkGameId,
+        name: id,
+        triggers: [HealthCheckTrigger.ModsChanged, HealthCheckTrigger.Manual],
+        checkMod: async () => makeHealthCheckResult({ checkId: id }),
+      }),
+    );
+    return id;
+  };
+
+  return {
+    ...base,
+    registry,
+    gameId,
+    parkCheck,
+    registerModCheck,
+    // the registry keys off arbitrary extension-supplied ids, not just the built-in union
+    run: (id: string) => registry.runHealthCheck(id as HealthCheckId, base.api, true),
+    resultFor: (id: string) => registry.get(id as HealthCheckId)?.lastResult,
+    releaseParked: async () => {
+      releases.forEach((release) => release());
+      await Promise.all(bodies);
+    },
+  };
 }
 
 /**

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -11,6 +11,7 @@ import type { ICollectionMod } from "../extensions/collections/types/ICollection
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
+import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
@@ -23,6 +24,7 @@ import type {
 } from "../types/collections/ICollectionInstallSession";
 import type { DialogType, IDialogResult } from "../types/IDialog";
 import type { IExtensionApi } from "../types/IExtensionContext";
+import type { IHealthCheckResult } from "../types/IHealthCheck";
 import type { IState } from "../types/IState";
 
 /** A dispatched redux-act action as the harness sees it. */
@@ -130,6 +132,69 @@ export interface IInstallManagerHarness extends IApiHarness {
   // moving toward #private enforcement), so the harness is the single typed seam that exposes it -
   // suites prime/inspect phase state through this rather than casting the manager per test.
   phaseTracker: InstallPhaseTracker;
+}
+
+/** What a health-check registry test arranges. */
+export interface IHealthCheckHarnessOpts {
+  // the game the active profile is on (defaults to skyrimse)
+  gameId?: string;
+  profileId?: string;
+}
+
+/** A check registered by the harness whose body parks until the harness releases it. */
+export interface IParkCheckOpts {
+  id: string;
+  // the registry aborts the run after this many ms
+  timeout: number;
+  // how long the parked body sleeps between work iterations
+  tickMs?: number;
+  // whether the body stops on the registry's abort (default true). False models a check that
+  // cannot bail out promptly, such as one parked mid-readdir: it keeps working after the run
+  // is abandoned.
+  respectAbort?: boolean;
+}
+
+export interface IParkedCheck {
+  id: string;
+  // how many times the registry has entered the body
+  starts: () => number;
+  // how many work iterations the body has completed, which keeps rising for as long as it runs
+  ticks: () => number;
+  // whether every body started so far has returned. Poll with vi.waitFor, never a fixed sleep:
+  // a body leaves its loop on its next tick, at a time no test can pin down under load.
+  hasSettled: () => boolean;
+}
+
+/** A per-mod check registered by the harness, optionally scoped to one game. */
+export interface IModCheckOpts {
+  id: string;
+  gameId?: string;
+}
+
+export interface IHealthCheckHarness extends IApiHarness {
+  // the real registry under test, constructed against the fake api
+  registry: HealthCheckRegistry;
+  // the game the active profile is on, which is what the per-mod runner enumerates mods for
+  gameId: string;
+  // register a check whose body parks until releaseParked, so a run can hit its timeout with the
+  // body still in flight
+  parkCheck: (opts: IParkCheckOpts) => IParkedCheck;
+  // register an IModHealthCheck, which the registry routes through runPerModCheck
+  registerModCheck: (opts: IModCheckOpts) => string;
+  // run one registered check, bypassing the result cache
+  run: (id: string) => Promise<IHealthCheckResult | undefined>;
+  // the result the registry currently holds for a check, as the health-check UI would read it
+  resultFor: (id: string) => IHealthCheckResult | undefined;
+  // unpark every body and resolve once all have returned; the healthCheckTest fixture awaits
+  // this on teardown so no body ticks on into the next test
+  releaseParked: () => Promise<void>;
+}
+
+/** High-water mark of concurrent operations; `enter`/`leave` bracket each holder's window. */
+export interface IConcurrencyProbe {
+  enter: () => void;
+  leave: () => void;
+  peak: () => number;
 }
 
 // One member of a collection revision. `tag` is the member's stable identity: keep the same tag

--- a/src/renderer/src/test-utils/healthCheckTest.ts
+++ b/src/renderer/src/test-utils/healthCheckTest.ts
@@ -1,0 +1,31 @@
+import { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
+import { makeHealthCheckHarness } from "./builders";
+import { test as harnessTest } from "./harnessTest";
+import type { IHealthCheckHarness, IHealthCheckHarnessOpts } from "./harnessTypes";
+
+export interface IHealthCheckFixtures {
+  // build a harness around the real HealthCheckRegistry and the fake api
+  makeHealthCheck: (opts?: IHealthCheckHarnessOpts) => IHealthCheckHarness;
+}
+
+/**
+ * Base test for HealthCheckRegistry scheduling suites. Extends the shared harnessTest with a
+ * `makeHealthCheck` factory over the real registry, and releases every parked check body on
+ * teardown. That teardown is what makes this a fixture rather than a bare builder: a parked body
+ * outlives the run that started it, and must not tick on into the next test.
+ */
+export const test = harnessTest.extend<IHealthCheckFixtures>({
+  makeHealthCheck: async ({ task: _task }, use) => {
+    const built: IHealthCheckHarness[] = [];
+    // `use` is the vitest fixture callback, not React's use() hook.
+    // eslint-disable-next-line @eslint-react/rules-of-hooks
+    await use((opts) => {
+      const harness = makeHealthCheckHarness(HealthCheckRegistry, opts);
+      built.push(harness);
+      return harness;
+    });
+    for (const harness of built) {
+      await harness.releaseParked();
+    }
+  },
+});

--- a/src/renderer/src/types/IHealthCheck.ts
+++ b/src/renderer/src/types/IHealthCheck.ts
@@ -42,7 +42,15 @@ export interface IHealthCheckResult<TMetadata = unknown> {
   isLegacyTest?: boolean;
 }
 
-export type HealthCheckFunction = (api: IExtensionApi) => Promise<IHealthCheckResult>;
+/**
+ * `signal` aborts once `timeout` elapses. A check that loops over mods, files or network calls
+ * must poll it and return early: the registry cannot stop a body that ignores it, and holds the
+ * check's slot until the body returns.
+ */
+export type HealthCheckFunction = (
+  api: IExtensionApi,
+  signal?: AbortSignal,
+) => Promise<IHealthCheckResult>;
 export type HealthCheckFixFunction = (api: IExtensionApi) => Promise<void>;
 
 export interface IHealthCheck {
@@ -52,6 +60,8 @@ export interface IHealthCheck {
   category: HealthCheckCategory;
   severity: HealthCheckSeverity;
   triggers: HealthCheckTrigger[];
+  /** The game this check applies to; skipped while another is active. Omit to run for all. */
+  gameId?: string;
   dependencies?: string[];
   timeout?: number;
   cacheDuration?: number;
@@ -93,6 +103,7 @@ export interface IModCheckContext {
 export type PerModCheckFunction = (
   api: IExtensionApi,
   mod: IModCheckContext,
+  signal?: AbortSignal,
 ) => Promise<IHealthCheckResult>;
 
 /**


### PR DESCRIPTION
Fixes a renderer memory leak that crashes Vortex during installs on large mod libraries (#23776: 39 OOM kills in ~24h on a 4852-mod Skyrim setup, ~3.3 GB against a 4 GB ceiling).

Three faults compound:

- **Per-mod checks are not scoped to a game.** The runner enumerates mods for the ACTIVE game, so the `xrebirth-*` checks walk whatever game is managed. `IHealthCheck` gains `gameId`: the registry runs such a check only while that game is active, and discards a result it holds for another.
- **The walk is unbounded.** `runPerModCheck` walks in waves of `MOD_WALK_CONCURRENCY` (16), holding one wave's file lists rather than the whole library's. A mod whose staging folder cannot be read fails on its own.
- **A timed-out run is not cancelled.** The registry aborts an `AbortSignal` on timeout and holds the check's concurrency slot until the body settles, so a re-trigger waits rather than stacking another pass.

16 is measured: the walk is filesystem-bound and flat from 8 to 128 concurrency (~1-2s for 4900 mods / 280K files either way), so the cap costs nothing.

Tests cover each fault and use no fixed sleeps — the harness exposes `hasSettled()` for `vi.waitFor`, and the fan-out probe runs on microtasks rather than timers.

### Public API

Additive and optional; existing extensions compile unchanged (`etc/vortex.api.md` regenerated).

```ts
type HealthCheckFunction = (api, signal?: AbortSignal) => Promise<IHealthCheckResult>
type PerModCheckFunction = (api, mod, signal?: AbortSignal) => Promise<IHealthCheckResult>
interface IHealthCheck { gameId?: string }
```

### Known limitations

- A timed-out check's partial result is discarded in favour of `Health check timed out`; the runner labels it `(stopped after N of M mods)` but nothing consumes it.
- The 30s budget does not scale with library size.

closes #23776
closes LAZ-834
