### PR TITLE
Fix i18n module type

### DIFF
--- a/src/renderer/src/util/i18n.ts
+++ b/src/renderer/src/util/i18n.ts
@@ -40,6 +40,7 @@ class MultiBackend implements BackendModule<BackendOptions> {
   #lastReadLanguage: string;
   #services: Services;
 
+  static type = "backend" as const;
   type: "backend" = "backend" as const;
 
   constructor(services: Services, backendOptions: BackendOptions) {
@@ -121,6 +122,8 @@ class MultiBackend implements BackendModule<BackendOptions> {
 
 class HighlightPP implements PostProcessorModule {
   name: string = "HighlightPP";
+
+  static type = "postProcessor" as const;
   type: "postProcessor" = "postProcessor" as const;
 
   process: PostProcessorModule["process"] = (value, key) => {


### PR DESCRIPTION
Broke in #23796 API didn't make it clear that the `type` field had to be static on the class itself.