### PR TITLE
Add Health Check scan and install analytics (LAZ-551, Phase 2)

### DIFF
--- a/src/renderer/src/extensions/health_check/api/index.ts
+++ b/src/renderer/src/extensions/health_check/api/index.ts
@@ -3,11 +3,14 @@
  * Combines all API modules into a single interface
  */
 
-import type { IExtensionApi } from "../../../types/IExtensionContext";
-import type { HealthCheckTrigger } from "../../../types/IHealthCheck";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import { HealthCheckTrigger } from "@/types/IHealthCheck";
+
 import type { HealthCheckRegistry } from "../core/HealthCheckRegistry";
 import type { LegacyTestAdapter } from "../core/LegacyTestAdapter";
+import { createHealthCheckTracker } from "../hooks/useHealthCheckTracking";
 import type { IHealthCheckApi } from "../types";
+import { countActiveIssues } from "../utils/shared/listedEntries";
 import { createCustomCheckApi, type ICustomCheckApi } from "./customCheckApi";
 import { createLegacyApi, type ILegacyApi } from "./legacyApi";
 import { createResultsApi, type IResultsApi } from "./resultsApi";
@@ -21,6 +24,7 @@ export function createHealthCheckApi(
   const customApi = createCustomCheckApi(registry, api);
   const legacyApi = createLegacyApi(legacyAdapter, registry);
   const resultsApi = createResultsApi(registry);
+  const { trackScanCompleted, trackScanTriggered } = createHealthCheckTracker(api);
 
   return {
     custom: customApi,
@@ -34,8 +38,32 @@ export function createHealthCheckApi(
     runAll: async () => {
       return registry.runAllHealthChecks(api);
     },
+    /**
+     * Run the checks registered for a trigger, bracketed by the scan_triggered /
+     * scan_completed analytics events. Every scan funnels through here —
+     * the refresh button, the automatic triggers, and the settings/flag listeners —
+     * so this is the one place the pair can be emitted without double counting.
+     * A run that throws deliberately leaves no scan_completed behind.
+     */
     runChecksByTrigger: async (trigger: HealthCheckTrigger) => {
-      return registry.runChecksByTrigger(trigger, api);
+      trackScanTriggered({
+        is_manual: trigger === HealthCheckTrigger.Manual,
+        previous_issue_count: countActiveIssues(api.getState()).total,
+      });
+
+      const startedAt = Date.now();
+      const results = await registry.runChecksByTrigger(trigger, api);
+      const counts = countActiveIssues(api.getState());
+
+      trackScanCompleted({
+        duration_ms: Date.now() - startedAt,
+        total_issues_found: counts.total,
+        warning_count: counts.warning,
+        suggestion_count: counts.suggestion,
+        health_check_passed: counts.total === 0,
+      });
+
+      return results;
     },
   };
 }

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -149,12 +149,13 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
         <div className="space-y-4">
           <RequirementBody
             api={api}
-            checkId={checkName}
-            issueId={entry.id}
             ctx={{
               api,
               showPremiumAd,
-              requestDownload: (candidate) => downloadFileRequirement(api, candidate),
+              issueId: entry.id,
+              checkId: checkName,
+              requestDownload: (candidate) =>
+                downloadFileRequirement(api, candidate, { issueId: entry.id, checkId: checkName }),
               onInstall: (candidate) =>
                 trackOneClickInstallClicked({
                   issue_id: entry.id,

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -112,7 +112,10 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
       return;
     }
 
-    candidates.forEach((candidate) => void downloadFileRequirement(api, candidate));
+    candidates.forEach(
+      (candidate) =>
+        void downloadFileRequirement(api, candidate, { issueId: entry.id, checkId: checkName }),
+    );
   };
 
   return (
@@ -188,7 +191,13 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                     mod_count: toInstall.length,
                   });
 
-                  toInstall.forEach((req) => void installDownloadedFile(api, req.uninstalledFile));
+                  toInstall.forEach(
+                    (req) =>
+                      void installDownloadedFile(api, req.uninstalledFile, {
+                        issueId: entry.id,
+                        checkId: checkName,
+                      }),
+                  );
                 }}
               >
                 {t("listing::install_uninstalled")}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -16,7 +16,6 @@ import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 import { Typography } from "@/ui/components/typography/Typography";
 
