### PR TITLE
Add persisted extension metadata

### DIFF
--- a/src/renderer/src/actions/app.ts
+++ b/src/renderer/src/actions/app.ts
@@ -1,5 +1,6 @@
 import * as reduxAct from "redux-act";
 
+import type { IExtension } from "../types/extensions";
 import type { VortexInstallType } from "../types/VortexInstallType";
 import safeCreateAction from "./safeCreateAction";
 
@@ -10,6 +11,11 @@ export const setStateVersion = safeCreateAction("SET_STATE_VERSION", (version) =
 export const setApplicationVersion = safeCreateAction(
   "SET_APPLICATION_VERSION",
   (version) => version,
+);
+
+export const addExtension = safeCreateAction(
+  "ADD_EXTENSION",
+  (extensionId: string, info: IExtension) => ({ extensionId, info }),
 );
 
 export const setExtensionEnabled = safeCreateAction(

--- a/src/renderer/src/extensions/extension_manager/installExtension.test.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.test.ts
@@ -50,7 +50,7 @@ describe("clearStaleRemovalFlags", () => {
     const api = {
       store: {
         dispatch,
-        getState: () => ({ session: { extensions: { installed } } }),
+        getState: () => ({ session: { extensions: { installed } }, app: { extensions: {} } }),
       },
     } as unknown as IExtensionApi;
     return { api, dispatch };

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -5,7 +5,7 @@ import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import * as _ from "lodash";
 import SevenZip from "node-7z";
 
-import { forgetExtension, removeExtension } from "../../actions";
+import { addExtension, forgetExtension, removeExtension } from "../../actions";
 import ExtensionManager from "../../ExtensionManager";
 import { log } from "../../logging";
 import type { ExtensionType, IExtension } from "../../types/extensions";
@@ -73,20 +73,27 @@ async function installExtensionDependencies(api: IExtensionApi, extPath: string)
 
     const state = api.getState();
     const { installed, available } = state.session.extensions;
+    const extState = state.app.extensions ?? {};
 
     const promises = handler.dependencies.map(async (dependencyId) => {
-      if (installed[dependencyId]) return;
+      if (installed[dependencyId] ?? extState[dependencyId]) return;
 
       const toInstall = available.find(
         (iter) => !iter.type && (iter.name === dependencyId || iter.id === dependencyId),
       );
 
       if (!toInstall) return;
-      const alreadyInstalled = Object.values(installed).some(
-        (entry) =>
-          (toInstall.modId !== undefined && entry.modId === toInstall.modId) ||
-          entry.name === toInstall.name,
-      );
+      const alreadyInstalled =
+        Object.values(installed).some(
+          (entry) =>
+            (toInstall.modId !== undefined && entry.modId === toInstall.modId) ||
+            entry.name === toInstall.name,
+        ) ||
+        Object.values(extState).some(
+          (entry) =>
+            (toInstall.modId !== undefined && entry.modId === toInstall.modId) ||
+            entry.name === toInstall.name,
+        );
       if (alreadyInstalled) return;
 
       await api.emitAndAwait<"install-extension">("install-extension", toInstall);
@@ -124,11 +131,12 @@ export function clearStaleRemovalFlags(
 ): void {
   const state: IState = api.store.getState();
   const { installed } = state.session.extensions;
+  const extState = state.app.extensions ?? {};
   // Compare paths, not key strings: info.json `id` can decouple the state key
   // from the folder basename, and the archive-name fallback differs again.
   const normalizedDest = path.normalize(destPath).toLowerCase();
   removedKeys.forEach((key) => {
-    const prevPath = installed[key]?.path;
+    const prevPath = installed[key]?.path ?? extState[key]?.path;
     if (prevPath !== undefined && path.normalize(prevPath).toLowerCase() === normalizedDest) {
       api.store.dispatch(forgetExtension(key));
     }
@@ -138,25 +146,50 @@ export function clearStaleRemovalFlags(
 function removeOldVersion(api: IExtensionApi, info: IExtension): string[] {
   const state = api.getState();
   const { installed } = state.session.extensions;
+  const extState = state.app.extensions ?? {};
 
   // should never be more than one but let's handle multiple to be safe
-  const previousVersions = Object.entries(installed).filter(([_, ext]) => {
-    if (ext.bundled) return false;
-    if (info.id !== undefined && ext.id === info.id) return true;
-    if (info.modId !== undefined && ext.modId === info.modId) return true;
-    return info.name === ext.name;
-  });
+  const previousVersions: string[] = [];
+
+  // Search session.extensions.installed (legacy, will be removed in LAZ-833)
+  for (const [key, ext] of Object.entries(installed)) {
+    if (ext.bundled) continue;
+    if (info.id !== undefined && ext.id === info.id) {
+      previousVersions.push(key);
+      continue;
+    }
+    if (info.modId !== undefined && ext.modId === info.modId) {
+      previousVersions.push(key);
+      continue;
+    }
+    if (info.name === ext.name) {
+      previousVersions.push(key);
+    }
+  }
+
+  // Also search state.app.extensions (persisted source).  Avoid duplicates
+  // when a key already matched via session.extensions.installed above.
+  for (const [key, ext] of Object.entries(extState)) {
+    if (ext.bundled) continue;
+    if (previousVersions.includes(key)) continue;
+    if (info.modId !== undefined && ext.modId === info.modId) {
+      previousVersions.push(key);
+      continue;
+    }
+    if (info.name === ext.name) {
+      previousVersions.push(key);
+    }
+  }
 
   if (previousVersions.length > 0) {
     log("info", "removing previous versions of the extension", {
       previousVersions,
       newPath: info.path,
-      paths: previousVersions.map(([_, ext]) => ext.path),
     });
   }
 
   previousVersions.forEach((key) => api.store.dispatch(removeExtension(key)));
-  return previousVersions.map(([key, _]) => key);
+  return previousVersions;
 }
 
 const requiredThemeFiles = ["variables.scss", "style.scss", "fonts.scss"];
@@ -367,9 +400,7 @@ async function installExtensionImpl(
 
       const manifestInfo = await Promise.resolve(readExtensionInfo(tempPath, false, info));
 
-      // merge the caller-provided info with the stuff parsed from the info.json file because there
-      // is data we may only know at runtime (e.g. the modId)
-      const fullInfo = { ...(manifestInfo.info || {}), ...info };
+      const fullInfo = { ...manifestInfo.info };
       if (fullInfo.type === undefined) {
         fullInfo.type = await validateInstall(tempPath, info);
       }
@@ -391,6 +422,9 @@ async function installExtensionImpl(
       await rename(tempPath, destPath);
 
       clearStaleRemovalFlags(api, removedKeys, destPath);
+
+      api.store.dispatch(addExtension(manifestInfo.id, fullInfo));
+
       emitExtensionInstalled(
         api,
         { ...fullInfo, type: fullInfo.type, id: manifestInfo.id },

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -80,33 +80,32 @@ function getAllDirectories(searchPath: string): PromiseBB<string[]> {
 function applyExtensionInfo(
   id: string,
   bundled: boolean,
-  values: Partial<IExtension>,
-  fallback: Partial<IExtension>,
+  archiveInfo: Partial<IExtension>,
+  manifestInfo: Partial<IExtension>,
 ): IExtension {
   const res = {
-    name: values.name || fallback.name || id,
-    author: values.author || fallback.author || "Unknown",
-    version: values.version || fallback.version || "0.0.0",
-    description: values.description || fallback.description || "Missing",
+    name: manifestInfo.name || archiveInfo.name || id,
+    author: manifestInfo.author || archiveInfo.author || "Unknown",
+    version: manifestInfo.version || archiveInfo.version || "0.0.0",
+    description: manifestInfo.description || archiveInfo.description || "Missing",
   } satisfies IExtension;
 
   // add optional settings if we have them
-  const add = <T>(key: string, value: T, fallbackValue: T) => {
-    if (value !== undefined) {
-      res[key] = value;
-    } else if (fallbackValue !== undefined) {
-      res[key] = fallbackValue;
+  const add = <T>(key: string, primary: T, secondary: T) => {
+    if (primary !== undefined) {
+      res[key] = primary;
+    } else if (secondary !== undefined) {
+      res[key] = secondary;
     }
   };
 
-  add("type", values.type, fallback.type);
-  add("path", values.path, fallback.path);
+  add("type", manifestInfo.type, archiveInfo.type);
+  add("path", archiveInfo.path, undefined);
   add("bundled", bundled, undefined);
   // modId/fileId are identity data assigned by the Nexus Mods manifest, not
-  // something an extension author controls via their own info.json, so the
-  // trusted, install-time-supplied fallback takes priority over the archive.
-  add("modId", fallback.modId, values.modId);
-  add("fileId", fallback.fileId, values.fileId);
+  // something an extension author controls via their own info.json.
+  add("modId", manifestInfo.modId, archiveInfo.modId);
+  add("fileId", manifestInfo.fileId, archiveInfo.fileId);
 
   return res;
 }
@@ -125,7 +124,7 @@ export function sanitize(input: string): string {
 export function readExtensionInfo(
   extensionPath: string,
   bundled: boolean,
-  fallback: Partial<IExtension> = {},
+  manifestInfo: Partial<IExtension> = {},
 ): PromiseBB<{ id: string; info: IExtension }> {
   const finalPath = extensionPath.replace(/\.installing$/, "");
 
@@ -137,14 +136,14 @@ export function readExtensionInfo(
       const id = data.id || path.basename(finalPath);
       return {
         id,
-        info: applyExtensionInfo(id, bundled, data, fallback),
+        info: applyExtensionInfo(id, bundled, data, manifestInfo),
       };
     })
     .catch(() => {
       const id = path.basename(finalPath);
       return {
         id,
-        info: applyExtensionInfo(id, bundled, {}, fallback),
+        info: applyExtensionInfo(id, bundled, {}, manifestInfo),
       };
     });
 }

--- a/src/renderer/src/reducers/app.ts
+++ b/src/renderer/src/reducers/app.ts
@@ -9,6 +9,22 @@ export const appReducer: IReducerSpec = {
     [actions.setStateVersion as any]: (state, payload) => setSafe(state, ["version"], payload),
     [actions.setApplicationVersion as any]: (state, payload) =>
       setSafe(state, ["appVersion"], payload),
+    [actions.addExtension as any]: (state, payload) => {
+      const { extensionId, info } = payload;
+      const existing = state.extensions?.[extensionId] ?? {};
+      return setSafe(state, ["extensions", extensionId], {
+        ...existing,
+        name: info.name,
+        version: info.version,
+        author: info.author,
+        description: info.description,
+        path: info.path,
+        modId: info.modId,
+        fileId: info.fileId,
+        type: info.type,
+        bundled: info.bundled,
+      });
+    },
     [actions.setExtensionEnabled as any]: (state, payload) =>
       setSafe(state, ["extensions", payload.extensionId, "enabled"], payload.enabled),
     [actions.setExtensionVersion as any]: (state, payload) =>

--- a/src/renderer/src/types/IState.ts
+++ b/src/renderer/src/types/IState.ts
@@ -12,7 +12,7 @@ import type { IHistoryPersistent, IHistoryState } from "../extensions/history_ma
 import type { IMod } from "../extensions/mod_management/types/IMod";
 import type { IProfile } from "../extensions/profile_management/types/IProfile";
 import type { ICollectionInstallState } from "./collections/ICollectionInstallSession";
-import type { IAvailableExtension, IExtension } from "./extensions";
+import type { ExtensionType, IAvailableExtension, IExtension } from "./extensions";
 import type { IAttributeState } from "./IAttributeState";
 import type { IDialog } from "./IDialog";
 import type { INotification } from "./INotification";
@@ -135,6 +135,22 @@ export interface IExtensionState {
   version: string;
   remove: boolean;
   endorsed: string;
+  /** Path to the extension folder on disk. Written at install time, read during boot reconciliation. */
+  path?: string;
+  /** Nexus Mods mod ID for this extension. Identity key for mapping to available/manifest entries. */
+  modId?: number;
+  /** Nexus Mods file ID for this specific version of the extension. */
+  fileId?: number;
+  /** Extension author display name. */
+  author?: string;
+  /** Extension type. */
+  type?: ExtensionType;
+  /** Human-readable description of the extension. */
+  description?: string;
+  /** Display name of the extension. */
+  name?: string;
+  /** True for extensions shipped with Vortex (bundled plugins dir). False or undefined for user-installed. */
+  bundled?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes LAZ-832.

- Extends `IExtensionState` with more fields
- New `addExtension` action and reducer
- Updated metadata priority