### PR TITLE
Disable zod's eval-based JIT under the renderer CSP (LAZ-866)

### DIFF
--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,3 +1,6 @@
+// oxlint-disable-next-line import/no-unassigned-import -- must run before any module below constructs a zod schema
+import "./zodJitless";
+
 export * from "./constants";
 export * from "./Debouncer";
 export * from "./errors";

--- a/src/shared/src/zodJitless.ts
+++ b/src/shared/src/zodJitless.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+// zod v4 JIT-compiles object schemas with new Function on first parse. The
+// renderer's CSP has no unsafe-eval, but this package is also loaded by the
+// preload before the document (and its CSP) exists, so zod's own eval probe
+// passes there and caches "eval allowed" for the whole process. Any schema
+// constructed after that then throws EvalError on its first parse inside the
+// CSP-bound page (LAZ-866: login failed on the access-token parse). jitless
+// disables the JIT for every schema constructed after this call, so this
+// module must stay the first import of the package entry.
+z.config({ jitless: true });


### PR DESCRIPTION
## Problem

2.5.0-beta.1: every login fails with an EvalError from `accessTokenSchema.safeParse` in `OAuth.receiveCode`. zod compiles object-schema parsers with `new Function`; the renderer CSP has no `unsafe-eval`. Token refresh parses the same schema, so existing sessions fail as tokens expire.

## Root cause

- zod v4 probes eval availability once per process and caches the result.
- The preload imports `@vortex/shared`, which constructs zod schemas at module init. Preloads run before the document CSP exists, so the probe passes and "eval allowed" is cached process-wide (`contextIsolation: false`, shared require cache).
- The first object-schema parse in the CSP-bound page then throws. Login's token parse is that first parse.

## Fix

`z.config({ jitless: true })` as the first import of shared's entry.

- Must run before the first schema construction: zod fixes the JIT decision per schema at construction time.
- Cannot live in the preload: rolldown hoists external requires, so `require("@vortex/shared")` runs before preload-local code.
- zod parses here are low-frequency; no measurable cost.

## Verification

- Failure reproduced in a dev build; with the fix, schemas parse under the CSP and a real OAuth logout/login completes.
- 208 shared tests pass; build/lint/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