-import type { CheckName } from "../../utils/shared/tracking";
 import { PremiumModal } from "../premium_modal/PremiumModal";
 import { RequirementGroup } from "./RequirementGroup";
 import { DownloadRows } from "./rows/DownloadRows";
@@ -73,15 +72,12 @@ export const RequirementBody = ({
   report,
   ctx,
   api,
-  issueId,
-  checkId,
 }: {
   report: IFileRequirementReport;
   ctx: IFileActionContext;
   api: IExtensionApi;
-  issueId: string;
-  checkId: CheckName;
 }) => {
+  const { issueId, checkId } = ctx;
   const { t } = useTranslation("health_check");
   const [premiumOpen, setPremiumOpen] = useState(false);
   const [downloadingAll, setDownloadingAll] = useState(false);
@@ -110,7 +106,9 @@ export const RequirementBody = ({
     }
     setDownloadingAll(true);
     void Promise.all(
-      installAllCandidates.map((candidate) => downloadFileRequirement(api, candidate)),
+      installAllCandidates.map((candidate) =>
+        downloadFileRequirement(api, candidate, { issueId, checkId }),
+      ),
     ).then((results) => {
       // On full success the requirements clear and this view unmounts; only reset
       // when something failed and the buttons are still around.

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
@@ -27,7 +27,9 @@ export const InstallUninstalledRows = ({
 }) => {
   const { t } = useTranslation("health_check");
   const file = requirement.uninstalledFile;
-  const { isLoading, onClick } = useInstallButton(() => installDownloadedFile(ctx.api, file));
+  const { isLoading, onClick } = useInstallButton(() =>
+    installDownloadedFile(ctx.api, file, { issueId: ctx.issueId, checkId: ctx.checkId }),
+  );
 
   const handleInstall = () => {
     ctx.onInstallDownloaded(file);

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -34,6 +34,9 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const { t } = useTranslation(["health_check", "common"]);
   const mod = entry.data as IModRequirementExt;
 
+  const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
+
   const {
     givenFeedback,
     showPremiumAd,
@@ -43,7 +46,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     installInApp,
     handlePositiveFeedback,
     handleFeedbackSuccess,
-  } = useModRequirementActions(api, mod, onBack);
+  } = useModRequirementActions(api, mod, { issueId: entry.id, checkId: checkName }, onBack);
 
   const hiddenRequirementMap = useSelector(hiddenModRequirements);
   const isHidden = useMemo(
@@ -60,8 +63,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     trackIssueHidden,
     trackIssueUnhidden,
   } = useHealthCheckTracking(api);
-  const issueType = issueTypeForCheck(entry.checkId);
-  const checkName = checkNameForCheck(entry.checkId);
   const modVersion = mod.mainFile?.version ?? "";
 
   // detail_viewed fires once per detail open; entry-prop changes as the check re-runs

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -18,6 +18,9 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   const { t } = useTranslation(["health_check", "common"]);
   const mod = entry.data as IModRequirementExt;
 
+  const issueType = issueTypeForCheck(entry.checkId);
+  const checkName = checkNameForCheck(entry.checkId);
+
   const {
     givenFeedback,
     showPremiumAd,
@@ -27,10 +30,8 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     installInApp,
     handlePositiveFeedback,
     handleFeedbackSuccess,
-  } = useModRequirementActions(api, mod);
+  } = useModRequirementActions(api, mod, { issueId: entry.id, checkId: checkName });
 
-  const issueType = issueTypeForCheck(entry.checkId);
-  const checkName = checkNameForCheck(entry.checkId);
   const { trackOneClickInstallClicked, trackIssueHidden, trackIssueUnhidden } =
     useHealthCheckTracking(api);
 

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.test.ts
@@ -86,6 +86,30 @@ describe("createHealthCheckTracker", () => {
     expect(events[0].properties).not.toHaveProperty("check_id");
   });
 
+  it("emits the scan lifecycle pair", () => {
+    const { tracker, events } = harness();
+    tracker.trackScanTriggered({ is_manual: true, previous_issue_count: 4 });
+    tracker.trackScanCompleted({
+      duration_ms: 1200,
+      total_issues_found: 2,
+      warning_count: 1,
+      suggestion_count: 1,
+      health_check_passed: false,
+    });
+    expect(events.map((e) => e.eventName)).toEqual([
+      "health_check_scan_triggered",
+      "health_check_scan_completed",
+    ]);
+    expect(events[0].properties).toEqual({ is_manual: true, previous_issue_count: 4 });
+  });
+
+  it("omits issue_id from install events when the install isn't tied to one issue", () => {
+    const { tracker, events } = harness();
+    tracker.trackInstallStarted({ mod_id: 42, mod_name: "SkyUI", mod_version: "5.2" });
+    expect(events[0].eventName).toBe("health_check_install_started");
+    expect(events[0].properties).not.toHaveProperty("issue_id");
+  });
+
   it("strips undefined optional properties", () => {
     const { tracker, events } = harness();
     tracker.trackPremiumModalShown({ trigger: "single_install" });

--- a/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useHealthCheckTracking.ts
@@ -73,6 +73,19 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     trackPassedViewed: () => track("health_check_passed_viewed"),
 
+    // Scan lifecycle. Emitted by the non-React api layer around every check run,
+    // manual (refresh button) or automatic (game / profile / mods / settings change).
+    trackScanTriggered: (props: { is_manual: boolean; previous_issue_count: number }) =>
+      track("health_check_scan_triggered", props),
+
+    trackScanCompleted: (props: {
+      duration_ms: number;
+      total_issues_found: number;
+      warning_count: number;
+      suggestion_count: number;
+      health_check_passed: boolean;
+    }) => track("health_check_scan_completed", props),
+
     trackTabSwitched: (props: { tab: HealthCheckTab; issue_count_in_tab: number }) =>
       track("health_check_tab_switched", props),
 
@@ -106,6 +119,27 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
         is_adult_content: boolean;
       },
     ) => track("health_check_one_click_install_clicked", props),
+
+    // Install lifecycle, bracketing the actual download + install a health-check action
+    // kicks off (see trackedInstall). The app-wide mods_installation_* events cover the
+    // install itself for every source; these are the health-check funnel's own view of it,
+    // carrying the issue scope and spanning the download too. The scope is optional
+    // because the actions stay callable without analytics context.
+    trackInstallStarted: (
+      props: OptionalIssueScope & { mod_id: number; mod_name: string; mod_version: string },
+    ) => track("health_check_install_started", props),
+
+    trackInstallCompleted: (
+      props: OptionalIssueScope & {
+        mod_id: number;
+        mod_name: string;
+        mod_version: string;
+        duration_ms: number;
+      },
+    ) => track("health_check_install_completed", props),
+
+    trackInstallFailed: (props: OptionalIssueScope & { mod_id: number; error_reason: string }) =>
+      track("health_check_install_failed", props),
 
     trackInstallDownloadedClicked: (props: IssueScope & { mod_id: number; mod_count: number }) =>
       track("health_check_install_downloaded_clicked", props),

--- a/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
@@ -10,6 +10,7 @@ import { shouldShowPremiumAd } from "../../nexus_integration/selectors";
 import { setFeedbackGiven } from "../actions/persistent";
 import { feedbackGivenMap } from "../selectors";
 import type { IModRequirementExt } from "../types";
+import type { IInstallContext } from "../utils/shared/installTracking";
 
 /**
  * Shared action logic for a single mod requirement, used by both the listing row
@@ -17,13 +18,18 @@ import type { IModRequirementExt } from "../types";
  * analytics + the negative-reason modal), and opening the mod page. Keeps the two
  * call sites behaviourally identical.
  *
- * `onInstalled` runs after a successful install (e.g. navigate back from detail).
+ * `tracking` is the listing entry the mod belongs to, attributed to the install funnel
+ * events. `onInstalled` runs after a successful install (e.g. navigate back from detail).
  */
 export function useModRequirementActions(
   api: IExtensionApi,
   mod: IModRequirementExt,
+  tracking: IInstallContext,
   onInstalled?: () => void,
 ) {
+  // Destructured so the install callback depends on stable primitives rather than the
+  // caller's per-render `tracking` literal.
+  const { issueId, checkId } = tracking;
   const [showPremiumModal, setShowPremiumModal] = useState(false);
 
   const feedbackMap = useSelector(feedbackGivenMap);
@@ -47,9 +53,9 @@ export function useModRequirementActions(
       setShowPremiumModal(true);
       return;
     }
-    await onDownloadRequirement(api, mod);
+    await onDownloadRequirement(api, mod, undefined, { issueId, checkId });
     onInstalled?.();
-  }, [api, mod, showPremiumAd, onInstalled]);
+  }, [api, mod, issueId, checkId, showPremiumAd, onInstalled]);
 
   const handlePositiveFeedback = useCallback(() => {
     api.store?.dispatch(setFeedbackGiven(mod.requiredBy.modId, mod.id));

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
@@ -1,5 +1,6 @@
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
+import type { CheckName } from "../shared/tracking";
 import { openFilePage, openModPage } from "./fileRequirementActions";
 import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
 import type { IFileRequirementCandidate } from "./mapRequirementsReport";
@@ -34,6 +35,9 @@ export interface IFileRequirementData {
 export interface IFileActionContext {
   api: IExtensionApi;
   showPremiumAd: boolean;
+  /** The issue these cards resolve, and the check that surfaced it, for the analytics events. */
+  issueId: string;
+  checkId: CheckName;
   /** Download a candidate, opening the premium upsell first for free users. Resolves to whether a download ran. */
   requestDownload: (candidate: IFileRequirementCandidate) => Promise<boolean>;
   /** Appearance for a card's install button; demoted to "moderate" when an "install all" is shown. */

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -9,6 +9,7 @@ import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { opn, renderModName, sanitizeCSSId } from "@/util/api";
 
+import { type IInstallContext, trackedInstall } from "../shared/installTracking";
 import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
 import type { IFileRequirementCandidate } from "./mapRequirementsReport";
 
@@ -43,6 +44,7 @@ function modPageUrl(ref: INexusFileRef): string | undefined {
 export async function downloadFileRequirement(
   api: IExtensionApi,
   candidate: IFileRequirementCandidate,
+  context?: IInstallContext,
 ): Promise<boolean> {
   if (shouldShowPremiumAd(api.getState())) {
     openFilePage(api, candidate);
@@ -66,25 +68,38 @@ export async function downloadFileRequirement(
   const nxmUrl = `nxm://${domain}/mods/${mod.id}/files/${file.id}`;
 
   try {
-    const dlId = await new Promise<string>((resolve, reject) =>
-      api.events.emit(
-        "start-download",
-        [nxmUrl],
-        { game: internalGameId, name: candidate.fileName, fileId: file.id, modId: mod.id },
-        undefined,
-        (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
-        undefined,
-        { allowInstall: false },
-      ),
-    );
+    await trackedInstall(
+      api,
+      {
+        issue_id: context?.issueId,
 
-    await new Promise<string>((resolve, reject) =>
-      api.events.emit(
-        "start-install-download",
-        dlId,
-        { allowAutoEnable: true },
-        (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
-      ),
+        check_id: context?.checkId,
+        mod_id: mod.id,
+        mod_name: candidate.modName,
+        mod_version: candidate.version,
+      },
+      async () => {
+        const dlId = await new Promise<string>((resolve, reject) =>
+          api.events.emit(
+            "start-download",
+            [nxmUrl],
+            { game: internalGameId, name: candidate.fileName, fileId: file.id, modId: mod.id },
+            undefined,
+            (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
+            undefined,
+            { allowInstall: false },
+          ),
+        );
+
+        await new Promise<string>((resolve, reject) =>
+          api.events.emit(
+            "start-install-download",
+            dlId,
+            { allowAutoEnable: true },
+            (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
+          ),
+        );
+      },
     );
 
     return true;
@@ -105,21 +120,37 @@ export async function downloadFileRequirement(
 export async function installDownloadedFile(
   api: IExtensionApi,
   file: IDownloadedFile,
+  context?: IInstallContext,
 ): Promise<boolean> {
   try {
-    await new Promise<string>((resolve, reject) =>
-      api.events.emit(
-        "start-install-download",
-        file.downloadId,
-        { allowAutoEnable: true },
-        (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
-      ),
+    await trackedInstall(
+      api,
+      {
+        issue_id: context?.issueId,
+
+        check_id: context?.checkId,
+        mod_id: decodeUID(file.modUID)?.id ?? 0,
+        mod_name: file.modName,
+        mod_version: file.version,
+      },
+      async () => {
+        await new Promise<string>((resolve, reject) =>
+          api.events.emit(
+            "start-install-download",
+            file.downloadId,
+            { allowAutoEnable: true },
+            (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
+          ),
+        );
+      },
     );
+
     return true;
   } catch (err) {
     api.showErrorNotification(`Failed to install requirement: ${file.modName}`, err, {
       allowReport: false,
     });
+
     return false;
   }
 }

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
@@ -8,6 +8,7 @@ import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IGame } from "@/types/IGame";
 import { getGame, toPromise } from "@/util/api";
 
+import { type IInstallContext, trackedInstall } from "../shared/installTracking";
 import { getModFilesWithCache } from "./modFiles";
 
 /**
@@ -17,6 +18,7 @@ export async function onDownloadRequirement(
   api: IExtensionApi,
   mod: IModRequirementExt,
   file?: IModFileInfo,
+  context?: IInstallContext,
 ): Promise<void> {
   if (!Number.isInteger(mod.modId) || mod.modId <= 0) {
     api.showErrorNotification(
@@ -65,25 +67,38 @@ export async function onDownloadRequirement(
   // so the file lands in the same folder the install handler later looks in.
   const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
 
-  const dlId = await toPromise<string>((cb) =>
-    api.events.emit(
-      "start-download",
-      [nxmUrl],
-      { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
-      undefined,
-      cb,
-      undefined,
-      { allowInstall: false },
-    ),
-  );
+  await trackedInstall(
+    api,
+    {
+      issue_id: context?.issueId,
 
-  const installedModId = await toPromise<string>((cb) =>
-    api.events.emit(
-      "start-install-download",
-      dlId,
-      { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
-      cb,
-    ),
+      check_id: context?.checkId,
+      mod_id: modId,
+      mod_name: mod.modName,
+      mod_version: targetFile.version,
+    },
+    async () => {
+      const dlId = await toPromise<string>((cb) =>
+        api.events.emit(
+          "start-download",
+          [nxmUrl],
+          { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
+          undefined,
+          cb,
+          undefined,
+          { allowInstall: false },
+        ),
+      );
+
+      await toPromise<string>((cb) =>
+        api.events.emit(
+          "start-install-download",
+          dlId,
+          { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
+          cb,
+        ),
+      );
+    },
   );
 
   api.sendNotification({

--- a/src/renderer/src/extensions/health_check/utils/shared/installTracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/installTracking.ts
@@ -1,0 +1,62 @@
+import { classifyErrorCode } from "@/extensions/analytics/mixpanel/error-code";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+
+import { createHealthCheckTracker } from "../../hooks/useHealthCheckTracking";
+import type { CheckName } from "./tracking";
+
+/**
+ * The issue an install action resolves, and the check that surfaced it. Threaded from the
+ * listing row / detail view that started it down to the action, which is where the funnel
+ * events are emitted. Optional throughout: the actions stay usable without analytics context.
+ */
+export interface IInstallContext {
+  issueId: string;
+  checkId: CheckName;
+}
+
+/** The mod being installed, as every health_check_install_* event identifies it. */
+export interface IInstallIdentity {
+  /** The issue scope. Absent only where an action isn't tied to one issue. */
+  issue_id?: string;
+  check_id?: CheckName;
+  mod_id: number;
+  mod_name: string;
+  mod_version: string;
+}
+
+/**
+ * Bracket a health-check-initiated install with the install_started / install_completed /
+ * install_failed funnel events (LAZ-551).
+ *
+ * `run` should cover only the work that follows the user committing to the install — past
+ * the premium gate and any id resolution — so a free user being routed to the website, or
+ * a requirement with unusable ids, doesn't register as a failed install. Failures are
+ * reported with the same low-cardinality tokens as the app-wide mods_installation_failed
+ * event, and are re-thrown so callers keep owning the user-facing error handling.
+ */
+export const trackedInstall = async (
+  api: IExtensionApi,
+  identity: IInstallIdentity,
+  run: () => Promise<void>,
+): Promise<void> => {
+  const { trackInstallCompleted, trackInstallFailed, trackInstallStarted } =
+    createHealthCheckTracker(api);
+  const startedAt = Date.now();
+
+  trackInstallStarted(identity);
+
+  try {
+    await run();
+  } catch (err) {
+    trackInstallFailed({
+      issue_id: identity.issue_id,
+      check_id: identity.check_id,
+      mod_id: identity.mod_id,
+      error_reason: classifyErrorCode(err),
+    });
+
+    throw err;
+  }
+
+  trackInstallCompleted({ ...identity, duration_ms: Date.now() - startedAt });
+};

--- a/src/renderer/src/extensions/health_check/utils/shared/listedEntries.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/listedEntries.ts
@@ -2,6 +2,7 @@ import type { IState } from "@/types/IState";
 
 import { healthCheckContent } from "../../views/content/registry";
 import type { IHealthCheckContent, IHealthCheckEntry } from "../../views/content/types";
+import { issueTypeForCheck } from "./tracking";
 
 /** One listing entry paired with the content provider that owns it. */
 export interface IListedEntry {
@@ -23,3 +24,26 @@ export const selectListedEntries = (state: IState): IListedEntry[] => {
   }
   return items;
 };
+
+/** Issue totals split by confidence band, as the page and scan events report them. */
+export interface IIssueCounts {
+  total: number;
+  warning: number;
+  suggestion: number;
+}
+
+/** Split a set of listing entries into warning / suggestion totals. */
+export const countIssues = (items: IListedEntry[]): IIssueCounts => {
+  const warning = items.filter(
+    (item) => issueTypeForCheck(item.entry.checkId) === "warning",
+  ).length;
+
+  return { total: items.length, warning, suggestion: items.length - warning };
+};
+
+/**
+ * Counts for the issues the user actually sees — hidden entries excluded, so a fully
+ * dismissed loadout reports the same "passed" the listing shows.
+ */
+export const countActiveIssues = (state: IState): IIssueCounts =>
+  countIssues(selectListedEntries(state).filter((item) => !item.hidden));

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -39,8 +39,8 @@ import {
   lastHealthCheckRun,
   modRequirementsCheckResult,
 } from "../selectors";
-import { type IListedEntry, selectListedEntries } from "../utils/shared/listedEntries";
-import { type HealthCheckTab, issueTypeForCheck } from "../utils/shared/tracking";
+import { countIssues, type IListedEntry, selectListedEntries } from "../utils/shared/listedEntries";
+import type { HealthCheckTab } from "../utils/shared/tracking";
 import { healthCheckContent } from "./content/registry";
 import type { IBulkInstallItem } from "./content/types";
 import HealthCheckDetailPage from "./HealthCheckDetailPage";
@@ -153,15 +153,13 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
 
   useEffect(() => {
     if (active && !wasActiveRef.current) {
-      const warningCount = activeItems.filter(
-        (item) => issueTypeForCheck(item.entry.checkId) === "warning",
-      ).length;
+      const counts = countIssues(activeItems);
 
       trackPageViewed({
-        active_issue_count: activeItems.length,
+        active_issue_count: counts.total,
         hidden_issue_count: hiddenItems.length,
-        warning_count: warningCount,
-        suggestion_count: activeItems.length - warningCount,
+        warning_count: counts.warning,
+        suggestion_count: counts.suggestion,
         last_scan_timestamp: lastHealthCheckRun(api.getState()),
       });
     }

--- a/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
@@ -3,6 +3,7 @@ import {
   installDownloadedFile,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
+  categoryOf,
   downloadCandidates,
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
@@ -10,10 +11,12 @@ import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IState } from "@/types/IState";
 
 import { setFileRequirementHidden } from "../../actions/persistent";
+import { FILE_REQUIREMENTS_CHECK_ID } from "../../checks/fileRequirementsCheck";
 import { DetailView } from "../../components/file_requirement/DetailView";
 import { ListingRow } from "../../components/file_requirement/ListingRow";
 import { fileRequirementsCheckResult, hiddenFileRequirements } from "../../selectors";
-import { isFileEntryHidden, pushReportEntries } from "./fileRequirementEntries";
+import { checkNameForCheck } from "../../utils/shared/tracking";
+import { fileEntryId, isFileEntryHidden, pushReportEntries } from "./fileRequirementEntries";
 import type { IBulkInstallItem, IHealthCheckContent, IHealthCheckEntry } from "./types";
 
 export const fileRequirementsContent: IHealthCheckContent = {
@@ -60,22 +63,27 @@ export const fileRequirementsContent: IHealthCheckContent = {
     }
     const hiddenMap = hiddenFileRequirements(state);
     const items: IBulkInstallItem[] = [];
+    const checkId = checkNameForCheck(FILE_REQUIREMENTS_CHECK_ID);
     for (const source of Object.values(result)) {
       const hidden = new Set(hiddenMap[source.sourceFileUID] ?? []);
       for (const requirement of source.requirements) {
         if (hidden.has(requirement.requirementDefId)) {
           continue;
         }
+        // The listing splits a source file's requirements per category, so the issue an
+        // install belongs to is the entry for this requirement's own category.
+        const issueId = fileEntryId(source.sourceFileUID, categoryOf(requirement));
         for (const candidate of downloadCandidates([requirement])) {
           items.push({
             key: candidate.fileUID,
-            install: () => void downloadFileRequirement(api, candidate),
+            install: () => void downloadFileRequirement(api, candidate, { issueId, checkId }),
           });
         }
         if (requirement.kind === "correct-version-uninstalled") {
           items.push({
             key: requirement.uninstalledFile.fileUID,
-            install: () => void installDownloadedFile(api, requirement.uninstalledFile),
+            install: () =>
+              void installDownloadedFile(api, requirement.uninstalledFile, { issueId, checkId }),
           });
         }
       }

--- a/src/renderer/src/extensions/health_check/views/content/ModRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/ModRequirementsContent.tsx
@@ -8,13 +8,14 @@ import { DetailView } from "../../components/mod_requirement/DetailView";
 import { ListingRow } from "../../components/mod_requirement/ListingRow";
 import { allModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
-import { isModHidden } from "./modRequirementEntries";
+import { checkNameForCheck } from "../../utils/shared/tracking";
+import { isModHidden, modEntryId } from "./modRequirementEntries";
 import type { IBulkInstallItem, IHealthCheckContent } from "./types";
 
 export const modRequirementsContent: IHealthCheckContent = {
   selectEntries: (state) =>
     allModRequirements(state).map((mod) => ({
-      id: `${mod.requiredBy.modId}-${mod.uid || `${mod.gameId}-${mod.modId || mod.modName}`}`,
+      id: modEntryId(mod),
       checkId: MOD_REQUIREMENTS_CHECK_ID,
       severity: "suggestion",
       data: mod,
@@ -36,7 +37,10 @@ export const modRequirementsContent: IHealthCheckContent = {
       .map((mod) => ({
         key: mod.uid || `${mod.gameId}-${mod.modId}`,
         install: () => {
-          void onDownloadRequirement(api, mod);
+          void onDownloadRequirement(api, mod, undefined, {
+            issueId: modEntryId(mod),
+            checkId: checkNameForCheck(MOD_REQUIREMENTS_CHECK_ID),
+          });
         },
       })),
 };

--- a/src/renderer/src/extensions/health_check/views/content/fileRequirementEntries.ts
+++ b/src/renderer/src/extensions/health_check/views/content/fileRequirementEntries.ts
@@ -25,6 +25,17 @@ export const isFileEntryHidden = (
   );
 };
 
+/**
+ * Listing-entry id for one source file's requirements of a given category — also the
+ * issue_id the analytics events report, so the bulk-install path can attribute an install
+ * to the same entry the listing shows.
+ */
+export const fileEntryId = (
+  sourceFileUID: string,
+  category: FileRequirementCategory,
+  hidden = false,
+): string => `${sourceFileUID}:${category}${hidden ? "::hidden" : ""}`;
+
 /** Group one source file's (visible or hidden) requirements into per-category report entries. */
 export const pushReportEntries = (
   entries: IHealthCheckEntry[],
@@ -33,9 +44,11 @@ export const pushReportEntries = (
   hidden: boolean,
 ): void => {
   const byCategory = new Map<FileRequirementCategory, IFileRequirement[]>();
+
   for (const requirement of requirements) {
     const category = categoryOf(requirement);
     const bucket = byCategory.get(category);
+
     if (bucket) {
       bucket.push(requirement);
     } else {
@@ -45,7 +58,7 @@ export const pushReportEntries = (
 
   for (const [category, reqs] of byCategory) {
     entries.push({
-      id: `${source.sourceFileUID}:${category}${hidden ? "::hidden" : ""}`,
+      id: fileEntryId(source.sourceFileUID, category, hidden),
       checkId: FILE_REQUIREMENTS_CHECK_ID,
       severity: "warning",
       data: {

--- a/src/renderer/src/extensions/health_check/views/content/modRequirementEntries.ts
+++ b/src/renderer/src/extensions/health_check/views/content/modRequirementEntries.ts
@@ -1,6 +1,13 @@
 import { hiddenModRequirements } from "../../selectors";
 import type { IModRequirementExt } from "../../types";
 
+/**
+ * Listing-entry id for a mod requirement — also the issue_id the analytics events report,
+ * so the bulk-install path can attribute an install to the same entry the listing shows.
+ */
+export const modEntryId = (mod: IModRequirementExt): string =>
+  `${mod.requiredBy.modId}-${mod.uid || `${mod.gameId}-${mod.modId || mod.modName}`}`;
+
 export const isModHidden = (
   state: Parameters<typeof hiddenModRequirements>[0],
   mod: IModRequirementExt,


### PR DESCRIPTION
## Summary

Phase 2 of the Health Check Mixpanel instrumentation (LAZ-551): the scan lifecycle and install funnel events.

**Stacked on #23790** — base is `laz-551`, so this diff is Phase 2 only. Merge #23790 first.

### Scan lifecycle

- `health_check_scan_triggered` — `is_manual`, `previous_issue_count`
- `health_check_scan_completed` — `duration_ms`, `total_issues_found`, `warning_count`, `suggestion_count`, `health_check_passed`

Emitted from `createHealthCheckApi`'s `runChecksByTrigger`, the single funnel every scan passes through (refresh button, automatic triggers, settings/flag listeners), so manual and automatic runs are counted exactly once. A run that throws deliberately leaves no `scan_completed` behind.

Counts come from new `countIssues` / `countActiveIssues` helpers and **exclude hidden entries**, so `health_check_passed` agrees with the "Health check passed" empty state rather than contradicting it when everything has been dismissed. `page_viewed` now reuses `countIssues` instead of its own inline warning count.

### Install funnel

- `health_check_install_started` / `_completed` (+ `duration_ms`) / `_failed` (`error_reason`)

New `trackedInstall(api, identity, run)` brackets an install and rethrows, so callers keep owning their error notifications. Two deliberate choices:

- `run` wraps only post-premium-gate work, so a free user redirected to the website is **not** recorded as a failed install.
- `error_reason` reuses the existing `classifyErrorCode`, giving the same low-cardinality tokens as `mods_installation_failed` — no raw error messages or filesystem paths reach Mixpanel.

`issue_id` reaches all eight install call sites: `issueId` added to `IFileActionContext`, plus extracted `fileEntryId()` / `modEntryId()` helpers so the bulk "install all" paths attribute to the same entry id the listing shows.

### Relationship to `mods_installation_*`

These coexist with the app-wide events by design rather than replacing them. `mods_installation_*` fires per-archive from `InstallManager` for every install source; these carry `issue_id`, span the download as well as the install, and cover only health-check-initiated actions.
