### PR TITLE
Add Health Check analytics tracking (LAZ-551, Phase 1)

### DIFF
--- a/src/renderer/src/extensions/analytics/index.ts
+++ b/src/renderer/src/extensions/analytics/index.ts
@@ -2,13 +2,16 @@ import * as os from "os";
 
 import { getErrorMessageOrDefault } from "@vortex/shared";
 
-import type { IExtensionContext } from "../../types/IExtensionContext";
-import { getCPUArch } from "../../util/nativeArch";
+import type { IExtensionContext } from "@/types/IExtensionContext";
+import { getCPUArch } from "@/util/nativeArch";
+
+import { activeGameId, activeProfileId } from "../../util/selectors";
 import { setAnalytics } from "./actions/analytics.action";
 import { HELP_ARTICLE, PRIVACY_POLICY } from "./constants";
 import AnalyticsMixpanel from "./mixpanel/MixpanelAnalytics";
 import type { MixpanelEvent } from "./mixpanel/MixpanelEvents";
-import { AppLaunchedEvent, ModsInstallationCompletedEvent } from "./mixpanel/MixpanelEvents";
+import { AppLaunchedEvent } from "./mixpanel/MixpanelEvents";
+import { numericNexusGameId } from "./mixpanel/numericGameId";
 import settingsReducer from "./reducers/settings.reducer";
 import { analyticsLog } from "./utils/analyticsLog";
 import SettingsAnalytics from "./views/SettingsAnalytics";
