### PR TITLE
collection installs wedge when optional members need no download (LAZ-843)

### DIFF
--- a/src/renderer/src/actions/collectionInstallTracking.ts
+++ b/src/renderer/src/actions/collectionInstallTracking.ts
@@ -35,6 +35,11 @@ export const finishInstallSession = createAction(
   (sessionId: string, success: boolean) => ({ sessionId, success }),
 );
 
+export const markSessionStalled = createAction(
+  "COLLECTION_MARK_SESSION_STALLED",
+  (sessionId: string, stalled: boolean) => ({ sessionId, stalled }),
+);
+
 export const clearOldSessions = createAction(
   "COLLECTION_CLEAR_OLD_SESSIONS",
   (daysOld: number) => ({ daysOld }),

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -17,6 +17,7 @@ import {
   getCollectionActiveSession,
   getCollectionInstallProgress,
   getFailedRequiredMods,
+  isActiveSessionStalled,
 } from "../../../util/collectionInstallSessionSelectors";
 import {
   reconstructSessionMods,
@@ -1051,11 +1052,13 @@ class InstallDriver {
       this.mApi.dismissNotification(INSTALLING_NOTIFICATION_ID + this.mCollection.id);
     }
 
-    // completed = every required member installed; failed = finished with required
-    // failures (partial). Both reach here via the review step; the count comes from
-    // the session SSOT while the collection is still set (before teardown below).
+    // completed = every required member installed; failed = finished with required failures
+    // (partial) or force-resolved by the stall watchdog. Both reach here via the review step; the
+    // state comes from the session SSOT while the collection is still set (before teardown below).
     const outcome: CollectionInstallOutcome =
-      this.isInstallComplete(true) && getFailedRequiredMods(this.mApi.getState()).length === 0
+      this.isInstallComplete(true) &&
+      getFailedRequiredMods(this.mApi.getState()).length === 0 &&
+      !isActiveSessionStalled(this.mApi.getState())
         ? "completed"
         : "failed";
     this.completeInstallationTracking(outcome);

--- a/src/renderer/src/extensions/collections/views/InstallDialog/InstallFinishedDialog.tsx
+++ b/src/renderer/src/extensions/collections/views/InstallDialog/InstallFinishedDialog.tsx
@@ -18,6 +18,7 @@ import type { IState } from "../../../../types/IState";
 import {
   getFailedOptionalMods,
   getFailedRequiredMods,
+  isActiveSessionStalled,
 } from "../../../../util/collectionInstallSessionSelectors";
 import { NAMESPACE } from "../../constants";
 import type InstallDriver from "../../util/InstallDriver";
@@ -131,9 +132,11 @@ function InstallFinishedDialog(props: IInstallFinishedDialogProps) {
   // any required member failed the collection isn't fully installed, so the dialog switches to an
   // "incomplete" variant: reworded copy, a "View failed mods" action, and the optional-mods / clone
   // actions suppressed - there's no point offering to add optional mods on top of a broken required
-  // set.
+  // set. A session force-resolved by the stall watchdog is incomplete regardless of which members
+  // it failed: those failures are by fiat, not the outcome of real install attempts.
   const failedRequired = useSelector<IState, ICollectionModInstallInfo[]>(getFailedRequiredMods);
-  const hasFailures = failedRequired.length > 0;
+  const stalled = useSelector<IState, boolean>(isActiveSessionStalled);
+  const hasFailures = failedRequired.length > 0 || stalled;
 
   // Optional members the user SELECTED that then failed. A failed optional annotates the result but
   // does not make the collection "incomplete" (that is driven by failedRequired), so it never

--- a/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Collection-install completion for a selected optional whose archive is already on disk - what a
+ * resumed install produces, since reconstructModStatus maps such a member to "downloaded".
+ *
+ * The member sits at OPTIONAL_PHASE and fires no download event, so the trailing phase has to be
+ * admitted to the walk on its own. Without that the gate stays at phase 0, nothing installs or
+ * settles the member, and the install cannot complete.
+ *
+ * Pins both halves of the contract: the phase becomes reachable, and admitting it does not let
+ * optionals overtake required members. Regression cover for LAZ-843.
+ */
+import { describe, expect, vi } from "vitest";
+
+import {
+  makeDownload,
+  makeInstallState,
+  makeMod,
+  makeModInstallInfo,
+  makeProfile,
+  makeReference,
+  makeRule,
+  makeSession,
+} from "../../test-utils/builders";
+import type { IDriverHarnessState, IInstallManagerHarness } from "../../test-utils/harnessTypes";
+import { test as imTest } from "../../test-utils/installManagerTest";
+import { generateCollectionSessionId, modRuleId } from "../../util/collectionInstallSession";
+import { getCollectionInstallProgress } from "../../util/collectionInstallSessionSelectors";
+import { MOD_TYPE } from "../collections/constants";
+import type InstallManager from "./InstallManager";
+import { OPTIONAL_PHASE } from "./util/rulePhase";
+
+vi.mock("../../util/log", () => {
+  const log = vi.fn();
+  return { default: log, log };
+});
+
+const GAME = "skyrimse";
+const PROFILE = "prof-1";
+const COLLECTION = "col-1";
+
+// the private phase-engine entry points the completion poll drives on every tick / on stall rescue
+interface IManagerInternals {
+  reQueueDownloadedMods: (
+    api: unknown,
+    sourceModId: string,
+    allMods: unknown[],
+    currentPhase: number,
+  ) => void;
+  checkCollectionPhaseStatus: (
+    api: unknown,
+    sourceModId: string,
+    phase: number,
+  ) => { phaseComplete: boolean; needsRequeue: boolean; allMods: unknown[] };
+  driveSelectedOptionals: (api: unknown, sourceModId: string) => void;
+  admitSettledOptionalPhase: (sourceModId: string, api: unknown) => void;
+  pollAllPhasesComplete: (api: unknown, sourceModId: string) => Promise<void>;
+  mDependencyInstalls: Record<string, () => void>;
+  maybeAdvancePhase: (sourceModId: string, api: unknown) => void;
+  getTerminalModCount: (api: unknown, sourceModId: string) => number;
+}
+
+const internals = (manager: InstallManager): IManagerInternals =>
+  manager as unknown as IManagerInternals;
+
+const requiredRule = makeRule({
+  type: "requires",
+  reference: makeReference({ tag: "req-a", gameId: GAME }),
+});
+
+// selected by the user - ignored:false is what installRecommended persists - so it counts toward
+// completion, and its archive is already in the download folder
+const taggedOptionalRule = makeRule({
+  type: "recommends",
+  reference: makeReference({ tag: "opt-a", gameId: GAME }),
+  ignored: false,
+});
+
+// the same member without a reference tag, resolvable only by md5
+const md5OnlyOptionalRule = makeRule({
+  type: "recommends",
+  reference: makeReference({ tag: undefined, gameId: GAME, fileMD5: "md5-opt-a" }),
+  ignored: false,
+});
+
+/**
+ * A resumed install with the required member terminal, the selected optional reconstructed as
+ * "downloaded", and phase 0 complete, deployed and allowed.
+ */
+function makeParkedInstall(
+  makeInstallManager: (overrides?: Partial<IDriverHarnessState>) => IInstallManagerHarness,
+  opts: {
+    optional?: "downloaded" | "pending";
+    required?: "installed" | "downloaded";
+    // false models a member the advance-scan cannot resolve: no reference tag, md5 only
+    optionalTagged?: boolean;
+    // true models a round that gathered no dependencies at all, so phase state was never set up
+    uninitialisedPhase?: boolean;
+  } = {},
+) {
+  const {
+    optional: optionalStatus = "downloaded",
+    required: requiredStatus = "installed",
+    optionalTagged = true,
+    uninitialisedPhase = false,
+  } = opts;
+  const optionalRule = optionalTagged ? taggedOptionalRule : md5OnlyOptionalRule;
+  const sessionId = generateCollectionSessionId(COLLECTION, PROFILE);
+
+  const h = makeInstallManager({
+    profiles: { [PROFILE]: makeProfile({ id: PROFILE, gameId: GAME }) },
+    mods: {
+      [GAME]: {
+        [COLLECTION]: makeMod({
+          id: COLLECTION,
+          type: MOD_TYPE,
+          rules: [requiredRule, optionalRule],
+          attributes: { collectionId: 1 },
+        }),
+        // the required member, already installed and therefore terminal
+        "inst-req-a": makeMod({
+          id: "inst-req-a",
+          state: "installed",
+          attributes: { referenceTag: "req-a", installedAsDependency: true },
+        }),
+      },
+    },
+    downloads: {
+      // already on disk, so no download event will fire for it. A non-zero size matters: it is what
+      // sends queueInstallation down the start-now branch rather than leaving the task pending.
+      "dl-opt": makeDownload({
+        id: "dl-opt",
+        state: "finished",
+        game: [GAME],
+        size: 1024,
+        localPath: "opt-a.7z",
+        fileMD5: "md5-opt-a",
+        modInfo: { referenceTag: "opt-a" },
+      }),
+    },
+    session: makeInstallState({
+      activeSession: makeSession({
+        sessionId,
+        collectionId: COLLECTION,
+        profileId: PROFILE,
+        gameId: GAME,
+        mods: {
+          [modRuleId(requiredRule)]: makeModInstallInfo({
+            rule: requiredRule,
+            type: "requires",
+            status: requiredStatus,
+            ...(requiredStatus === "installed" ? { modId: "inst-req-a" } : {}),
+            phase: 0,
+          }),
+          // non-terminal, at the trailing phase - what a resume writes for this member
+          [modRuleId(optionalRule)]: makeModInstallInfo({
+            rule: optionalRule,
+            type: "recommends",
+            status: optionalStatus,
+            phase: OPTIONAL_PHASE,
+          }),
+        },
+        totalRequired: 1,
+        totalOptional: 1,
+        installedCount: 1,
+        downloadedCount: 2,
+      }),
+    }),
+  });
+
+  h.setState((draft) => {
+    draft.settings.profiles.activeProfileId = PROFILE;
+  });
+
+  // OPTIONAL_PHASE is deliberately absent from downloadsFinished: no download event adds it
+  const phaseState = h.phaseTracker.ensure(COLLECTION);
+  if (!uninitialisedPhase) {
+    phaseState.allowedPhase = 0;
+    phaseState.downloadsFinished.add(0);
+    phaseState.deployedPhases.add(0);
+  }
+
+  return { h, phaseState };
+}
+
+describe("collection install completion with a selected, already-downloaded optional", () => {
+  imTest(
+    "every required member is terminal while the collection is not yet complete",
+    async ({ makeInstallManager }) => {
+      const { h } = makeParkedInstall(makeInstallManager);
+
+      expect(internals(h.manager).getTerminalModCount(h.api, COLLECTION)).toBe(1);
+      // phase 0 complete is what sends the driver to review / postprocess...
+      expect(
+        internals(h.manager).checkCollectionPhaseStatus(h.api, COLLECTION, 0).phaseComplete,
+      ).toBe(true);
+      // ...while the poll's completion gate still counts the outstanding optional
+      expect(getCollectionInstallProgress(h.getState())?.isComplete).toBe(false);
+    },
+  );
+
+  imTest(
+    "the phase gate advances to OPTIONAL_PHASE once phase 0 is complete and deployed",
+    async ({ makeInstallManager }) => {
+      const { h, phaseState } = makeParkedInstall(makeInstallManager);
+
+      // the two steps the poll runs back to back once the current phase is settled and deployed
+      internals(h.manager).admitSettledOptionalPhase(COLLECTION, h.api);
+      internals(h.manager).maybeAdvancePhase(COLLECTION, h.api);
+
+      expect(phaseState.allowedPhase).toBe(OPTIONAL_PHASE);
+      // stepping into the phase hands the ready archive to handleDownloadFinished, which is what
+      // builds the dependency (install spec included) and queues the install. Asserted via the
+      // lookup cache because only that method populates it, and unlike the pending queue it is not
+      // drained the moment the install starts.
+      expect(phaseState.downloadLookupCache?.byTag.get("opt-a")).toBe("dl-opt");
+    },
+  );
+
+  // A round whose gather returns nothing never initialises phase state at all, so allowedPhase is
+  // undefined and maybeAdvancePhase bails at "awaiting first finished phase" on every tick. Merely
+  // recording the phase as downloads-finished is not enough here - admission has to initialise the
+  // gate too, or the walk never starts and the install hangs until the stall timeout.
+  imTest(
+    "admission initialises the gate when the round gathered no dependencies",
+    async ({ makeInstallManager }) => {
+      const { h, phaseState } = makeParkedInstall(makeInstallManager, {
+        uninitialisedPhase: true,
+      });
+      expect(phaseState.allowedPhase).toBeUndefined();
+
+      const mgr = internals(h.manager);
+      mgr.admitSettledOptionalPhase(COLLECTION, h.api);
+
+      // the gate is now open AND started - without the second half the walk would bail at
+      // "awaiting first finished phase" on every tick
+      expect(phaseState.downloadsFinished.has(OPTIONAL_PHASE)).toBe(true);
+      expect(phaseState.allowedPhase).toBe(OPTIONAL_PHASE);
+
+      // the hand-off itself comes from the poll's requeue on the same tick (the walk pauses to
+      // deploy the newly-entered phase first), so drive that too
+      const status = mgr.checkCollectionPhaseStatus(h.api, COLLECTION, OPTIONAL_PHASE);
+      mgr.reQueueDownloadedMods(h.api, COLLECTION, status.allMods, OPTIONAL_PHASE);
+      expect(phaseState.downloadLookupCache?.byTag.get("opt-a")).toBe("dl-opt");
+    },
+  );
+
+  imTest(
+    "the gate does NOT reach OPTIONAL_PHASE while a required member is still outstanding",
+    async ({ makeInstallManager }) => {
+      const { h, phaseState } = makeParkedInstall(makeInstallManager, { required: "downloaded" });
+
+      internals(h.manager).admitSettledOptionalPhase(COLLECTION, h.api);
+      internals(h.manager).maybeAdvancePhase(COLLECTION, h.api);
+
+      expect(phaseState.allowedPhase).toBe(0);
+      // nothing was handed off for install either
+      expect(phaseState.downloadLookupCache?.byTag.size).toBe(0);
+    },
+  );
+
+  // maybeAdvancePhase's own hand-off scan is gated on `rule.reference?.tag` and resolves by
+  // reference tag alone, so a member identified only by md5 relies on the poll's requeue backstop
+  // (which matches through findDownloadForMod) to reach handleDownloadFinished.
+  imTest(
+    "an optional identified only by md5 still reaches the installer",
+    async ({ makeInstallManager }) => {
+      const { h, phaseState } = makeParkedInstall(makeInstallManager, { optionalTagged: false });
+      const mgr = internals(h.manager);
+
+      mgr.admitSettledOptionalPhase(COLLECTION, h.api);
+      mgr.maybeAdvancePhase(COLLECTION, h.api);
+      const status = mgr.checkCollectionPhaseStatus(
+        h.api,
+        COLLECTION,
+        phaseState.allowedPhase ?? 0,
+      );
+      mgr.reQueueDownloadedMods(h.api, COLLECTION, status.allMods, phaseState.allowedPhase ?? 0);
+
+      expect(phaseState.allowedPhase).toBe(OPTIONAL_PHASE);
+      expect(phaseState.downloadLookupCache?.byMd5.get("md5-opt-a")).toBe("dl-opt");
+    },
+  );
+
+  // The admission lives in the completion poll, not in maybeAdvancePhase, so the walk stays a pure
+  // function of tracker state. The other tests here call the two steps directly; this one drives the
+  // real poll for a single tick, so removing the call from the poll cannot pass unnoticed.
+  imTest("the completion poll admits the phase on its own tick", async ({ makeInstallManager }) => {
+    vi.useFakeTimers();
+    try {
+      const { h, phaseState } = makeParkedInstall(makeInstallManager);
+      const mgr = internals(h.manager);
+      // the poll bails immediately unless a dependency install is registered for the collection
+      mgr.mDependencyInstalls[COLLECTION] = () => undefined;
+
+      const polling = mgr.pollAllPhasesComplete(h.api, COLLECTION);
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(phaseState.downloadsFinished.has(OPTIONAL_PHASE)).toBe(true);
+
+      // let the poll observe a cancelled install so it resolves instead of looping forever
+      delete mgr.mDependencyInstalls[COLLECTION];
+      await vi.advanceTimersByTimeAsync(600);
+      await polling;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // the same member is instead downloaded by driveSelectedOptionals when it has no archive yet, so
+  // the two paths together cover both statuses a selected optional can be parked at
+  imTest(
+    "a still-pending optional is claimed for download instead",
+    async ({ makeInstallManager }) => {
+      const { h } = makeParkedInstall(makeInstallManager, { optional: "pending" });
+
+      internals(h.manager).driveSelectedOptionals(h.api, COLLECTION);
+
+      // claimed up front, before the async gather resolves
+      expect(
+        h.getState().session.collections.activeSession?.mods[modRuleId(taggedOptionalRule)]?.status,
+      ).toBe("downloading");
+    },
+  );
+});

--- a/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
@@ -38,7 +38,7 @@ const GAME = "skyrimse";
 const PROFILE = "prof-1";
 const COLLECTION = "col-1";
 
-// the private phase-engine entry points the completion poll drives on every tick / on stall rescue
+// the private InstallManager internals these tests drive directly
 interface IManagerInternals {
   reQueueDownloadedMods: (
     api: unknown,
@@ -54,6 +54,25 @@ interface IManagerInternals {
   driveSelectedOptionals: (api: unknown, sourceModId: string) => void;
   admitSettledOptionalPhase: (sourceModId: string, api: unknown) => void;
   pollAllPhasesComplete: (api: unknown, sourceModId: string) => Promise<void>;
+  withInstructions: (
+    api: unknown,
+    sourceName: string,
+    title: string,
+    id: string,
+    instructions: string,
+    recommendations: boolean,
+    cb: () => PromiseLike<unknown>,
+  ) => Promise<unknown>;
+  mPendingInstalls: Map<string, unknown>;
+  startQueuedInstallation: (
+    api: unknown,
+    dep: unknown,
+    downloadId: string,
+    gameId: string,
+    sourceModId: string,
+    recommended: boolean,
+    phase: number,
+  ) => void;
   mDependencyInstalls: Record<string, () => void>;
   maybeAdvancePhase: (sourceModId: string, api: unknown) => void;
   getTerminalModCount: (api: unknown, sourceModId: string) => number;
@@ -95,6 +114,9 @@ function makeParkedInstall(
     optionalTagged?: boolean;
     // true models a round that gathered no dependencies at all, so phase state was never set up
     uninitialisedPhase?: boolean;
+    // true removes the download record entirely: the member claims "downloaded" but nothing can
+    // resolve an archive for it, so no rescue path can make progress
+    noDownloadRecord?: boolean;
   } = {},
 ) {
   const {
@@ -102,6 +124,7 @@ function makeParkedInstall(
     required: requiredStatus = "installed",
     optionalTagged = true,
     uninitialisedPhase = false,
+    noDownloadRecord = false,
   } = opts;
   const optionalRule = optionalTagged ? taggedOptionalRule : md5OnlyOptionalRule;
   const sessionId = generateCollectionSessionId(COLLECTION, PROFILE);
@@ -124,19 +147,21 @@ function makeParkedInstall(
         }),
       },
     },
-    downloads: {
-      // already on disk, so no download event will fire for it. A non-zero size matters: it is what
-      // sends queueInstallation down the start-now branch rather than leaving the task pending.
-      "dl-opt": makeDownload({
-        id: "dl-opt",
-        state: "finished",
-        game: [GAME],
-        size: 1024,
-        localPath: "opt-a.7z",
-        fileMD5: "md5-opt-a",
-        modInfo: { referenceTag: "opt-a" },
-      }),
-    },
+    downloads: noDownloadRecord
+      ? {}
+      : {
+          // already on disk, so no download event will fire for it. A non-zero size matters: it is what
+          // sends queueInstallation down the start-now branch rather than leaving the task pending.
+          "dl-opt": makeDownload({
+            id: "dl-opt",
+            state: "finished",
+            game: [GAME],
+            size: 1024,
+            localPath: "opt-a.7z",
+            fileMD5: "md5-opt-a",
+            modInfo: { referenceTag: "opt-a" },
+          }),
+        },
     session: makeInstallState({
       activeSession: makeSession({
         sessionId,
@@ -319,6 +344,106 @@ describe("collection install completion with a selected, already-downloaded opti
       expect(
         h.getState().session.collections.activeSession?.mods[modRuleId(taggedOptionalRule)]?.status,
       ).toBe("downloading");
+    },
+  );
+});
+
+describe("stall recovery", () => {
+  // A single optional re-driven from the required pass has no install-recommendations batch
+  // context; the instructions prompt must still show rather than throw - a throw here is swallowed
+  // by the dependency error path into a silent requeue that parks the member on "installing".
+  imTest(
+    "instructions prompt works without a recommendations batch context",
+    async ({ makeInstallManager }) => {
+      const { h } = makeParkedInstall(makeInstallManager);
+      h.setNextDialog({ action: "Install", input: {} });
+      const cb = vi.fn().mockResolvedValue("mod-x");
+
+      const result = await internals(h.manager).withInstructions(
+        h.api,
+        "DELIGHT",
+        "Some optional",
+        "opt-a",
+        "author instructions text",
+        true,
+        cb,
+      );
+
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(result).toBe("mod-x");
+    },
+  );
+
+  // Skipping the instructions prompt must settle the member as skipped: a Skip reject that falls
+  // into the generic requeue parks the member on "installing" with a pending entry nothing drives.
+  imTest(
+    "declining the instructions prompt settles the member skipped",
+    async ({ makeInstallManager }) => {
+      const { h } = makeParkedInstall(makeInstallManager);
+      const mgr = internals(h.manager);
+      mgr.mDependencyInstalls[COLLECTION] = () => undefined;
+      h.setNextDialog({ action: "Skip", input: {} });
+
+      mgr.startQueuedInstallation(
+        h.api,
+        {
+          reference: taggedOptionalRule.reference,
+          extra: { instructions: "author instructions" },
+          phase: OPTIONAL_PHASE,
+        },
+        "dl-opt",
+        GAME,
+        COLLECTION,
+        true,
+        OPTIONAL_PHASE,
+      );
+
+      await vi.waitFor(() => {
+        expect(
+          h.getState().session.collections.activeSession?.mods[modRuleId(taggedOptionalRule)]
+            ?.status,
+        ).toBe("ignored");
+      });
+      // the durable flag is set too, and nothing is left parked
+      const rule = h
+        .getState()
+        .persistent.mods[GAME][COLLECTION].rules?.find((r) => r.reference?.tag === "opt-a");
+      expect(rule?.ignored).toBe(true);
+      expect(mgr.mPendingInstalls.size).toBe(0);
+    },
+  );
+
+  // The stall force-resolve is the end of the line: nothing will ever settle the remaining
+  // members, and their residue (pending installs) poisons the next round's requeue and admission.
+  // Resolving must settle every non-terminal member as failed and tear the engine state down.
+  imTest(
+    "force-resolve settles outstanding members failed and clears pending residue",
+    async ({ makeInstallManager }) => {
+      vi.useFakeTimers();
+      try {
+        const { h } = makeParkedInstall(makeInstallManager, { noDownloadRecord: true });
+        const mgr = internals(h.manager);
+        mgr.mDependencyInstalls[COLLECTION] = () => undefined;
+        // residue of an earlier degraded round
+        mgr.mPendingInstalls.set(`${COLLECTION}:ghost-download`, {});
+
+        const polling = mgr.pollAllPhasesComplete(h.api, COLLECTION);
+        // first timeout + rescue, then second timeout -> force-resolve
+        await vi.advanceTimersByTimeAsync(301_000);
+        await vi.advanceTimersByTimeAsync(301_000);
+        await polling;
+
+        expect(
+          h.getState().session.collections.activeSession?.mods[modRuleId(taggedOptionalRule)]
+            ?.status,
+        ).toBe("failed");
+        expect(mgr.mPendingInstalls.size).toBe(0);
+        // the failures are by watchdog fiat, so the session is marked stalled - the finished
+        // dialog presents this as "installation incomplete" rather than complete-with-failures
+        expect(h.getState().session.collections.activeSession?.stalled).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -61,7 +61,11 @@ import { generate as shortid } from "shortid";
  * See AGENTS-COLLECTIONS.md for architectural overview.
  */
 import { removeDownload, setDownloadModInfo, startActivity, stopActivity } from "../../actions";
-import { markModInstalled, updateModStatus } from "../../actions/collectionInstallTracking";
+import {
+  markModInstalled,
+  markSessionStalled,
+  updateModStatus,
+} from "../../actions/collectionInstallTracking";
 import {
   type IConditionResult,
   type IDialogContent,
@@ -2162,6 +2166,10 @@ class InstallManager {
     const installPath = this.mGetInstallPath(gameId);
     log("info", "start installing dependencies", { modId });
 
+    // a fresh round is a fresh attempt: clear the stalled marker so a retry that succeeds
+    // presents as complete (no-op unless modId is the actively-installing collection)
+    api.store.dispatch(markSessionStalled(generateCollectionSessionId(modId, profile.id), false));
+
     const aggregationId = `install-dependencies-${modId}`;
     this.mNotificationAggregator.startAggregation(
       aggregationId,
@@ -2651,22 +2659,34 @@ class InstallManager {
           const nonRetryable =
             unknownError instanceof InsufficientDiskSpace ||
             (unknownError instanceof ProcessCanceled && !installCanceled);
+          // UserCanceled(true) is the "skipped" flavour - the user declined this member at a
+          // prompt (the instructions dialog's Skip), as opposed to cancelling the whole install
+          const userSkipped = unknownError instanceof UserCanceled && unknownError.skipped === true;
           const recovery = planDependencyErrorRecovery({
             installCanceled,
             ruleIgnored,
             isCanceled,
             hasRetriesLeft,
             nonRetryable,
+            userSkipped,
           });
           if (recovery.action === "requeue") {
             // A transient error OR a download cancelled as collateral while the install is still
             // live. Requeue rather than abandoning the member non-terminal - a dangling member
             // both blocks completion and gets re-prompted on the next install pass.
+            log("warn", "dependency install failed, requeued for retry", {
+              installKey,
+              error: err.message,
+              retry: currentRetryCount + 1,
+            });
             this.mPendingInstalls.set(installKey, dep);
             this.mDependencyRetryCount.set(installKey, currentRetryCount + 1);
           } else {
             this.mDependencyRetryCount.delete(installKey);
-            if (recovery.action === "fail") {
+            if (recovery.action === "skip") {
+              // same settle the free-user skip performs: durable ignore + session "ignored"
+              markCollectionMemberSkipped(api, { reference: dep.reference });
+            } else if (recovery.action === "fail") {
               // Retries exhausted: settle the member as failed (terminal) so the collection can
               // still complete and the member is not re-prompted. writeCollectionSession no-ops
               // over an already-terminal status, so this only settles a genuinely stuck member.
@@ -2814,6 +2834,10 @@ class InstallManager {
               activeInstalls: this.mActiveInstalls.size,
               pendingInstalls: this.mPendingInstalls.size,
             });
+            // cleanupPendingInstalls resyncs the session from reality, so it must run before the
+            // settle or it would overwrite it
+            this.cleanupPendingInstalls(sourceModId, true);
+            this.failOutstandingMembers(api, sourceModId);
             return resolve();
           }
         }
@@ -3625,6 +3649,26 @@ class InstallManager {
     // downloadsFinished directly is load-bearing: it also initialises allowedPhase, without which
     // the walk bails at "awaiting first finished phase" forever when the round gathered nothing.
     this.markPhaseDownloadsFinished(sourceModId, OPTIONAL_PHASE, api);
+  }
+
+  /**
+   * Stall force-resolve: no driver will ever settle the remaining members, and leaving them
+   * non-terminal wedges completion forever. Settles every still non-terminal member as failed
+   * (terminal, revertible on retry) so the collection completes visibly ("N mods failed").
+   */
+  private failOutstandingMembers(api: IExtensionApi, sourceModId: string): void {
+    const session = getCollectionActiveSession(api.getState());
+    if (session === undefined || session.collectionId !== sourceModId) {
+      return;
+    }
+    // the members below fail by watchdog fiat, not by their own attempts: mark the session so
+    // the finished dialog presents the install as incomplete rather than complete-with-failures
+    api.store.dispatch(markSessionStalled(session.sessionId, true));
+    Object.values(session.mods).forEach((mod) => {
+      if (!isTerminalMemberStatus(mod.status) && mod.rule?.reference != null) {
+        this.writeCollectionSession(mod.rule.reference, { type: "status", status: "failed" });
+      }
+    });
   }
 
   private maybeAdvancePhase(sourceModId: string, api: IExtensionApi) {
@@ -7243,9 +7287,12 @@ class InstallManager {
     if (recommendations) {
       return Promise.resolve(
         (async () => {
+          // The batch context exists only while installRecommendations drives a whole pass; a
+          // single optional re-driven from the required pass (requeue, driveSelectedOptionals) has
+          // none, so every context access must tolerate undefined.
           const context = getBatchContext("install-recommendations", "");
-          let action = context.get<string>("remember-instructions");
-          const remaining = context.get<number>("num-instructions") - 1;
+          let action = context?.get<string>("remember-instructions");
+          const remaining = (context?.get<number>("num-instructions") ?? 1) - 1;
 
           if (action == null) {
             let checkboxes: ICheckbox[];
@@ -7272,12 +7319,12 @@ class InstallManager {
             );
 
             if (result.input["remember"]) {
-              context.set("remember-instructions", result.action);
+              context?.set("remember-instructions", result.action);
             }
             action = result.action;
           }
 
-          context.set<number>("num-instructions", remaining);
+          context?.set<number>("num-instructions", remaining);
 
           if (action === "Install") {
             return cb();

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -69,6 +69,7 @@ import {
   dismissNotification,
 } from "../../actions/notifications";
 import { log } from "../../logging";
+import type { ICollectionModInstallInfo } from "../../types/collections/ICollectionInstallSession";
 import type { ICheckbox, IDialogResult } from "../../types/IDialog";
 import type { IExtensionApi, ThunkStore } from "../../types/IExtensionContext";
 import type { IProfile, IState } from "../../types/IState";
@@ -76,6 +77,7 @@ import { getBatchContext, type IBatchContext } from "../../util/BatchContext";
 import calculateFolderSize from "../../util/calculateFolderSize";
 import {
   generateCollectionSessionId,
+  isOutstandingOptionalMember,
   isTerminalMemberStatus,
   modRuleId,
 } from "../../util/collectionInstallSession";
@@ -188,11 +190,13 @@ import metaLookupMatch from "./util/metaLookupMatch";
 import modName, { renderModReference } from "./util/modName";
 import queryGameId from "./util/queryGameId";
 import { reconcileOrphanedArchive } from "./util/reconcileOrphanedArchive";
-import { rulePhase } from "./util/rulePhase";
+import { selectRequeueCandidates } from "./util/requeueCandidates";
+import { OPTIONAL_PHASE, rulePhase } from "./util/rulePhase";
 import testModReference, {
   downloadToModRef,
   idOnlyRef,
   isDependencyRule,
+  isRequiredRule,
   modMatchesInstallSpec,
   referenceEqual,
   ruleInstallSpec,
@@ -2877,6 +2881,9 @@ class InstallManager {
           }
           if (!hasQueuedDeployments && !this.hasActiveOrPendingInstallation(sourceModId)) {
             if (phaseState.deployedPhases.has(phaseState.allowedPhase ?? 0)) {
+              // the walk is about to look for somewhere to go - make the trailing optional phase
+              // reachable first if its members need no download
+              this.admitSettledOptionalPhase(sourceModId, api);
               // Phase already deployed, maybe advance
               this.maybeAdvancePhase(sourceModId, api);
             } else {
@@ -3203,7 +3210,7 @@ class InstallManager {
   private reQueueDownloadedMods(
     api: IExtensionApi,
     sourceModId: string,
-    allMods: any[],
+    allMods: ICollectionModInstallInfo[],
     currentPhase: number,
   ): void {
     const phaseState = this.mPhaseTracker.get(sourceModId);
@@ -3213,41 +3220,20 @@ class InstallManager {
 
     const downloads = api.getState().persistent.downloads.files;
 
-    // Expand the filter to include mods that are downloaded OR have downloads available
-    // Also log detailed status information to debug the filtering
-    const allModsWithDetails = allMods.map((mod: any) => ({
-      ...mod,
-      downloadId: mod.rule?.reference
-        ? this.findDownloadForMod(mod.rule.reference, downloads)
-        : null,
-    }));
-
-    // Look for mods that are marked as 'downloaded' and ready to install
-    // Do NOT include 'pending' mods as they are already queued for installation
-    const allDownloadedMods = allModsWithDetails.filter((mod: any) => {
-      const hasDownload = mod.downloadId != null;
-      const modPhase = mod.phase ?? 0;
-      const isDownloaded = mod.status === "downloaded";
-
-      // Allow mods from current phase or earlier phases that haven't been completed
-      // This prevents the deadlock where phase 1 mods can't be processed during phase 2+ cycles
-      const isEligiblePhase = modPhase <= currentPhase;
-
-      // Only requeue mods that are 'downloaded' status - pending mods are already queued
-      return isEligiblePhase && isDownloaded && hasDownload;
-    });
+    // pure selection, see util/requeueCandidates: 'downloaded' members with a resolvable download at
+    // or before the current phase. 'pending' members are already queued.
+    const allDownloadedMods = selectRequeueCandidates(allMods, currentPhase, (reference) =>
+      this.findDownloadForMod(reference, downloads),
+    );
 
     const downloadedPhases = new Set<number>();
     let anyQueued = false;
     let anyMarkedSkipped = false;
 
-    allDownloadedMods.forEach((mod: any) => {
+    allDownloadedMods.forEach((mod) => {
       const modPhase = mod.phase ?? 0;
       downloadedPhases.add(modPhase);
 
-      if (modPhase > currentPhase) {
-        return; // Skip this mod, it will be processed when its phase is active
-      }
       const downloadId = mod.downloadId;
       if (!downloadId) {
         if (mod.type === "recommends") {
@@ -3513,7 +3499,12 @@ class InstallManager {
     }
   }
 
-  // Called when downloads for a phase have been queued/processed
+  /**
+   * Called when downloads for a phase have been queued/processed. NOTE: this also OPENS the gate -
+   * it sets allowedPhase to `phase` when nothing has been allowed yet, bypassing maybeAdvancePhase's
+   * completeness/deployment walk. Callers that could mark a later phase first must establish
+   * ordering themselves (see admitSettledOptionalPhase).
+   */
   private markPhaseDownloadsFinished(sourceModId: string, phase: number, api: IExtensionApi) {
     this.mPhaseTracker.ensure(sourceModId);
     const state = this.mPhaseTracker.get(sourceModId);
@@ -3577,6 +3568,63 @@ class InstallManager {
     }, 0);
 
     return pending === 0;
+  }
+
+  /**
+   * Make the trailing optional phase reachable when its members need no download - an archive on
+   * disk, or a bundled member. Nothing else marks it for them: they fire no download event, and a
+   * round that gathers no dependencies never initialises phase state at all.
+   *
+   * Called from the completion poll, not maybeAdvancePhase, so the walk stays a pure function of
+   * tracker state. Sibling of driveSelectedOptionals, which covers members that DO need a download.
+   *
+   * Safe to scope to OPTIONAL_PHASE: a non-terminal member absent from the round's dependency list
+   * can only be an optional, since filterDependencyRules drops ignored rules and only optionals are
+   * ignored, while an absent required member was classified "existing" (installed and enabled) and
+   * reconstructs as terminal.
+   */
+  private admitSettledOptionalPhase(sourceModId: string, api: IExtensionApi): void {
+    const phaseState = this.mPhaseTracker.get(sourceModId);
+    // already admitted - skip the scan, which would otherwise repeat on every 500ms tick
+    if (phaseState === undefined || phaseState.downloadsFinished.has(OPTIONAL_PHASE)) {
+      return;
+    }
+    const state = api.getState();
+    const session = getCollectionActiveSession(state);
+    if (session === undefined || session.collectionId !== sourceModId) {
+      return;
+    }
+    const downloads = state.persistent.downloads.files;
+    const members = Object.values(session.mods);
+
+    // Admitting the phase can also initialise allowedPhase (see below), which would let optionals
+    // overtake. Refuse while any required member is outstanding.
+    if (members.some((mod) => isRequiredRule(mod) && !isTerminalMemberStatus(mod.status))) {
+      return;
+    }
+    const ready = members.some(
+      (mod) =>
+        isOutstandingOptionalMember(mod) &&
+        // the only non-terminal status whose archive is already recorded, and what a resume writes
+        // for a member found on disk. Tested first to keep findDownloadForMod - a scan of every
+        // download - off members still fetching or not started.
+        mod.status === "downloaded" &&
+        // a bundled member ships inside the collection archive, so it needs no download either
+        (mod.rule?.extra?.localPath != null ||
+          (mod.rule?.reference != null &&
+            this.findDownloadForMod(mod.rule.reference, downloads) != null)),
+    );
+    if (!ready) {
+      return;
+    }
+
+    log("debug", "phase gating: optional phase has nothing left to download, admitting it", {
+      sourceModId,
+    });
+    // The bookkeeping a download event performs. Going through it rather than adding to
+    // downloadsFinished directly is load-bearing: it also initialises allowedPhase, without which
+    // the walk bails at "awaiting first finished phase" forever when the round gathered nothing.
+    this.markPhaseDownloadsFinished(sourceModId, OPTIONAL_PHASE, api);
   }
 
   private maybeAdvancePhase(sourceModId: string, api: IExtensionApi) {

--- a/src/renderer/src/extensions/mod_management/util/requeueCandidates.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/requeueCandidates.test.ts
@@ -1,0 +1,83 @@
+/**
+ * selectRequeueCandidates - the pure decision behind InstallManager's requeue pass.
+ *
+ * The phase bound carries the weight: optionals sit at the trailing OPTIONAL_PHASE, so they must not
+ * be requeued while a required phase runs, and must be requeued once the gate reaches it. The second
+ * half is regression cover for LAZ-843.
+ */
+import { describe, expect, it } from "vitest";
+
+import { makeModInstallInfo, makeReference, makeRule } from "../../../test-utils/builders";
+import type {
+  CollectionModStatus,
+  ICollectionModInstallInfo,
+} from "../../../types/collections/ICollectionInstallSession";
+import { selectRequeueCandidates } from "./requeueCandidates";
+import { OPTIONAL_PHASE } from "./rulePhase";
+
+const requiredMember = makeModInstallInfo({
+  rule: makeRule({ type: "requires", reference: makeReference({ tag: "req-a" }) }),
+  type: "requires",
+  status: "downloaded",
+  phase: 0,
+});
+
+const optionalMember = makeModInstallInfo({
+  rule: makeRule({ type: "recommends", reference: makeReference({ tag: "opt-a" }) }),
+  type: "recommends",
+  status: "downloaded",
+  phase: OPTIONAL_PHASE,
+});
+
+// every member's archive resolves to a download, so the phase/status filters are what decide
+const allResolve = () => "dl-1";
+const tagsOf = (members: ICollectionModInstallInfo[], phase: number) =>
+  selectRequeueCandidates(members, phase, allResolve).map((c) => c.rule.reference.tag);
+
+describe("selectRequeueCandidates", () => {
+  it("selects a downloaded member at or before the phase being processed", () => {
+    expect(tagsOf([requiredMember], 0)).toEqual(["req-a"]);
+    expect(tagsOf([requiredMember], 2)).toEqual(["req-a"]);
+  });
+
+  it("holds an optional back while a required phase is still being processed", () => {
+    // OPTIONAL_PHASE (666) > 0, so the optional must not overtake the required members
+    expect(tagsOf([requiredMember, optionalMember], 0)).toEqual(["req-a"]);
+  });
+
+  it("selects a downloaded optional once the gate reaches OPTIONAL_PHASE (LAZ-843)", () => {
+    expect(tagsOf([requiredMember, optionalMember], OPTIONAL_PHASE)).toEqual(["req-a", "opt-a"]);
+  });
+
+  it("skips members that are not at 'downloaded'", () => {
+    const statuses: CollectionModStatus[] = [
+      "pending",
+      "downloading",
+      "installing",
+      "installed",
+      "failed",
+      "ignored",
+    ];
+    for (const status of statuses) {
+      expect(tagsOf([{ ...optionalMember, status }], OPTIONAL_PHASE)).toEqual([]);
+    }
+  });
+
+  it("skips a member whose download cannot be resolved", () => {
+    expect(selectRequeueCandidates([optionalMember], OPTIONAL_PHASE, () => null)).toEqual([]);
+  });
+
+  it("attaches the resolved downloadId to each candidate", () => {
+    const [candidate] = selectRequeueCandidates([optionalMember], OPTIONAL_PHASE, () => "dl-opt");
+    expect(candidate.downloadId).toBe("dl-opt");
+  });
+
+  it("defaults a member with no recorded phase to phase 0", () => {
+    expect(tagsOf([{ ...optionalMember, phase: undefined }], 0)).toEqual(["opt-a"]);
+  });
+
+  it("tolerates a member with no reference", () => {
+    const bare = { status: "downloaded", type: "requires" } as unknown as ICollectionModInstallInfo;
+    expect(selectRequeueCandidates([bare], 0, allResolve)).toEqual([]);
+  });
+});

--- a/src/renderer/src/extensions/mod_management/util/requeueCandidates.ts
+++ b/src/renderer/src/extensions/mod_management/util/requeueCandidates.ts
@@ -1,0 +1,38 @@
+/**
+ * Which session members a requeue pass should hand back to the installer - the DECISION, kept pure
+ * and apart from the side effects in reQueueDownloadedMods (which starts the installs it queues,
+ * leaving nothing queued to inspect). Mirrors how the driver separates isInstallComplete from
+ * finalizeInstalledCollection.
+ */
+import type { ICollectionModInstallInfo } from "../../../types/collections/ICollectionInstallSession";
+import type { IModReference } from "../types/IMod";
+
+/** A session member selected for requeue, with the finished download that backs it. */
+export type IRequeueCandidate = ICollectionModInstallInfo & { downloadId: string };
+
+/**
+ * Members at "downloaded" - archive present, nothing installing them - that are backed by a
+ * resolvable download and belong to a phase at or before the one being processed.
+ *
+ * The phase bound keeps optionals in their lane: `recommends` members sit at OPTIONAL_PHASE, so they
+ * become eligible only once the gate reaches it, never while a required phase runs. Whether the gate
+ * can reach OPTIONAL_PHASE is InstallPhaseTracker's concern, not this filter's.
+ *
+ * `resolveDownloadId` is injected so the download-matching heuristics stay with the caller and this
+ * selection needs no redux state.
+ */
+export function selectRequeueCandidates(
+  members: ICollectionModInstallInfo[],
+  currentPhase: number,
+  resolveDownloadId: (reference: IModReference) => string | null,
+): IRequeueCandidate[] {
+  return members.flatMap((member) => {
+    // "pending" members are deliberately excluded - they are already queued for installation. Both
+    // cheap tests run before resolveDownloadId, which scans every download.
+    if (member?.status !== "downloaded" || (member.phase ?? 0) > currentPhase) {
+      return [];
+    }
+    const downloadId = member.rule?.reference ? resolveDownloadId(member.rule.reference) : null;
+    return downloadId != null ? [{ ...member, downloadId }] : [];
+  });
+}

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -318,6 +318,36 @@ describe("installTracking reducer", () => {
     });
   });
 
+  describe("markSessionStalled", () => {
+    it("sets and clears the stalled marker on the active session", () => {
+      const state = makeInstallState({ activeSession: makeSession() });
+
+      const stalled = reduce(state, actions.markSessionStalled, {
+        sessionId: "col1_prof1",
+        stalled: true,
+      });
+      expect(stalled.activeSession.stalled).toBe(true);
+
+      // a retry round clears it, so a retry that succeeds presents as complete
+      const cleared = reduce(stalled, actions.markSessionStalled, {
+        sessionId: "col1_prof1",
+        stalled: false,
+      });
+      expect(cleared.activeSession.stalled).toBe(false);
+    });
+
+    it("is a no-op when sessionId does not match or no session is active", () => {
+      const state = makeInstallState({ activeSession: makeSession() });
+      expect(reduce(state, actions.markSessionStalled, { sessionId: "wrong", stalled: true })).toBe(
+        state,
+      );
+      const empty = makeInstallState();
+      expect(
+        reduce(empty, actions.markSessionStalled, { sessionId: "col1_prof1", stalled: true }),
+      ).toBe(empty);
+    });
+  });
+
   describe("defaults", () => {
     it("provides a valid initial state", () => {
       expect(reducer.defaults).toEqual({

--- a/src/renderer/src/reducers/collectionInstallTracking.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.ts
@@ -135,6 +135,13 @@ const collectionInstallReducer = {
 
       return newState;
     },
+
+    [actions.markSessionStalled as any]: (state: types.ICollectionInstallState, payload: any) => {
+      if (!state.activeSession || state.activeSession.sessionId !== payload.sessionId) {
+        return state;
+      }
+      return setSafe(state, ["activeSession", "stalled"], payload.stalled);
+    },
   },
 
   defaults: initialState,

--- a/src/renderer/src/types/collections/ICollectionInstallSession.ts
+++ b/src/renderer/src/types/collections/ICollectionInstallSession.ts
@@ -60,6 +60,13 @@ export interface ICollectionInstallSession {
   failedCount: number;
   /** Number of optional mods skipped */
   ignoredCount: number;
+  /**
+   * Set when the stall watchdog force-resolved this session: remaining members were settled as
+   * failed by the watchdog rather than by their own install attempts, so the install did not
+   * genuinely finish. Drives the "installation incomplete" presentation and the failed outcome;
+   * cleared when a new install round starts on the session.
+   */
+  stalled?: boolean;
 }
 
 export interface ICollectionInstallState {

--- a/src/renderer/src/util/collectionInstallSession.test.ts
+++ b/src/renderer/src/util/collectionInstallSession.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import { makeDownload, makeMod, makeRule, makeSession, modsByRule } from "../test-utils/builders";
-import { freeUserDownloadPosition, reconstructModStatus } from "./collectionInstallSession";
+import type {
+  CollectionModStatus,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
+import {
+  freeUserDownloadPosition,
+  isOutstandingOptionalMember,
+  reconstructModStatus,
+} from "./collectionInstallSession";
 
 describe("reconstructModStatus", () => {
   it('rehydrates an ignored rule as the terminal "ignored" status so a skip survives a restart', () => {
@@ -131,5 +139,30 @@ describe("freeUserDownloadPosition", () => {
 
   it("clamps the total to at least 1 so an empty session never divides oddly", () => {
     expect(freeUserDownloadPosition(makeSession())).toEqual({ position: 1, total: 1 });
+  });
+});
+
+describe("isOutstandingOptionalMember", () => {
+  const member = (type: "requires" | "recommends", status: CollectionModStatus) =>
+    ({ type, status }) as Pick<ICollectionModInstallInfo, "type" | "status">;
+
+  it("is true for an optional member that has not settled", () => {
+    // "optional" (offered but not selected) is deliberately non-terminal, so it counts too
+    const statuses = ["pending", "downloading", "downloaded", "installing", "optional"] as const;
+    for (const status of statuses) {
+      expect(isOutstandingOptionalMember(member("recommends", status))).toBe(true);
+    }
+  });
+
+  it("is false once the optional member reaches a terminal status", () => {
+    for (const status of ["installed", "failed", "ignored"] as const) {
+      expect(isOutstandingOptionalMember(member("recommends", status))).toBe(false);
+    }
+  });
+
+  it("is false for required members regardless of status - they are not the optional phase's work", () => {
+    for (const status of ["pending", "downloaded", "installed"] as const) {
+      expect(isOutstandingOptionalMember(member("requires", status))).toBe(false);
+    }
   });
 });

--- a/src/renderer/src/util/collectionInstallSession.ts
+++ b/src/renderer/src/util/collectionInstallSession.ts
@@ -1,8 +1,10 @@
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type { IMod, IModReference, IModRule } from "../extensions/mod_management/types/IMod";
+import { isOptionalRule } from "../extensions/mod_management/util/testModReference";
 import type {
   CollectionModStatus,
   ICollectionInstallSession,
+  ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
 
 /**
@@ -15,6 +17,26 @@ import type {
  */
 export function isTerminalMemberStatus(status: CollectionModStatus): boolean {
   return status === "installed" || status === "failed" || status === "ignored";
+}
+
+/**
+ * An optional (recommends) member with no decided outcome yet, so it still blocks completion.
+ *
+ * This is the single definition of "an optional that still needs installing" as judged from the
+ * SESSION, shared by the install-progress selector (which needs it to stop counting the member as
+ * complete) and by InstallManager's optional-phase admission (which needs it to decide the trailing
+ * phase still has work). Those two must never disagree: an admission gate that thinks a member is
+ * done while the completion gate does not is what wedges an install.
+ *
+ * Deliberately NOT the same question as `selectedOptionalRules` (mod_management/util/dependencies),
+ * which decides what to DOWNLOAD from the durable `ignored` flag on the live rules plus the mods
+ * table. That one runs before a session entry necessarily reflects the user's latest choice, so it
+ * reads different inputs on purpose and is not merged here.
+ */
+export function isOutstandingOptionalMember(
+  mod: Pick<ICollectionModInstallInfo, "type" | "status">,
+): boolean {
+  return isOptionalRule(mod) && !isTerminalMemberStatus(mod.status);
 }
 
 /**

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -43,6 +43,10 @@ export const getCollectionActiveSession = (
   return collectionsState?.activeSession;
 };
 
+/** Whether the active session was force-resolved by the stall watchdog (see the field doc). */
+export const isActiveSessionStalled = (state: IState): boolean =>
+  getCollectionActiveSession(state)?.stalled === true;
+
 /**
  * Get the session ID of the last completed installation
  * @returns The last active session ID or undefined

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -17,7 +17,7 @@ import type {
   CollectionModStatus,
 } from "../types/collections/ICollectionInstallSession";
 import type { IDownload, IMod, IState } from "../types/IState";
-import { isTerminalMemberStatus } from "./collectionInstallSession";
+import { isOutstandingOptionalMember, isTerminalMemberStatus } from "./collectionInstallSession";
 
 /**
  * Selectors for the installTracking reducer
@@ -319,8 +319,10 @@ export const getCollectionInstallProgress = createSelector(
     const installedActiveOptional = activeOptionals.filter(
       (mod) => mod.status === "installed",
     ).length;
-    const completedActiveOptional = activeOptionals.filter((mod) =>
-      isTerminalMemberStatus(mod.status),
+    // "completed" is exactly "no longer outstanding" - shared with InstallManager's optional-phase
+    // admission via isOutstandingOptionalMember so the two gates cannot drift apart
+    const completedActiveOptional = activeOptionals.filter(
+      (mod) => !isOutstandingOptionalMember(mod),
     ).length;
 
     const effectiveTotal = session.totalRequired + activeOptionals.length;

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -156,6 +156,23 @@ describe("planDependencyErrorRecovery", () => {
     ).toEqual({ action: "leave" });
   });
 
+  it("settles a member the user declined at a prompt as skipped, not requeued", () => {
+    // the instructions dialog's Skip throws UserCanceled(skipped=true); requeueing would re-ask
+    // the question the user just answered, and leaving it would park the member non-terminal
+    expect(planDependencyErrorRecovery({ ...base, isCanceled: true, userSkipped: true })).toEqual({
+      action: "skip",
+    });
+  });
+
+  it("a whole-install cancel or a durable ignore still wins over userSkipped", () => {
+    expect(
+      planDependencyErrorRecovery({ ...base, installCanceled: true, userSkipped: true }),
+    ).toEqual({ action: "leave" });
+    expect(planDependencyErrorRecovery({ ...base, ruleIgnored: true, userSkipped: true })).toEqual({
+      action: "leave",
+    });
+  });
+
   it("requeues a transient error while retries remain", () => {
     expect(planDependencyErrorRecovery({ ...base })).toEqual({ action: "requeue" });
   });

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -58,6 +58,7 @@ export function planSessionWrite(
 /** What the dependency-install error handler should do with a member whose attempt threw. */
 export type DependencyErrorRecovery =
   | { action: "leave" } // decided elsewhere (explicit skip) or whole install torn down: do nothing
+  | { action: "skip" } // the user declined this member (e.g. the instructions prompt): settle it skipped
   | { action: "requeue" } // retryable: attempt again
   | { action: "fail"; showError: boolean }; // terminal: settle as failed, report only a real error
 
@@ -68,6 +69,9 @@ export type DependencyErrorRecovery =
  * - an explicitly skipped member (ruleIgnored) or a whole-install cancel (installCanceled) is left
  *   untouched - the skip is terminal and a cancelled install is rebuilt on resume; requeuing a
  *   skipped member would re-prompt the very download a free user just skipped;
+ * - a member the user declined at a prompt (userSkipped, the UserCanceled "skipped" flag) is
+ *   settled as skipped - requeuing it would re-ask the question the user just answered, and
+ *   leaving it would park the member non-terminal;
  * - a non-retryable failure (e.g. the disk is full) is settled as failed immediately - retrying
  *   cannot succeed, so burning the retry budget only leaves the member non-terminal for longer;
  * - otherwise, while retries remain the member is requeued - a transient error or a download
@@ -82,9 +86,13 @@ export function planDependencyErrorRecovery(input: {
   isCanceled: boolean;
   hasRetriesLeft: boolean;
   nonRetryable?: boolean;
+  userSkipped?: boolean;
 }): DependencyErrorRecovery {
   if (input.installCanceled || input.ruleIgnored) {
     return { action: "leave" };
+  }
+  if (input.userSkipped) {
+    return { action: "skip" };
   }
   if (!input.nonRetryable && input.hasRetriesLeft) {
     return { action: "requeue" };


### PR DESCRIPTION
Fixes [LAZ-843](https://linear.app/nexus-mods/issue/LAZ-843) collection installs that never
finish: the optional-mods dialog re-appears with no progress and "done" never arrives.

Also fixes [LAZ-844](https://linear.app/nexus-mods/issue/LAZ-843) as part of the stall mechanism.

Phases become installable via download-finished events, but the trailing optional phase has no
event when its members' archives are already on disk (resumed install, bundled member). The phase
stays unreachable, the members never settle, and the install loops on the 10-minute stall cycle.

- The completion poll now admits `OPTIONAL_PHASE` once all required members are terminal and an
  outstanding optional has its archive; routed through `markPhaseDownloadsFinished` so the gate
  initialises when the round gathered nothing. Optionals cannot overtake required members.
- `withInstructions` no longer throws on a missing batch context (optional driven from the
  required pass); the throw was swallowed into a silent requeue, parking the member forever.
- Skip on the instructions prompt settles the member as skipped instead of requeueing.
- The stall force-resolve settles remaining members as failed, clears pending residue (which
  chained degraded rounds), and marks the session `stalled`: the dialog shows "installation
  incomplete" and the driver reports a failed outcome; a new round clears the marker.
- Requeue extraction into a pure `selectRequeueCandidates`; shared outstanding-optional predicate
  so the admission and completion gates cannot drift; the swallowed requeue error is now logged.

Regression tests on every fixed path, each red-checked. Live A/B on the original wedge.

closes LAZ-843
closes LAZ-844