### PR TITLE
Health Check - Implement missing OR cases

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -353,13 +353,15 @@ describe("checkFileRequirements / resolution", () => {
 
   test("reports an OR with a download branch and an owned-but-disabled enable branch", async () => {
     const metadata = await runWith({
-      // or_src depends on or_def, satisfiable by EITHER group or_g1 (not owned) or
-      // or_g2 (owned but disabled). Neither is enabled, so the OR is unsatisfied.
-      refs: [ref("or_src"), ref("or_g2_file", false)],
+      // or_src depends on or_def, satisfiable by EITHER group or_g1 (not owned) or or_g2,
+      // whose acceptable version is installed but disabled while a wrong version of the
+      // same chain is enabled. Neither is enabled, so the OR is unsatisfied.
+      refs: [ref("or_src"), ref("or_g2_file", false), ref("or_g2_wrong")],
       versions: {
         or_src: { chain: "or_srcChain", modId: "or_srcMod" },
         or_g1_file: { chain: "or_g1", modId: "or_g1Mod", name: "Alt A", version: "1.0" },
         or_g2_file: { chain: "or_g2", modId: "or_g2Mod", name: "Alt B", version: "2.0" },
+        or_g2_wrong: { chain: "or_g2", modId: "or_g2Mod", name: "Alt B", version: "1.0" },
       },
       candidates: [
         candidate({
@@ -393,6 +395,145 @@ describe("checkFileRequirements / resolution", () => {
       "or_g1_file",
     );
     expect(enableBranch?.kind === "enable" && enableBranch.correctFile.fileUID).toBe("or_g2_file");
+    expect(enableBranch?.kind === "enable" && enableBranch.enabledFile?.fileUID).toBe(
+      "or_g2_wrong",
+    );
+  });
+
+  test("hides an OR whose alternative is owned but deliberately disabled", async () => {
+    const metadata = await runWith({
+      // ord_g2_file is an acceptable version the user installed and then disabled, with no
+      // wrong version enabled to explain it: enabling it would clear the OR, so the whole
+      // requirement stays hidden (LAZ-840).
+      refs: [ref("ord_src"), ref("ord_g2_file", false)],
+      versions: {
+        ord_src: { chain: "ord_srcChain", modId: "ord_srcMod" },
+        ord_g1_file: { chain: "ord_g1", modId: "ord_g1Mod", name: "Alt A", version: "1.0" },
+        ord_g2_file: { chain: "ord_g2", modId: "ord_g2Mod", name: "Alt B", version: "2.0" },
+      },
+      candidates: [
+        candidate({
+          source_version_id: "ord_src",
+          definition_id: "ord_def",
+          version_id: "ord_g1_file",
+          mod_file_id: "ord_g1",
+          mod_id: "ord_g1Mod",
+        }),
+        candidate({
+          source_version_id: "ord_src",
+          definition_id: "ord_def",
+          version_id: "ord_g2_file",
+          mod_file_id: "ord_g2",
+          mod_id: "ord_g2Mod",
+        }),
+      ],
+    });
+
+    expect(metadata?.fileRequirements).toEqual({});
+  });
+
+  test("reports an OR install branch for an alternative that is downloaded but not installed", async () => {
+    const metadata = await runWith({
+      // oru_g2_file is an acceptable version the user downloaded but never installed. It
+      // must still show as its own alternative, or the user thinks only oru_g1 will do.
+      refs: [ref("oru_src")],
+      downloadedRefs: [downloadedRef("oru_g2_file")],
+      versions: {
+        oru_src: { chain: "oru_srcChain", modId: "oru_srcMod" },
+        oru_g1_file: { chain: "oru_g1", modId: "oru_g1Mod", name: "Alt A", version: "1.0" },
+        oru_g2_file: { chain: "oru_g2", modId: "oru_g2Mod", name: "Alt B", version: "2.0" },
+      },
+      candidates: [
+        candidate({
+          source_version_id: "oru_src",
+          definition_id: "oru_def",
+          version_id: "oru_g1_file",
+          mod_file_id: "oru_g1",
+          mod_id: "oru_g1Mod",
+        }),
+        candidate({
+          source_version_id: "oru_src",
+          definition_id: "oru_def",
+          version_id: "oru_g2_file",
+          mod_file_id: "oru_g2",
+          mod_id: "oru_g2Mod",
+        }),
+      ],
+      modDetails: [
+        { id: "oru_g1Mod", name: "Alt A", adult_content: false },
+        { id: "moduid-oru_g2_file", name: "Alt B", adult_content: true },
+      ],
+    });
+
+    const [req] = metadata?.fileRequirements["oru_src"]?.requirements ?? [];
+    expect(req?.kind).toBe("or");
+    if (req?.kind !== "or") {
+      throw new Error("expected an OR requirement");
+    }
+    expect(req.branches).toHaveLength(2);
+
+    const downloadBranch = req.branches.find((b) => b.kind === "download");
+    const installBranch = req.branches.find((b) => b.kind === "install");
+    expect(downloadBranch?.kind === "download" && downloadBranch.candidate.fileUID).toBe(
+      "oru_g1_file",
+    );
+    expect(installBranch?.kind === "install" && installBranch.uninstalledFile).toMatchObject({
+      fileUID: "oru_g2_file",
+      downloadId: "download-oru_g2_file",
+    });
+    expect(installBranch?.kind === "install" && installBranch.enabledFile).toBeUndefined();
+
+    // The downloaded alternative's display data is backfilled from /mods/batch, same as a
+    // non-OR downloaded requirement.
+    const detailsByUID = mockDownloadedHydrator.mock.calls.at(-1)?.[2];
+    expect(detailsByUID?.get("moduid-oru_g2_file")).toMatchObject({ adultContent: true });
+  });
+
+  test("offers a version switch on an OR install branch when a wrong version is enabled", async () => {
+    const metadata = await runWith({
+      // ors_g2_file is downloaded but not installed, and a wrong version of its chain is
+      // enabled: installing it has to switch the active version.
+      refs: [ref("ors_src"), ref("ors_g2_wrong")],
+      downloadedRefs: [downloadedRef("ors_g2_file")],
+      versions: {
+        ors_src: { chain: "ors_srcChain", modId: "ors_srcMod" },
+        ors_g1_file: { chain: "ors_g1", modId: "ors_g1Mod", name: "Alt A", version: "1.0" },
+        ors_g2_file: { chain: "ors_g2", modId: "ors_g2Mod", name: "Alt B", version: "2.0" },
+        ors_g2_wrong: { chain: "ors_g2", modId: "ors_g2Mod", name: "Alt B", version: "1.0" },
+      },
+      candidates: [
+        candidate({
+          source_version_id: "ors_src",
+          definition_id: "ors_def",
+          version_id: "ors_g1_file",
+          mod_file_id: "ors_g1",
+          mod_id: "ors_g1Mod",
+        }),
+        candidate({
+          source_version_id: "ors_src",
+          definition_id: "ors_def",
+          version_id: "ors_g2_file",
+          mod_file_id: "ors_g2",
+          mod_id: "ors_g2Mod",
+        }),
+      ],
+      modDetails: [{ id: "ors_g1Mod", name: "Alt A", adult_content: false }],
+    });
+
+    const [req] = metadata?.fileRequirements["ors_src"]?.requirements ?? [];
+    expect(req?.kind).toBe("or");
+    if (req?.kind !== "or") {
+      throw new Error("expected an OR requirement");
+    }
+
+    const installBranch = req.branches.find((b) => b.kind === "install");
+    expect(installBranch?.kind === "install" && installBranch.uninstalledFile.fileUID).toBe(
+      "ors_g2_file",
+    );
+    expect(installBranch?.kind === "install" && installBranch.enabledFile).toMatchObject({
+      fileUID: "ors_g2_wrong",
+      enabled: true,
+    });
   });
 
   test("reports nothing when the enabled installed version satisfies the dependency", async () => {
@@ -481,6 +622,38 @@ describe("checkFileRequirements / resolution", () => {
         fileUID: "uninstalledDependency",
         downloadId: "download-uninstalledDependency",
       },
+    });
+    expect(reqs?.[0].kind === "correct-version-uninstalled" && reqs[0].enabledFile).toBeUndefined();
+  });
+
+  test("carries the wrong enabled version on a downloaded-but-not-installed requirement", async () => {
+    const metadata = await runWith({
+      // su_correct is downloaded but not installed while su_wrong, another version of the
+      // same chain, is enabled: installing it has to switch the active version.
+      refs: [ref("su_src"), ref("su_wrong")],
+      downloadedRefs: [downloadedRef("su_correct")],
+      versions: {
+        su_src: { chain: "su_srcChain", modId: "su_srcMod" },
+        su_correct: { chain: "su_depChain", modId: "su_depMod", name: "Dep", version: "2.0" },
+        su_wrong: { chain: "su_depChain", modId: "su_depMod", name: "Dep", version: "1.0" },
+      },
+      candidates: [
+        candidate({
+          source_version_id: "su_src",
+          definition_id: "su_def",
+          version_id: "su_correct",
+          mod_file_id: "su_depChain",
+          mod_id: "su_depMod",
+        }),
+      ],
+    });
+
+    const reqs = metadata?.fileRequirements["su_src"]?.requirements;
+    expect(reqs).toHaveLength(1);
+    expect(reqs?.[0]).toMatchObject({
+      kind: "correct-version-uninstalled",
+      uninstalledFile: { fileUID: "su_correct" },
+      enabledFile: { fileUID: "su_wrong", enabled: true },
     });
   });
 });

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -152,13 +152,16 @@ async function runWith(opts: {
   versions: Record<string, VersionFixture>;
   candidates: V3Candidate[];
   modDetails?: V3ModDetail[];
+  /** Installed files the hydrator can't resolve, e.g. their mod left the store. */
+  unhydratable?: string[];
 }): Promise<IFileRequirementsCheckMetadata | undefined> {
   const downloadedRefs = opts.downloadedRefs ?? [];
+  const unhydratable = new Set(opts.unhydratable ?? []);
   mockGather.mockResolvedValue(opts.refs);
   mockGatherDownloaded.mockResolvedValue(downloadedRefs);
   mockHydrator.mockReturnValue((fileUID: string) => {
     const found = opts.refs.find((r) => r.fileUID === fileUID);
-    return found ? installedFile(fileUID, found.enabled) : undefined;
+    return found && !unhydratable.has(fileUID) ? installedFile(fileUID, found.enabled) : undefined;
   });
   mockDownloadedHydrator.mockReturnValue((fileUID: string) => {
     const found = downloadedRefs.find((r) => r.fileUID === fileUID);
@@ -430,6 +433,49 @@ describe("checkFileRequirements / resolution", () => {
     });
 
     expect(metadata?.fileRequirements).toEqual({});
+  });
+
+  test("still offers an OR enable branch when the wrong enabled version can't be hydrated", async () => {
+    const metadata = await runWith({
+      // Same shape as the enable-branch case, but the wrong version has no display data -
+      // its mod left the store, so it isn't really installed any more. The alternative is
+      // still actionable, as a plain enable rather than a switch.
+      refs: [ref("orh_src"), ref("orh_g2_file", false), ref("orh_g2_wrong")],
+      unhydratable: ["orh_g2_wrong"],
+      versions: {
+        orh_src: { chain: "orh_srcChain", modId: "orh_srcMod" },
+        orh_g1_file: { chain: "orh_g1", modId: "orh_g1Mod" },
+        orh_g2_file: { chain: "orh_g2", modId: "orh_g2Mod" },
+        orh_g2_wrong: { chain: "orh_g2", modId: "orh_g2Mod" },
+      },
+      candidates: [
+        candidate({
+          source_version_id: "orh_src",
+          definition_id: "orh_def",
+          version_id: "orh_g1_file",
+          mod_file_id: "orh_g1",
+          mod_id: "orh_g1Mod",
+        }),
+        candidate({
+          source_version_id: "orh_src",
+          definition_id: "orh_def",
+          version_id: "orh_g2_file",
+          mod_file_id: "orh_g2",
+          mod_id: "orh_g2Mod",
+        }),
+      ],
+    });
+
+    const [req] = metadata?.fileRequirements["orh_src"]?.requirements ?? [];
+    expect(req?.kind).toBe("or");
+    if (req?.kind !== "or") {
+      throw new Error("expected an OR requirement");
+    }
+    expect(req.branches).toHaveLength(2);
+
+    const enableBranch = req.branches.find((b) => b.kind === "enable");
+    expect(enableBranch?.kind === "enable" && enableBranch.correctFile.fileUID).toBe("orh_g2_file");
+    expect(enableBranch?.kind === "enable" && enableBranch.enabledFile).toBeUndefined();
   });
 
   test("reports an OR install branch for an alternative that is downloaded but not installed", async () => {

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -171,7 +171,13 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                   });
 
                   toInstall.forEach(
-                    (req) => void installDownloadedFile(api, req.uninstalledFile, identity),
+                    (req) =>
+                      void installDownloadedFile(
+                        api,
+                        req.uninstalledFile,
+                        identity,
+                        req.enabledFile,
+                      ),
                   );
                 }}
               >

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
@@ -1,0 +1,93 @@
+import { mdiCheck, mdiSwapHorizontal } from "@mdi/js";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  downloadedToFileData,
+  fileWebLinks,
+  type IFileActionContext,
+} from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
+import {
+  installDownloadedFile,
+  viewDownloadInMods,
+} from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
+import type {
+  IDownloadedFile,
+  IInstalledFile,
+} from "@/extensions/health_check/utils/fileRequirements/installedFiles";
+import { Button } from "@/ui/components/button/Button";
+import { nxmModOutline } from "@/ui/icon-paths";
+
+import { useInstallButton } from "../../../hooks/useInstallButton";
+import { FileRequirement } from "../FileRequirement";
+
+/**
+ * An "install this downloaded version" card for one downloaded-but-not-installed file
+ * (install-uninstalled rows + OR install branch).
+ */
+export const InstallDownloadedCard = ({
+  ctx,
+  file,
+  enabledFile,
+  isOr,
+}: {
+  ctx: IFileActionContext;
+  file: IDownloadedFile;
+  /** The wrong version to switch off, if any; absent means a plain install. */
+  enabledFile?: IInstalledFile;
+  isOr?: boolean;
+}) => {
+  const { t } = useTranslation("health_check");
+  const { isLoading, onClick } = useInstallButton(() =>
+    installDownloadedFile(ctx.api, file, ctx.identity, enabledFile),
+  );
+
+  // With a wrong version enabled the install is really a version switch, so it reads as one.
+  const isSwitch = enabledFile !== undefined;
+
+  const handleInstall = () => {
+    ctx.onInstallDownloaded(file);
+    onClick();
+  };
+
+  const handleViewInMods = () => {
+    ctx.onViewInMods(file);
+    viewDownloadInMods(ctx.api, file);
+  };
+
+  return (
+    <FileRequirement
+      actions={
+        <>
+          <Button
+            appearance="subdued"
+            brand="neutral"
+            leftIconPath={nxmModOutline}
+            size="sm"
+            onClick={handleViewInMods}
+          >
+            {t("detail::item::view_in_mods")}
+          </Button>
+
+          <Button
+            appearance="strong"
+            brand="neutral"
+            isLoading={isLoading}
+            leftIconPath={isSwitch ? mdiSwapHorizontal : mdiCheck}
+            size="sm"
+            onClick={handleInstall}
+          >
+            {isLoading
+              ? t("detail::item::installing")
+              : isSwitch
+                ? t("detail::item::enable_this_version")
+                : t("detail::item::install_uninstalled")}
+          </Button>
+        </>
+      }
+      file={downloadedToFileData(file)}
+      isOr={isOr}
+      {...fileWebLinks(ctx.api, file)}
+    />
+  );
+};

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
@@ -1,22 +1,9 @@
-import { mdiCheck } from "@mdi/js";
 import React from "react";
-import { useTranslation } from "react-i18next";
 
-import {
-  downloadedToFileData,
-  fileWebLinks,
-  type IFileActionContext,
-} from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
-import {
-  installDownloadedFile,
-  viewDownloadInMods,
-} from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
+import type { IFileActionContext } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
-import { Button } from "@/ui/components/button/Button";
-import { nxmModOutline } from "@/ui/icon-paths";
 
-import { useInstallButton } from "../../../hooks/useInstallButton";
-import { FileRequirement } from "../FileRequirement";
+import { InstallDownloadedCard } from "../cards/InstallDownloadedCard";
 
 export const InstallUninstalledRows = ({
   ctx,
@@ -24,51 +11,10 @@ export const InstallUninstalledRows = ({
 }: {
   ctx: IFileActionContext;
   requirement: Extract<IFileRequirement, { kind: "correct-version-uninstalled" }>;
-}) => {
-  const { t } = useTranslation("health_check");
-  const file = requirement.uninstalledFile;
-  const { isLoading, onClick } = useInstallButton(() =>
-    installDownloadedFile(ctx.api, file, ctx.identity),
-  );
-
-  const handleInstall = () => {
-    ctx.onInstallDownloaded(file);
-    onClick();
-  };
-
-  const handleViewInMods = () => {
-    ctx.onViewInMods(file);
-    viewDownloadInMods(ctx.api, file);
-  };
-
-  return (
-    <FileRequirement
-      actions={
-        <>
-          <Button
-            appearance="subdued"
-            brand="neutral"
-            leftIconPath={nxmModOutline}
-            size="sm"
-            onClick={handleViewInMods}
-          >
-            {t("detail::item::view_in_mods")}
-          </Button>
-
-          <Button
-            appearance="strong"
-            brand="neutral"
-            isLoading={isLoading}
-            leftIconPath={mdiCheck}
-            size="sm"
-            onClick={handleInstall}
-          >
-            {isLoading ? t("detail::item::installing") : t("detail::item::install_uninstalled")}
-          </Button>
-        </>
-      }
-      file={downloadedToFileData(file)}
-      {...fileWebLinks(ctx.api, file)}
-    />
-  );
-};
+}) => (
+  <InstallDownloadedCard
+    ctx={ctx}
+    enabledFile={requirement.enabledFile}
+    file={requirement.uninstalledFile}
+  />
+);

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
@@ -1,10 +1,53 @@
 import React from "react";
 
 import type { IFileActionContext } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
-import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import type {
+  IFileRequirement,
+  IFileRequirementBranch,
+} from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 
 import { CandidateCard } from "../cards/CandidateCard";
 import { EnableCard } from "../cards/EnableCard";
+import { InstallDownloadedCard } from "../cards/InstallDownloadedCard";
+
+/** The card for one OR alternative, by the action picking it needs. */
+const branchCard = (
+  branch: IFileRequirementBranch,
+  ctx: IFileActionContext,
+  optionPosition: number,
+  optionCount: number,
+) => {
+  switch (branch.kind) {
+    case "download":
+      return (
+        <CandidateCard
+          candidate={branch.candidate}
+          ctx={ctx}
+          isOr={true}
+          optionCount={optionCount}
+          optionPosition={optionPosition}
+        />
+      );
+    case "install":
+      return (
+        <InstallDownloadedCard
+          ctx={ctx}
+          enabledFile={branch.enabledFile}
+          file={branch.uninstalledFile}
+          isOr={true}
+        />
+      );
+    case "enable":
+      return (
+        <EnableCard
+          correctFile={branch.correctFile}
+          ctx={ctx}
+          enabledFile={branch.enabledFile}
+          isOr={true}
+        />
+      );
+  }
+};
 
 export const OrRows = ({
   ctx,
@@ -14,25 +57,10 @@ export const OrRows = ({
   requirement: Extract<IFileRequirement, { kind: "or" }>;
 }) => (
   <>
-    {requirement.branches.map((branch, index) =>
-      branch.kind === "download" ? (
-        <CandidateCard
-          candidate={branch.candidate}
-          ctx={ctx}
-          isOr={true}
-          key={branch.modFileId}
-          optionCount={requirement.branches.length}
-          optionPosition={index + 1}
-        />
-      ) : (
-        <EnableCard
-          correctFile={branch.correctFile}
-          ctx={ctx}
-          enabledFile={branch.enabledFile}
-          isOr={true}
-          key={branch.modFileId}
-        />
-      ),
-    )}
+    {requirement.branches.map((branch, index) => (
+      <React.Fragment key={branch.modFileId}>
+        {branchCard(branch, ctx, index + 1, requirement.branches.length)}
+      </React.Fragment>
+    ))}
   </>
 );

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -39,8 +39,9 @@ function modPageUrl(ref: INexusFileRef): string | undefined {
 }
 
 /**
- * Download and install a missing / wrong-version file. Free users can't 1-click install,
- * so open the file page instead (website download); the premium upsell is out of MVP scope.
+ * Download and install a missing / wrong-version file, then make it the active version.
+ * Free users can't 1-click install, so open the file page instead (website download); the
+ * premium upsell is out of MVP scope.
  */
 export async function downloadFileRequirement(
   api: IExtensionApi,
@@ -90,7 +91,7 @@ export async function downloadFileRequirement(
           ),
         );
 
-        await new Promise<string>((resolve, reject) =>
+        const modId = await new Promise<string>((resolve, reject) =>
           api.events.emit(
             "start-install-download",
             dlId,
@@ -98,6 +99,8 @@ export async function downloadFileRequirement(
             (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
           ),
         );
+
+        await activateInstalledVersion(api, modId);
       },
     );
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -292,14 +292,43 @@ function loadoutRowModId(api: IExtensionApi, file: IInstalledFile): string {
 }
 
 /**
+ * The mod-list row to reveal for a downloaded archive. The archive gets a row of its own
+ * only while none of its mod's versions are installed - otherwise the mod list collapses it
+ * into the installed version's row, so reveal that one instead.
+ */
+function downloadRowId(api: IExtensionApi, file: IDownloadedFile): string {
+  const state = api.getState();
+  const profile = activeProfile(state);
+  const gameId = profile?.gameId;
+  const nexusModId = decodeUID(file.modUID)?.id;
+  if (!gameId || nexusModId === undefined) {
+    return file.downloadId;
+  }
+  const mods = state.persistent.mods[gameId] ?? {};
+  const versions = Object.keys(mods).filter(
+    (id) =>
+      mods[id].archiveId !== file.downloadId &&
+      Number(mods[id].attributes?.modId) === nexusModId &&
+      mods[id].state === "installed",
+  );
+  if (versions.length === 0) {
+    return file.downloadId;
+  }
+  // The collapsed row is the enabled version, when there is one.
+  const enabled = versions.find((id) => profile?.modState?.[id]?.enabled === true);
+  return enabled ?? versions[0];
+}
+
+/**
  * Navigate to the Mods page and highlight the row for a downloaded-but-not-installed
- * archive, using the download ID as the row key.
+ * archive.
  */
 export function viewDownloadInMods(api: IExtensionApi, file: IDownloadedFile): void {
+  const rowId = downloadRowId(api, file);
   api.events.emit("show-main-page", "Mods");
   setTimeout(() => {
-    api.events.emit("mods-scroll-to", file.downloadId);
-    api.highlightControl(`.${sanitizeCSSId(file.downloadId)}`, 5000);
+    api.events.emit("mods-scroll-to", rowId);
+    api.highlightControl(`.${sanitizeCSSId(rowId)}`, 5000);
   }, 2000);
 }
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -112,14 +112,44 @@ export async function downloadFileRequirement(
 }
 
 /**
- * Install a file that has already been downloaded. Uses the download ID directly
- * as the archive ID - no mod-store lookup needed. No premium gate applies since
- * the file is already local.
+ * Make a just-installed mod the enabled version, switching off a wrong enabled version of
+ * the same chain. The requirement only clears once the correct version is enabled, so
+ * don't leave that to the user's auto-enable-on-install setting.
+ */
+function activateInstalledVersion(
+  api: IExtensionApi,
+  modId: string,
+  wrong?: IInstalledFile,
+): Promise<void> {
+  const profile = activeProfile(api.getState());
+  if (!profile) {
+    log("warn", "cannot activate installed version: no active profile", { modId });
+    return Promise.resolve();
+  }
+  // The install may have replaced the wrong version, or reused its mod entry, leaving
+  // nothing to disable.
+  const mods = api.getState().persistent.mods[profile.gameId] ?? {};
+  const wrongIds =
+    wrong !== undefined && wrong.modId !== modId && mods[wrong.modId] !== undefined
+      ? [wrong.modId]
+      : [];
+  return Promise.resolve(
+    setModsEnabled(api, profile.id, wrongIds, false, { reason: "health_check" }).then(() =>
+      setModsEnabled(api, profile.id, [modId], true, { reason: "health_check" }),
+    ),
+  );
+}
+
+/**
+ * Install a file that has already been downloaded, then make it the active version. Uses
+ * the download ID directly as the archive ID - no mod-store lookup needed. No premium gate
+ * applies since the file is already local.
  */
 export async function installDownloadedFile(
   api: IExtensionApi,
   file: IDownloadedFile,
   identity?: IssueAnalyticsIdentity,
+  enabledFile?: IInstalledFile,
 ): Promise<boolean> {
   try {
     await trackedInstall(
@@ -131,7 +161,7 @@ export async function installDownloadedFile(
         mod_version: file.version,
       },
       async () => {
-        await new Promise<string>((resolve, reject) =>
+        const modId = await new Promise<string>((resolve, reject) =>
           api.events.emit(
             "start-install-download",
             file.downloadId,
@@ -139,6 +169,8 @@ export async function installDownloadedFile(
             (err: Error | null, res: string) => (err ? reject(err) : resolve(res)),
           ),
         );
+
+        await activateInstalledVersion(api, modId, enabledFile);
       },
     );
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
@@ -100,8 +100,16 @@ export const switchTargets = (
   );
 
 /** The required mod's display name for one OR alternative. */
-const branchModName = (branch: IFileRequirementBranch): string =>
-  branch.kind === "download" ? branch.candidate.modName : branch.correctFile.modName;
+const branchModName = (branch: IFileRequirementBranch): string => {
+  switch (branch.kind) {
+    case "download":
+      return branch.candidate.modName;
+    case "install":
+      return branch.uninstalledFile.modName;
+    case "enable":
+      return branch.correctFile.modName;
+  }
+};
 
 /** The required mod's display name for a requirement (used in the listing summary). */
 export const requirementModName = (requirement: IFileRequirement, orJoin: string): string => {

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -199,11 +199,13 @@ describe("makeInstalledFileHydrator", () => {
     return makeInstalledFileHydrator(api, [INSTALLED_REF], map)("file-a");
   }
 
-  test("takes the fetched adult flag over the originating download's", () => {
+  test("takes the fetched adult flag over the originating download's, and its thumbnail", () => {
     const details: IModDetails = { ...DETAILS, modUID: INSTALLED_MOD_UID };
     expect(hydrateInstalled(false, details)).toMatchObject({
       modUID: INSTALLED_MOD_UID,
       adultContent: true,
+      // the fixture mod has no pictureUrl attribute of its own
+      thumbnailUrl: "http://img/details.png",
     });
   });
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, test } from "vitest";
 
 import type { IDownload } from "@/extensions/download_management/types/IDownload";
 import type { IModDetails } from "@/extensions/health_check/types";
+import { makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
-import { makeDownloadedFileHydrator, type IDownloadedFileRef } from "./installedFiles";
+import {
+  makeDownloadedFileHydrator,
+  makeInstalledFileHydrator,
+  type IDownloadedFileRef,
+  type IInstalledFileRef,
+} from "./installedFiles";
 
 const REF: IDownloadedFileRef = { fileUID: "file-1", modUID: "mod-1", downloadId: "dl-1" };
 
@@ -58,7 +64,7 @@ describe("makeDownloadedFileHydrator", () => {
   });
 
   describe("thumbnail / summary / adult flag", () => {
-    test("prefers the download's own nexus.modInfo over mod details", () => {
+    test("prefers the download's own summary and thumbnail over mod details", () => {
       const dl = download({
         nexus: {
           modInfo: {
@@ -84,9 +90,17 @@ describe("makeDownloadedFileHydrator", () => {
       });
     });
 
-    test("keeps contains_adult_content:false over details:true (guards ?? vs ||)", () => {
+    test("takes the fetched adult flag over the download's own (LAZ-849)", () => {
       const dl = download({ nexus: { modInfo: { contains_adult_content: false } } });
-      expect(hydrate(dl, DETAILS)?.adultContent).toBe(false);
+      expect(hydrate(dl, DETAILS)?.adultContent).toBe(true);
+    });
+
+    test("keeps the download's adult flag when no details were fetched (guards ?? vs ||)", () => {
+      const dl = download({ nexus: { modInfo: { contains_adult_content: true } } });
+      expect(hydrate(dl)?.adultContent).toBe(true);
+      expect(
+        hydrate(download({ nexus: { modInfo: { contains_adult_content: false } } }))?.adultContent,
+      ).toBe(false);
     });
 
     test("leaves summary/thumbnail undefined and adult false when neither source supplies them", () => {
@@ -133,5 +147,69 @@ describe("makeDownloadedFileHydrator", () => {
       expect(hydrate(download({ meta: { fileVersion: "3.1" }, nexus: {} }))?.version).toBe("3.1");
       expect(hydrate(download({ nexus: {} }))?.version).toBe("");
     });
+  });
+});
+
+describe("makeInstalledFileHydrator", () => {
+  // Numeric downloadGame so the composite UID resolves without the Nexus games list.
+  const INSTALLED_MOD_UID = makeModUID({ gameId: "1704", modId: "42", fileId: "7" });
+  const INSTALLED_REF: IInstalledFileRef = {
+    fileUID: "file-a",
+    modId: "mod-a",
+    enabled: true,
+    emitRequirements: true,
+  };
+
+  /** Hydrate one installed mod whose archive stores `adultInDownload`, if given. */
+  function hydrateInstalled(adultInDownload?: boolean, details?: IModDetails) {
+    const api = {
+      getState: () => ({
+        settings: { profiles: { activeProfileId: "p1" } },
+        persistent: {
+          profiles: { p1: { id: "p1", gameId: "skyrimse" } },
+          mods: {
+            skyrimse: {
+              "mod-a": {
+                id: "mod-a",
+                state: "installed",
+                archiveId: "dl-a",
+                attributes: {
+                  source: "nexus",
+                  modId: 42,
+                  fileId: 7,
+                  downloadGame: "1704",
+                  logicalFileName: "Mod A",
+                },
+              },
+            },
+          },
+          downloads: {
+            files: {
+              "dl-a": download(
+                adultInDownload === undefined
+                  ? { nexus: { ids: {} } }
+                  : { nexus: { modInfo: { contains_adult_content: adultInDownload } } },
+              ),
+            },
+          },
+        },
+      }),
+    } as unknown as IExtensionApi;
+    const map = details ? new Map([[details.modUID, details]]) : new Map<string, IModDetails>();
+    return makeInstalledFileHydrator(api, [INSTALLED_REF], map)("file-a");
+  }
+
+  test("takes the fetched adult flag over the originating download's", () => {
+    const details: IModDetails = { ...DETAILS, modUID: INSTALLED_MOD_UID };
+    expect(hydrateInstalled(false, details)).toMatchObject({
+      modUID: INSTALLED_MOD_UID,
+      adultContent: true,
+    });
+  });
+
+  test("falls back to the download's adult flag when no details were fetched", () => {
+    expect(hydrateInstalled(true)?.adultContent).toBe(true);
+    expect(hydrateInstalled(false)?.adultContent).toBe(false);
+    expect(hydrateInstalled()?.adultContent).toBe(false);
   });
 });

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -265,7 +265,9 @@ function toDownloadedFile(
       modName,
     version: download.modInfo?.meta?.fileVersion ?? "",
     thumbnailUrl: modInfo.picture_url ?? details?.thumbnailUrl ?? undefined,
-    adultContent: modInfo.contains_adult_content ?? details?.adultContent ?? false,
+    // The fetched flag wins: a download's stored modInfo can carry a defaulted
+    // `contains_adult_content: false`, and a mod can be flagged after it was downloaded.
+    adultContent: details?.adultContent ?? modInfo.contains_adult_content ?? false,
   };
 }
 
@@ -291,24 +293,29 @@ export function makeDownloadedFileHydrator(
   };
 }
 
+/** Resolve a Nexus mod UID for an installed mod, or "" if not possible. */
+function resolveModUID(attributes: IInstalledModAttributes, gameId: string): string {
+  return (
+    makeModUID({
+      gameId: attributes.downloadGame ?? gameId,
+      modId: String(attributes.modId ?? ""),
+      fileId: String(attributes.fileId ?? ""),
+    }) ?? ""
+  );
+}
+
 /**
  * Build the display shape for one installed file from its Vortex mod.
  */
 function toInstalledFile(
   mod: IMod,
   fileUID: string,
+  modUID: string,
   enabled: boolean,
-  gameId: string,
   adultContent: boolean,
 ): IInstalledFile {
   const attributes: IInstalledModAttributes = mod.attributes ?? {};
   const modName = renderModName(mod);
-  const modUID =
-    makeModUID({
-      gameId: attributes.downloadGame ?? gameId,
-      modId: String(attributes.modId ?? ""),
-      fileId: String(attributes.fileId ?? ""),
-    }) ?? "";
   return {
     modId: mod.id,
     fileUID,
@@ -326,12 +333,14 @@ function toInstalledFile(
 
 /**
  * A `fileUID -> IInstalledFile` hydrator over the gathered refs, reading the mod
- * store on demand so only surfaced files are hydrated. The adult-content flag is
- * read from the originating download (linked via `archiveId`), or defaults to false.
+ * store on demand so only surfaced files are hydrated. The adult-content flag comes
+ * from the fetched mod details, falling back to the originating download (linked via
+ * `archiveId`), whose archive may be gone or predate the mod being flagged.
  */
 export function makeInstalledFileHydrator(
   api: IExtensionApi,
   refs: IInstalledFileRef[],
+  modDetailsByUID: Map<string, IModDetails>,
 ): (fileUID: string) => IInstalledFile | undefined {
   const state = api.getState();
   const gameId = activeProfile(state)?.gameId;
@@ -348,14 +357,11 @@ export function makeInstalledFileHydrator(
     if (!mod) {
       return undefined;
     }
+    const modUID = resolveModUID(mod.attributes ?? {}, gameId);
     const download = mod.archiveId ? downloads[mod.archiveId] : undefined;
     const modInfo = (download?.modInfo?.nexus?.modInfo ?? {}) as INexusModDisplayInfo;
-    return toInstalledFile(
-      mod,
-      fileUID,
-      ref.enabled,
-      gameId,
-      modInfo.contains_adult_content ?? false,
-    );
+    const adultContent =
+      modDetailsByUID.get(modUID)?.adultContent ?? modInfo.contains_adult_content ?? false;
+    return toInstalledFile(mod, fileUID, modUID, ref.enabled, adultContent);
   };
 }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -305,14 +305,17 @@ function resolveModUID(attributes: IInstalledModAttributes, gameId: string): str
 }
 
 /**
- * Build the display shape for one installed file from its Vortex mod.
+ * Build the display shape for one installed file from its Vortex mod. The mod's own
+ * attributes carry the display data, backfilled from the fetched details when they don't
+ * (`modInfo` is the originating download's block, whose archive may since have gone).
  */
 function toInstalledFile(
   mod: IMod,
   fileUID: string,
   modUID: string,
   enabled: boolean,
-  adultContent: boolean,
+  modInfo: INexusModDisplayInfo,
+  details: IModDetails | undefined,
 ): IInstalledFile {
   const attributes: IInstalledModAttributes = mod.attributes ?? {};
   const modName = renderModName(mod);
@@ -325,17 +328,17 @@ function toInstalledFile(
     // used only as a fallback when no display name was stored.
     fileName: attributes.logicalFileName ?? attributes.fileName ?? modName,
     version: attributes.version ?? "",
-    thumbnailUrl: attributes.pictureUrl,
-    adultContent,
+    thumbnailUrl: attributes.pictureUrl ?? details?.thumbnailUrl,
+    // The fetched flag wins: a mod can be flagged adult after it was installed.
+    adultContent: details?.adultContent ?? modInfo.contains_adult_content ?? false,
     enabled,
   };
 }
 
 /**
  * A `fileUID -> IInstalledFile` hydrator over the gathered refs, reading the mod
- * store on demand so only surfaced files are hydrated. The adult-content flag comes
- * from the fetched mod details, falling back to the originating download (linked via
- * `archiveId`), whose archive may be gone or predate the mod being flagged.
+ * store on demand so only surfaced files are hydrated. `modDetailsByUID` backfills the
+ * thumbnail and adult flag the mod's own attributes don't carry.
  */
 export function makeInstalledFileHydrator(
   api: IExtensionApi,
@@ -360,8 +363,6 @@ export function makeInstalledFileHydrator(
     const modUID = resolveModUID(mod.attributes ?? {}, gameId);
     const download = mod.archiveId ? downloads[mod.archiveId] : undefined;
     const modInfo = (download?.modInfo?.nexus?.modInfo ?? {}) as INexusModDisplayInfo;
-    const adultContent =
-      modDetailsByUID.get(modUID)?.adultContent ?? modInfo.contains_adult_content ?? false;
-    return toInstalledFile(mod, fileUID, modUID, ref.enabled, adultContent);
+    return toInstalledFile(mod, fileUID, modUID, ref.enabled, modInfo, modDetailsByUID.get(modUID));
   };
 }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
@@ -215,6 +215,8 @@ function classifyDependency(
     // A deliberately disabled alternative (nothing wrong enabled to explain it) counts as
     // satisfied - enabling it would clear the OR - matching the single-branch rule below.
     // Drop this guard to surface it as an "enable this version" card instead.
+    // Deliberately on the resolver's state, not on hydrated display data: whether to
+    // surface the OR at all can't depend on whether a file we never render resolved.
     if (branches.some((b) => b.satisfyingDisabled.length > 0 && b.wrongEnabled.length === 0)) {
       return undefined;
     }
@@ -299,8 +301,9 @@ function classifyOrBranch(
   branch: DependencyBranch,
   hydrate: HydrateFile,
 ): IFileRequirementBranch | undefined {
-  // Owned-but-disabled alternative: enabling it satisfies the OR without a download. Only
-  // reached with a wrong version enabled - the guard above drops the OR otherwise.
+  // Owned-but-disabled alternative: enabling it satisfies the OR without a download. The
+  // guard above means a wrong version is enabled, so this is normally a switch; if that
+  // version's mod has since left the store it won't hydrate, and a plain enable is right.
   if (branch.satisfyingDisabled.length > 0) {
     const hydratedCorrect = hydrate(branch.satisfyingDisabled[0]);
     if (!hydratedCorrect || hydratedCorrect.kind !== "installed") {

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
@@ -69,7 +69,8 @@ export interface IWrongVersionEnabledRequirement {
 
 /**
  * One alternative (update group) of an OR requirement, already classified to the
- * action it needs if chosen: download a file, or enable an owned-but-disabled one.
+ * action it needs if chosen: download a file, install an already-downloaded one, or
+ * enable an owned-but-disabled one.
  */
 export type IFileRequirementBranch =
   | {
@@ -78,6 +79,15 @@ export type IFileRequirementBranch =
       modFileId: string;
       /** The file to download for this alternative */
       candidate: IFileRequirementCandidate;
+    }
+  | {
+      kind: "install";
+      /** Update group this alternative belongs to */
+      modFileId: string;
+      /** The acceptable, downloaded-but-not-installed version to install */
+      uninstalledFile: IDownloadedFile;
+      /** A wrong version of the same chain currently enabled, if any (makes it a switch) */
+      enabledFile?: IInstalledFile;
     }
   | {
       kind: "enable";
@@ -90,8 +100,8 @@ export type IFileRequirementBranch =
     };
 
 /**
- * Several alternatives satisfy the requirement; the user picks one. Branches that
- * are owned-but-disabled offer an enable/switch action instead of a download.
+ * Several alternatives satisfy the requirement; the user picks one. Branches whose
+ * version is already owned offer an install or enable/switch action instead of a download.
  */
 export interface IOrFileRequirement {
   kind: "or";
@@ -110,6 +120,8 @@ export interface IUninstalledFileRequirement {
   requirementDefId: string;
   /** The downloaded-but-not-installed file to install */
   uninstalledFile: IDownloadedFile;
+  /** A wrong version of the same chain currently enabled, if any (makes it a switch) */
+  enabledFile?: IInstalledFile;
 }
 
 /**
@@ -172,6 +184,15 @@ function toCandidate(candidate: Candidate): IFileRequirementCandidate {
   };
 }
 
+/** The wrong version currently enabled on a branch, when there is one we can display. */
+function enabledWrongFile(
+  branch: DependencyBranch,
+  hydrate: HydrateFile,
+): IInstalledFile | undefined {
+  const hydrated = branch.wrongEnabled.length > 0 ? hydrate(branch.wrongEnabled[0]) : undefined;
+  return hydrated?.kind === "installed" ? hydrated.file : undefined;
+}
+
 /**
  * Classify a resolved dependency into a surfaced requirement, or undefined to drop it.
  * A multi-branch dependency is an OR; a single branch maps to a missing / wrong-version
@@ -191,6 +212,13 @@ function classifyDependency(
   // OR: more than one alternative update group. Classify each branch to the action
   // it needs; drop branches we can't act on. An OR with no actionable branch is dropped.
   if (branches.length > 1) {
+    // A deliberately disabled alternative (nothing wrong enabled to explain it) counts as
+    // satisfied - enabling it would clear the OR - matching the single-branch rule below.
+    // Drop this guard to surface it as an "enable this version" card instead.
+    if (branches.some((b) => b.satisfyingDisabled.length > 0 && b.wrongEnabled.length === 0)) {
+      return undefined;
+    }
+
     const orBranches = branches
       .map((branch) => classifyOrBranch(branch, hydrate))
       .filter((branch): branch is IFileRequirementBranch => branch !== undefined);
@@ -207,21 +235,16 @@ function classifyDependency(
   // Correct version owned but disabled.
   if (branch.satisfyingDisabled.length > 0) {
     // A wrong version is enabled too: offer switching the active version.
-    if (branch.wrongEnabled.length > 0) {
-      const hydratedEnabled = hydrate(branch.wrongEnabled[0]);
+    const enabledFile = enabledWrongFile(branch, hydrate);
+    if (enabledFile) {
       const hydratedCorrect = hydrate(branch.satisfyingDisabled[0]);
-      if (
-        !hydratedEnabled ||
-        hydratedEnabled.kind !== "installed" ||
-        !hydratedCorrect ||
-        hydratedCorrect.kind !== "installed"
-      ) {
+      if (!hydratedCorrect || hydratedCorrect.kind !== "installed") {
         return undefined;
       }
       return {
         kind: "wrong-version-enabled",
         requirementDefId: definitionId,
-        enabledFile: hydratedEnabled.file,
+        enabledFile,
         correctFile: hydratedCorrect.file,
       };
     }
@@ -240,6 +263,7 @@ function classifyDependency(
       kind: "correct-version-uninstalled",
       requirementDefId: definitionId,
       uninstalledFile: hydrated.file,
+      enabledFile: enabledWrongFile(branch, hydrate),
     } satisfies IUninstalledFileRequirement;
   }
 
@@ -267,28 +291,40 @@ function classifyDependency(
 }
 
 /**
- * Classify one OR alternative into the action it needs if the user picks it:
- * enable an owned-but-disabled version (switching off a wrong one if present), or
- * download the recommended file. Returns undefined when the branch isn't actionable.
+ * Classify one OR alternative into the action it needs if the user picks it: enable an
+ * owned-but-disabled version, install a downloaded one, or download the recommended file.
+ * Returns undefined when the branch isn't actionable. Ordered as in classifyDependency.
  */
 function classifyOrBranch(
   branch: DependencyBranch,
   hydrate: HydrateFile,
 ): IFileRequirementBranch | undefined {
-  // Owned-but-disabled alternative: enabling it satisfies the OR without a download.
+  // Owned-but-disabled alternative: enabling it satisfies the OR without a download. Only
+  // reached with a wrong version enabled - the guard above drops the OR otherwise.
   if (branch.satisfyingDisabled.length > 0) {
     const hydratedCorrect = hydrate(branch.satisfyingDisabled[0]);
     if (!hydratedCorrect || hydratedCorrect.kind !== "installed") {
       return undefined;
     }
-    const hydratedEnabled =
-      branch.wrongEnabled.length > 0 ? hydrate(branch.wrongEnabled[0]) : undefined;
-    const enabledFile = hydratedEnabled?.kind === "installed" ? hydratedEnabled.file : undefined;
     return {
       kind: "enable",
       modFileId: branch.modFileId,
       correctFile: hydratedCorrect.file,
-      enabledFile,
+      enabledFile: enabledWrongFile(branch, hydrate),
+    };
+  }
+
+  // Downloaded but not installed: installing it satisfies the OR without a download.
+  if (branch.satisfyingUninstalled.length > 0) {
+    const hydrated = hydrate(branch.satisfyingUninstalled[0]);
+    if (!hydrated || hydrated.kind !== "downloaded") {
+      return undefined;
+    }
+    return {
+      kind: "install",
+      modFileId: branch.modFileId,
+      uninstalledFile: hydrated.file,
+      enabledFile: enabledWrongFile(branch, hydrate),
     };
   }
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -62,9 +62,9 @@ function ownedFiles(requirement: IFileRequirement): IOwnedFile[] {
 }
 
 /**
- * Mod UIDs of the owned files the check surfaces. Their display data (thumbnail,
- * summary, adult flag) comes from the local mod / download record, which can be
- * incomplete or stale, so it is backfilled from the mods endpoint.
+ * Mod UIDs of the owned files the check surfaces. Their thumbnail and adult flag - plus
+ * the summary, for downloads - come from the local mod / download record, which can be
+ * incomplete or stale, so they are backfilled from the mods endpoint.
  */
 function surfacedModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
   const uids = new Set<string>();

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -140,6 +140,11 @@ export async function runFileLevelRequirements(
     });
     return [];
   });
+  if (details.length === 0) {
+    // Nothing to backfill, so a second pass would reproduce what we already have.
+    return initial;
+  }
+
   const modDetailsByUID = new Map(details.map((detail) => [detail.modUID, detail]));
   return mapRequirementsReport(report, buildHydrate(modDetailsByUID), context);
 }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -2,8 +2,10 @@ import {
   checkFileLevelRequirements,
   type InstalledFile,
 } from "@nexusmods/file-dependency-resolver";
+import { getErrorMessage, unknownToError } from "@vortex/shared";
 
 import { activeProfile } from "@/extensions/profile_management/selectors";
+import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
 import type { IModDetails } from "../../types";
@@ -14,33 +16,62 @@ import {
   gatherInstalledFiles,
   makeDownloadedFileHydrator,
   makeInstalledFileHydrator,
+  type IDownloadedFile,
+  type IInstalledFile,
 } from "./installedFiles";
 import {
   type HydrateFile,
+  type IFileRequirement,
+  type IFileRequirementBranch,
   type IFileRequirementsCheckMetadata,
   mapRequirementsReport,
 } from "./mapRequirementsReport";
 
-/** Mod UIDs of the downloaded-but-not-installed archives the check surfaces. */
-function surfacedDownloadModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
-  const uids = new Set<string>();
-  const add = (modUID: string): void => {
-    if (modUID) {
-      uids.add(modUID);
-    }
-  };
+/** A file the user already has, installed or only downloaded. */
+type IOwnedFile = IInstalledFile | IDownloadedFile;
 
+/** The already-owned files (installed or downloaded) one OR alternative surfaces. */
+function branchOwnedFiles(branch: IFileRequirementBranch): IOwnedFile[] {
+  switch (branch.kind) {
+    case "download":
+      return [];
+    case "install":
+      return [branch.uninstalledFile, ...(branch.enabledFile ? [branch.enabledFile] : [])];
+    case "enable":
+      return [branch.correctFile, ...(branch.enabledFile ? [branch.enabledFile] : [])];
+  }
+}
+
+/** The already-owned files one requirement surfaces; download candidates come hydrated. */
+function ownedFiles(requirement: IFileRequirement): IOwnedFile[] {
+  switch (requirement.kind) {
+    case "missing":
+      return [];
+    case "wrong-version-installed":
+      return [requirement.installedFile];
+    case "wrong-version-enabled":
+      return [requirement.correctFile, requirement.enabledFile];
+    case "correct-version-uninstalled":
+      return [
+        requirement.uninstalledFile,
+        ...(requirement.enabledFile ? [requirement.enabledFile] : []),
+      ];
+    case "or":
+      return requirement.branches.flatMap(branchOwnedFiles);
+  }
+}
+
+/**
+ * Mod UIDs of the owned files the check surfaces. Their display data (thumbnail,
+ * summary, adult flag) comes from the local mod / download record, which can be
+ * incomplete or stale, so it is backfilled from the mods endpoint.
+ */
+function surfacedModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
+  const uids = new Set<string>();
   for (const fileReq of Object.values(metadata.fileRequirements)) {
-    for (const req of fileReq.requirements) {
-      if (req.kind === "correct-version-uninstalled") {
-        add(req.uninstalledFile.modUID);
-      } else if (req.kind === "or") {
-        // An OR alternative can be downloaded-but-not-installed too.
-        for (const branch of req.branches) {
-          if (branch.kind === "install") {
-            add(branch.uninstalledFile.modUID);
-          }
-        }
+    for (const file of fileReq.requirements.flatMap(ownedFiles)) {
+      if (file.modUID) {
+        uids.add(file.modUID);
       }
     }
   }
@@ -78,8 +109,8 @@ export async function runFileLevelRequirements(
     ports: createResolverPorts(api),
   });
 
-  const hydrateInstalled = makeInstalledFileHydrator(api, installedRefs);
   const buildHydrate = (modDetailsByUID: Map<string, IModDetails>): HydrateFile => {
+    const hydrateInstalled = makeInstalledFileHydrator(api, installedRefs, modDetailsByUID);
     const hydrateDownloaded = makeDownloadedFileHydrator(api, downloadedRefs, modDetailsByUID);
     return (fileUID) => {
       const installed = hydrateInstalled(fileUID);
@@ -92,18 +123,23 @@ export async function runFileLevelRequirements(
 
   const context = { gameId, modsChecked: installedRefs.length, errors: [] };
 
-  // First pass without mod details reveals which downloaded archives the check
-  // actually surfaces, so we only fetch details for those.
+  // First pass without mod details reveals which owned files the check actually
+  // surfaces, so we only fetch details for those.
   const initial = mapRequirementsReport(report, buildHydrate(new Map()), context);
-  const modUIDs = surfacedDownloadModUIDs(initial);
+  const modUIDs = surfacedModUIDs(initial);
   if (modUIDs.length === 0) {
     return initial;
   }
 
-  // Backfill display data (thumbnail, summary, adult flag) missing from those
-  // unenriched downloads via the batched, cached mod-details endpoint, then
-  // re-map with it. See toDownloadedFile.
-  const details = await getModDetails(api, modUIDs).catch((): IModDetails[] => []);
+  // Backfill display data (thumbnail, summary, adult flag) via the batched, cached
+  // mod-details endpoint, then re-map with it. See toDownloadedFile / toInstalledFile.
+  const details = await getModDetails(api, modUIDs).catch((err: unknown): IModDetails[] => {
+    log("warn", "failed to fetch mod details for file requirements", {
+      count: modUIDs.length,
+      error: getErrorMessage(unknownToError(err)),
+    });
+    return [];
+  });
   const modDetailsByUID = new Map(details.map((detail) => [detail.modUID, detail]));
   return mapRequirementsReport(report, buildHydrate(modDetailsByUID), context);
 }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -24,10 +24,23 @@ import {
 /** Mod UIDs of the downloaded-but-not-installed archives the check surfaces. */
 function surfacedDownloadModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
   const uids = new Set<string>();
+  const add = (modUID: string): void => {
+    if (modUID) {
+      uids.add(modUID);
+    }
+  };
+
   for (const fileReq of Object.values(metadata.fileRequirements)) {
     for (const req of fileReq.requirements) {
-      if (req.kind === "correct-version-uninstalled" && req.uninstalledFile.modUID) {
-        uids.add(req.uninstalledFile.modUID);
+      if (req.kind === "correct-version-uninstalled") {
+        add(req.uninstalledFile.modUID);
+      } else if (req.kind === "or") {
+        // An OR alternative can be downloaded-but-not-installed too.
+        for (const branch of req.branches) {
+          if (branch.kind === "install") {
+            add(branch.uninstalledFile.modUID);
+          }
+        }
       }
     }
   }

--- a/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
@@ -85,7 +85,13 @@ export const fileRequirementsContent: IHealthCheckContent = {
         if (requirement.kind === "correct-version-uninstalled") {
           items.push({
             key: requirement.uninstalledFile.fileUID,
-            install: () => void installDownloadedFile(api, requirement.uninstalledFile, identity),
+            install: () =>
+              void installDownloadedFile(
+                api,
+                requirement.uninstalledFile,
+                identity,
+                requirement.enabledFile,
+              ),
           });
         }
       }


### PR DESCRIPTION
Closes LAZ-840
Closes LAZ-849

If one of the branches of an OR requirement was alerady downloaded, or had wrong versions enabled etc, that branch would not show correctly.
Added support for all the possible cases.