### PR TITLE
Emit Health Check feedback events from both checks (LAZ-551, was LAZ-682)

### DIFF
--- a/src/renderer/src/extensions/analytics/index.ts
+++ b/src/renderer/src/extensions/analytics/index.ts
@@ -6,6 +6,7 @@ import type { IExtensionContext } from "@/types/IExtensionContext";
 import { getCPUArch } from "@/util/nativeArch";
 
 import { activeGameId, activeProfileId } from "../../util/selectors";
+import { nexusGamesProm } from "../nexus_integration/util";
 import { setAnalytics } from "./actions/analytics.action";
 import { HELP_ARTICLE, PRIVACY_POLICY } from "./constants";
 import AnalyticsMixpanel from "./mixpanel/MixpanelAnalytics";
@@ -77,6 +78,9 @@ function init(context: IExtensionContext): boolean {
       updateGameContext();
     });
 
+    // Retry once: covers analytics starting before the Nexus games cache has loaded.
+    let retriedGameContext = false;
+
     const updateGameContext = () => {
       const state = context.api.getState();
       const gameId = activeGameId(state);
@@ -88,10 +92,13 @@ function init(context: IExtensionContext): boolean {
         return;
       }
 
-      AnalyticsMixpanel.setGameContext({
-        gameId: numericNexusGameId(gameId),
-        profileId,
-      });
+      const numericGameId = numericNexusGameId(gameId);
+      AnalyticsMixpanel.setGameContext({ gameId: numericGameId, profileId });
+
+      if (numericGameId === null && !retriedGameContext) {
+        retriedGameContext = true;
+        void nexusGamesProm().then(() => updateGameContext());
+      }
     };
 
     function startAnalytics() {

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.test.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.test.ts
@@ -12,6 +12,7 @@ const mp = vi.hoisted(() => ({
   identify: vi.fn(),
   register: vi.fn(),
   unregister: vi.fn(),
+  get_property: vi.fn(),
   track: vi.fn(),
   reset: vi.fn(),
 }));
@@ -58,7 +59,8 @@ describe("MixpanelAnalytics.setGameContext", () => {
     });
   });
 
