### PR TITLE
Use new extension installed state

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -375,9 +375,9 @@ manual: boolean;
 }, {}>;
 
 // @public (undocumented)
-const addExtension: reduxAct.ComplexActionCreator2<string, IExtension, {
+const addExtension: reduxAct.ComplexActionCreator2<string, ExtensionInfo, {
     extensionId: string;
-    info: IExtension;
+    info: ExtensionInfo;
 }, {}>;
 
 // @public
@@ -1061,6 +1061,36 @@ function ensureFileAsync(filePath: string): Promise_2<void>;
 
 // @public (undocumented)
 export const ErrorBoundary: any;
+
+// @public
+interface ExtensionInfo {
+    // (undocumented)
+    author: string;
+    // (undocumented)
+    bundled?: boolean;
+    // (undocumented)
+    description: string;
+    // (undocumented)
+    fileId?: number;
+    // (undocumented)
+    id?: string;
+    // (undocumented)
+    issueTrackerURL?: string;
+    // (undocumented)
+    modId?: number;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    namespace?: string;
+    // (undocumented)
+    path?: string;
+    // Warning: (ae-forgotten-export) The symbol "ExtensionType" needs to be exported by the entry point api.d.ts
+    //
+    // (undocumented)
+    type?: ExtensionType;
+    // (undocumented)
+    version: string;
+}
 
 // @public (undocumented)
 type ExtensionLoadFailureDependency = {
@@ -1798,8 +1828,6 @@ interface IAvailableExtension extends IExtensionDownloadInfo {
     tags: string[];
     // (undocumented)
     timestamp: number;
-    // Warning: (ae-forgotten-export) The symbol "ExtensionType" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     type?: ExtensionType;
     // (undocumented)
@@ -2313,33 +2341,8 @@ interface IExecInfo {
     execPath: string;
 }
 
-// @public
-interface IExtension {
-    // (undocumented)
-    author: string;
-    // (undocumented)
-    bundled?: boolean;
-    // (undocumented)
-    description: string;
-    // (undocumented)
-    fileId?: number;
-    // (undocumented)
-    id?: string;
-    // (undocumented)
-    issueTrackerURL?: string;
-    // (undocumented)
-    modId?: number;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    namespace?: string;
-    // (undocumented)
-    path?: string;
-    // (undocumented)
-    type?: ExtensionType;
-    // (undocumented)
-    version: string;
-}
+// @public @deprecated (undocumented)
+type IExtension = ExtensionInfo;
 
 // @public
 interface IExtensionApi {
@@ -2495,17 +2498,17 @@ interface IExtensionOptional {
 
 // @public (undocumented)
 interface IExtensionState {
-    author?: string;
+    author: string;
     bundled?: boolean;
-    description?: string;
+    description: string;
     // (undocumented)
     enabled: boolean | "failed";
     // (undocumented)
     endorsed: string;
     fileId?: number;
     modId?: number;
-    name?: string;
-    path?: string;
+    name: string;
+    path: string;
     // (undocumented)
     remove: boolean;
     type?: ExtensionType;
@@ -6266,6 +6269,7 @@ declare namespace types {
         CollectionModStatus,
         IAvailableExtension,
         IExtension,
+        ExtensionInfo,
         LoadOrder,
         LoadOrder as FBLOLoadOrder,
         LockedState as FBLOLockState,

--- a/extensions/extension-dashlet/src/ExtensionsDashlet.tsx
+++ b/extensions/extension-dashlet/src/ExtensionsDashlet.tsx
@@ -244,7 +244,7 @@ function mapStateToProps(state: types.IState): IConnectedProps {
   return {
     extensionState: state.app.extensions,
     extensions: state.session.extensions.available,
-    installed: state.session.extensions.installed,
+    installed: state.app.extensions ?? {},
     downloads: state.persistent.downloads.files,
     user: util.getSafe(state, ["persistent", "nexus", "userInfo", "name"], undefined),
   };

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -1818,7 +1818,7 @@ class ExtensionManager {
 
     const state: IState = this.mApi.store.getState();
     this.mExtensions
-      .filter((ext) => ext.dynamic)
+      .filter((ext) => ext.dynamic && !ext.info?.bundled)
       .forEach((ext) => {
         try {
           let oldVersion = getSafe(state.app, ["extensions", ext.name, "version"], "0.0.0");

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -3081,7 +3081,7 @@ class ExtensionManager {
     );
     for (const ext of scanned) {
       if (!loadedFromState.has(ext.name)) {
-        this.mPendingAdds.push({ extId: ext.name, info: ext.info });
+        this.mPendingAdds.push({ extId: ext.name, info: { ...ext.info, path: ext.path } });
         result.push(ext);
         loadedExtensions.add(ext.name);
       }

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -859,12 +859,11 @@ class ExtensionManager {
     }
 
     // Check for extensions marked for removal
-    const extensionsPath = path.join(getVortexPath("userData"), "plugins");
     this.mPendingRemoves = [];
-    Object.keys(this.mExtensionState)
-      .filter((extId) => this.mExtensionState[extId].remove)
-      .forEach((extId) => {
-        const extPath = path.join(extensionsPath, extId);
+    Object.entries(this.mExtensionState)
+      .filter(([_, entry]) => entry.remove)
+      .forEach(([extId, entry]) => {
+        const extPath = entry.path;
         log("info", "removing", extPath);
         try {
           fs.removeSync(extPath);
@@ -886,6 +885,7 @@ class ExtensionManager {
     this.mExtensions = this.prepareExtensions();
 
     log("info", "outdated extensions", { numOutdated: this.mOutdated.length });
+    const extensionsPath = path.join(getVortexPath("userData"), "plugins");
     if (this.mOutdated.length > 0) {
       const removeOps: Array<{
         type: "set";

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -21,7 +21,12 @@ import * as semver from "semver";
 import { generate as shortid } from "shortid";
 import stringFormat from "string-template";
 
-import { forgetExtension, setExtensionEnabled, setExtensionVersion } from "./actions/app";
+import {
+  addExtension,
+  forgetExtension,
+  setExtensionEnabled,
+  setExtensionVersion,
+} from "./actions/app";
 import type { DialogActions, DialogType, IDialogContent } from "./actions/notifications";
 import {
   addNotification,
@@ -731,6 +736,7 @@ class ExtensionManager {
   // Pending actions to dispatch when setStore() is called (renderer-only architecture)
   private mPendingDisables: string[] = [];
   private mPendingRemoves: string[] = [];
+  private mPendingAdds: Array<{ extId: string; info: IExtension }> = [];
   // Extension-registered persistors for custom hives (e.g., loadOrder -> plugins.txt)
   private mExtensionPersistors: {
     [hive: string]: { persistor: IPersistor; debounce: number };
@@ -965,6 +971,11 @@ class ExtensionManager {
       store.dispatch(forgetExtension(extId));
     });
     this.mPendingRemoves = [];
+
+    this.mPendingAdds.forEach(({ extId, info }) => {
+      store.dispatch(addExtension(extId, info));
+    });
+    this.mPendingAdds = [];
 
     this.mExtensionState = getSafe(store.getState(), ["app", "extensions"], {});
 
@@ -3011,31 +3022,72 @@ class ExtensionManager {
 
     require("./util/extensionRequire").default(() => this.extensions);
 
-    const extensionPaths = ExtensionManager.getExtensionPaths();
     const loadedExtensions = new Set<string>();
-    let dynamicallyLoaded = [];
-    return Object.keys(staticExtensions)
-      .map((name: string) => ({
-        name,
-        namespace: name,
-        path: path.resolve(__dirname, "extensions", name),
-        initFunc: () => {
-          const f = staticExtensions[name];
-          return ExtensionManager.getExtensionInitFunc(f());
-        },
-        dynamic: false,
-      }))
-      .concat(
-        ...extensionPaths.map((extSpec) => {
-          const newExtensions = this.loadDynamicExtensions(
-            extSpec,
-            loadedExtensions,
-            dynamicallyLoaded,
-          );
-          dynamicallyLoaded = dynamicallyLoaded.concat(newExtensions);
-          return newExtensions;
-        }),
-      );
+    let dynamicallyLoaded: IRegisteredExtension[] = [];
+
+    const staticExts = Object.keys(staticExtensions).map((name: string) => ({
+      name,
+      namespace: name,
+      path: path.resolve(__dirname, "extensions", name),
+      initFunc: () => {
+        const f = staticExtensions[name];
+        return ExtensionManager.getExtensionInitFunc(f());
+      },
+      dynamic: false,
+    }));
+
+    // --- User extensions: load from persisted state, then reconcile ---
+    const userExts = this.loadUserExtensions(loadedExtensions, dynamicallyLoaded);
+    dynamicallyLoaded = dynamicallyLoaded.concat(userExts);
+
+    // --- Bundled extensions: fresh disk scan every boot (never persisted) ---
+    const bundledExts = this.loadDynamicExtensions(
+      { path: getVortexPath("bundledPlugins"), bundled: true },
+      loadedExtensions,
+      dynamicallyLoaded,
+    );
+
+    return staticExts.concat(userExts).concat(bundledExts);
+  }
+
+  private loadUserExtensions(
+    loadedExtensions: Set<string>,
+    alreadyLoaded: IRegisteredExtension[],
+  ): IRegisteredExtension[] {
+    const userPath = path.join(getVortexPath("userData"), "plugins");
+
+    // 1. Load from persisted state by path (primary source)
+    const result: IRegisteredExtension[] = [];
+    const loadedFromState = new Set<string>();
+    for (const [extId, state] of Object.entries(this.mExtensionState)) {
+      if (state.remove || state.enabled === false) continue;
+      if (state.path === undefined || !fs.existsSync(state.path)) {
+        this.mPendingRemoves.push(extId);
+        continue;
+      }
+      const ext = this.loadDynamicExtension(state.path, alreadyLoaded, false);
+      if (ext !== undefined) {
+        result.push(ext);
+        loadedExtensions.add(ext.name);
+        loadedFromState.add(ext.name);
+      }
+    }
+
+    // 2. Disk scan for extensions not tracked in state (reconciliation)
+    const scanned = this.loadDynamicExtensions(
+      { path: userPath, bundled: false },
+      loadedExtensions,
+      alreadyLoaded,
+    );
+    for (const ext of scanned) {
+      if (!loadedFromState.has(ext.name)) {
+        this.mPendingAdds.push({ extId: ext.name, info: ext.info });
+        result.push(ext);
+        loadedExtensions.add(ext.name);
+      }
+    }
+
+    return result;
   }
 }
 

--- a/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
+++ b/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
@@ -11,8 +11,8 @@ import Modal from "../../controls/Modal";
 import Spinner from "../../controls/Spinner";
 import { IconButton } from "../../controls/TooltipControls";
 import ZoomableImage from "../../controls/ZoomableImage";
-import type { IAvailableExtension, IExtension, ISelector } from "../../types/extensions";
-import type { IState } from "../../types/IState";
+import type { IAvailableExtension, ISelector } from "../../types/extensions";
+import type { IExtensionState, IState } from "../../types/IState";
 import { getApplication } from "../../util/application";
 import opn from "../../util/opn";
 import { largeNumToString } from "../../util/util";
@@ -48,7 +48,7 @@ function makeSelectorId(ext: IAvailableExtension): string {
 
 interface IConnectedProps {
   availableExtensions: IAvailableExtension[];
-  extensions: { [extId: string]: IExtension };
+  extensions: { [extId: string]: IExtensionState };
   updateTime: number;
   language: string;
 }
@@ -253,7 +253,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
           const iter = extensions[key];
           return (
             (ext.modId !== undefined && iter.modId === ext.modId) ||
-            (ext.id !== undefined && (iter.id || key) === ext.id)
+            (ext.id !== undefined && key === ext.id)
           );
         }) !== undefined
     );
@@ -439,7 +439,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
 function mapStateToProps(state: IState): IConnectedProps {
   return {
     availableExtensions: state.session.extensions.available,
-    extensions: state.session.extensions.installed,
+    extensions: state.app.extensions ?? {},
     updateTime: state.session.extensions.updateTime,
     language: state.settings.interface.language,
   };

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -126,7 +126,26 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
     const { t, extensions, localState } = this.props;
     const { oldExtensions, showBundled } = this.state;
 
-    const extensionsWithState = this.mergeExt(extensions, showBundled);
+    const bundled = (this.context?.api?.getLoadedExtensions?.() ?? [])
+      .filter((ext) => ext.dynamic && ext.info?.bundled)
+      .reduce<{ [extId: string]: IExtensionState }>((prev, ext) => {
+        prev[ext.name] = {
+          enabled: true,
+          version: ext.info?.version ?? "",
+          remove: false,
+          endorsed: "Undecided",
+          name: ext.info?.name ?? ext.name,
+          author: ext.info?.author ?? "Unknown",
+          description: ext.info?.description ?? "",
+          path: ext.path,
+          bundled: true,
+        };
+        return prev;
+      }, {});
+
+    const allExtensions = showBundled ? { ...extensions, ...bundled } : extensions;
+
+    const extensionsWithState = this.mergeExt(allExtensions, showBundled);
 
     // normalize extension config so they differ only if the effective configuration actually
     // differs, leaving out the endorsement state

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -330,8 +330,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
 
   private removeExtension = (extIds: string[]) => {
     extIds.forEach((extId) => {
-      const ext = this.props.extensions[extId];
-      this.props.onRemoveExtension(path.basename(ext.path));
+      this.props.onRemoveExtension(extId);
     });
   };
 }

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -19,7 +19,7 @@ import IconBar from "../../controls/IconBar";
 import type { ITableRowAction } from "../../controls/Table";
 import Table from "../../controls/Table";
 import ToolbarIcon from "../../controls/ToolbarIcon";
-import type { IExtension, IExtensionWithState } from "../../types/extensions";
+import type { IExtensionWithState } from "../../types/extensions";
 import type { IExtensionLoadFailure, IExtensionState, IState } from "../../types/IState";
 import type { ITableAttribute } from "../../types/ITableAttribute";
 import { relaunch } from "../../util/commandLine";
@@ -39,11 +39,10 @@ export interface IExtensionManagerProps {
 }
 
 interface IConnectedProps {
-  extensionConfig: { [extId: string]: IExtensionState };
+  extensions: { [extId: string]: IExtensionState };
   downloads: { [dlId: string]: IDownload };
   downloadPath: string;
   loadFailures: { [extId: string]: IExtensionLoadFailure[] };
-  extensions: { [extId: string]: IExtension };
 }
 
 interface IActionProps {
@@ -55,7 +54,7 @@ interface IActionProps {
 type IProps = IExtensionManagerProps & IConnectedProps & IActionProps;
 
 interface IComponentState {
-  oldExtensionConfig: { [extId: string]: IExtensionState };
+  oldExtensions: { [extId: string]: IExtensionState };
   showBundled: boolean;
 }
 
@@ -67,7 +66,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
     super(props);
 
     this.initState({
-      oldExtensionConfig: props.extensionConfig,
+      oldExtensions: props.extensions,
       showBundled: false,
     });
 
@@ -76,7 +75,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
         icon: "delete",
         title: "Remove",
         action: this.removeExtension,
-        condition: (instanceId: string) => !this.props.extensions[instanceId].bundled,
+        condition: (instanceId: string) => !this.props.extensions[instanceId]?.bundled,
         singleRowAction: true,
       },
     ];
@@ -89,9 +88,9 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
         onSetExtensionEnabled(extId, enabled);
       },
       onToggleExtensionEnabled: (extName: string) => {
-        const { extensionConfig, extensions, onSetExtensionEnabled } = this.props;
+        const { extensions, onSetExtensionEnabled } = this.props;
         const extId = Object.keys(extensions).find((iter) => extensions[iter].name === extName);
-        const enabled = !getSafe(extensionConfig, [extId, "enabled"], true);
+        const enabled = !(extensions[extId]?.enabled ?? true);
         log("info", "user toggling extension manually", { extId, enabled });
         onSetExtensionEnabled(extId, enabled);
       },
@@ -124,10 +123,10 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
   }
 
   public render(): JSX.Element {
-    const { t, extensions, localState, extensionConfig } = this.props;
-    const { oldExtensionConfig, showBundled } = this.state;
+    const { t, extensions, localState } = this.props;
+    const { oldExtensions, showBundled } = this.state;
 
-    const extensionsWithState = this.mergeExt(extensions, extensionConfig, showBundled);
+    const extensionsWithState = this.mergeExt(extensions, showBundled);
 
     // normalize extension config so they differ only if the effective configuration actually
     // differs, leaving out the endorsement state
@@ -163,7 +162,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
               <FlexLayout type="column">
                 <FlexLayout.Fixed>
                   {localState.reloadNecessary ||
-                  !_.isEqual(configId(extensionConfig), configId(oldExtensionConfig))
+                  !_.isEqual(configId(extensions), configId(oldExtensions))
                     ? this.renderReload()
                     : null}
                 </FlexLayout.Fixed>
@@ -284,29 +283,28 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
   };
 
   private mergeExt(
-    extensions: { [id: string]: IExtension },
-    extensionConfig: { [id: string]: IExtensionState },
+    extensions: { [id: string]: IExtensionState },
     includeBundled: boolean,
   ): { [id: string]: IExtensionWithState } {
     const { loadFailures } = this.props;
     return Object.keys(extensions).reduce((prev, id) => {
-      if (!includeBundled && extensions[id].bundled) {
+      const state = extensions[id];
+
+      if (!includeBundled && state.bundled) {
         return prev;
       }
 
-      if (!getSafe(extensionConfig, [id, "remove"], false)) {
-        const enabled =
-          loadFailures[id] === undefined
-            ? getSafe(extensionConfig, [id, "enabled"], true)
-            : "failed";
-        const endorsed: EndorsedStatus = getSafe(extensionConfig, [id, "endorsed"], "Undecided");
-        prev[id] = {
-          ...extensions[id],
-          enabled,
-          endorsed,
-          loadFailures: loadFailures[id] || [],
-        };
+      if (state.remove) {
+        return prev;
       }
+
+      const enabled = loadFailures[id] === undefined ? (state.enabled ?? true) : "failed";
+
+      prev[id] = {
+        ...state,
+        enabled,
+        loadFailures: loadFailures[id] || [],
+      };
       return prev;
     }, {});
   }
@@ -314,23 +312,17 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
   private removeExtension = (extIds: string[]) => {
     extIds.forEach((extId) => {
       const ext = this.props.extensions[extId];
-      this.props.onRemoveExtension(path.basename(ext.path || extId));
+      this.props.onRemoveExtension(path.basename(ext.path));
     });
   };
 }
 
-const emptyObject = {};
-
 function mapStateToProps(state: IState): IConnectedProps {
   return {
-    // TODO: don't use || {} in mapStateToProps because {} is always a new object and
-    //   thus causes constant re-drawing. but when removing this, make sure no access
-    //   to undefined can happen
-    extensionConfig: state.app.extensions || emptyObject,
+    extensions: state.app.extensions ?? ({} as { [extId: string]: IExtensionState }),
     loadFailures: state.session.base.extLoadFailures,
     downloads: state.persistent.downloads.files,
     downloadPath: selectors.downloadPath(state),
-    extensions: state.session.extensions.installed,
   };
 }
 

--- a/src/renderer/src/extensions/extension_manager/actions.ts
+++ b/src/renderer/src/extensions/extension_manager/actions.ts
@@ -1,16 +1,11 @@
 import { createAction } from "redux-act";
 
 import type { IExtensionOptional } from "../../types/api";
-import type { IAvailableExtension, IExtension } from "../../types/extensions";
+import type { IAvailableExtension } from "../../types/extensions";
 
 export const setAvailableExtensions = createAction(
   "SET_AVAILABLE_EXTENSIONS",
   (extensions: IAvailableExtension[]) => extensions,
-);
-
-export const setInstalledExtensions = createAction(
-  "SET_INSTALLED_EXTENSIONS",
-  (extensions: { [extId: string]: IExtension }) => extensions,
 );
 
 export const setExtensionsUpdate = createAction(

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -206,7 +206,8 @@ async function installDependency(api: IExtensionApi, dependencyId: string): Prom
 
   const success = await downloadAndInstallExtension(api, toDownload);
   if (success) {
-    signalRestartNeeded(api);
+    const gameName = toDownload.name?.startsWith("Game:") ? toDownload.name : undefined;
+    signalRestartNeeded(api, gameName);
   } else {
     api.showErrorNotification(
       "Failed to install extension",
@@ -285,9 +286,10 @@ function checkMissingDependencies(
   });
 }
 
-function signalRestartNeeded(api: IExtensionApi): void {
+function signalRestartNeeded(api: IExtensionApi, gameName?: string): void {
   if (!localState.reloadNecessary) {
     localState.reloadNecessary = true;
+    const relaunchArgs = gameName !== undefined ? ["--game", gameName] : undefined;
     api.sendNotification({
       id: "extension-updates",
       type: "success",
@@ -295,7 +297,7 @@ function signalRestartNeeded(api: IExtensionApi): void {
       actions: [
         {
           title: "Restart now",
-          action: () => relaunch(),
+          action: () => relaunch(relaunchArgs),
         },
       ],
     });
@@ -381,7 +383,10 @@ function init(context: IExtensionContext) {
       await didFetchAvailableExtensions;
       const success = await downloadAndInstallExtension(context.api, ext);
 
-      if (success) signalRestartNeeded(context.api);
+      if (success) {
+        const gameName = ext.name?.startsWith("Game:") ? ext.name : undefined;
+        signalRestartNeeded(context.api, gameName);
+      }
       return success;
     });
 
@@ -485,7 +490,7 @@ function init(context: IExtensionContext) {
 
       if (modId !== undefined && ext !== undefined) {
         const success = await downloadAndInstallExtension(context.api, ext);
-        if (success) signalRestartNeeded(context.api);
+        if (success) signalRestartNeeded(context.api, ext.gameName);
         return success;
       } else {
         context.api.sendNotification({

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -206,7 +206,10 @@ async function installDependency(api: IExtensionApi, dependencyId: string): Prom
 
   const success = await downloadAndInstallExtension(api, toDownload);
   if (success) {
-    const gameName = toDownload.name?.startsWith("Game:") ? toDownload.name : undefined;
+    const gameName =
+      toDownload.type === "game" || toDownload.name?.startsWith("Game:")
+        ? toDownload.name
+        : undefined;
     signalRestartNeeded(api, gameName);
   } else {
     api.showErrorNotification(
@@ -384,7 +387,8 @@ function init(context: IExtensionContext) {
       const success = await downloadAndInstallExtension(context.api, ext);
 
       if (success) {
-        const gameName = ext.name?.startsWith("Game:") ? ext.name : undefined;
+        const gameName =
+          ext.type === "game" || ext.name?.startsWith("Game:") ? ext.name : undefined;
         signalRestartNeeded(context.api, gameName);
       }
       return success;

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -1,33 +1,27 @@
-import * as _ from "lodash";
 import * as semver from "semver";
 
 import { log } from "@/logging";
 
 import { setDialogVisible, setExtensionEnabled } from "../../actions";
 import { isExtSame } from "../../ExtensionManager";
-import type {
-  IAvailableExtension,
-  IExtension,
-  IExtensionDownloadInfo,
-} from "../../types/extensions";
+import type { IAvailableExtension, IExtensionDownloadInfo } from "../../types/extensions";
 import type {
   IExtensionApi,
   IExtensionContext,
   ISupportedResult,
 } from "../../types/IExtensionContext";
-import type { NotificationDismiss } from "../../types/INotification";
-import type { IExtensionLoadFailure, IState } from "../../types/IState";
+import type { IExtensionLoadFailure, IExtensionState, IState } from "../../types/IState";
 import { getGame } from "../../util/api";
 import { relaunch } from "../../util/commandLine";
 import { DataInvalid, ProcessCanceled } from "../../util/CustomErrors";
 import makeReactive from "../../util/makeReactive";
-import { setAvailableExtensions, setExtensionsUpdate, setInstalledExtensions } from "./actions";
+import { setAvailableExtensions, setExtensionsUpdate } from "./actions";
 import BrowseExtensions from "./BrowseExtensions";
 import type { IBrowseExtensionsProps } from "./BrowseExtensions";
 import ExtensionManager from "./ExtensionManager";
 import type { IExtensionManagerProps } from "./ExtensionManager";
 import sessionReducer from "./reducers";
-import { downloadAndInstallExtension, fetchAvailableExtensions, readExtensions } from "./util";
+import { downloadAndInstallExtension, fetchAvailableExtensions } from "./util";
 
 declare module "../../types/IExtensionContext" {
   interface ApiEvents {
@@ -47,10 +41,11 @@ const localState: ILocalState = makeReactive({
 
 async function checkForUpdates(api: IExtensionApi): Promise<void> {
   const state = api.getState();
-  const { available, installed } = state.session.extensions;
+  const { available } = state.session.extensions;
+  const installed = state.app.extensions ?? {};
 
   const updateable = Object.values(installed).reduce<
-    { current: IExtension; update: IAvailableExtension }[]
+    { current: IExtensionState; update: IAvailableExtension }[]
   >((prev, ext) => {
     const update = available.find((iter) => isExtSame(ext, iter));
 
@@ -96,10 +91,14 @@ async function checkForUpdates(api: IExtensionApi): Promise<void> {
       forceRestart = true;
       updateable.push({
         current: {
+          enabled: true,
+          version: "",
+          remove: false,
+          endorsed: "Undecided",
+          name: update.name,
           author: update.author,
           description: update.description.short,
-          name: update.name,
-          version: "",
+          path: "",
         },
         update,
       });
@@ -173,18 +172,14 @@ async function updateAvailableExtensions(
   }
 }
 
-async function installDependency(
-  api: IExtensionApi,
-  dependencyId: string,
-  updateInstalled: (initial: boolean) => Promise<void>,
-): Promise<boolean> {
+async function installDependency(api: IExtensionApi, dependencyId: string): Promise<boolean> {
   const state = api.getState();
   const availableExtensions = state.session.extensions.available;
-  const installedExtensions = state.session.extensions.installed;
+  const installedExtensions = state.app.extensions ?? {};
 
   if (installedExtensions[dependencyId] !== undefined) {
     // installed, probably failed to load or disabled
-    if (!state.app.extensions[dependencyId].enabled) {
+    if (!installedExtensions[dependencyId].enabled) {
       api.store.dispatch(setExtensionEnabled(dependencyId, true));
       return true;
     } else {
@@ -211,7 +206,7 @@ async function installDependency(
 
   const success = await downloadAndInstallExtension(api, toDownload);
   if (success) {
-    await updateInstalled(false);
+    signalRestartNeeded(api);
   } else {
     api.showErrorNotification(
       "Failed to install extension",
@@ -247,10 +242,8 @@ function checkMissingDependencies(
 
   if (missingDependencies.size === 0) return;
 
-  const updateInstalled = genUpdateInstalledExtensions(api);
-
   const promises = missingDependencies.values().map((dependencyId) =>
-    installDependency(api, dependencyId, updateInstalled).catch((err) => {
+    installDependency(api, dependencyId).catch((err) => {
       api.showErrorNotification("Failed to install extension", err, {
         message: dependencyId,
       });
@@ -292,49 +285,21 @@ function checkMissingDependencies(
   });
 }
 
-function genUpdateInstalledExtensions(api: IExtensionApi) {
-  return async (initial: boolean): Promise<void> => {
-    try {
-      // TODO: native Promise
-      const extensions = await Promise.resolve(readExtensions(true));
-
-      const state = api.getState();
-      if (!initial && !_.isEqual(state.session.extensions.installed, extensions)) {
-        if (!localState.reloadNecessary) {
-          localState.reloadNecessary = true;
-
-          // Identify newly installed game extensions so we can pass --game
-          // on restart, allowing the profile manager to offer to manage it
-          const oldInstalled = state.session.extensions.installed;
-          const newGameExt = Object.entries(extensions).find(
-            ([id, info]) => oldInstalled[id] === undefined && info.name?.startsWith("Game:"),
-          );
-          const relaunchArgs =
-            newGameExt !== undefined ? ["--game", newGameExt[1].name] : undefined;
-
-          api.sendNotification({
-            id: "extension-updates",
-            type: "success",
-            message: "Extensions installed, please restart to use them",
-            actions: [
-              {
-                title: "Restart now",
-                action: () => {
-                  relaunch(relaunchArgs);
-                },
-              },
-            ],
-          });
-        }
-      }
-      api.store.dispatch(setInstalledExtensions(extensions));
-    } catch (err) {
-      // this probably only occurs if the user deletes the plugins directory after start
-      api.showErrorNotification("Failed to read extension directory", err, {
-        allowReport: false,
-      });
-    }
-  };
+function signalRestartNeeded(api: IExtensionApi): void {
+  if (!localState.reloadNecessary) {
+    localState.reloadNecessary = true;
+    api.sendNotification({
+      id: "extension-updates",
+      type: "success",
+      message: "Extensions installed, please restart to use them",
+      actions: [
+        {
+          title: "Restart now",
+          action: () => relaunch(),
+        },
+      ],
+    });
+  }
 }
 
 function parseInstallCmdLine(argument: string): IExtensionDownloadInfo {
@@ -350,18 +315,19 @@ function parseInstallCmdLine(argument: string): IExtensionDownloadInfo {
 }
 
 function init(context: IExtensionContext) {
-  const updateExtensions = genUpdateInstalledExtensions(context.api);
   context.registerReducer(["session", "extensions"], sessionReducer);
 
   context.registerMainPage("extensions", "Extensions", ExtensionManager, {
     priority: 20,
     hotkey: "X",
     group: "global",
-    // visible: () => context.api.store.getState().settings.interface.advanced,
     props: () =>
       ({
         localState,
-        updateExtensions: () => updateExtensions(false),
+        updateExtensions: () => {
+          signalRestartNeeded(context.api);
+          return Promise.resolve();
+        },
       }) satisfies Partial<IExtensionManagerProps>,
   });
 
@@ -379,7 +345,10 @@ function init(context: IExtensionContext) {
     () =>
       ({
         localState,
-        updateExtensions: () => updateExtensions(false),
+        updateExtensions: () => {
+          signalRestartNeeded(context.api);
+          return Promise.resolve();
+        },
         onRefreshExtensions: forceUpdateExtensions,
       }) satisfies Partial<IBrowseExtensionsProps>,
   );
@@ -404,7 +373,6 @@ function init(context: IExtensionContext) {
     const didFetchAvailableExtensions = new Promise<void>((resolve) => (onDidFetch = resolve));
 
     void (async () => {
-      await updateExtensions(true);
       await updateAvailableExtensions(context.api);
       onDidFetch();
     })();
@@ -413,15 +381,16 @@ function init(context: IExtensionContext) {
       await didFetchAvailableExtensions;
       const success = await downloadAndInstallExtension(context.api, ext);
 
-      if (success) void updateExtensions(false);
+      if (success) signalRestartNeeded(context.api);
       return success;
     });
 
     context.api.events.on("gamemode-activated", (gameMode: string) => {
       const state = context.api.getState();
       const game = getGame(gameMode);
-      const gameExtId = Object.keys(state.session.extensions.installed).find(
-        (key) => game.extensionPath === state.session.extensions.installed[key].path,
+      const extState = state.app.extensions ?? {};
+      const gameExtId = Object.keys(extState).find(
+        (key) => game.extensionPath === extState[key].path,
       );
 
       if (!gameExtId || !state.session.extensions.optional[gameExtId]) {
@@ -430,7 +399,7 @@ function init(context: IExtensionContext) {
 
       const requiredIds: string[] = [];
       for (const ext of state.session.extensions.optional[gameExtId]) {
-        if (!state.session.extensions.installed[ext.id]) {
+        if (extState[ext.id] === undefined) {
           requiredIds.push(ext.id);
         }
       }
@@ -464,7 +433,7 @@ function init(context: IExtensionContext) {
                       action: () => {
                         dismiss();
                         const promises = requiredIds.map((id) =>
-                          installDependency(context.api, id, updateExtensions),
+                          installDependency(context.api, id),
                         );
                         void Promise.all(promises);
                       },
@@ -476,9 +445,7 @@ function init(context: IExtensionContext) {
             {
               title: "Install Extension/s",
               action: () => {
-                const promises = requiredIds.map((id) =>
-                  installDependency(context.api, id, updateExtensions),
-                );
+                const promises = requiredIds.map((id) => installDependency(context.api, id));
                 void Promise.all(promises);
               },
             },
@@ -491,12 +458,11 @@ function init(context: IExtensionContext) {
       const state = context.api.getState();
       const modId = state.persistent.downloads.files[archiveId]?.modInfo?.nexus?.ids?.modId;
       const ext = state.session.extensions.available.find((iter) => iter.modId === modId);
+      const extState = state.app.extensions ?? {};
       const isInstalled =
-        Object.values(state.session.extensions.installed).find(
+        Object.values(extState).find(
           (inst) =>
-            !!inst?.modId && // Corrupt state ? (#9935)
-            inst.modId === ext?.modId &&
-            inst.version === ext?.version,
+            inst.modId !== undefined && inst.modId === ext?.modId && inst.version === ext?.version,
         ) !== undefined;
 
       if (isInstalled) {
@@ -511,7 +477,7 @@ function init(context: IExtensionContext) {
 
       if (modId !== undefined && ext !== undefined) {
         const success = await downloadAndInstallExtension(context.api, ext);
-        if (success) void updateExtensions(false);
+        if (success) signalRestartNeeded(context.api);
         return success;
       } else {
         context.api.sendNotification({

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -389,18 +389,26 @@ function init(context: IExtensionContext) {
       const state = context.api.getState();
       const game = getGame(gameMode);
       const extState = state.app.extensions ?? {};
-      const gameExtId = Object.keys(extState).find(
-        (key) => game.extensionPath === extState[key].path,
-      );
+
+      // Search both persisted user extensions and loaded bundled extensions.
+      const gameExtId =
+        Object.keys(extState).find((key) => game.extensionPath === extState[key].path) ??
+        context.api.getLoadedExtensions().find((ext) => ext.path === game.extensionPath)?.name;
 
       if (!gameExtId || !state.session.extensions.optional[gameExtId]) {
         return;
       }
 
       const requiredIds: string[] = [];
-      for (const ext of state.session.extensions.optional[gameExtId]) {
-        if (extState[ext.id] === undefined) {
-          requiredIds.push(ext.id);
+      const loadedExts = context.api.getLoadedExtensions();
+      for (const opt of state.session.extensions.optional[gameExtId]) {
+        const installed =
+          extState[opt.id] !== undefined ||
+          loadedExts.some(
+            (le) => le.info?.name === opt.id || le.info?.id === opt.id || le.name === opt.id,
+          );
+        if (!installed) {
+          requiredIds.push(opt.id);
         }
       }
 

--- a/src/renderer/src/extensions/extension_manager/installExtension.test.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.test.ts
@@ -44,13 +44,31 @@ describe("clearStaleRemovalFlags", () => {
   const extensionsPath = path.join("C:", "ProgramData", "vortex", "plugins");
 
   const makeApi = (
-    installed: Record<string, { path: string }>,
+    entries: Record<string, { path: string }>,
   ): { api: IExtensionApi; dispatch: ReturnType<typeof vi.fn> } => {
     const dispatch = vi.fn();
+    const extState = Object.fromEntries(
+      Object.entries(entries).map(([key, val]) => [
+        key,
+        {
+          enabled: true,
+          version: "1.0.0",
+          remove: true,
+          endorsed: "Undecided",
+          name: key,
+          author: "test",
+          description: "test extension",
+          path: val.path,
+        },
+      ]),
+    );
     const api = {
       store: {
         dispatch,
-        getState: () => ({ session: { extensions: { installed } }, app: { extensions: {} } }),
+        getState: () => ({
+          session: { extensions: { available: [] } },
+          app: { extensions: extState },
+        }),
       },
     } as unknown as IExtensionApi;
     return { api, dispatch };

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -402,7 +402,8 @@ async function installExtensionImpl(
 
       clearStaleRemovalFlags(api, removedKeys, destPath);
 
-      api.store.dispatch(addExtension(manifestInfo.id, { ...fullInfo, path: destPath }));
+      const extId = fullInfo.id ?? dirName;
+      api.store.dispatch(addExtension(extId, { ...fullInfo, path: destPath }));
 
       emitExtensionInstalled(
         api,

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -402,7 +402,7 @@ async function installExtensionImpl(
 
       clearStaleRemovalFlags(api, removedKeys, destPath);
 
-      api.store.dispatch(addExtension(manifestInfo.id, fullInfo));
+      api.store.dispatch(addExtension(manifestInfo.id, { ...fullInfo, path: destPath }));
 
       emitExtensionInstalled(
         api,

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -130,13 +130,12 @@ export function clearStaleRemovalFlags(
   destPath: string,
 ): void {
   const state: IState = api.store.getState();
-  const { installed } = state.session.extensions;
   const extState = state.app.extensions ?? {};
   // Compare paths, not key strings: info.json `id` can decouple the state key
   // from the folder basename, and the archive-name fallback differs again.
   const normalizedDest = path.normalize(destPath).toLowerCase();
   removedKeys.forEach((key) => {
-    const prevPath = installed[key]?.path ?? extState[key]?.path;
+    const prevPath = extState[key]?.path;
     if (prevPath !== undefined && path.normalize(prevPath).toLowerCase() === normalizedDest) {
       api.store.dispatch(forgetExtension(key));
     }
@@ -145,33 +144,13 @@ export function clearStaleRemovalFlags(
 
 function removeOldVersion(api: IExtensionApi, info: IExtension): string[] {
   const state = api.getState();
-  const { installed } = state.session.extensions;
   const extState = state.app.extensions ?? {};
 
   // should never be more than one but let's handle multiple to be safe
   const previousVersions: string[] = [];
 
-  // Search session.extensions.installed (legacy, will be removed in LAZ-833)
-  for (const [key, ext] of Object.entries(installed)) {
-    if (ext.bundled) continue;
-    if (info.id !== undefined && ext.id === info.id) {
-      previousVersions.push(key);
-      continue;
-    }
-    if (info.modId !== undefined && ext.modId === info.modId) {
-      previousVersions.push(key);
-      continue;
-    }
-    if (info.name === ext.name) {
-      previousVersions.push(key);
-    }
-  }
-
-  // Also search state.app.extensions (persisted source).  Avoid duplicates
-  // when a key already matched via session.extensions.installed above.
   for (const [key, ext] of Object.entries(extState)) {
     if (ext.bundled) continue;
-    if (previousVersions.includes(key)) continue;
     if (info.modId !== undefined && ext.modId === info.modId) {
       previousVersions.push(key);
       continue;

--- a/src/renderer/src/extensions/extension_manager/reducers.ts
+++ b/src/renderer/src/extensions/extension_manager/reducers.ts
@@ -9,8 +9,6 @@ const sessionReducer: IReducerSpec = {
   reducers: {
     [actions.setAvailableExtensions as any]: (state, payload) =>
       setSafe(state, ["available"], payload),
-    [actions.setInstalledExtensions as any]: (state, payload) =>
-      setSafe(state, ["installed"], payload),
     [actions.setOptionalExtensions as any]: (state, payload) =>
       setSafe(state, ["optional"], payload),
     [actions.setExtensionsUpdate as any]: (state, payload) =>
@@ -18,7 +16,6 @@ const sessionReducer: IReducerSpec = {
   },
   defaults: {
     available: [],
-    installed: {},
     optional: {},
     updateTime: 0,
   },

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -99,6 +99,7 @@ function applyExtensionInfo(
     }
   };
 
+  add("id", archiveInfo.id, manifestInfo.id);
   add("type", manifestInfo.type, archiveInfo.type);
   add("path", archiveInfo.path, undefined);
   add("bundled", bundled, undefined);

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -313,6 +313,7 @@ export async function downloadAndInstallExtension(
     return true;
   } catch (err) {
     if (err instanceof UserCanceled) return false;
+    log("error", "error installing extension", err);
 
     api.showDialog(
       "error",

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -5,7 +5,8 @@ import memoizeOne from "memoize-one";
 import React, { type ComponentClass, useCallback, useMemo, useRef, useState } from "react";
 import type { WithTranslation } from "react-i18next";
 
-import type { IAvailableExtension, IExtension } from "@/types/extensions";
+import type { IAvailableExtension } from "@/types/extensions";
+import type { IExtensionState } from "@/types/IState";
 import type { IState } from "@/types/IState";
 import { Listing } from "@/ui/components/listing/Listing";
 import { Pagination } from "@/ui/components/pagination/Pagination";
@@ -59,7 +60,7 @@ interface IConnectedProps {
   gameMode: string;
   pickerLayout: "list" | "small" | "large";
   extensions: IAvailableExtension[];
-  extensionsInstalled: { [extId: string]: IExtension };
+  extensionsInstalled: { [extId: string]: IExtensionState };
   sortManaged: string;
   sortUnmanaged: string;
 }
@@ -468,7 +469,7 @@ function mapStateToProps(state: IState): IConnectedProps {
     profiles: state.persistent.profiles,
     knownGames: state.session.gameMode.known,
     extensions: state.session.extensions.available,
-    extensionsInstalled: state.session.extensions.installed,
+    extensionsInstalled: state.app.extensions ?? {},
     sortManaged: state.settings.gameMode.sortManaged ?? "alphabetical",
     sortUnmanaged: state.settings.gameMode.sortUnmanaged ?? "alphabetical",
   };

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -1393,8 +1393,9 @@ export function refreshEndorsements(store: Redux.Store<any>, nexus: Nexus) {
       return prev;
     }, {});
     const state: IState = store.getState();
-    Object.keys(state.session.extensions.installed).forEach((extId) => {
-      const modId = state.session.extensions.installed[extId].modId;
+    const extState = state.app.extensions ?? {};
+    Object.keys(extState).forEach((extId) => {
+      const modId = extState[extId].modId;
 
       if (modId !== undefined) {
         const endorsed = getSafe(endorseMap, [SITE_ID, modId], "Undecided");

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -27,11 +27,7 @@ import type { IDialogResult } from "../../actions/notifications";
 import { addNotification, showDialog } from "../../actions/notifications";
 import { clearUIBlocker, setProgress, setUIBlocker } from "../../actions/session";
 import { log } from "../../logging";
-import type {
-  IExtension,
-  IExtensionDownloadInfo,
-  IRegisteredExtension,
-} from "../../types/extensions";
+import type { IExtensionDownloadInfo, IRegisteredExtension } from "../../types/extensions";
 import type { IExtensionApi, IExtensionContext, ThunkStore } from "../../types/IExtensionContext";
 import type { IGameStored, IState } from "../../types/IState";
 import { relaunch } from "../../util/commandLine";
@@ -56,7 +52,6 @@ import {
 import { getSafe } from "../../util/storeHelper";
 import { batchDispatch, truthy } from "../../util/util";
 import { emitGameManaged, emitGameUnmanaged } from "../analytics/mixpanel/gameManageAnalytics";
-import { readExtensions } from "../extension_manager/util";
 import { getGame, getGameStubDownloadInfo } from "../gamemode_management/util/getGame";
 import { ensureStagingDirectory } from "../mod_management/stagingDirectory";
 import { purgeMods } from "../mod_management/util/deploy";
@@ -1120,35 +1115,31 @@ function init(context: IExtensionContext): boolean {
         // name, because at the time we download an extension we don't actually know
         // the game id yet.
 
-        readExtensions(false).then((extensions: { [extId: string]: IExtension }) => {
-          const extPathLookup = Object.values(extensions).reduce((prevExt, ext) => {
-            if (ext.path !== undefined) {
-              prevExt[ext.path] = ext.name;
-            }
-            return prevExt;
-          }, {});
+        const extState = context.api.getState().app.extensions ?? {};
+        const extPathLookup = Object.values(extState).reduce((prevExt, ext) => {
+          prevExt[ext.path] = ext.name;
+          return prevExt;
+        }, {});
 
-          const game = known.find(
-            (iter) =>
-              iter.id === commandLine.game ||
-              extPathLookup[iter.extensionPath] === commandLine.game,
-          );
+        const game = known.find(
+          (iter) =>
+            iter.id === commandLine.game || extPathLookup[iter.extensionPath] === commandLine.game,
+        );
 
-          if (game !== undefined) {
-            // Wait for discovery to populate before deciding undiscovered vs
-            // discovered; otherwise this races the fire-and-forget
-            // startQuickDiscovery in gamemode_management.once() and pops the
-            // "Game not discovered" dialog even though discovery would have
-            // succeeded.
-            context.api
-              .emitAndAwait("discover-game", game.id)
-              .then(() => manageGame(context.api, game.id));
-          } else {
-            log("warn", "game specified on command line not found", {
-              game: commandLine.game,
-            });
-          }
-        });
+        if (game !== undefined) {
+          // Wait for discovery to populate before deciding undiscovered vs
+          // discovered; otherwise this races the fire-and-forget
+          // startQuickDiscovery in gamemode_management.once() and pops the
+          // "Game not discovered" dialog even though discovery would have
+          // succeeded.
+          context.api
+            .emitAndAwait("discover-game", game.id)
+            .then(() => manageGame(context.api, game.id));
+        } else {
+          log("warn", "game specified on command line not found", {
+            game: commandLine.game,
+          });
+        }
       }
     }
 

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -779,9 +779,7 @@ async function init(): Promise<ExtensionManager | null> {
 async function load(extensions: ExtensionManager): Promise<void> {
   const { i18n, tFunc, error } = await getI18n("en", () => {
     const state = store.getState();
-    return Object.values(state.session.extensions.installed).filter(
-      (ext) => ext.type === "translation",
-    );
+    return Object.values(state.app.extensions ?? {}).filter((ext) => ext.type === "translation");
   });
 
   if (error) {

--- a/src/renderer/src/types/IState.ts
+++ b/src/renderer/src/types/IState.ts
@@ -135,21 +135,21 @@ export interface IExtensionState {
   version: string;
   remove: boolean;
   endorsed: string;
-  /** Path to the extension folder on disk. Written at install time, read during boot reconciliation. */
-  path?: string;
+  /** Display name of the extension. */
+  name: string;
+  /** Extension author display name. */
+  author: string;
+  /** Human-readable description of the extension. */
+  description: string;
+  /** Path to the extension folder on disk. */
+  path: string;
   /** Nexus Mods mod ID for this extension. Identity key for mapping to available/manifest entries. */
   modId?: number;
   /** Nexus Mods file ID for this specific version of the extension. */
   fileId?: number;
-  /** Extension author display name. */
-  author?: string;
   /** Extension type. */
   type?: ExtensionType;
-  /** Human-readable description of the extension. */
-  description?: string;
-  /** Display name of the extension. */
-  name?: string;
-  /** True for extensions shipped with Vortex (bundled plugins dir). False or undefined for user-installed. */
+  /** True for extensions shipped with Vortex (bundled plugins dir). Always false or absent for state entries. */
   bundled?: boolean;
 }
 

--- a/src/renderer/src/types/api.ts
+++ b/src/renderer/src/types/api.ts
@@ -35,7 +35,7 @@ export type {
   ICollectionInstallSession,
   CollectionModStatus,
 } from "./collections/ICollectionInstallSession";
-export type { IAvailableExtension, IExtension } from "./extensions";
+export type { IAvailableExtension, IExtension, ExtensionInfo } from "./extensions";
 export type {
   LoadOrder,
   LoadOrder as FBLOLoadOrder,

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -19,9 +19,9 @@ export type ExtensionInit = (context: IExtensionContext) => boolean;
 export type ExtensionType = "game" | "translation" | "theme";
 
 /**
- * Information about an extension available from the info.json file
+ * Raw shape of an extension's info.json file.
  */
-export interface IExtension {
+export interface ExtensionInfo {
   // id of the extension. We strongly advice against setting this manually
   // in info.json because it mustn't be changed once the extension is released.
   // if this isn't set, Vortex will assign something automatically that at least
@@ -45,10 +45,12 @@ export interface IExtension {
   issueTrackerURL?: string;
 }
 
-export type IExtensionWithState = IExtension &
-  IExtensionState & {
-    loadFailures: IExtensionLoadFailure[];
-  };
+/** @deprecated Use ExtensionInfo instead */
+export type IExtension = ExtensionInfo;
+
+export type IExtensionWithState = IExtensionState & {
+  loadFailures: IExtensionLoadFailure[];
+};
 
 export interface IExtensionDownloadInfo {
   name: string;

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -56,6 +56,7 @@ export interface IExtensionDownloadInfo {
   name: string;
   modId?: number;
   fileId?: number;
+  type?: ExtensionType;
 }
 
 /**


### PR DESCRIPTION
**NOTE:** This requires testing, not just code reviewing. Verify already installed extensions appear as usual and new extensions can be installed without issue. 

- Clarifies differences between `IExtensionState` and `IExtension` (which got renamed to `ExtensionInfo`)
- Consolidates extension state usage
- Fully moves extension tracking to new state based system

Closes LAZ-833.