@@ -25,11 +28,12 @@ function init(context: IExtensionContext): boolean {
 
     // check for update when the user changes the analytics, toggle
     const analyticsSettings = ["settings", "analytics", "enabled"];
-    context.api.onStateChange(analyticsSettings, (oldState, newState) => {
+    context.api.onStateChange(analyticsSettings, (_, newState) => {
       if (ignoreNextAnalyticsStateChange) {
         ignoreNextAnalyticsStateChange = false;
         return;
       }
+
       if (newState) {
         startAnalytics();
       } else {
@@ -38,7 +42,7 @@ function init(context: IExtensionContext): boolean {
     });
 
     // Check for user login
-    context.api.onStateChange(["persistent", "nexus", "userInfo"], (previous, current) => {
+    context.api.onStateChange(["persistent", "nexus", "userInfo"], (_, current) => {
       //showConsentDialog();
 
       if (enabled() && current) {
@@ -66,25 +70,52 @@ function init(context: IExtensionContext): boolean {
       AnalyticsMixpanel.trackEvent(event);
     });
 
-    async function startAnalytics() {
+    // Keep the active-game super properties in sync so every event carries game scope.
+    // Fires on game switch (each game has its own active profile) and profile switch;
+    // re-registering the same game is idempotent.
+    context.api.onStateChange(["settings", "profiles", "activeProfileId"], () => {
+      updateGameContext();
+    });
+
+    const updateGameContext = () => {
+      const state = context.api.getState();
+      const gameId = activeGameId(state);
+      const profileId = activeProfileId(state);
+
+      if (!gameId || !profileId) {
+        // No active game (e.g. games dashboard) — clear so stale scope can't leak.
+        AnalyticsMixpanel.setGameContext(null);
+        return;
+      }
+
+      AnalyticsMixpanel.setGameContext({
+        gameId: numericNexusGameId(gameId),
+        profileId,
+      });
+    };
+
+    function startAnalytics() {
       if (AnalyticsMixpanel.isUserSet()) {
         return;
       }
 
       try {
         const userInfo = getUserInfo();
+
         if (userInfo === undefined) {
           analyticsLog("warn", "Tried to start analytics but user not logged in");
           return;
         }
-
-        const state = context.api.getState();
 
         // Determine environment for analytics routing
         // Development environment uses dev token, production uses prod token
         const isProduction = process.env.NODE_ENV !== "development";
 
         AnalyticsMixpanel.start(userInfo, isProduction);
+
+        // Register game scope before the first event so app_launched carries the
+        // current game (and clears any stale value persisted from a previous session).
+        updateGameContext();
 
         // Send app_launched event
         AnalyticsMixpanel.trackEvent(
@@ -106,7 +137,7 @@ function init(context: IExtensionContext): boolean {
       }
     }
 
-    async function stopAnalytics() {
+    function stopAnalytics() {
       AnalyticsMixpanel.stop();
       analyticsLog("info", "Analytics stopped");
     }
@@ -152,7 +183,7 @@ function init(context: IExtensionContext): boolean {
                     },
                   ],
                 )
-                .then((result) => {
+                .then(() => {
                   dismiss();
                   return Promise.resolve();
                 });

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for MixpanelAnalytics.setGameContext: it registers the active game/profile super
+ * properties (game_id / profile_id) while a game is active, clears them when none is, and
+ * no-ops entirely when analytics hasn't been started (user opted out).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IValidateKeyDataV2 } from "../../nexus_integration/types/IValidateKeyData";
+
+const mp = vi.hoisted(() => ({
+  init: vi.fn(),
+  identify: vi.fn(),
+  register: vi.fn(),
+  unregister: vi.fn(),
+  track: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock("mixpanel-browser", () => ({ default: mp }));
+vi.mock("../../../util/application", () => ({ getApplication: () => ({ version: "1.2.3" }) }));
+
+import analyticsMixpanel from "./MixpanelAnalytics";
+
+const userInfo = {
+  userId: 42,
+  isPremium: false,
+  isSupporter: false,
+  isLifetime: false,
+} as IValidateKeyDataV2;
+
+describe("MixpanelAnalytics.setGameContext", () => {
+  beforeEach(() => {
+    analyticsMixpanel.stop();
+    vi.clearAllMocks();
+  });
+
+  it("no-ops when analytics has not been started (opted out)", () => {
+    analyticsMixpanel.setGameContext({
+      gameId: 1704,
+      profileId: "abc123",
+    });
+    expect(mp.register).not.toHaveBeenCalled();
+    expect(mp.unregister).not.toHaveBeenCalled();
+  });
+
+  it("registers game/profile super properties when a game is active", () => {
+    analyticsMixpanel.start(userInfo, false);
+    mp.register.mockClear(); // start() registers the user super properties itself
+
+    analyticsMixpanel.setGameContext({
+      gameId: 1704,
+      profileId: "abc123",
+    });
+
+    expect(mp.register).toHaveBeenCalledWith({
+      game_id: 1704,
+      profile_id: "abc123",
+    });
+  });
+
+  it("registers a null game_id when the numeric id is unresolved", () => {
+    analyticsMixpanel.start(userInfo, false);
+    mp.register.mockClear();
+
+    analyticsMixpanel.setGameContext({
+      gameId: null,
+      profileId: "abc123",
+    });
+
+    expect(mp.register).toHaveBeenCalledWith({
+      game_id: null,
+      profile_id: "abc123",
+    });
+  });
+
+  it("clears game/profile super properties when no game is active", () => {
+    analyticsMixpanel.start(userInfo, false);
+    mp.register.mockClear();
+
+    analyticsMixpanel.setGameContext(null);
+
+    expect(mp.unregister).toHaveBeenCalledWith("game_id");
+    expect(mp.unregister).toHaveBeenCalledWith("profile_id");
+    expect(mp.register).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
@@ -120,6 +120,26 @@ class MixpanelAnalytics {
   }
 
   /**
+   * Register (or clear) the active-game super properties so every subsequent event
+   * carries game/profile scope without each event having to pass it. Pass `null` when
+   * no game is active (e.g. the games dashboard) so stale scope can't leak onto
+   * game-agnostic events. `game_id` is the numeric Nexus id; `profile_id` is the active
+   * profile's id.
+   */
+  public setGameContext(context: { gameId: number | null; profileId: string } | null) {
+    if (!this.isUserSet()) return;
+    if (context === null) {
+      mixpanel.unregister("game_id");
+      mixpanel.unregister("profile_id");
+      return;
+    }
+    mixpanel.register({
+      game_id: context.gameId,
+      profile_id: context.profileId,
+    });
+  }
+
+  /**
    * Disable tracking
    */
   public stop() {

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -20,7 +20,11 @@ import { setFileRequirementHidden } from "../../actions/persistent";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
 import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useReportCopy } from "../../hooks/useReportCopy";
-import { issueTypeForCheck, resolutionTypeForCategory } from "../../utils/shared/tracking";
+import {
+  checkNameForCheck,
+  issueTypeForCheck,
+  resolutionTypeForCategory,
+} from "../../utils/shared/tracking";
 import { isFileEntryHidden } from "../../views/content/fileRequirementEntries";
 import type { IDetailViewProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -33,6 +37,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const { summary } = useReportCopy(report);
 
   const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
   const resolutionType = resolutionTypeForCategory(report.category);
   const {
     trackDetailViewed,
@@ -54,6 +59,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   useEffect(() => {
     trackDetailViewed({
       issue_id: entry.id,
+      check_id: checkName,
       issue_type: issueType,
       resolution_type: resolutionType,
       required_mod_count: report.requirements.length,
@@ -65,10 +71,11 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const isHidden = useSelector((state: IState) => isFileEntryHidden(state, entry));
   const toggleHideEntry = () => {
     if (isHidden) {
-      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+      trackIssueUnhidden({ issue_id: entry.id, check_id: checkName, issue_type: issueType });
     } else {
       trackIssueHidden({
         issue_id: entry.id,
+        check_id: checkName,
         issue_type: issueType,
         resolution_type: resolutionType,
       });
@@ -142,6 +149,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
         <div className="space-y-4">
           <RequirementBody
             api={api}
+            checkId={checkName}
             issueId={entry.id}
             ctx={{
               api,
@@ -150,6 +158,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               onInstall: (candidate) =>
                 trackOneClickInstallClicked({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,
                   mod_name: candidate.modName,
                   mod_version: candidate.version,
@@ -158,6 +167,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               onPickOption: (candidate, position, total) =>
                 trackPickOptionSelected({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,
                   mod_name: candidate.modName,
                   option_position: position,
@@ -166,11 +176,13 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               onInstallAll: (candidates) =>
                 trackInstallAllInGroupClicked({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_count: candidates.length,
                 }),
               onOpenModPage: (candidate) => {
                 const modPageProps = {
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,
                   mod_name: candidate.modName,
                   mod_version: candidate.version,
@@ -188,6 +200,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                 if (enabledFile) {
                   trackEnableThisVersionClicked({
                     issue_id: entry.id,
+                    check_id: checkName,
                     mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
                     required_version: correctFile.version,
                     current_version: enabledFile.version,
@@ -195,6 +208,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                 } else {
                   trackEnableClicked({
                     issue_id: entry.id,
+                    check_id: checkName,
                     mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
                     mod_name: correctFile.modName,
                     mod_version: correctFile.version,
@@ -204,12 +218,14 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               onViewInMods: (file) =>
                 trackViewInModsClicked({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(file.modUID)?.id ?? 0,
                   mod_name: file.modName,
                 }),
               onInstallDownloaded: (file) =>
                 trackInstallDownloadedClicked({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(file.modUID)?.id ?? 0,
                   mod_count: 1,
                 }),

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -142,6 +142,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
         <div className="space-y-4">
           <RequirementBody
             api={api}
+            issueId={entry.id}
             ctx={{
               api,
               showPremiumAd,

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
@@ -8,6 +8,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import { severityStyleMap } from "@/extensions/health_check/utils/shared/severityStyles";
+import { decodeUID } from "@/extensions/nexus_integration/util/UIDs";
 import type { IState } from "@/types/IState";
 import { Icon } from "@/ui/components/icon/Icon";
 import { Typography } from "@/ui/components/typography/Typography";
@@ -17,7 +18,9 @@ import { joinClasses } from "@/ui/utils/joinClasses";
 import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { setFileRequirementHidden } from "../../actions/persistent";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useReportCopy } from "../../hooks/useReportCopy";
+import { issueTypeForCheck, resolutionTypeForCategory } from "../../utils/shared/tracking";
 import { isFileEntryHidden } from "../../views/content/fileRequirementEntries";
 import type { IDetailViewProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -29,13 +32,54 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const count = report.requirements.length;
   const { summary } = useReportCopy(report);
 
+  const issueType = issueTypeForCheck(entry.checkId);
+  const resolutionType = resolutionTypeForCategory(report.category);
+  const {
+    trackDetailViewed,
+    trackOneClickInstallClicked,
+    trackPickOptionSelected,
+    trackInstallAllInGroupClicked,
+    trackInstallViaModPageClicked,
+    trackViewModPageClicked,
+    trackEnableClicked,
+    trackEnableThisVersionClicked,
+    trackViewInModsClicked,
+    trackInstallDownloadedClicked,
+    trackIssueHidden,
+    trackIssueUnhidden,
+  } = useHealthCheckTracking(api);
+
+  // detail_viewed fires once per detail open; entry-prop changes as the check re-runs
+  // shouldn't re-fire it, so the mount-only effect is intentional.
+  useEffect(() => {
+    trackDetailViewed({
+      issue_id: entry.id,
+      issue_type: issueType,
+      resolution_type: resolutionType,
+      required_mod_count: report.requirements.length,
+      source_mod_name: report.sourceModName,
+    });
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
+
   const isHidden = useSelector((state: IState) => isFileEntryHidden(state, entry));
   const toggleHideEntry = () => {
+    if (isHidden) {
+      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+    } else {
+      trackIssueHidden({
+        issue_id: entry.id,
+        issue_type: issueType,
+        resolution_type: resolutionType,
+      });
+    }
+
     for (const req of report.requirements) {
       api.store?.dispatch(
         setFileRequirementHidden(report.sourceFileUID, req.requirementDefId, !isHidden),
       );
     }
+
     onBack();
   };
 
@@ -102,6 +146,72 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               api,
               showPremiumAd,
               requestDownload: (candidate) => downloadFileRequirement(api, candidate),
+              onInstall: (candidate) =>
+                trackOneClickInstallClicked({
+                  issue_id: entry.id,
+                  mod_id: decodeUID(candidate.modUID)?.id ?? 0,
+                  mod_name: candidate.modName,
+                  mod_version: candidate.version,
+                  is_adult_content: candidate.adultContent,
+                }),
+              onPickOption: (candidate, position, total) =>
+                trackPickOptionSelected({
+                  issue_id: entry.id,
+                  mod_id: decodeUID(candidate.modUID)?.id ?? 0,
+                  mod_name: candidate.modName,
+                  option_position: position,
+                  total_options: total,
+                }),
+              onInstallAll: (candidates) =>
+                trackInstallAllInGroupClicked({
+                  issue_id: entry.id,
+                  mod_count: candidates.length,
+                }),
+              onOpenModPage: (candidate) => {
+                const modPageProps = {
+                  issue_id: entry.id,
+                  mod_id: decodeUID(candidate.modUID)?.id ?? 0,
+                  mod_name: candidate.modName,
+                  mod_version: candidate.version,
+                };
+
+                // Free users install via the website (a resolution action); premium users
+                // browsing to the mod page is informational.
+                if (showPremiumAd) {
+                  trackInstallViaModPageClicked(modPageProps);
+                } else {
+                  trackViewModPageClicked(modPageProps);
+                }
+              },
+              onEnable: (correctFile, enabledFile) => {
+                if (enabledFile) {
+                  trackEnableThisVersionClicked({
+                    issue_id: entry.id,
+                    mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
+                    required_version: correctFile.version,
+                    current_version: enabledFile.version,
+                  });
+                } else {
+                  trackEnableClicked({
+                    issue_id: entry.id,
+                    mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
+                    mod_name: correctFile.modName,
+                    mod_version: correctFile.version,
+                  });
+                }
+              },
+              onViewInMods: (file) =>
+                trackViewInModsClicked({
+                  issue_id: entry.id,
+                  mod_id: decodeUID(file.modUID)?.id ?? 0,
+                  mod_name: file.modName,
+                }),
+              onInstallDownloaded: (file) =>
+                trackInstallDownloadedClicked({
+                  issue_id: entry.id,
+                  mod_id: decodeUID(file.modUID)?.id ?? 0,
+                  mod_count: 1,
+                }),
             }}
             report={report}
           />

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -17,12 +17,15 @@ import {
   uninstalledFiles,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
+import { decodeUID } from "@/extensions/nexus_integration/util/UIDs";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 
 import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useReportCopy } from "../../hooks/useReportCopy";
+import { issueTypeForCheck, resolutionTypeForCategory } from "../../utils/shared/tracking";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
@@ -37,15 +40,41 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   const [showPremium, setShowPremium] = useState(false);
   const { givenFeedback, markFeedback } = useFileRequirementFeedback(api, report.sourceFileUID);
 
+  const {
+    trackOneClickInstallClicked,
+    trackInstallAllInGroupClicked,
+    trackPickModInstallClicked,
+    trackEnableThisVersionClicked,
+    trackInstallDownloadedClicked,
+    trackIssueHidden,
+    trackIssueUnhidden,
+  } = useHealthCheckTracking(api);
+
+  const issueType = issueTypeForCheck(entry.checkId);
   const candidates = downloadCandidates(report.requirements);
   const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
   const toInstall = uninstalledFiles(report.requirements);
   const orJoin = ` ${t("listing::item::or_join")} `;
 
+  const handleToggleHide = () => {
+    if (isHidden) {
+      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+    } else {
+      trackIssueHidden({
+        issue_id: entry.id,
+        issue_type: issueType,
+        resolution_type: resolutionTypeForCategory(report.category),
+      });
+    }
+
+    onToggleHide();
+  };
+
   const names = report.requirements
     .map((requirement) => requirementModName(requirement, orJoin))
     .filter(Boolean);
+
   const namesLine =
     names.length > 1
       ? `${names[0]} ${t("listing::item::more_count", { count: names.length - 1 })}`
@@ -53,10 +82,25 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
   const doQuickInstall = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (candidates.length === 1) {
+      const candidate = candidates[0];
+
+      trackOneClickInstallClicked({
+        issue_id: entry.id,
+        mod_id: decodeUID(candidate.modUID)?.id ?? 0,
+        mod_name: candidate.modName,
+        mod_version: candidate.version,
+        is_adult_content: candidate.adultContent,
+      });
+    } else {
+      trackInstallAllInGroupClicked({ issue_id: entry.id, mod_count: candidates.length });
+    }
+
     if (showPremiumAd) {
       setShowPremium(true);
       return;
     }
+
     candidates.forEach((candidate) => void downloadFileRequirement(api, candidate));
   };
 
@@ -85,6 +129,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
+                trackPickModInstallClicked({ issue_id: entry.id, issue_type: issueType });
                 onOpen();
               }}
             >
@@ -98,6 +143,12 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
+                trackEnableThisVersionClicked({
+                  issue_id: entry.id,
+                  mod_id: decodeUID(switches[0].correct.modUID)?.id ?? 0,
+                  required_version: switches[0].correct.version,
+                  current_version: switches[0].wrong.version,
+                });
                 switchActiveVersions(api, switches);
               }}
             >
@@ -113,6 +164,13 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
+
+                  trackInstallDownloadedClicked({
+                    issue_id: entry.id,
+                    mod_id: decodeUID(toInstall[0].uninstalledFile.modUID)?.id ?? 0,
+                    mod_count: toInstall.length,
+                  });
+
                   toInstall.forEach((req) => void installDownloadedFile(api, req.uninstalledFile));
                 }}
               >
@@ -129,7 +187,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
             variant="listing"
             onHelpful={markFeedback}
             onNotHelpful={markFeedback}
-            onToggleHide={onToggleHide}
+            onToggleHide={handleToggleHide}
           />
         }
         severity={entry.severity}
@@ -144,6 +202,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
         onClose={() => setShowPremium(false)}
         onDownload={() => {
           setShowPremium(false);
+
           // Free-user fallback: a single candidate opens its mod page; otherwise
           // open the detail so each requirement's mod page is reachable.
           if (candidates.length === 1) {

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -25,7 +25,11 @@ import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
 import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useReportCopy } from "../../hooks/useReportCopy";
-import { issueTypeForCheck, resolutionTypeForCategory } from "../../utils/shared/tracking";
+import {
+  checkNameForCheck,
+  issueTypeForCheck,
+  resolutionTypeForCategory,
+} from "../../utils/shared/tracking";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
@@ -51,6 +55,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   } = useHealthCheckTracking(api);
 
   const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
   const candidates = downloadCandidates(report.requirements);
   const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
@@ -59,10 +64,11 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
   const handleToggleHide = () => {
     if (isHidden) {
-      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+      trackIssueUnhidden({ issue_id: entry.id, check_id: checkName, issue_type: issueType });
     } else {
       trackIssueHidden({
         issue_id: entry.id,
+        check_id: checkName,
         issue_type: issueType,
         resolution_type: resolutionTypeForCategory(report.category),
       });
@@ -87,13 +93,18 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
       trackOneClickInstallClicked({
         issue_id: entry.id,
+        check_id: checkName,
         mod_id: decodeUID(candidate.modUID)?.id ?? 0,
         mod_name: candidate.modName,
         mod_version: candidate.version,
         is_adult_content: candidate.adultContent,
       });
     } else {
-      trackInstallAllInGroupClicked({ issue_id: entry.id, mod_count: candidates.length });
+      trackInstallAllInGroupClicked({
+        issue_id: entry.id,
+        check_id: checkName,
+        mod_count: candidates.length,
+      });
     }
 
     if (showPremiumAd) {
@@ -129,7 +140,11 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                trackPickModInstallClicked({ issue_id: entry.id, issue_type: issueType });
+                trackPickModInstallClicked({
+                  issue_id: entry.id,
+                  check_id: checkName,
+                  issue_type: issueType,
+                });
                 onOpen();
               }}
             >
@@ -145,6 +160,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                 e.stopPropagation();
                 trackEnableThisVersionClicked({
                   issue_id: entry.id,
+                  check_id: checkName,
                   mod_id: decodeUID(switches[0].correct.modUID)?.id ?? 0,
                   required_version: switches[0].correct.version,
                   current_version: switches[0].wrong.version,
@@ -167,6 +183,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
                   trackInstallDownloadedClicked({
                     issue_id: entry.id,
+                    check_id: checkName,
                     mod_id: decodeUID(toInstall[0].uninstalledFile.modUID)?.id ?? 0,
                     mod_count: toInstall.length,
                   });
@@ -203,6 +220,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
           api,
           trigger: candidates.length === 1 ? "single_install" : "batch_install",
           issueId: entry.id,
+          checkId: checkName,
           modId: candidates.length === 1 ? (decodeUID(candidates[0].modUID)?.id ?? 0) : undefined,
           modCount: candidates.length,
         }}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -1,4 +1,4 @@
-import { mdiCallSplit, mdiCheck, mdiSwapHorizontal, mdiTrayArrowDown } from "@mdi/js";
+import { mdiCallSplit, mdiCheck, mdiMonitorArrowDownVariant, mdiSwapHorizontal } from "@mdi/js";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -68,7 +68,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
             <Button
               appearance="moderate"
               brand="neutral"
-              leftIconPath={mdiTrayArrowDown}
+              leftIconPath={mdiMonitorArrowDownVariant}
               rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
               size="sm"
               onClick={doQuickInstall}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -199,6 +199,13 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
       <PremiumModal
         downloadScope={candidates.length === 1 ? "single" : "all"}
         isOpen={showPremium}
+        tracking={{
+          api,
+          trigger: candidates.length === 1 ? "single_install" : "batch_install",
+          issueId: entry.id,
+          modId: candidates.length === 1 ? (decodeUID(candidates[0].modUID)?.id ?? 0) : undefined,
+          modCount: candidates.length,
+        }}
         onClose={() => setShowPremium(false)}
         onDownload={() => {
           setShowPremium(false);

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -41,20 +41,16 @@ const groupTitleKey = (category: FileRequirementCategory): string => {
   }
 };
 
-const requirementRows = (
-  requirement: IFileRequirement,
-  ctx: IFileActionContext,
-  api: IExtensionApi,
-) => {
+const requirementRows = (requirement: IFileRequirement, ctx: IFileActionContext) => {
   switch (requirement.kind) {
     case "missing":
       return <DownloadRows ctx={ctx} requirement={requirement} />;
     case "wrong-version-installed":
       return <ReplaceRows ctx={ctx} requirement={requirement} />;
     case "correct-version-uninstalled":
-      return <InstallUninstalledRows api={api} requirement={requirement} />;
+      return <InstallUninstalledRows ctx={ctx} requirement={requirement} />;
     case "wrong-version-enabled":
-      return <ToggleRows api={api} requirement={requirement} />;
+      return <ToggleRows ctx={ctx} requirement={requirement} />;
     case "or":
       return <OrRows ctx={ctx} requirement={requirement} />;
   }
@@ -102,6 +98,7 @@ export const RequirementBody = ({
   };
 
   const installAll = () => {
+    ctx.onInstallAll(installAllCandidates);
     if (ctx.showPremiumAd) {
       setPremiumOpen(true);
       return;
@@ -140,7 +137,7 @@ export const RequirementBody = ({
         <RequirementGroup actions={installAllAction} title={title}>
           {requirements.map((requirement) => (
             <React.Fragment key={requirement.requirementDefId}>
-              {requirementRows(requirement, rowCtx, api)}
+              {requirementRows(requirement, rowCtx)}
             </React.Fragment>
           ))}
         </RequirementGroup>
@@ -150,7 +147,7 @@ export const RequirementBody = ({
             {index > 0 && <AndDivider />}
 
             <RequirementGroup actions={index === 0 ? installAllAction : undefined} title={title}>
-              {requirementRows(requirement, rowCtx, api)}
+              {requirementRows(requirement, rowCtx)}
             </RequirementGroup>
           </React.Fragment>
         ))

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -72,10 +72,12 @@ export const RequirementBody = ({
   report,
   ctx,
   api,
+  issueId,
 }: {
   report: IFileRequirementReport;
   ctx: IFileActionContext;
   api: IExtensionApi;
+  issueId: string;
 }) => {
   const { t } = useTranslation("health_check");
   const [premiumOpen, setPremiumOpen] = useState(false);
@@ -156,6 +158,12 @@ export const RequirementBody = ({
       <PremiumModal
         downloadScope="all"
         isOpen={premiumOpen}
+        tracking={{
+          api,
+          trigger: "batch_install",
+          issueId,
+          modCount: installAllCandidates.length,
+        }}
         onClose={() => setPremiumOpen(false)}
         onDownload={() => setPremiumOpen(false)}
       />

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 import { Typography } from "@/ui/components/typography/Typography";
 
+import type { CheckName } from "../../utils/shared/tracking";
 import { PremiumModal } from "../premium_modal/PremiumModal";
 import { RequirementGroup } from "./RequirementGroup";
 import { DownloadRows } from "./rows/DownloadRows";
@@ -73,11 +74,13 @@ export const RequirementBody = ({
   ctx,
   api,
   issueId,
+  checkId,
 }: {
   report: IFileRequirementReport;
   ctx: IFileActionContext;
   api: IExtensionApi;
   issueId: string;
+  checkId: CheckName;
 }) => {
   const { t } = useTranslation("health_check");
   const [premiumOpen, setPremiumOpen] = useState(false);
@@ -162,6 +165,7 @@ export const RequirementBody = ({
           api,
           trigger: "batch_install",
           issueId,
+          checkId,
           modCount: installAllCandidates.length,
         }}
         onClose={() => setPremiumOpen(false)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -1,4 +1,4 @@
-import { mdiOpenInNew, mdiTrayArrowDown } from "@mdi/js";
+import { mdiMonitorArrowDownVariant, mdiOpenInNew } from "@mdi/js";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -51,7 +51,7 @@ export const CandidateCard = ({
             appearance={ctx.installButtonAppearance ?? "strong"}
             brand="neutral"
             isLoading={loading}
-            leftIconPath={mdiTrayArrowDown}
+            leftIconPath={mdiMonitorArrowDownVariant}
             rightIcon={ctx.showPremiumAd ? <PremiumBadge /> : undefined}
             size="sm"
             onClick={onClick}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -20,18 +20,38 @@ export const CandidateCard = ({
   ctx,
   candidate,
   isOr,
+  optionPosition,
+  optionCount,
 }: {
   ctx: IFileActionContext;
   candidate: IFileRequirementCandidate;
   isOr?: boolean;
+  optionPosition?: number;
+  optionCount?: number;
 }) => {
   const { t } = useTranslation(["health_check", "common"]);
+
   const { isLoading, onClick } = useInstallButton(
     () => ctx.requestDownload(candidate),
     ctx.showPremiumAd,
   );
 
   const loading = isLoading || !!ctx.isDownloadingAll;
+
+  const handleInstall = () => {
+    if (isOr) {
+      ctx.onPickOption(candidate, optionPosition ?? 0, optionCount ?? 0);
+    } else {
+      ctx.onInstall(candidate);
+    }
+
+    onClick();
+  };
+
+  const handleModPage = () => {
+    ctx.onOpenModPage(candidate);
+    openModPage(ctx.api, candidate);
+  };
 
   return (
     <FileRequirement
@@ -42,7 +62,7 @@ export const CandidateCard = ({
             brand="neutral"
             leftIconPath={mdiOpenInNew}
             size="sm"
-            onClick={() => openModPage(ctx.api, candidate)}
+            onClick={handleModPage}
           >
             {t("detail::item::install_via_mod_page")}
           </Button>
@@ -54,7 +74,7 @@ export const CandidateCard = ({
             leftIconPath={mdiMonitorArrowDownVariant}
             rightIcon={ctx.showPremiumAd ? <PremiumBadge /> : undefined}
             size="sm"
-            onClick={onClick}
+            onClick={handleInstall}
           >
             {loading ? t("detail::item::downloading") : t("detail::item::install_one_click")}
           </Button>

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import {
   fileWebLinks,
+  type IFileActionContext,
   installedToFileData,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import {
@@ -12,7 +13,6 @@ import {
   viewInLoadout,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IInstalledFile } from "@/extensions/health_check/utils/fileRequirements/installedFiles";
-import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { nxmModOutline } from "@/ui/icon-paths";
 
@@ -20,18 +20,33 @@ import { FileRequirement } from "../FileRequirement";
 
 /** A "switch to this disabled version" card for one installed file (toggle + OR enable). */
 export const EnableCard = ({
-  api,
+  ctx,
   correctFile,
   enabledFile,
   isOr,
 }: {
-  api: IExtensionApi;
+  ctx: IFileActionContext;
   correctFile: IInstalledFile;
   /** The wrong version to switch off, if any; absent means a plain enable. */
   enabledFile?: IInstalledFile;
   isOr?: boolean;
 }) => {
   const { t } = useTranslation("health_check");
+
+  const handleViewInMods = () => {
+    ctx.onViewInMods(correctFile);
+    viewInLoadout(ctx.api, correctFile);
+  };
+
+  const handleEnable = () => {
+    ctx.onEnable(correctFile, enabledFile);
+
+    if (enabledFile) {
+      switchActiveVersion(ctx.api, enabledFile, correctFile);
+    } else {
+      enableInstalledFile(ctx.api, correctFile);
+    }
+  };
 
   return (
     <FileRequirement
@@ -42,7 +57,7 @@ export const EnableCard = ({
             brand="neutral"
             leftIconPath={nxmModOutline}
             size="sm"
-            onClick={() => viewInLoadout(api, correctFile)}
+            onClick={handleViewInMods}
           >
             {t("detail::item::view_in_mods")}
           </Button>
@@ -52,11 +67,7 @@ export const EnableCard = ({
             brand="neutral"
             leftIconPath={mdiSwapHorizontal}
             size="sm"
-            onClick={() =>
-              enabledFile
-                ? switchActiveVersion(api, enabledFile, correctFile)
-                : enableInstalledFile(api, correctFile)
-            }
+            onClick={handleEnable}
           >
             {t("detail::item::enable_this_version")}
           </Button>
@@ -64,7 +75,7 @@ export const EnableCard = ({
       }
       file={installedToFileData(correctFile)}
       isOr={isOr}
-      {...fileWebLinks(api, correctFile)}
+      {...fileWebLinks(ctx.api, correctFile)}
     />
   );
 };

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
@@ -5,13 +5,13 @@ import { useTranslation } from "react-i18next";
 import {
   downloadedToFileData,
   fileWebLinks,
+  type IFileActionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import {
   installDownloadedFile,
   viewDownloadInMods,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
-import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { nxmModOutline } from "@/ui/icon-paths";
 
@@ -19,16 +19,25 @@ import { useInstallButton } from "../../../hooks/useInstallButton";
 import { FileRequirement } from "../FileRequirement";
 
 export const InstallUninstalledRows = ({
-  api,
+  ctx,
   requirement,
 }: {
-  api: IExtensionApi;
+  ctx: IFileActionContext;
   requirement: Extract<IFileRequirement, { kind: "correct-version-uninstalled" }>;
 }) => {
   const { t } = useTranslation("health_check");
-  const { isLoading, onClick } = useInstallButton(() =>
-    installDownloadedFile(api, requirement.uninstalledFile),
-  );
+  const file = requirement.uninstalledFile;
+  const { isLoading, onClick } = useInstallButton(() => installDownloadedFile(ctx.api, file));
+
+  const handleInstall = () => {
+    ctx.onInstallDownloaded(file);
+    onClick();
+  };
+
+  const handleViewInMods = () => {
+    ctx.onViewInMods(file);
+    viewDownloadInMods(ctx.api, file);
+  };
 
   return (
     <FileRequirement
@@ -39,7 +48,7 @@ export const InstallUninstalledRows = ({
             brand="neutral"
             leftIconPath={nxmModOutline}
             size="sm"
-            onClick={() => viewDownloadInMods(api, requirement.uninstalledFile)}
+            onClick={handleViewInMods}
           >
             {t("detail::item::view_in_mods")}
           </Button>
@@ -50,14 +59,14 @@ export const InstallUninstalledRows = ({
             isLoading={isLoading}
             leftIconPath={mdiCheck}
             size="sm"
-            onClick={onClick}
+            onClick={handleInstall}
           >
             {isLoading ? t("detail::item::installing") : t("detail::item::install_uninstalled")}
           </Button>
         </>
       }
-      file={downloadedToFileData(requirement.uninstalledFile)}
-      {...fileWebLinks(api, requirement.uninstalledFile)}
+      file={downloadedToFileData(file)}
+      {...fileWebLinks(ctx.api, file)}
     />
   );
 };

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
@@ -14,13 +14,20 @@ export const OrRows = ({
   requirement: Extract<IFileRequirement, { kind: "or" }>;
 }) => (
   <>
-    {requirement.branches.map((branch) =>
+    {requirement.branches.map((branch, index) =>
       branch.kind === "download" ? (
-        <CandidateCard candidate={branch.candidate} ctx={ctx} isOr={true} key={branch.modFileId} />
+        <CandidateCard
+          candidate={branch.candidate}
+          ctx={ctx}
+          isOr={true}
+          key={branch.modFileId}
+          optionCount={requirement.branches.length}
+          optionPosition={index + 1}
+        />
       ) : (
         <EnableCard
-          api={ctx.api}
           correctFile={branch.correctFile}
+          ctx={ctx}
           enabledFile={branch.enabledFile}
           isOr={true}
           key={branch.modFileId}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -23,6 +23,11 @@ export const ReplaceRows = ({
 }) => {
   const { t } = useTranslation("health_check");
 
+  const handleViewInMods = () => {
+    ctx.onViewInMods(requirement.installedFile);
+    viewInLoadout(ctx.api, requirement.installedFile);
+  };
+
   return (
     <>
       <div className="space-y-3 border-b border-surface-mid pb-6">
@@ -45,7 +50,7 @@ export const ReplaceRows = ({
               brand="neutral"
               leftIconPath={nxmModOutline}
               size="sm"
-              onClick={() => viewInLoadout(ctx.api, requirement.installedFile)}
+              onClick={handleViewInMods}
             >
               {t("detail::item::view_in_mods")}
             </Button>

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { installedToFileData } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
+import {
+  type IFileActionContext,
+  installedToFileData,
+} from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { viewInLoadout } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
-import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
 import { nxmModOutline } from "@/ui/icon-paths";
@@ -13,13 +15,18 @@ import { EnableCard } from "../cards/EnableCard";
 import { FileRequirement } from "../FileRequirement";
 
 export const ToggleRows = ({
-  api,
+  ctx,
   requirement,
 }: {
-  api: IExtensionApi;
+  ctx: IFileActionContext;
   requirement: Extract<IFileRequirement, { kind: "wrong-version-enabled" }>;
 }) => {
   const { t } = useTranslation("health_check");
+
+  const handleViewInMods = () => {
+    ctx.onViewInMods(requirement.enabledFile);
+    viewInLoadout(ctx.api, requirement.enabledFile);
+  };
 
   return (
     <>
@@ -29,8 +36,8 @@ export const ToggleRows = ({
         </Typography>
 
         <EnableCard
-          api={api}
           correctFile={requirement.correctFile}
+          ctx={ctx}
           enabledFile={requirement.enabledFile}
         />
       </div>
@@ -47,7 +54,7 @@ export const ToggleRows = ({
               brand="neutral"
               leftIconPath={nxmModOutline}
               size="sm"
-              onClick={() => viewInLoadout(api, requirement.enabledFile)}
+              onClick={handleViewInMods}
             >
               {t("detail::item::view_in_mods")}
             </Button>

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -5,7 +5,7 @@ import {
   mdiOpenInNew,
   mdiWeb,
 } from "@mdi/js";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
@@ -19,9 +19,11 @@ import { TypographyLink } from "@/ui/components/typography/TypographyLink";
 import { opn } from "@/util/api";
 
 import { setModRequirementHidden } from "../../actions/persistent";
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import { hiddenModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
+import { issueTypeForCheck } from "../../utils/shared/tracking";
 import type { IDetailViewProps } from "../../views/content/types";
 import { Divider } from "../divider/Divider";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -49,16 +51,90 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     [hiddenRequirementMap, mod.requiredBy.modId, mod.id],
   );
 
+  const {
+    trackDetailViewed,
+    trackOneClickInstallClicked,
+    trackInstallViaModPageClicked,
+    trackViewModPageClicked,
+    trackSuggestionSourceLinkClicked,
+    trackIssueHidden,
+    trackIssueUnhidden,
+  } = useHealthCheckTracking(api);
+  const issueType = issueTypeForCheck(entry.checkId);
+  const modVersion = mod.mainFile?.version ?? "";
+
+  // detail_viewed fires once per detail open; entry-prop changes as the check re-runs
+  // shouldn't re-fire it, so the mount-only effect is intentional.
+  useEffect(() => {
+    trackDetailViewed({
+      issue_id: entry.id,
+      issue_type: issueType,
+      resolution_type: "install",
+      required_mod_count: 1,
+      source_mod_name: mod.requiredBy.modName,
+    });
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
+
+  const handleInstall = () => {
+    trackOneClickInstallClicked({
+      issue_id: entry.id,
+      mod_id: mod.modId,
+      mod_name: mod.modName,
+      mod_version: modVersion,
+      is_adult_content: mod.mainFile?.adultContent ?? false,
+    });
+
+    void installInApp();
+  };
+
+  // Free users are routed to the website to install (a resolution action); premium users
+  // clicking through to the mod page is informational — track them as distinct events.
+  const handleModPage = () => {
+    const modPageProps = {
+      issue_id: entry.id,
+      mod_id: mod.modId,
+      mod_name: mod.modName,
+      mod_version: modVersion,
+    };
+
+    if (showPremiumAd) {
+      trackInstallViaModPageClicked(modPageProps);
+    } else {
+      trackViewModPageClicked(modPageProps);
+    }
+
+    openModPage();
+  };
+
   const openRequiringModPage = useCallback(() => {
+    trackSuggestionSourceLinkClicked({ issue_id: entry.id, mod_id: mod.requiredBy.modId });
+
     if (mod.requiredBy.modUrl) {
       opn(mod.requiredBy.modUrl).catch(() => undefined);
     }
-  }, [mod.requiredBy.modUrl]);
+  }, [trackSuggestionSourceLinkClicked, entry.id, mod.requiredBy.modId, mod.requiredBy.modUrl]);
 
   const handleToggleHide = useCallback(() => {
+    if (isHidden) {
+      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+    } else {
+      trackIssueHidden({ issue_id: entry.id, issue_type: issueType, resolution_type: "install" });
+    }
+
     api.store?.dispatch(setModRequirementHidden(mod.requiredBy.modId, mod.id, !isHidden));
     onBack();
-  }, [api, mod.requiredBy.modId, mod.id, isHidden, onBack]);
+  }, [
+    api,
+    mod.requiredBy.modId,
+    mod.id,
+    isHidden,
+    onBack,
+    entry.id,
+    issueType,
+    trackIssueHidden,
+    trackIssueUnhidden,
+  ]);
 
   // External installs can't be auto-detected, so confirming just hides the
   // requirement from future checks.
@@ -67,17 +143,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     onBack();
   }, [api, mod.requiredBy.modId, mod.id, onBack]);
 
-  // mainFile is denormalized by the check, so no fetch is needed here. External
-  // requirements aren't hosted on Nexus, so surface the URL and a caution note
-  // in place of the file name and mod summary.
-  const fileData = mod.externalRequirement
-    ? {
-        ...modToFileData(mod, mod.mainFile),
-        modDescription: t("detail::item::external_hosted_note"),
-        fileName: mod.modUrl ?? "",
-        fileVersion: "",
-      }
-    : modToFileData(mod, mod.mainFile);
   const severityStyle = severityStyleMap[entry.severity];
 
   return (
@@ -132,7 +197,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                       brand="neutral"
                       leftIconPath={mdiOpenInNew}
                       size="sm"
-                      onClick={openModPage}
+                      onClick={handleModPage}
                     >
                       {t("detail::item::install_via_mod_page")}
                     </Button>
@@ -144,14 +209,23 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                     leftIconPath={mdiMonitorArrowDownVariant}
                     rightIcon={showPremiumAd ? <PremiumBadge /> : undefined}
                     size="sm"
-                    onClick={() => void installInApp()}
+                    onClick={handleInstall}
                   >
                     {t("detail::item::install_one_click")}
                   </Button>
                 </>
               )
             }
-            file={fileData}
+            file={
+              mod.externalRequirement
+                ? {
+                    ...modToFileData(mod, mod.mainFile),
+                    modDescription: t("detail::item::external_hosted_note"),
+                    fileName: mod.modUrl ?? "",
+                    fileVersion: "",
+                  }
+                : modToFileData(mod, mod.mainFile)
+            }
             {...(mod.externalRequirement
               ? { fileIconPath: mdiWeb, hideImage: true, onOpenFile: openModPage }
               : {})}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -23,7 +23,7 @@ import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import { hiddenModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
-import { issueTypeForCheck } from "../../utils/shared/tracking";
+import { checkNameForCheck, issueTypeForCheck } from "../../utils/shared/tracking";
 import type { IDetailViewProps } from "../../views/content/types";
 import { Divider } from "../divider/Divider";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -61,6 +61,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     trackIssueUnhidden,
   } = useHealthCheckTracking(api);
   const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
   const modVersion = mod.mainFile?.version ?? "";
 
   // detail_viewed fires once per detail open; entry-prop changes as the check re-runs
@@ -68,6 +69,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   useEffect(() => {
     trackDetailViewed({
       issue_id: entry.id,
+      check_id: checkName,
       issue_type: issueType,
       resolution_type: "install",
       required_mod_count: 1,
@@ -79,6 +81,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const handleInstall = () => {
     trackOneClickInstallClicked({
       issue_id: entry.id,
+      check_id: checkName,
       mod_id: mod.modId,
       mod_name: mod.modName,
       mod_version: modVersion,
@@ -93,6 +96,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const handleModPage = () => {
     const modPageProps = {
       issue_id: entry.id,
+      check_id: checkName,
       mod_id: mod.modId,
       mod_name: mod.modName,
       mod_version: modVersion,
@@ -108,18 +112,33 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   };
 
   const openRequiringModPage = useCallback(() => {
-    trackSuggestionSourceLinkClicked({ issue_id: entry.id, mod_id: mod.requiredBy.modId });
+    trackSuggestionSourceLinkClicked({
+      issue_id: entry.id,
+      check_id: checkName,
+      mod_id: mod.requiredBy.modId,
+    });
 
     if (mod.requiredBy.modUrl) {
       opn(mod.requiredBy.modUrl).catch(() => undefined);
     }
-  }, [trackSuggestionSourceLinkClicked, entry.id, mod.requiredBy.modId, mod.requiredBy.modUrl]);
+  }, [
+    trackSuggestionSourceLinkClicked,
+    entry.id,
+    checkName,
+    mod.requiredBy.modId,
+    mod.requiredBy.modUrl,
+  ]);
 
   const handleToggleHide = useCallback(() => {
     if (isHidden) {
-      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+      trackIssueUnhidden({ issue_id: entry.id, check_id: checkName, issue_type: issueType });
     } else {
-      trackIssueHidden({ issue_id: entry.id, issue_type: issueType, resolution_type: "install" });
+      trackIssueHidden({
+        issue_id: entry.id,
+        check_id: checkName,
+        issue_type: issueType,
+        resolution_type: "install",
+      });
     }
 
     api.store?.dispatch(setModRequirementHidden(mod.requiredBy.modId, mod.id, !isHidden));
@@ -131,6 +150,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     isHidden,
     onBack,
     entry.id,
+    checkName,
     issueType,
     trackIssueHidden,
     trackIssueUnhidden,
@@ -290,6 +310,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
           api,
           trigger: "single_install",
           issueId: entry.id,
+          checkId: checkName,
           modId: mod.modId,
           modCount: 1,
         }}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -286,6 +286,13 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
 
       <PremiumModal
         isOpen={showPremiumModal}
+        tracking={{
+          api,
+          trigger: "single_install",
+          issueId: entry.id,
+          modId: mod.modId,
+          modCount: 1,
+        }}
         onClose={() => setShowPremiumModal(false)}
         onDownload={() => {
           setShowPremiumModal(false);

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -112,6 +112,13 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
       <PremiumModal
         isOpen={showPremiumModal}
+        tracking={{
+          api,
+          trigger: "single_install",
+          issueId: entry.id,
+          modId: mod.modId,
+          modCount: 1,
+        }}
         onClose={() => setShowPremiumModal(false)}
         onDownload={() => {
           setShowPremiumModal(false);

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -8,7 +8,7 @@ import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import type { IModRequirementExt } from "../../types";
-import { issueTypeForCheck } from "../../utils/shared/tracking";
+import { checkNameForCheck, issueTypeForCheck } from "../../utils/shared/tracking";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
@@ -30,12 +30,14 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   } = useModRequirementActions(api, mod);
 
   const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
   const { trackOneClickInstallClicked, trackIssueHidden, trackIssueUnhidden } =
     useHealthCheckTracking(api);
 
   const handleInstall = () => {
     trackOneClickInstallClicked({
       issue_id: entry.id,
+      check_id: checkName,
       mod_id: mod.modId,
       mod_name: mod.modName,
       mod_version: mod.mainFile?.version ?? "",
@@ -47,9 +49,14 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
 
   const handleToggleHide = () => {
     if (isHidden) {
-      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+      trackIssueUnhidden({ issue_id: entry.id, check_id: checkName, issue_type: issueType });
     } else {
-      trackIssueHidden({ issue_id: entry.id, issue_type: issueType, resolution_type: "install" });
+      trackIssueHidden({
+        issue_id: entry.id,
+        check_id: checkName,
+        issue_type: issueType,
+        resolution_type: "install",
+      });
     }
 
     onToggleHide();
@@ -116,6 +123,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
           api,
           trigger: "single_install",
           issueId: entry.id,
+          checkId: checkName,
           modId: mod.modId,
           modCount: 1,
         }}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 import { useModRequirementActions } from "../../hooks/useModRequirementActions";
 import type { IModRequirementExt } from "../../types";
+import { issueTypeForCheck } from "../../utils/shared/tracking";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
@@ -26,6 +28,32 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     handlePositiveFeedback,
     handleFeedbackSuccess,
   } = useModRequirementActions(api, mod);
+
+  const issueType = issueTypeForCheck(entry.checkId);
+  const { trackOneClickInstallClicked, trackIssueHidden, trackIssueUnhidden } =
+    useHealthCheckTracking(api);
+
+  const handleInstall = () => {
+    trackOneClickInstallClicked({
+      issue_id: entry.id,
+      mod_id: mod.modId,
+      mod_name: mod.modName,
+      mod_version: mod.mainFile?.version ?? "",
+      is_adult_content: mod.mainFile?.adultContent ?? false,
+    });
+
+    void installInApp();
+  };
+
+  const handleToggleHide = () => {
+    if (isHidden) {
+      trackIssueUnhidden({ issue_id: entry.id, issue_type: issueType });
+    } else {
+      trackIssueHidden({ issue_id: entry.id, issue_type: issueType, resolution_type: "install" });
+    }
+
+    onToggleHide();
+  };
 
   return (
     <>
@@ -52,7 +80,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                void installInApp();
+                handleInstall();
               }}
             >
               {t("detail::item::install_one_click")}
@@ -69,7 +97,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
             variant="listing"
             onHelpful={handlePositiveFeedback}
             onNotHelpful={handleFeedbackSuccess}
-            onToggleHide={onToggleHide}
+            onToggleHide={handleToggleHide}
           />
         }
         severity={entry.severity}

--- a/src/renderer/src/extensions/health_check/components/premium_banner/PremiumBanner.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_banner/PremiumBanner.tsx
@@ -12,6 +12,7 @@ import { Campaign, Content, Section, nexusModsURL } from "@/util/util";
 
 import { PREMIUM_PATH } from "../../../nexus_integration/constants";
 import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
+import type { CheckName } from "../../utils/shared/tracking";
 
 /** Where the premium banner is shown. */
 export type BannerPlacement = "list" | "detail";
@@ -21,20 +22,26 @@ export interface IPremiumBannerTracking {
   api: IExtensionApi;
   placement: BannerPlacement;
   totalIssues: number;
-  /** The issue in view, on a detail page. */
+  /** The issue in view, on a detail page. Both absent on the cross-check listing. */
   issueId?: string;
+  checkId?: CheckName;
 }
 
 export const PremiumBanner = ({ tracking }: { tracking: IPremiumBannerTracking }) => {
-  const { api, placement, totalIssues, issueId } = tracking;
+  const { api, placement, totalIssues, issueId, checkId } = tracking;
   const showPremiumAd = useSelector(shouldShowPremiumAd);
   const { trackPremiumBannerShown, trackPremiumBannerClicked } = useHealthCheckTracking(api);
 
   useEffect(() => {
     if (showPremiumAd) {
-      trackPremiumBannerShown({ placement, total_issues: totalIssues, issue_id: issueId });
+      trackPremiumBannerShown({
+        placement,
+        total_issues: totalIssues,
+        issue_id: issueId,
+        check_id: checkId,
+      });
     }
-  }, [showPremiumAd, placement, totalIssues, issueId, trackPremiumBannerShown]);
+  }, [showPremiumAd, placement, totalIssues, issueId, checkId, trackPremiumBannerShown]);
 
   if (!showPremiumAd) {
     return null;
@@ -56,6 +63,7 @@ export const PremiumBanner = ({ tracking }: { tracking: IPremiumBannerTracking }
                     placement,
                     total_issues: totalIssues,
                     issue_id: issueId,
+                    check_id: checkId,
                   });
 
                   opn(

--- a/src/renderer/src/extensions/health_check/components/premium_banner/PremiumBanner.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_banner/PremiumBanner.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import { shouldShowPremiumAd } from "@/extensions/nexus_integration/selectors";
+import type { IExtensionApi } from "@/types/IExtensionContext";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 import { Typography } from "@/ui/components/typography/Typography";
 import { TypographyLink } from "@/ui/components/typography/TypographyLink";
@@ -10,9 +11,30 @@ import { opn } from "@/util/api";
 import { Campaign, Content, Section, nexusModsURL } from "@/util/util";
 
 import { PREMIUM_PATH } from "../../../nexus_integration/constants";
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
 
-export const PremiumBanner = () => {
+/** Where the premium banner is shown. */
+export type BannerPlacement = "list" | "detail";
+
+/** Analytics context for the premium upsell banner. */
+export interface IPremiumBannerTracking {
+  api: IExtensionApi;
+  placement: BannerPlacement;
+  totalIssues: number;
+  /** The issue in view, on a detail page. */
+  issueId?: string;
+}
+
+export const PremiumBanner = ({ tracking }: { tracking: IPremiumBannerTracking }) => {
+  const { api, placement, totalIssues, issueId } = tracking;
   const showPremiumAd = useSelector(shouldShowPremiumAd);
+  const { trackPremiumBannerShown, trackPremiumBannerClicked } = useHealthCheckTracking(api);
+
+  useEffect(() => {
+    if (showPremiumAd) {
+      trackPremiumBannerShown({ placement, total_issues: totalIssues, issue_id: issueId });
+    }
+  }, [showPremiumAd, placement, totalIssues, issueId, trackPremiumBannerShown]);
 
   if (!showPremiumAd) {
     return null;
@@ -30,6 +52,12 @@ export const PremiumBanner = () => {
                 brand="neutral-translucent"
                 typographyType="inherit"
                 onClick={() => {
+                  trackPremiumBannerClicked({
+                    placement,
+                    total_issues: totalIssues,
+                    issue_id: issueId,
+                  });
+
                   opn(
                     nexusModsURL(PREMIUM_PATH, {
                       section: Section.Users,

--- a/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
@@ -1,7 +1,8 @@
 import { mdiCheck, mdiDiamondStone, mdiOpenInNew } from "@mdi/js";
-import React, { type ReactNode } from "react";
+import React, { type ReactNode, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { Icon } from "@/ui/components/icon/Icon";
 import { Modal } from "@/ui/components/modal/Modal";
@@ -10,6 +11,10 @@ import { Campaign, Content, Section, nexusModsURL } from "@/util/util";
 
 import { opn } from "../../../../util/api";
 import { PREMIUM_PATH } from "../../../nexus_integration/constants";
+import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
+
+/** Which 1-click flow surfaced the premium upsell modal. */
+export type PremiumTrigger = "single_install" | "batch_install" | "install_all";
 
 const ListItem = ({ children }: { children: ReactNode }) => (
   <li className="flex gap-x-1">
@@ -19,31 +24,59 @@ const ListItem = ({ children }: { children: ReactNode }) => (
   </li>
 );
 
+/** Analytics context for the premium upsell modal. */
+export interface IPremiumModalTracking {
+  api: IExtensionApi;
+  /** Which 1-click flow surfaced the upsell, for the analytics funnel. */
+  trigger: PremiumTrigger;
+  issueId?: string;
+  modId?: number;
+  modCount?: number;
+}
+
 export const PremiumModal = ({
   isOpen,
   downloadScope = "single",
   onClose,
   onDownload,
+  tracking,
 }: {
   isOpen: boolean;
   downloadScope?: "single" | "all";
   onClose: () => void;
   onDownload: () => void;
+  tracking: IPremiumModalTracking;
 }) => {
   const { t } = useTranslation(["health_check"]);
+  const { api, trigger, issueId, modId, modCount } = tracking;
 
-  const goPremium = React.useCallback(() => {
-    opn(
-      nexusModsURL(PREMIUM_PATH, {
-        section: Section.Users,
-        campaign: Campaign.BuyPremium,
-        content: Content.HealthCheckAd,
-      }),
-    ).catch(() => undefined);
-  }, []);
+  const {
+    trackPremiumModalShown,
+    trackPremiumModalDismissed,
+    trackPremiumModalUnlockClicked,
+    trackPremiumModalFallbackClicked,
+  } = useHealthCheckTracking(api);
+
+  useEffect(() => {
+    if (isOpen) {
+      trackPremiumModalShown({
+        trigger,
+        issue_id: issueId,
+        mod_id: modId,
+        mod_count: modCount,
+      });
+    }
+  }, [isOpen, trigger, issueId, modId, modCount, trackPremiumModalShown]);
 
   return (
-    <Modal isOpen={isOpen} title={t(`premium::modal::title::${downloadScope}`)} onClose={onClose}>
+    <Modal
+      isOpen={isOpen}
+      title={t(`premium::modal::title::${downloadScope}`)}
+      onClose={() => {
+        trackPremiumModalDismissed({ trigger, issue_id: issueId });
+        onClose();
+      }}
+    >
       <Typography appearance="subdued" as="div" className="space-y-2" typographyType="body-sm">
         <p className="whitespace-pre-line">{t(`premium::modal::description::${downloadScope}`)}</p>
 
@@ -62,12 +95,21 @@ export const PremiumModal = ({
 
       <div className="mt-4 grid grid-cols-2 gap-x-2">
         <Button
-          brand="neutral"
           appearance="moderate"
+          brand="neutral"
           className="w-full"
           leftIconPath={downloadScope === "single" && mdiOpenInNew}
           size="sm"
-          onClick={onDownload}
+          onClick={() => {
+            trackPremiumModalFallbackClicked({
+              trigger,
+              issue_id: issueId,
+              mod_count: modCount,
+              fallback_type: downloadScope === "single" ? "single_mod_page" : "batch_mod_pages",
+            });
+
+            onDownload();
+          }}
         >
           {t(`premium::modal::buttons::secondary::${downloadScope}`)}
         </Button>
@@ -77,7 +119,21 @@ export const PremiumModal = ({
           className="w-full"
           leftIconPath={mdiDiamondStone}
           size="sm"
-          onClick={goPremium}
+          onClick={() => {
+            trackPremiumModalUnlockClicked({
+              trigger,
+              issue_id: issueId,
+              mod_count: modCount,
+            });
+
+            opn(
+              nexusModsURL(PREMIUM_PATH, {
+                section: Section.Users,
+                campaign: Campaign.BuyPremium,
+                content: Content.HealthCheckAd,
+              }),
+            ).catch(() => undefined);
+          }}
         >
           {t("premium::modal::buttons::primary")}
         </Button>

--- a/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
@@ -12,6 +12,7 @@ import { Campaign, Content, Section, nexusModsURL } from "@/util/util";
 import { opn } from "../../../../util/api";
 import { PREMIUM_PATH } from "../../../nexus_integration/constants";
 import { useHealthCheckTracking } from "../../hooks/useHealthCheckTracking";
+import type { CheckName } from "../../utils/shared/tracking";
 
 /** Which 1-click flow surfaced the premium upsell modal. */
 export type PremiumTrigger = "single_install" | "batch_install" | "install_all";
@@ -29,7 +30,9 @@ export interface IPremiumModalTracking {
   api: IExtensionApi;
   /** Which 1-click flow surfaced the upsell, for the analytics funnel. */
   trigger: PremiumTrigger;
+  /** Both absent for the cross-check install-all upsell raised from the listing. */
   issueId?: string;
+  checkId?: CheckName;
   modId?: number;
   modCount?: number;
 }
@@ -48,7 +51,7 @@ export const PremiumModal = ({
   tracking: IPremiumModalTracking;
 }) => {
   const { t } = useTranslation(["health_check"]);
-  const { api, trigger, issueId, modId, modCount } = tracking;
+  const { api, trigger, issueId, checkId, modId, modCount } = tracking;
 
   const {
     trackPremiumModalShown,
@@ -62,18 +65,19 @@ export const PremiumModal = ({
       trackPremiumModalShown({
         trigger,
         issue_id: issueId,
+        check_id: checkId,
         mod_id: modId,
         mod_count: modCount,
       });
     }
-  }, [isOpen, trigger, issueId, modId, modCount, trackPremiumModalShown]);
+  }, [isOpen, trigger, issueId, checkId, modId, modCount, trackPremiumModalShown]);
 
   return (
     <Modal
       isOpen={isOpen}
       title={t(`premium::modal::title::${downloadScope}`)}
       onClose={() => {
-        trackPremiumModalDismissed({ trigger, issue_id: issueId });
+        trackPremiumModalDismissed({ trigger, issue_id: issueId, check_id: checkId });
         onClose();
       }}
     >
@@ -104,6 +108,7 @@ export const PremiumModal = ({
             trackPremiumModalFallbackClicked({
               trigger,
               issue_id: issueId,
+              check_id: checkId,
               mod_count: modCount,
               fallback_type: downloadScope === "single" ? "single_mod_page" : "batch_mod_pages",
             });
@@ -123,6 +128,7 @@ export const PremiumModal = ({
             trackPremiumModalUnlockClicked({
               trigger,
               issue_id: issueId,
+              check_id: checkId,
               mod_count: modCount,
             });
 

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
@@ -50,12 +50,40 @@ describe("createHealthCheckTracker", () => {
     const { tracker, events } = harness();
     tracker.trackOneClickInstallClicked({
       issue_id: "a-b",
+      check_id: "file_requirements",
       mod_id: 42,
       mod_name: "SkyUI",
       mod_version: "5.2",
       is_adult_content: false,
     });
     expect(events[0].eventName).toBe("health_check_one_click_install_clicked");
+  });
+
+  it("carries check_id so the two checks stay separable on shared event names", () => {
+    const { tracker, events } = harness();
+    tracker.trackOneClickInstallClicked({
+      issue_id: "a-b",
+      check_id: "mod_requirements",
+      mod_id: 42,
+      mod_name: "SkyUI",
+      mod_version: "5.2",
+      is_adult_content: false,
+    });
+    tracker.trackBackClicked({
+      issue_id: "a-b",
+      check_id: "file_requirements",
+      time_spent_on_detail_ms: 900,
+    });
+    expect(events.map((e) => e.properties.check_id)).toEqual([
+      "mod_requirements",
+      "file_requirements",
+    ]);
+  });
+
+  it("omits check_id on a cross-check premium surface", () => {
+    const { tracker, events } = harness();
+    tracker.trackPremiumBannerShown({ placement: "list", total_issues: 3 });
+    expect(events[0].properties).not.toHaveProperty("check_id");
   });
 
   it("strips undefined optional properties", () => {

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
@@ -60,9 +60,9 @@ describe("createHealthCheckTracker", () => {
 
   it("strips undefined optional properties", () => {
     const { tracker, events } = harness();
-    tracker.trackPremiumModalShown({ trigger_context: "single_install" });
+    tracker.trackPremiumModalShown({ trigger: "single_install" });
     expect(events[0].eventName).toBe("health_check_premium_modal_shown");
-    expect(events[0].properties).toEqual({ trigger_context: "single_install" });
+    expect(events[0].properties).toEqual({ trigger: "single_install" });
     expect(events[0].properties).not.toHaveProperty("issue_id");
   });
 });

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the Health Check tracking factory: each callback emits a
+ * `analytics-track-mixpanel-event` carrying the right event name and property bag,
+ * and undefined optional props are stripped (HealthCheckEvent's contract).
+ */
+import { EventEmitter } from "events";
+
+import { describe, expect, it } from "vitest";
+
+import type { IExtensionApi } from "@/types/IExtensionContext";
+
+import type { MixpanelEvent } from "../../analytics/mixpanel/MixpanelEvents";
+import { createHealthCheckTracker } from "./useHealthCheckTracking";
+
+function harness() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  const tracker = createHealthCheckTracker({ events: emitter } as unknown as IExtensionApi);
+  return { tracker, events };
+}
+
+describe("createHealthCheckTracker", () => {
+  it("emits page_viewed with its properties", () => {
+    const { tracker, events } = harness();
+    tracker.trackPageViewed({
+      active_issue_count: 3,
+      hidden_issue_count: 1,
+      warning_count: 2,
+      suggestion_count: 1,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].eventName).toBe("health_check_page_viewed");
+    expect(events[0].properties).toEqual({
+      active_issue_count: 3,
+      hidden_issue_count: 1,
+      warning_count: 2,
+      suggestion_count: 1,
+    });
+  });
+
+  it("emits a no-property event (passed_viewed) with an empty bag", () => {
+    const { tracker, events } = harness();
+    tracker.trackPassedViewed();
+    expect(events[0].eventName).toBe("health_check_passed_viewed");
+    expect(events[0].properties).toEqual({});
+  });
+
+  it("uses the underscore one_click name", () => {
+    const { tracker, events } = harness();
+    tracker.trackOneClickInstallClicked({
+      issue_id: "a-b",
+      mod_id: 42,
+      mod_name: "SkyUI",
+      mod_version: "5.2",
+      is_adult_content: false,
+    });
+    expect(events[0].eventName).toBe("health_check_one_click_install_clicked");
+  });
+
+  it("strips undefined optional properties", () => {
+    const { tracker, events } = harness();
+    tracker.trackPremiumModalShown({ trigger_context: "single_install" });
+    expect(events[0].eventName).toBe("health_check_premium_modal_shown");
+    expect(events[0].properties).toEqual({ trigger_context: "single_install" });
+    expect(events[0].properties).not.toHaveProperty("issue_id");
+  });
+});

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
@@ -5,10 +5,29 @@ import type { IExtensionApi } from "@/types/IExtensionContext";
 
 import type { BannerPlacement } from "../components/premium_banner/PremiumBanner";
 import type { PremiumTrigger } from "../components/premium_modal/PremiumModal";
-import type { HealthCheckTab, IssueType, ResolutionType } from "../utils/shared/tracking";
+import type {
+  CheckName,
+  HealthCheckTab,
+  IssueType,
+  ResolutionType,
+} from "../utils/shared/tracking";
 
 /** Which free-user fallback the premium modal offered. */
 type PremiumFallbackType = "single_mod_page" | "batch_mod_pages";
+
+/**
+ * Carried by every issue-scoped event. Both checks emit the same event names, so
+ * `check_id` is what lets reporting split them; `issue_type` stays alongside it as the
+ * coarser confidence band the KPIs are written in. Cross-check aggregates (page_viewed,
+ * tab_switched, hide_all, install_all, settings_opened) carry neither.
+ */
+type IssueScope = {
+  issue_id: string;
+  check_id: CheckName;
+};
+
+/** Scope for the premium surfaces, which appear both against one issue and page-wide. */
+type OptionalIssueScope = Partial<IssueScope>;
 
 /**
  * Build a Health Check analytics event. Returns the app-wide MixpanelEvent shape so it
@@ -66,140 +85,124 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
       track("health_check_one_click_install_all_clicked", props),
 
     // Issue list
-    trackIssueExpanded: (props: {
-      issue_id: string;
-      issue_type: IssueType;
-      resolution_type: ResolutionType;
-      mod_name: string;
-      position_in_list: number;
-    }) => track("health_check_issue_expanded", props),
+    trackIssueExpanded: (
+      props: IssueScope & {
+        issue_type: IssueType;
+        resolution_type: ResolutionType;
+        mod_name: string;
+        position_in_list: number;
+      },
+    ) => track("health_check_issue_expanded", props),
 
     // Detail view
-    trackDetailViewed: (props: {
-      issue_id: string;
-      issue_type: IssueType;
-      resolution_type: ResolutionType;
-      required_mod_count: number;
-      source_mod_name: string;
-    }) => track("health_check_detail_viewed", props),
+    trackDetailViewed: (
+      props: IssueScope & {
+        issue_type: IssueType;
+        resolution_type: ResolutionType;
+        required_mod_count: number;
+        source_mod_name: string;
+      },
+    ) => track("health_check_detail_viewed", props),
 
-    trackBackClicked: (props: { issue_id: string; time_spent_on_detail_ms: number }) =>
+    trackBackClicked: (props: IssueScope & { time_spent_on_detail_ms: number }) =>
       track("health_check_back_clicked", props),
 
     // Install flow
-    trackOneClickInstallClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_name: string;
-      mod_version: string;
-      is_adult_content: boolean;
-    }) => track("health_check_one_click_install_clicked", props),
+    trackOneClickInstallClicked: (
+      props: IssueScope & {
+        mod_id: number;
+        mod_name: string;
+        mod_version: string;
+        is_adult_content: boolean;
+      },
+    ) => track("health_check_one_click_install_clicked", props),
 
-    trackInstallDownloadedClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_count: number;
-    }) => track("health_check_install_downloaded_clicked", props),
+    trackInstallDownloadedClicked: (props: IssueScope & { mod_id: number; mod_count: number }) =>
+      track("health_check_install_downloaded_clicked", props),
 
-    trackInstallAllInGroupClicked: (props: { issue_id: string; mod_count: number }) =>
+    trackInstallAllInGroupClicked: (props: IssueScope & { mod_count: number }) =>
       track("health_check_install_all_in_group_clicked", props),
 
     // Enable flow
-    trackEnableClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_name: string;
-      mod_version: string;
-    }) => track("health_check_enable_clicked", props),
+    trackEnableClicked: (
+      props: IssueScope & { mod_id: number; mod_name: string; mod_version: string },
+    ) => track("health_check_enable_clicked", props),
 
-    trackEnableThisVersionClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      required_version: string;
-      current_version: string;
-    }) => track("health_check_enable_this_version_clicked", props),
+    trackEnableThisVersionClicked: (
+      props: IssueScope & {
+        mod_id: number;
+        required_version: string;
+        current_version: string;
+      },
+    ) => track("health_check_enable_this_version_clicked", props),
 
-    trackEnableAllClicked: (props: { issue_id: string; mod_count: number }) =>
+    trackEnableAllClicked: (props: IssueScope & { mod_count: number }) =>
       track("health_check_enable_all_clicked", props),
 
     // Pick flow
-    trackPickModInstallClicked: (props: { issue_id: string; issue_type: IssueType }) =>
+    trackPickModInstallClicked: (props: IssueScope & { issue_type: IssueType }) =>
       track("health_check_pick_mod_install_clicked", props),
 
-    trackPickOptionSelected: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_name: string;
-      option_position: number;
-      total_options: number;
-    }) => track("health_check_pick_option_selected", props),
+    trackPickOptionSelected: (
+      props: IssueScope & {
+        mod_id: number;
+        mod_name: string;
+        option_position: number;
+        total_options: number;
+      },
+    ) => track("health_check_pick_option_selected", props),
 
     // Navigation & external
-    trackInstallViaModPageClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_name: string;
-      mod_version: string;
-    }) => track("health_check_install_via_mod_page_clicked", props),
+    trackInstallViaModPageClicked: (
+      props: IssueScope & { mod_id: number; mod_name: string; mod_version: string },
+    ) => track("health_check_install_via_mod_page_clicked", props),
 
-    trackViewModPageClicked: (props: {
-      issue_id: string;
-      mod_id: number;
-      mod_name: string;
-      mod_version: string;
-    }) => track("health_check_view_mod_page_clicked", props),
+    trackViewModPageClicked: (
+      props: IssueScope & { mod_id: number; mod_name: string; mod_version: string },
+    ) => track("health_check_view_mod_page_clicked", props),
 
-    trackViewInModsClicked: (props: { issue_id: string; mod_id: number; mod_name: string }) =>
+    trackViewInModsClicked: (props: IssueScope & { mod_id: number; mod_name: string }) =>
       track("health_check_view_in_mods_clicked", props),
 
-    trackSuggestionSourceLinkClicked: (props: { issue_id: string; mod_id: number }) =>
+    trackSuggestionSourceLinkClicked: (props: IssueScope & { mod_id: number }) =>
       track("health_check_suggestion_source_link_clicked", props),
 
-    // Premium modal
-    trackPremiumModalShown: (props: {
-      trigger: PremiumTrigger;
-      issue_id?: string;
-      mod_id?: number;
-      mod_count?: number;
-    }) => track("health_check_premium_modal_shown", props),
+    // Premium modal. Scope is optional: the install-all upsell is raised from the
+    // listing, across both checks, so it has no single issue or check to name.
+    trackPremiumModalShown: (
+      props: OptionalIssueScope & { trigger: PremiumTrigger; mod_id?: number; mod_count?: number },
+    ) => track("health_check_premium_modal_shown", props),
 
-    trackPremiumModalDismissed: (props: { trigger: PremiumTrigger; issue_id?: string }) =>
+    trackPremiumModalDismissed: (props: OptionalIssueScope & { trigger: PremiumTrigger }) =>
       track("health_check_premium_modal_dismissed", props),
 
-    trackPremiumModalUnlockClicked: (props: {
-      trigger: PremiumTrigger;
-      issue_id?: string;
-      mod_count?: number;
-    }) => track("health_check_premium_modal_unlock_clicked", props),
+    trackPremiumModalUnlockClicked: (
+      props: OptionalIssueScope & { trigger: PremiumTrigger; mod_count?: number },
+    ) => track("health_check_premium_modal_unlock_clicked", props),
 
-    trackPremiumModalFallbackClicked: (props: {
-      trigger: PremiumTrigger;
-      fallback_type: PremiumFallbackType;
-      issue_id?: string;
-      mod_count?: number;
-    }) => track("health_check_premium_modal_fallback_clicked", props),
+    trackPremiumModalFallbackClicked: (
+      props: OptionalIssueScope & {
+        trigger: PremiumTrigger;
+        fallback_type: PremiumFallbackType;
+        mod_count?: number;
+      },
+    ) => track("health_check_premium_modal_fallback_clicked", props),
 
-    // Premium banner
-    trackPremiumBannerShown: (props: {
-      placement: BannerPlacement;
-      total_issues: number;
-      issue_id?: string;
-    }) => track("health_check_premium_banner_shown", props),
+    // Premium banner. Scope is set on a detail page and absent on the listing.
+    trackPremiumBannerShown: (
+      props: OptionalIssueScope & { placement: BannerPlacement; total_issues: number },
+    ) => track("health_check_premium_banner_shown", props),
 
-    trackPremiumBannerClicked: (props: {
-      placement: BannerPlacement;
-      total_issues: number;
-      issue_id?: string;
-    }) => track("health_check_premium_banner_clicked", props),
+    trackPremiumBannerClicked: (
+      props: OptionalIssueScope & { placement: BannerPlacement; total_issues: number },
+    ) => track("health_check_premium_banner_clicked", props),
 
     // Visibility
-    trackIssueHidden: (props: {
-      issue_id: string;
-      issue_type: IssueType;
-      resolution_type?: ResolutionType;
-    }) => track("health_check_issue_hidden", props),
+    trackIssueHidden: (
+      props: IssueScope & { issue_type: IssueType; resolution_type?: ResolutionType },
+    ) => track("health_check_issue_hidden", props),
 
-    trackIssueUnhidden: (props: { issue_id: string; issue_type: IssueType }) =>
+    trackIssueUnhidden: (props: IssueScope & { issue_type: IssueType }) =>
       track("health_check_issue_unhidden", props),
   };
 };

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
@@ -1,0 +1,214 @@
+import { useMemo } from "react";
+
+import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+
+import type {
+  BannerContext,
+  HealthCheckTab,
+  IssueType,
+  PremiumFallbackType,
+  PremiumTriggerContext,
+  ResolutionType,
+} from "../utils/shared/tracking";
+
+/**
+ * Build a Health Check analytics event. Returns the app-wide MixpanelEvent shape so it
+ * rides the `analytics-track-mixpanel-event` bus, but lives here rather than in the
+ * shared MixpanelEvents catalogue so the feature owns its own events. Strips `undefined`
+ * values so optional props don't get sent as null. game_id / profile_id / user_type are
+ * attached globally as super properties, never here.
+ */
+const healthCheckEvent = (
+  eventName: string,
+  properties: Record<string, unknown> = {},
+): MixpanelEvent => ({
+  eventName,
+  properties: Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined),
+  ),
+});
+
+/**
+ * Centralised Health Check analytics (LAZ-551). One typed surface for every
+ * event so components emit intent (`trackIssueExpanded(...)`) instead of building
+ * Mixpanel events by hand. game_id / profile_id / user_type ride along as global
+ * super properties, so no event repeats them. Consent gating is handled centrally
+ * by the analytics extension — callers don't check it.
+ *
+ * `createHealthCheckTracker` is the pure factory (no React) so it can be unit
+ * tested directly; `useHealthCheckTracking` just memoises it per api.
+ */
+export const createHealthCheckTracker = (api: IExtensionApi) => {
+  const track = (eventName: string, properties: Record<string, unknown> = {}) => {
+    api.events.emit("analytics-track-mixpanel-event", healthCheckEvent(eventName, properties));
+  };
+
+  return {
+    // Page-level
+    trackPageViewed: (props: {
+      active_issue_count: number;
+      hidden_issue_count: number;
+      warning_count: number;
+      suggestion_count: number;
+      last_scan_timestamp?: number;
+    }) => track("health_check_page_viewed", props),
+
+    trackPassedViewed: () => track("health_check_passed_viewed"),
+
+    trackTabSwitched: (props: { tab: HealthCheckTab; issue_count_in_tab: number }) =>
+      track("health_check_tab_switched", props),
+
+    trackHideAllClicked: (props: { issue_count_hidden: number }) =>
+      track("health_check_hide_all_clicked", props),
+
+    trackSettingsOpened: () => track("health_check_settings_opened"),
+
+    trackOneClickInstallAllClicked: (props: { issue_count: number; mod_count: number }) =>
+      track("health_check_one_click_install_all_clicked", props),
+
+    // Issue list
+    trackIssueExpanded: (props: {
+      issue_id: string;
+      issue_type: IssueType;
+      resolution_type: ResolutionType;
+      mod_name: string;
+      position_in_list: number;
+    }) => track("health_check_issue_expanded", props),
+
+    // Detail view
+    trackDetailViewed: (props: {
+      issue_id: string;
+      issue_type: IssueType;
+      resolution_type: ResolutionType;
+      required_mod_count: number;
+      source_mod_name: string;
+    }) => track("health_check_detail_viewed", props),
+
+    trackBackClicked: (props: { issue_id: string; time_spent_on_detail_ms: number }) =>
+      track("health_check_back_clicked", props),
+
+    // Install flow
+    trackOneClickInstallClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_name: string;
+      mod_version: string;
+      is_adult_content: boolean;
+    }) => track("health_check_one_click_install_clicked", props),
+
+    trackInstallDownloadedClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_count: number;
+    }) => track("health_check_install_downloaded_clicked", props),
+
+    trackInstallAllInGroupClicked: (props: { issue_id: string; mod_count: number }) =>
+      track("health_check_install_all_in_group_clicked", props),
+
+    // Enable flow
+    trackEnableClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_name: string;
+      mod_version: string;
+    }) => track("health_check_enable_clicked", props),
+
+    trackEnableThisVersionClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      required_version: string;
+      current_version: string;
+    }) => track("health_check_enable_this_version_clicked", props),
+
+    trackEnableAllClicked: (props: { issue_id: string; mod_count: number }) =>
+      track("health_check_enable_all_clicked", props),
+
+    // Pick flow
+    trackPickModInstallClicked: (props: { issue_id: string; issue_type: IssueType }) =>
+      track("health_check_pick_mod_install_clicked", props),
+
+    trackPickOptionSelected: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_name: string;
+      option_position: number;
+      total_options: number;
+    }) => track("health_check_pick_option_selected", props),
+
+    // Navigation & external
+    trackInstallViaModPageClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_name: string;
+      mod_version: string;
+    }) => track("health_check_install_via_mod_page_clicked", props),
+
+    trackViewModPageClicked: (props: {
+      issue_id: string;
+      mod_id: number;
+      mod_name: string;
+      mod_version: string;
+    }) => track("health_check_view_mod_page_clicked", props),
+
+    trackViewInModsClicked: (props: { issue_id: string; mod_id: number; mod_name: string }) =>
+      track("health_check_view_in_mods_clicked", props),
+
+    trackSuggestionSourceLinkClicked: (props: { issue_id: string; mod_id: number }) =>
+      track("health_check_suggestion_source_link_clicked", props),
+
+    // Premium modal
+    trackPremiumModalShown: (props: {
+      trigger_context: PremiumTriggerContext;
+      issue_id?: string;
+      mod_id?: number;
+      mod_count?: number;
+    }) => track("health_check_premium_modal_shown", props),
+
+    trackPremiumModalDismissed: (props: {
+      trigger_context: PremiumTriggerContext;
+      issue_id?: string;
+    }) => track("health_check_premium_modal_dismissed", props),
+
+    trackPremiumModalUnlockClicked: (props: {
+      trigger_context: PremiumTriggerContext;
+      issue_id?: string;
+      mod_count?: number;
+    }) => track("health_check_premium_modal_unlock_clicked", props),
+
+    trackPremiumModalFallbackClicked: (props: {
+      trigger_context: PremiumTriggerContext;
+      fallback_type: PremiumFallbackType;
+      issue_id?: string;
+      mod_count?: number;
+    }) => track("health_check_premium_modal_fallback_clicked", props),
+
+    // Premium banner
+    trackPremiumBannerShown: (props: {
+      context: BannerContext;
+      total_issues: number;
+      issue_id?: string;
+    }) => track("health_check_premium_banner_shown", props),
+
+    trackPremiumBannerClicked: (props: {
+      context: BannerContext;
+      total_issues: number;
+      issue_id?: string;
+    }) => track("health_check_premium_banner_clicked", props),
+
+    // Visibility
+    trackIssueHidden: (props: {
+      issue_id: string;
+      issue_type: IssueType;
+      resolution_type?: ResolutionType;
+    }) => track("health_check_issue_hidden", props),
+
+    trackIssueUnhidden: (props: { issue_id: string; issue_type: IssueType }) =>
+      track("health_check_issue_unhidden", props),
+  };
+};
+
+export type HealthCheckTracker = ReturnType<typeof createHealthCheckTracker>;
+
+export const useHealthCheckTracking = (api: IExtensionApi): HealthCheckTracker =>
+  useMemo(() => createHealthCheckTracker(api), [api]);

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
@@ -3,14 +3,12 @@ import { useMemo } from "react";
 import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
-import type {
-  BannerContext,
-  HealthCheckTab,
-  IssueType,
-  PremiumFallbackType,
-  PremiumTriggerContext,
-  ResolutionType,
-} from "../utils/shared/tracking";
+import type { BannerPlacement } from "../components/premium_banner/PremiumBanner";
+import type { PremiumTrigger } from "../components/premium_modal/PremiumModal";
+import type { HealthCheckTab, IssueType, ResolutionType } from "../utils/shared/tracking";
+
+/** Which free-user fallback the premium modal offered. */
+type PremiumFallbackType = "single_mod_page" | "batch_mod_pages";
 
 /**
  * Build a Health Check analytics event. Returns the app-wide MixpanelEvent shape so it
@@ -159,25 +157,23 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     // Premium modal
     trackPremiumModalShown: (props: {
-      trigger_context: PremiumTriggerContext;
+      trigger: PremiumTrigger;
       issue_id?: string;
       mod_id?: number;
       mod_count?: number;
     }) => track("health_check_premium_modal_shown", props),
 
-    trackPremiumModalDismissed: (props: {
-      trigger_context: PremiumTriggerContext;
-      issue_id?: string;
-    }) => track("health_check_premium_modal_dismissed", props),
+    trackPremiumModalDismissed: (props: { trigger: PremiumTrigger; issue_id?: string }) =>
+      track("health_check_premium_modal_dismissed", props),
 
     trackPremiumModalUnlockClicked: (props: {
-      trigger_context: PremiumTriggerContext;
+      trigger: PremiumTrigger;
       issue_id?: string;
       mod_count?: number;
     }) => track("health_check_premium_modal_unlock_clicked", props),
 
     trackPremiumModalFallbackClicked: (props: {
-      trigger_context: PremiumTriggerContext;
+      trigger: PremiumTrigger;
       fallback_type: PremiumFallbackType;
       issue_id?: string;
       mod_count?: number;
@@ -185,13 +181,13 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     // Premium banner
     trackPremiumBannerShown: (props: {
-      context: BannerContext;
+      placement: BannerPlacement;
       total_issues: number;
       issue_id?: string;
     }) => track("health_check_premium_banner_shown", props),
 
     trackPremiumBannerClicked: (props: {
-      context: BannerContext;
+      placement: BannerPlacement;
       total_issues: number;
       issue_id?: string;
     }) => track("health_check_premium_banner_clicked", props),

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
@@ -48,7 +48,7 @@ const healthCheckEvent = (
 
 /**
  * Centralised Health Check analytics (LAZ-551). One typed surface for every
- * event so components emit intent (`trackIssueExpanded(...)`) instead of building
+ * event so components emit intent (`trackDetailViewed(...)`) instead of building
  * Mixpanel events by hand. game_id / profile_id / user_type ride along as global
  * super properties, so no event repeats them. Consent gating is handled centrally
  * by the analytics extension — callers don't check it.
@@ -83,16 +83,6 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     trackOneClickInstallAllClicked: (props: { issue_count: number; mod_count: number }) =>
       track("health_check_one_click_install_all_clicked", props),
-
-    // Issue list
-    trackIssueExpanded: (
-      props: IssueScope & {
-        issue_type: IssueType;
-        resolution_type: ResolutionType;
-        mod_name: string;
-        position_in_list: number;
-      },
-    ) => track("health_check_issue_expanded", props),
 
     // Detail view
     trackDetailViewed: (
@@ -135,9 +125,6 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
         current_version: string;
       },
     ) => track("health_check_enable_this_version_clicked", props),
-
-    trackEnableAllClicked: (props: IssueScope & { mod_count: number }) =>
-      track("health_check_enable_all_clicked", props),
 
     // Pick flow
     trackPickModInstallClicked: (props: IssueScope & { issue_type: IssueType }) =>

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
@@ -4,6 +4,12 @@ import { openFilePage, openModPage } from "./fileRequirementActions";
 import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
 import type { IFileRequirementCandidate } from "./mapRequirementsReport";
 
+/** A mod reference the analytics callbacks can attribute an event to. */
+export interface ITrackedModRef {
+  modUID: string;
+  modName: string;
+}
+
 // Helpers shared by the requirement cards: the mod-page / file-page open handlers,
 // the mappers that adapt a requirement's domain objects into the base
 // FileRequirement card's props, and the action-context shape threaded to the cards.
@@ -34,6 +40,21 @@ export interface IFileActionContext {
   installButtonAppearance?: "strong" | "moderate";
   /** True while "install all" is running; puts every card's install button into the loading state. */
   isDownloadingAll?: boolean;
+  // Analytics intent — cards emit what the user did; the owner maps it to Mixpanel events.
+  /** 1-click install of a single required candidate. */
+  onInstall: (candidate: IFileRequirementCandidate) => void;
+  /** Picking one of the "OR" alternatives (1-based position within the options). */
+  onPickOption: (candidate: IFileRequirementCandidate, position: number, total: number) => void;
+  /** The group-level "install all" button. */
+  onInstallAll: (candidates: IFileRequirementCandidate[]) => void;
+  /** Opening a candidate's mod page (owner splits install-via vs view by user tier). */
+  onOpenModPage: (candidate: IFileRequirementCandidate) => void;
+  /** Enabling an installed version, optionally switching off the wrong one. */
+  onEnable: (correctFile: IInstalledFile, enabledFile?: IInstalledFile) => void;
+  /** Navigating to a mod in the local mods list. */
+  onViewInMods: (file: ITrackedModRef) => void;
+  /** Installing an already-downloaded file. */
+  onInstallDownloaded: (file: IDownloadedFile) => void;
 }
 
 /** Mod-page / file-page open handlers for a candidate or installed file. */

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { issueTypeForCheck, resolutionTypeForCategory } from "./tracking";
+
+describe("issueTypeForCheck", () => {
+  it("maps the file-level check to warning", () => {
+    expect(issueTypeForCheck("check-file-level-requirements")).toBe("warning");
+  });
+
+  it("maps the mod-level check to suggestion", () => {
+    expect(issueTypeForCheck("check-nexus-mod-requirements")).toBe("suggestion");
+  });
+});
+
+describe("resolutionTypeForCategory", () => {
+  it.each([
+    ["download", "install"],
+    ["install-uninstalled", "install"],
+    ["toggle", "enable"],
+    ["or", "pick"],
+    ["download-replace", "update"],
+  ] as const)("maps %s to %s", (category, expected) => {
+    expect(resolutionTypeForCategory(category)).toBe(expected);
+  });
+});

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
@@ -1,0 +1,51 @@
+import type { HealthCheckId } from "../../types";
+import type { FileRequirementCategory } from "../fileRequirements/fileRequirementReport";
+
+/**
+ * Shared analytics vocabulary for the Health Check tracking events (LAZ-551).
+ * The concrete events are emitted through the useHealthCheckTracking hook.
+ */
+
+/** Confidence band of an issue: file-level requirements are warnings, mod-level are suggestions. */
+export type IssueType = "warning" | "suggestion";
+
+/** The resolution flow an issue offers. */
+export type ResolutionType = "install" | "enable" | "pick" | "update";
+
+/** Which listing tab is active. */
+export type HealthCheckTab = "active" | "hidden";
+
+/** Where a premium prompt was surfaced from. */
+export type PremiumTriggerContext = "single_install" | "batch_install" | "install_all";
+
+/** Which free-user fallback the premium modal offered. */
+export type PremiumFallbackType = "single_mod_page" | "batch_mod_pages";
+
+/** Where the premium banner is shown. */
+export type BannerContext = "list" | "detail";
+
+/**
+ * issue_type for an entry, keyed off the check it belongs to: the file-level
+ * requirements check surfaces higher-confidence warnings, the mod-level check
+ * surfaces lower-confidence suggestions.
+ */
+export const issueTypeForCheck = (checkId: HealthCheckId): IssueType =>
+  checkId === "check-file-level-requirements" ? "warning" : "suggestion";
+
+/**
+ * resolution_type for a file-requirement report category. Mod requirements are
+ * always an install, so callers there pass "install" directly.
+ */
+export const resolutionTypeForCategory = (category: FileRequirementCategory): ResolutionType => {
+  switch (category) {
+    case "toggle":
+      return "enable";
+    case "or":
+      return "pick";
+    case "download-replace":
+      return "update";
+    case "download":
+    case "install-uninstalled":
+      return "install";
+  }
+};

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
@@ -16,6 +16,27 @@ export type ResolutionType = "install" | "enable" | "pick" | "update";
 export type HealthCheckTab = "active" | "hidden";
 
 /**
+ * Which check an issue came from, as a stable analytics name. Deliberately decoupled
+ * from the internal `HealthCheckId` constants so renaming a check id can't silently
+ * break reporting, and it is the discriminator the KPIs split on — `issue_type` only
+ * has two values, so a third check would have to reuse one and collide.
+ */
+export type CheckName = "file_requirements" | "mod_requirements";
+
+/**
+ * Exhaustive by construction: registering a third check widens `HealthCheckId` and
+ * makes this a build error, rather than silently reporting the new check as one of
+ * the existing two.
+ */
+const CHECK_NAMES: Record<HealthCheckId, CheckName> = {
+  "check-file-level-requirements": "file_requirements",
+  "check-nexus-mod-requirements": "mod_requirements",
+};
+
+/** check_id for an entry — the reliable per-check key on every issue-scoped event. */
+export const checkNameForCheck = (checkId: HealthCheckId): CheckName => CHECK_NAMES[checkId];
+
+/**
  * issue_type for an entry, keyed off the check it belongs to: the file-level
  * requirements check surfaces higher-confidence warnings, the mod-level check
  * surfaces lower-confidence suggestions.

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
@@ -15,15 +15,6 @@ export type ResolutionType = "install" | "enable" | "pick" | "update";
 /** Which listing tab is active. */
 export type HealthCheckTab = "active" | "hidden";
 
-/** Where a premium prompt was surfaced from. */
-export type PremiumTriggerContext = "single_install" | "batch_install" | "install_all";
-
-/** Which free-user fallback the premium modal offered. */
-export type PremiumFallbackType = "single_mod_page" | "batch_mod_pages";
-
-/** Where the premium banner is shown. */
-export type BannerContext = "list" | "detail";
-
 /**
  * issue_type for an entry, keyed off the check it belongs to: the file-level
  * requirements check surfaces higher-confidence warnings, the mod-level check

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -1,5 +1,5 @@
 import { mdiArrowLeft } from "@mdi/js";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
@@ -12,6 +12,7 @@ import { PageScroll } from "@/views/components/Page/PageScroll";
 
 import { BetaBadge } from "../components/beta_badge/BetaBadge";
 import { PremiumBanner } from "../components/premium_banner/PremiumBanner";
+import { useHealthCheckTracking } from "../hooks/useHealthCheckTracking";
 import {
   fileRequirementsCheckResult,
   hiddenFileRequirements,
@@ -43,6 +44,24 @@ function HealthCheckDetailPage({
 }: IHealthCheckDetailPageProps) {
   const { t } = useTranslation(["health_check", "common"]);
   const { DetailView } = content;
+
+  // back_clicked fires only on an explicit Back click (not the auto-return below when a
+  // requirement resolves), with the time spent on the detail page.
+  const { trackBackClicked } = useHealthCheckTracking(api);
+  const openedAtRef = useRef(0);
+
+  useEffect(() => {
+    openedAtRef.current = Date.now();
+  }, []);
+
+  const handleBack = () => {
+    trackBackClicked({
+      issue_id: entry.id,
+      time_spent_on_detail_ms: Date.now() - openedAtRef.current,
+    });
+
+    onBack();
+  };
 
   // Re-derive this entry from live state so requirements drop off as the health
   // check re-runs after an install/enable; once it's fully resolved (and no check
@@ -87,7 +106,7 @@ function HealthCheckDetailPage({
           brand="neutral"
           leftIconPath={mdiArrowLeft}
           size="sm"
-          onClick={onBack}
+          onClick={handleBack}
         >
           {t("common:::back")}
         </Button>

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -21,6 +21,7 @@ import {
   modRequirementsCheckResult,
 } from "../selectors";
 import { selectListedEntries } from "../utils/shared/listedEntries";
+import { checkNameForCheck } from "../utils/shared/tracking";
 import type { IHealthCheckContent, IHealthCheckEntry } from "./content/types";
 
 interface IHealthCheckDetailPageProps {
@@ -58,6 +59,7 @@ function HealthCheckDetailPage({
   const handleBack = () => {
     trackBackClicked({
       issue_id: entry.id,
+      check_id: checkNameForCheck(entry.checkId),
       time_spent_on_detail_ms: Date.now() - openedAtRef.current,
     });
 
@@ -121,6 +123,7 @@ function HealthCheckDetailPage({
             api,
             placement: "detail",
             issueId: shownEntry.id,
+            checkId: checkNameForCheck(shownEntry.checkId),
             totalIssues: selectListedEntries(api.getState()).length,
           }}
         />

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   isAnyHealthCheckRunning,
   modRequirementsCheckResult,
 } from "../selectors";
+import { selectListedEntries } from "../utils/shared/listedEntries";
 import type { IHealthCheckContent, IHealthCheckEntry } from "./content/types";
 
 interface IHealthCheckDetailPageProps {
@@ -115,7 +116,14 @@ function HealthCheckDetailPage({
       <PageScroll className="space-y-6 p-6">
         <DetailView api={api} entry={shownEntry} onBack={onBack} />
 
-        <PremiumBanner />
+        <PremiumBanner
+          tracking={{
+            api,
+            placement: "detail",
+            issueId: shownEntry.id,
+            totalIssues: selectListedEntries(api.getState()).length,
+          }}
+        />
       </PageScroll>
     </Page>
   );

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -156,6 +156,7 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
       const warningCount = activeItems.filter(
         (item) => issueTypeForCheck(item.entry.checkId) === "warning",
       ).length;
+
       trackPageViewed({
         active_issue_count: activeItems.length,
         hidden_issue_count: hiddenItems.length,
@@ -380,11 +381,18 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
           activeList
         )}
 
-        <PremiumBanner />
+        <PremiumBanner
+          tracking={{ api, placement: "list", totalIssues: activeCount + hiddenCount }}
+        />
 
         <PremiumModal
           downloadScope="all"
           isOpen={showInstallAllPremium}
+          tracking={{
+            api,
+            trigger: "install_all",
+            modCount: installAllItems.length,
+          }}
           onClose={() => setShowInstallAllPremium(false)}
           onDownload={() => setShowInstallAllPremium(false)}
         />

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -6,18 +6,15 @@ import {
   mdiEyeOff,
   mdiRefresh,
 } from "@mdi/js";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
 import { setOpenMainPage, setSettingsPage } from "@/actions/session";
-import { DisplayOptions } from "@/extensions/gamemode_management/components/DisplayOptions";
-import { Search } from "@/extensions/gamemode_management/components/Search";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IState } from "@/types/IState";
 import { Button } from "@/ui/components/button/Button";
 import { NoResults } from "@/ui/components/no_results/NoResults";
-import { Pictogram } from "@/ui/components/pictogram/Pictogram";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 import { TabBar } from "@/ui/components/tabs/TabBar";
 import { TabButton } from "@/ui/components/tabs/TabButton";
@@ -33,6 +30,7 @@ import { shouldShowPremiumAd } from "../../nexus_integration/selectors";
 import { BetaBadge } from "../components/beta_badge/BetaBadge";
 import { PremiumBanner } from "../components/premium_banner/PremiumBanner";
 import { PremiumModal } from "../components/premium_modal/PremiumModal";
+import { useHealthCheckTracking } from "../hooks/useHealthCheckTracking";
 import {
   fileRequirementsCheckResult,
   hiddenFileRequirements,
@@ -42,6 +40,7 @@ import {
   modRequirementsCheckResult,
 } from "../selectors";
 import { type IListedEntry, selectListedEntries } from "../utils/shared/listedEntries";
+import { type HealthCheckTab, issueTypeForCheck } from "../utils/shared/tracking";
 import { healthCheckContent } from "./content/registry";
 import type { IBulkInstallItem } from "./content/types";
 import HealthCheckDetailPage from "./HealthCheckDetailPage";
@@ -59,24 +58,27 @@ interface IHealthCheckPageProps {
  * per-result lastFullRun subscription re-render only this label. Renders
  * nothing until the first check run of the session.
  */
-function LastUpdated() {
+const LastUpdated = () => {
   const { t } = useTranslation(["health_check", "common"]);
   const lastRun = useSelector(lastHealthCheckRun);
   const time = useRelativeTime(lastRun, t);
+
   if (time === undefined) {
     return null;
   }
+
   return (
     <Typography appearance="subdued" brand="neutral-translucent" typographyType="body-sm">
       {t("listing::last_updated", { time })}
     </Typography>
   );
-}
+};
 
 /** No-choice install items from every check, de-duplicated across checks by key. */
-function collectInstallAllItems(state: IState, api: IExtensionApi): IBulkInstallItem[] {
+const collectInstallAllItems = (state: IState, api: IExtensionApi): IBulkInstallItem[] => {
   const seen = new Set<string>();
   const out: IBulkInstallItem[] = [];
+
   for (const content of Object.values(healthCheckContent)) {
     for (const item of content?.collectInstallAll?.(state, api) ?? []) {
       if (!seen.has(item.key)) {
@@ -85,14 +87,24 @@ function collectInstallAllItems(state: IState, api: IExtensionApi): IBulkInstall
       }
     }
   }
-  return out;
-}
 
-function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheckPageProps) {
+  return out;
+};
+
+const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheckPageProps) => {
   const { t } = useTranslation(["health_check", "common"]);
   const dispatch = useDispatch();
   const [selected, setSelected] = useState<IListedEntry | null>(null);
   const [selectedTab, setSelectedTab] = useState("active");
+
+  const {
+    trackPageViewed,
+    trackPassedViewed,
+    trackTabSwitched,
+    trackHideAllClicked,
+    trackSettingsOpened,
+    trackOneClickInstallAllClicked,
+  } = useHealthCheckTracking(api);
 
   // Clicking the Health check menu item while already on the page returns to
   // the listing (closes any open detail). setSelected is stable, so registering
@@ -134,6 +146,42 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
   const hiddenItems = useMemo(() => items.filter((item) => item.hidden), [items]);
   const supportsHide = useMemo(() => items.some((item) => item.content.supportsHide), [items]);
 
+  // page_viewed fires each time the page becomes active (it stays mounted across
+  // navigation, so key off the active-prop transition rather than mount). lastHealthCheckRun
+  // is read from state rather than subscribed, to avoid re-rendering the page on every scan.
+  const wasActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (active && !wasActiveRef.current) {
+      const warningCount = activeItems.filter(
+        (item) => issueTypeForCheck(item.entry.checkId) === "warning",
+      ).length;
+      trackPageViewed({
+        active_issue_count: activeItems.length,
+        hidden_issue_count: hiddenItems.length,
+        warning_count: warningCount,
+        suggestion_count: activeItems.length - warningCount,
+        last_scan_timestamp: lastHealthCheckRun(api.getState()),
+      });
+    }
+
+    wasActiveRef.current = !!active;
+  }, [active, activeItems, hiddenItems, trackPageViewed, api]);
+
+  // passed_viewed fires when the success/empty state becomes visible — on navigating to
+  // an already-passed page, or when a scan clears the last active issue while viewing.
+  const passedShownRef = useRef(false);
+
+  useEffect(() => {
+    const passed = !!active && !activeItems.length;
+
+    if (passed && !passedShownRef.current) {
+      trackPassedViewed();
+    }
+
+    passedShownRef.current = passed;
+  }, [active, activeItems, trackPassedViewed]);
+
   if (selected) {
     return (
       <HealthCheckDetailPage
@@ -151,6 +199,7 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
 
   const renderRow = (item: IListedEntry) => {
     const { content, entry } = item;
+
     return (
       <content.ListingRow
         api={api}
@@ -163,7 +212,19 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
     );
   };
 
+  const handleTabChange = (tab: string) => {
+    if (tab !== selectedTab) {
+      trackTabSwitched({
+        tab: tab as HealthCheckTab,
+        issue_count_in_tab: tab === "hidden" ? hiddenCount : activeCount,
+      });
+    }
+
+    setSelectedTab(tab);
+  };
+
   const hideAllActive = () => {
+    trackHideAllClicked({ issue_count_hidden: activeItems.length });
     activeItems.forEach((item) => item.content.toggleHide?.(api, item.entry));
   };
 
@@ -175,11 +236,18 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
   // collectInstallAllItems (by key) and again here at execution time via the seen set,
   // so a file shared across multiple source reports is only queued once.
   const installAll = () => {
+    trackOneClickInstallAllClicked({
+      issue_count: activeCount,
+      mod_count: installAllItems.length,
+    });
+
     if (showPremiumAd) {
       setShowInstallAllPremium(true);
       return;
     }
+
     const seen = new Set<string>();
+
     for (const item of installAllItems) {
       if (!seen.has(item.key)) {
         seen.add(item.key);
@@ -236,6 +304,7 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
             size="sm"
             title={t("common:::settings")}
             onClick={() => {
+              trackSettingsOpened();
               dispatch(setOpenMainPage("application_settings", false));
               dispatch(setSettingsPage("Vortex"));
             }}
@@ -249,7 +318,7 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
             tab={selectedTab}
             tabListId="health-check-mods"
             tabType="secondary"
-            onSetSelectedTab={setSelectedTab}
+            onSetSelectedTab={handleTabChange}
           >
             <div className="flex items-center justify-between">
               <TabBar>
@@ -322,6 +391,6 @@ function HealthCheckPage({ api, onRefresh, active, registerReset }: IHealthCheck
       </PageScroll>
     </Page>
   );
-}
+};
 
 export default HealthCheckPage;


### PR DESCRIPTION
Instruments the Health Check feature with Mixpanel analytics per LAZ-551. This is Phase 1 — all UI-driven events (page, mod-requirement path, file-requirement path, premium upsell). Phase 2 (scan lifecycle + install started/completed/failed) will follow in a separate PR.

### What's included

Global context
- Registers the active game (game_id, numeric Nexus id) and profile_id as Mixpanel super properties, cleared when no game is active — so every event carries game/profile scope without per-event plumbing. (game_name intentionally excluded per the data team.)

Tracking hook                                                                                                 
- New useHealthCheckTracking(api) — one typed callback per event, built on a pure createHealthCheckTracker factory (unit-testable without React, and reusable outside components in Phase 2).
- Pure mappers: issueTypeForCheck (file → warning, mod → suggestion) and resolutionTypeForCategory.

Also                                                                                                          
- Fixed the file-requirement 1-click install buttons to use the monitor-download icon (were using the tray icon), matching the mod path.