-  it("registers a null game_id when the numeric id is unresolved", () => {
+  it("leaves game_id untouched when the numeric id is unresolved", () => {
+    // Registering null would overwrite the (usually correct) game_id persisted from the last session.
     analyticsMixpanel.start(userInfo, false);
     mp.register.mockClear();
 
@@ -67,10 +69,8 @@ describe("MixpanelAnalytics.setGameContext", () => {
       profileId: "abc123",
     });
 
-    expect(mp.register).toHaveBeenCalledWith({
-      game_id: null,
-      profile_id: "abc123",
-    });
+    expect(mp.register).toHaveBeenCalledWith({ profile_id: "abc123" });
+    expect(mp.unregister).not.toHaveBeenCalled();
   });
 
   it("clears game/profile super properties when no game is active", () => {

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelAnalytics.ts
@@ -131,12 +131,31 @@ class MixpanelAnalytics {
     if (context === null) {
       mixpanel.unregister("game_id");
       mixpanel.unregister("profile_id");
+      analyticsServiceLog("mixpanel", "debug", "Game context cleared");
+      return;
+    }
+    if (context.gameId === null) {
+      // Unresolved id (games cache still loading): keep the persisted game_id; the caller retries.
+      mixpanel.register({ profile_id: context.profileId });
+      analyticsServiceLog("mixpanel", "debug", "Game context deferred (games cache not loaded)", {
+        kept_game_id: this.registeredGameId(),
+        profile_id: context.profileId,
+      });
       return;
     }
     mixpanel.register({
       game_id: context.gameId,
       profile_id: context.profileId,
     });
+    analyticsServiceLog("mixpanel", "debug", "Game context registered", {
+      game_id: context.gameId,
+      profile_id: context.profileId,
+    });
+  }
+
+  /** The game_id super property as mixpanel will send it — including a value persisted from a previous session. */
+  private registeredGameId(): number | null {
+    return (mixpanel.get_property("game_id") as number | undefined) ?? null;
   }
 
   /**
@@ -176,6 +195,7 @@ class MixpanelAnalytics {
 
     analyticsServiceLog("mixpanel", "debug", "Event tracked", {
       eventName: event.eventName,
+      game_id: this.registeredGameId(),
       properties: event.properties,
     });
   }

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -683,22 +683,3 @@ export class AppExtensionInstalledEvent implements MixpanelEvent {
  * @param required_by_mod_id Nexus mod ID of the mod that requires the dependency
  * @param feedback_reasons Array of reason keys (only for negative feedback)
  */
-export class HealthCheckFeedbackEvent implements MixpanelEvent {
-  readonly eventName = "health_check_feedback";
-  readonly properties: Record<string, any>;
-  constructor(
-    feedback_type: "positive" | "negative",
-    game_id: string,
-    mod_id: number,
-    required_by_mod_id: number,
-    feedback_reasons?: string[],
-  ) {
-    this.properties = {
-      feedback_type,
-      game_id,
-      mod_id,
-      required_by_mod_id,
-      ...(feedback_reasons?.length ? { feedback_reasons } : {}),
-    };
-  }
-}

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.test.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * EntryActions owns the three feedback events, so this covers what isn't visible at the
+ * tracker level: which affordance produces which event, and in particular that abandoning
+ * the reasons modal is recorded at all — before this it was recorded nowhere, neither as
+ * an event nor in state.
+ */
+import { EventEmitter } from "events";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { IExtensionApi } from "@/types/IExtensionContext";
+
+import type { MixpanelEvent } from "../../../analytics/mixpanel/MixpanelEvents";
+import {
+  HealthCheckTrackingProvider,
+  IssueProvider,
+} from "../../hooks/HealthCheckTracking.context";
+import type { IHealthCheckEntry } from "../../views/content/types";
+import { EntryActions } from "./EntryActions";
+
+// No i18n instance in the renderer test setup; keys are enough to find the controls.
+// Declared rather than inlined in the factory so it isn't read as a hook factory — and
+// a function declaration is hoisted, which a const wouldn't be when the factory runs.
+function fakeUseTranslation() {
+  return { t: (key: string) => key };
+}
+
+vi.mock("react-i18next", () => ({ useTranslation: fakeUseTranslation }));
+
+// RTL only auto-cleans when vitest runs with globals; this project doesn't, so without
+// this every render leaks into document.body and screen queries hit the previous test's
+// component — which silently sends its events to the previous test's emitter.
+afterEach(cleanup);
+
+const entry: IHealthCheckEntry = {
+  id: "uid-42:toggle",
+  checkId: "check-file-level-requirements",
+  severity: "warning",
+  resolutionType: "enable",
+  data: {},
+};
+
+function renderActions() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (e: MixpanelEvent) => events.push(e));
+  const api = { events: emitter } as unknown as IExtensionApi;
+  const onNotHelpful = vi.fn();
+
+  render(
+    <HealthCheckTrackingProvider api={api}>
+      <IssueProvider entry={entry}>
+        <EntryActions
+          givenFeedback={false}
+          variant="detail"
+          onHelpful={vi.fn()}
+          onNotHelpful={onNotHelpful}
+          onToggleHide={vi.fn()}
+        />
+      </IssueProvider>
+    </HealthCheckTrackingProvider>,
+  );
+
+  return { events, onNotHelpful };
+}
+
+describe("EntryActions feedback analytics", () => {
+  it("emits feedback_helpful carrying the ambient issue on thumbs-up", () => {
+    const { events } = renderActions();
+
+    fireEvent.click(screen.getByRole("button", { name: "common:::helpful" }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].eventName).toBe("health_check_feedback_helpful");
+    expect(events[0].properties).toEqual({
+      issue_id: "uid-42:toggle",
+      check_id: "file_requirements",
+      issue_type: "warning",
+      resolution_type: "enable",
+    });
+  });
+
+  it("emits feedback_not_helpful with the reasons on submit", () => {
+    const { events, onNotHelpful } = renderActions();
+
+    fireEvent.click(screen.getByRole("button", { name: "common:::not_helpful" }));
+    expect(events).toHaveLength(0);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "detail::feedback_modal::buttons::confirm" }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].eventName).toBe("health_check_feedback_not_helpful");
+    expect(events[0].properties.feedback_reasons).toEqual([]);
+    // The owner still persists; only the analytics moved.
+    expect(onNotHelpful).toHaveBeenCalledWith([]);
+  });
+
+  it("emits feedback_dismissed when the reasons modal is abandoned", () => {
+    const { events, onNotHelpful } = renderActions();
+
+    fireEvent.click(screen.getByRole("button", { name: "common:::not_helpful" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "detail::feedback_modal::buttons::cancel" }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].eventName).toBe("health_check_feedback_dismissed");
+    expect(events[0].properties).not.toHaveProperty("resolution_type");
+    // Abandoning isn't feedback, so nothing is persisted and the thumbs stay live.
+    expect(onNotHelpful).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
+import { useIssue, useIssueTracking } from "../../hooks/HealthCheckTracking.context";
 import { FeedbackModal } from "../feedback_modal/FeedbackModal";
 
 interface IEntryActionsProps {
@@ -29,7 +30,11 @@ export function EntryActions({
   onToggleHide,
 }: IEntryActionsProps) {
   const { t } = useTranslation(["health_check", "common"]);
+  const { issueType, resolutionType } = useIssue();
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+  const { trackFeedbackHelpful, trackFeedbackNotHelpful, trackFeedbackDismissed } =
+    useIssueTracking();
+
   const appearance = variant === "listing" ? "weak" : "subdued";
 
   const handle = (fn: () => void) => (e: React.MouseEvent) => {
@@ -62,7 +67,10 @@ export function EntryActions({
         leftIconPath={mdiThumbUpOutline}
         size="sm"
         title={t("common:::helpful")}
-        onClick={handle(onHelpful)}
+        onClick={handle(() => {
+          trackFeedbackHelpful({ issue_type: issueType, resolution_type: resolutionType });
+          onHelpful();
+        })}
       />
 
       <Button
@@ -88,8 +96,16 @@ export function EntryActions({
 
       <FeedbackModal
         isOpen={showFeedbackModal}
-        onClose={() => setShowFeedbackModal(false)}
+        onClose={() => {
+          trackFeedbackDismissed({ issue_type: issueType });
+          setShowFeedbackModal(false);
+        }}
         onSuccess={(reasons) => {
+          trackFeedbackNotHelpful({
+            issue_type: issueType,
+            resolution_type: resolutionType,
+            feedback_reasons: reasons,
+          });
           onNotHelpful(reasons);
           setShowFeedbackModal(false);
         }}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -20,7 +20,6 @@ import { setFileRequirementHidden } from "../../actions/persistent";
 import { useIssue, useIssueTracking } from "../../hooks/HealthCheckTracking.context";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
 import { useReportCopy } from "../../hooks/useReportCopy";
-import { resolutionTypeForCategory } from "../../utils/shared/tracking";
 import { isFileEntryHidden } from "../../views/content/fileRequirementEntries";
 import type { IDetailViewProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
@@ -32,8 +31,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const count = report.requirements.length;
   const { summary } = useReportCopy(report);
 
-  const { identity, issueType } = useIssue();
-  const resolutionType = resolutionTypeForCategory(report.category);
+  const { identity, issueType, resolutionType } = useIssue();
   const {
     trackDetailViewed,
     trackOneClickInstallClicked,
@@ -83,9 +81,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
 
   const showPremiumAd = useSelector(shouldShowPremiumAd);
 
-  // Feedback is keyed per source file (see useFileRequirementFeedback). NOTE:
-  // file-level feedback is persisted only, it does not emit a Mixpanel event yet
-  // (HealthCheckFeedbackEvent is mod-shaped).
+  // Feedback is keyed per source file (see useFileRequirementFeedback); EntryActions
+  // emits the analytics, this only records that feedback was given.
   const { givenFeedback, markFeedback } = useFileRequirementFeedback(api, report.sourceFileUID);
 
   return (

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -25,7 +25,6 @@ import { shouldShowPremiumAd } from "../../../nexus_integration/selectors";
 import { useIssue, useIssueTracking } from "../../hooks/HealthCheckTracking.context";
 import { useFileRequirementFeedback } from "../../hooks/useFileRequirementFeedback";
 import { useReportCopy } from "../../hooks/useReportCopy";
-import { resolutionTypeForCategory } from "../../utils/shared/tracking";
 import type { IListingRowProps } from "../../views/content/types";
 import { EntryActions } from "../entry_actions/EntryActions";
 import { ListingRow as ListingRowShell } from "../listing_row/ListingRow";
@@ -50,7 +49,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     trackIssueUnhidden,
   } = useIssueTracking();
 
-  const { identity, issueType } = useIssue();
+  const { identity, issueType, resolutionType } = useIssue();
   const candidates = downloadCandidates(report.requirements);
   const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
@@ -63,7 +62,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     } else {
       trackIssueHidden({
         issue_type: issueType,
-        resolution_type: resolutionTypeForCategory(report.category),
+        resolution_type: resolutionType,
       });
     }
 

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -33,7 +33,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const { t } = useTranslation(["health_check", "common"]);
   const mod = entry.data as IModRequirementExt;
 
-  const { identity, issueType } = useIssue();
+  const { identity, issueType, resolutionType } = useIssue();
 
   const {
     givenFeedback,
@@ -42,8 +42,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     setShowPremiumModal,
     openModPage,
     installInApp,
-    handlePositiveFeedback,
-    handleFeedbackSuccess,
+    markFeedback,
   } = useModRequirementActions(api, mod, identity, onBack);
 
   const hiddenRequirementMap = useSelector(hiddenModRequirements);
@@ -68,7 +67,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   useEffect(() => {
     trackDetailViewed({
       issue_type: issueType,
-      resolution_type: "install",
+      resolution_type: resolutionType,
       required_mod_count: 1,
       source_mod_name: mod.requiredBy.modName,
     });
@@ -112,7 +111,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     if (mod.requiredBy.modUrl) {
       opn(mod.requiredBy.modUrl).catch(() => undefined);
     }
-  }, [trackSuggestionSourceLinkClicked, entry.id, mod.requiredBy.modId, mod.requiredBy.modUrl]);
+  }, [trackSuggestionSourceLinkClicked, mod.requiredBy.modId, mod.requiredBy.modUrl]);
 
   const handleToggleHide = useCallback(() => {
     if (isHidden) {
@@ -120,7 +119,7 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     } else {
       trackIssueHidden({
         issue_type: issueType,
-        resolution_type: "install",
+        resolution_type: resolutionType,
       });
     }
 
@@ -132,8 +131,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
     mod.id,
     isHidden,
     onBack,
-    entry.id,
     issueType,
+    resolutionType,
     trackIssueHidden,
     trackIssueUnhidden,
   ]);
@@ -164,8 +163,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
             isHidden={isHidden}
             severity={entry.severity}
             variant="detail"
-            onHelpful={handlePositiveFeedback}
-            onNotHelpful={handleFeedbackSuccess}
+            onHelpful={markFeedback}
+            onNotHelpful={markFeedback}
             onToggleHide={handleToggleHide}
           />
         </div>

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -17,7 +17,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   const { t } = useTranslation(["health_check", "common"]);
   const mod = entry.data as IModRequirementExt;
 
-  const { identity, issueType } = useIssue();
+  const { identity, issueType, resolutionType } = useIssue();
 
   const {
     givenFeedback,
@@ -26,8 +26,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     setShowPremiumModal,
     openModPage,
     installInApp,
-    handlePositiveFeedback,
-    handleFeedbackSuccess,
+    markFeedback,
   } = useModRequirementActions(api, mod, identity);
 
   const { trackOneClickInstallClicked, trackIssueHidden, trackIssueUnhidden } = useIssueTracking();
@@ -49,7 +48,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
     } else {
       trackIssueHidden({
         issue_type: issueType,
-        resolution_type: "install",
+        resolution_type: resolutionType,
       });
     }
 
@@ -96,8 +95,8 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
             givenFeedback={givenFeedback}
             isHidden={isHidden}
             variant="listing"
-            onHelpful={handlePositiveFeedback}
-            onNotHelpful={handleFeedbackSuccess}
+            onHelpful={markFeedback}
+            onNotHelpful={markFeedback}
             onToggleHide={handleToggleHide}
           />
         }

--- a/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
@@ -2,7 +2,6 @@ import { mdiCheck, mdiDiamondStone, mdiOpenInNew } from "@mdi/js";
 import React, { type ReactNode, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { Icon } from "@/ui/components/icon/Icon";
 import { Modal } from "@/ui/components/modal/Modal";

--- a/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.test.tsx
+++ b/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.test.tsx
@@ -6,9 +6,9 @@
  */
 import { EventEmitter } from "events";
 
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
@@ -35,6 +35,7 @@ const fileEntry: IHealthCheckEntry = {
   id: "uid-42:download",
   checkId: "check-file-level-requirements",
   severity: "warning",
+  resolutionType: "update",
   data: {},
 };
 
@@ -42,23 +43,51 @@ const modEntry: IHealthCheckEntry = {
   id: "7-uid-9",
   checkId: "check-nexus-mod-requirements",
   severity: "suggestion",
+  resolutionType: "install",
   data: {},
+};
+
+// vitest runs without globals here, so RTL never auto-cleans; without this each
+// render leaks into document.body.
+afterEach(cleanup);
+
+/** Emits back_clicked with only its own properties — the identity should be supplied. */
+const BackClicker = () => {
+  const { trackBackClicked } = useIssueTracking();
+  trackBackClicked({ time_spent_on_detail_ms: 900 });
+  return null;
+};
+
+/** Emits an event carrying issue_type, to show both come from the enclosing issue. */
+const Unhider = () => {
+  const { trackIssueUnhidden } = useIssueTracking();
+  const { issueType } = useIssue();
+  trackIssueUnhidden({ issue_type: issueType });
+  return null;
+};
+
+/** A premium surface: reads an optional identity, so it works with or without an issue. */
+const Banner = () => {
+  const { trackPremiumBannerShown } = useTracker();
+  const identity = useOptionalIssue()?.identity;
+  trackPremiumBannerShown({ ...identity, placement: "list", total_issues: 3 });
+  return null;
+};
+
+/** Requires an issue; used to prove it throws rather than emitting without one. */
+const RequiresIssue = () => {
+  useIssueTracking();
+  return null;
 };
 
 describe("HealthCheckTracking context", () => {
   it("injects the identity, matching the payload the call site used to build by hand", () => {
     const { api, events } = harness();
 
-    const Consumer = () => {
-      const { trackBackClicked } = useIssueTracking();
-      trackBackClicked({ time_spent_on_detail_ms: 900 });
-      return null;
-    };
-
     render(
       <HealthCheckTrackingProvider api={api}>
         <IssueProvider entry={fileEntry}>
-          <Consumer />
+          <BackClicker />
         </IssueProvider>
       </HealthCheckTrackingProvider>,
     );
@@ -78,21 +107,14 @@ describe("HealthCheckTracking context", () => {
   it("scopes each issue to its own check", () => {
     const { api, events } = harness();
 
-    const Consumer = () => {
-      const { trackIssueUnhidden } = useIssueTracking();
-      const { issueType } = useIssue();
-      trackIssueUnhidden({ issue_type: issueType });
-      return null;
-    };
-
     render(
       <HealthCheckTrackingProvider api={api}>
         <IssueProvider entry={fileEntry}>
-          <Consumer />
+          <Unhider />
         </IssueProvider>
 
         <IssueProvider entry={modEntry}>
-          <Consumer />
+          <Unhider />
         </IssueProvider>
       </HealthCheckTrackingProvider>,
     );
@@ -114,37 +136,26 @@ describe("HealthCheckTracking context", () => {
       issueId: fileEntry.id,
     };
 
-    const Consumer = () => {
-      const { trackIssueUnhidden } = useIssueTracking();
-      const { issueType } = useIssue();
-      trackIssueUnhidden({ issue_type: issueType });
-      return null;
-    };
-
     render(
       <HealthCheckTrackingProvider api={api}>
         <IssueProvider entry={fileEntry}>
-          <Consumer />
+          <Unhider />
         </IssueProvider>
 
         <IssueProvider entry={dismissed}>
-          <Consumer />
+          <Unhider />
         </IssueProvider>
       </HealthCheckTrackingProvider>,
     );
 
-    expect(events.map((e) => e.properties.issue_id)).toEqual([fileEntry.id, fileEntry.id]);
+    expect(events.map((e) => e.properties.issue_id as string)).toEqual([
+      fileEntry.id,
+      fileEntry.id,
+    ]);
   });
 
   it("omits the identity for a premium surface rendered page-wide", () => {
     const { api, events } = harness();
-
-    const Banner = () => {
-      const { trackPremiumBannerShown } = useTracker();
-      const identity = useOptionalIssue()?.identity;
-      trackPremiumBannerShown({ ...identity, placement: "list", total_issues: 3 });
-      return null;
-    };
 
     render(
       <HealthCheckTrackingProvider api={api}>
@@ -158,18 +169,13 @@ describe("HealthCheckTracking context", () => {
   it("throws rather than emitting an issue event with no identity", () => {
     const { api } = harness();
 
-    const Consumer = () => {
-      useIssueTracking();
-      return null;
-    };
-
     // React logs the boundary-less error; the assertion is on the throw itself.
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     expect(() =>
       render(
         <HealthCheckTrackingProvider api={api}>
-          <Consumer />
+          <RequiresIssue />
         </HealthCheckTrackingProvider>,
       ),
     ).toThrow("useIssueTracking must be used within an IssueProvider");

--- a/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.tsx
+++ b/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useMemo, type ReactNode } from "react
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
-import type { IssueAnalyticsIdentity, IssueType } from "../utils/shared/tracking";
+import type { IssueAnalyticsIdentity, IssueType, ResolutionType } from "../utils/shared/tracking";
 import { checkNameForCheck, issueTypeForCheck } from "../utils/shared/tracking";
 import type { IHealthCheckEntry } from "../views/content/types";
 import { createHealthCheckTracker, type HealthCheckTracker } from "./healthCheckTracker";
@@ -23,10 +23,11 @@ import { createHealthCheckTracker, type HealthCheckTracker } from "./healthCheck
 
 const TrackerContext = createContext<HealthCheckTracker | undefined>(undefined);
 
-/** The issue an event belongs to, plus the issue_type that goes with it. */
+/** The issue an event belongs to, plus the vocabulary that describes it. */
 interface IIssueValue {
   identity: IssueAnalyticsIdentity;
   issueType: IssueType;
+  resolutionType: ResolutionType;
 }
 
 /**
@@ -79,6 +80,7 @@ const issueFor = (entry: IHealthCheckEntry): IIssueValue => ({
     check_id: checkNameForCheck(entry.checkId),
   },
   issueType: issueTypeForCheck(entry.checkId),
+  resolutionType: entry.resolutionType,
 });
 
 /** Scopes everything below it to one listing entry. */
@@ -89,12 +91,12 @@ export const IssueProvider = ({
   entry: IHealthCheckEntry;
   children?: ReactNode;
 }) => {
-  // entry is re-derived from live state as checks re-run, so key off its id and check
-  // rather than the object.
+  // entry is re-derived from live state as checks re-run, so key off the fields the
+  // value is built from rather than the object.
   const value = useMemo(
     () => issueFor(entry),
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-    [entry.id, entry.checkId],
+    [entry.id, entry.issueId, entry.checkId, entry.resolutionType],
   );
 
   return <IssueContext.Provider value={value}>{children}</IssueContext.Provider>;
@@ -118,8 +120,8 @@ export const useTracker = (): HealthCheckTracker => {
 export const useOptionalIssue = (): IIssueValue | undefined => useContext(IssueContext);
 
 /**
- * The enclosing issue: its identity to spread onto an event or hand to an install action, and
- * the issue_type for the events that carry one.
+ * The enclosing issue: its identity to spread onto an event or hand to an install action,
+ * plus the issue_type and resolution_type for the events that carry them.
  */
 export const useIssue = (): IIssueValue => {
   const issue = useOptionalIssue();
@@ -143,14 +145,18 @@ export const useIssueTracking = (): IssueTracker => {
   // Memoised before the guard, so the hook order is unconditional. Binding every method
   // (rather than just the subset IssueTracker exposes) keeps this a one-liner; the
   // excluded ones aren't reachable through the type.
-  const issueTracker = useMemo(
+  const issueTracker: IssueTracker | undefined = useMemo(
     () =>
       issue === undefined
         ? undefined
         : (Object.fromEntries(
             Object.entries(tracker).map(([name, emit]) => [
               name,
+              // Object.entries widens emit to the intersection of every tracker method, so
+              // it isn't callable as-is. no-unnecessary-type-assertion misreads this — remove
+              // the cast and tsc fails.
               (props: Record<string, unknown> = {}) =>
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 (emit as (p: Record<string, unknown>) => void)({ ...issue.identity, ...props }),
             ]),
           ) as IssueTracker),

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
@@ -50,6 +50,23 @@ describe("createHealthCheckTracker", () => {
     expect(events[1].properties).toEqual({ issue_count_unhidden: 10 });
   });
 
+  it("keeps feedback_reasons on not_helpful, and leaves resolution_type off dismissed", () => {
+    const { tracker, events } = harness();
+    const issue = { issue_id: "a-b", check_id: "file_requirements" } as const;
+
+    tracker.trackFeedbackNotHelpful({
+      ...issue,
+      issue_type: "warning",
+      resolution_type: "install",
+      feedback_reasons: ["wrong_mod", "already_installed"],
+    });
+    tracker.trackFeedbackDismissed({ ...issue, issue_type: "warning" });
+
+    expect(events[0].properties.feedback_reasons).toEqual(["wrong_mod", "already_installed"]);
+    expect(events[1].eventName).toBe("health_check_feedback_dismissed");
+    expect(events[1].properties).not.toHaveProperty("resolution_type");
+  });
+
   it("emits a no-property event (passed_viewed) with an empty bag", () => {
     const { tracker, events } = harness();
     tracker.trackPassedViewed();
@@ -85,7 +102,7 @@ describe("createHealthCheckTracker", () => {
       check_id: "file_requirements",
       time_spent_on_detail_ms: 900,
     });
-    expect(events.map((e) => e.properties.check_id)).toEqual([
+    expect(events.map((e) => e.properties.check_id as string)).toEqual([
       "mod_requirements",
       "file_requirements",
     ]);

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
@@ -220,6 +220,21 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
       props: OptionalIssueAnalyticsIdentity & { placement: BannerPlacement; total_issues: number },
     ) => track("health_check_premium_banner_clicked", props),
 
+    trackFeedbackHelpful: (
+      props: IssueAnalyticsIdentity & { issue_type: IssueType; resolution_type: ResolutionType },
+    ) => track("health_check_feedback_helpful", props),
+
+    trackFeedbackNotHelpful: (
+      props: IssueAnalyticsIdentity & {
+        issue_type: IssueType;
+        resolution_type: ResolutionType;
+        feedback_reasons: string[];
+      },
+    ) => track("health_check_feedback_not_helpful", props),
+
+    trackFeedbackDismissed: (props: IssueAnalyticsIdentity & { issue_type: IssueType }) =>
+      track("health_check_feedback_dismissed", props),
+
     // Visibility
     trackIssueHidden: (
       props: IssueAnalyticsIdentity & { issue_type: IssueType; resolution_type?: ResolutionType },

--- a/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
@@ -5,7 +5,6 @@ import { onDownloadRequirement } from "@/extensions/health_check/utils/modRequir
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { opn } from "@/util/api";
 
-import { HealthCheckFeedbackEvent } from "../../analytics/mixpanel/MixpanelEvents";
 import { shouldShowPremiumAd } from "../../nexus_integration/selectors";
 import { setFeedbackGiven } from "../actions/persistent";
 import { feedbackGivenMap } from "../selectors";
@@ -54,30 +53,11 @@ export function useModRequirementActions(
     onInstalled?.();
   }, [api, mod, identity, showPremiumAd, onInstalled]);
 
-  const handlePositiveFeedback = useCallback(() => {
+  // Persistence only — EntryActions owns the feedback analytics, so both thumbs record
+  // the same thing here.
+  const markFeedback = useCallback(() => {
     api.store?.dispatch(setFeedbackGiven(mod.requiredBy.modId, mod.id));
-    api.events.emit(
-      "analytics-track-mixpanel-event",
-      new HealthCheckFeedbackEvent("positive", mod.gameId, mod.modId, mod.requiredBy.modId),
-    );
   }, [api, mod]);
-
-  const handleFeedbackSuccess = useCallback(
-    (reasons: string[]) => {
-      api.store?.dispatch(setFeedbackGiven(mod.requiredBy.modId, mod.id));
-      api.events.emit(
-        "analytics-track-mixpanel-event",
-        new HealthCheckFeedbackEvent(
-          "negative",
-          mod.gameId,
-          mod.modId,
-          mod.requiredBy.modId,
-          reasons,
-        ),
-      );
-    },
-    [api, mod],
-  );
 
   return {
     givenFeedback,
@@ -86,7 +66,6 @@ export function useModRequirementActions(
     setShowPremiumModal,
     openModPage,
     installInApp,
-    handlePositiveFeedback,
-    handleFeedbackSuccess,
+    markFeedback,
   };
 }

--- a/src/renderer/src/extensions/health_check/views/content/ModRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/ModRequirementsContent.tsx
@@ -29,6 +29,7 @@ export const modRequirementsContent: IHealthCheckContent = {
       id: modEntryId(mod),
       checkId: MOD_REQUIREMENTS_CHECK_ID,
       severity: "suggestion",
+      resolutionType: "install",
       data: mod,
     })),
   ListingRow,

--- a/src/renderer/src/extensions/health_check/views/content/fileRequirementEntries.ts
+++ b/src/renderer/src/extensions/health_check/views/content/fileRequirementEntries.ts
@@ -10,6 +10,7 @@ import type {
 
 import { FILE_REQUIREMENTS_CHECK_ID } from "../../checks/fileRequirementsCheck";
 import { hiddenFileRequirements } from "../../selectors";
+import { resolutionTypeForCategory } from "../../utils/shared/tracking";
 import type { IHealthCheckEntry } from "./types";
 
 /** Whether a (homogeneous, per-category) report entry's requirements are all hidden. */
@@ -70,6 +71,7 @@ export const pushReportEntries = (
       issueId: fileIssueId(source.sourceFileUID, category),
       checkId: FILE_REQUIREMENTS_CHECK_ID,
       severity: "warning",
+      resolutionType: resolutionTypeForCategory(category),
       data: {
         sourceFileUID: source.sourceFileUID,
         sourceModName: source.sourceModName,

--- a/src/renderer/src/extensions/health_check/views/content/types.ts
+++ b/src/renderer/src/extensions/health_check/views/content/types.ts
@@ -5,6 +5,7 @@ import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IState } from "@/types/IState";
 
 import type { HealthCheckId } from "../../types";
+import type { ResolutionType } from "../../utils/shared/tracking";
 
 /**
  * A single item a health check contributes to the listing. Generic across all
@@ -27,6 +28,12 @@ export interface IHealthCheckEntry<TData = unknown> {
   checkId: HealthCheckId;
   /** Drives the severity icon/colour in the shared shell. */
   severity: Severity;
+  /**
+   * Which resolution flow this issue offers, reported as `resolution_type`. Set by the
+   * content module, which is the only thing that knows — deriving it centrally would
+   * mean reaching into each check's `data`.
+   */
+  resolutionType: ResolutionType;
   /** Check-specific payload (e.g. IFileLevelRequirements, IModRequirementExt). */
   data: TData;
 }


### PR DESCRIPTION
Both checks emit all three, each carrying the standard issue identity (`issue_id`, `check_id`):

| Event | Props |                                                                                             
|---|---|                                                                                                     
| `health_check_feedback_helpful` | `issue_type`, `resolution_type` |                                         
| `health_check_feedback_not_helpful` | `issue_type`, `resolution_type`, `feedback_reasons` |                 
| `health_check_feedback_dismissed` | `issue_type` |                                                          

`health_check_feedback` is **retired** — replaced, not double-emitted. It only ever covered mod requirements, so no file-requirement feedback existed in that history to lose. It wasn't in `etc/vortex.api.md`, so no API report regeneration.                                                                                          

### Three deliberate deviations from the spec                                                                 

All three are raised on LAZ-551 for the data team:                                                            

1. **`feedback_reasons` kept** although section 4 omits it. It's the substance of a negative — which of  `incorrect_requirement` / `requirement_already_installed` / `explanation_was_unclear` / `other` — and the file path captures it for the first time here.
2. **`mod_id` / `required_by_mod_id` dropped.** Feedback is on the issue, not one required mod; `issue_id` already joins to the whole funnel and keeps the two checks symmetric.
3. **`feedback_dismissed` means abandoning the reasons modal**, not the "dismiss/X icon on feedback" the spec  describes — no such icon exists. The real flow is thumbs-down → modal asking why → Cancel. Note it doesn't persist, so a user who opens and abandons repeatedly emits it each time; that's honest but isn't one-per-user

### Implementation notes for review                                                                            

**`EntryActions` emits all three itself**, rather than each of the four owners mapping callbacks. One implementation instead of four, and it's the only way `feedback_dismissed` is reachable — the modal lives in that component. The owners' `on*` callbacks stay, but now only persist.

That needs `resolution_type`, so **`resolutionType` became a property of `IHealthCheckEntry`**, set by the content module that knows it (`resolutionTypeForCategory(category)` for file, `"install"` for mod). Deliberately *not* derived inside the tracking context — that would mean reaching into each check's `data` payload and breaking the content-registry abstraction. The requirement components now read it from the issue context instead of deriving it locally.                                                                       

**Also fixes a latent test-infrastructure bug.** The renderer's vitest config has no `globals: true`, so `@testing-library/react` never auto-cleans: every `render` leaked into `document.body`, and `screen` queries then matched the *previous* test's component — sending its events to that test's emitter. This presents as a click handler that demonstrably fires while the current test's assertions see nothing. `afterEach(cleanup)` added to both render-based test files. Worth considering repo-wide, since any renderer component test has the same trap.