### PR TITLE
Rename Game settings page header to match sidebar 

### DIFF
--- a/src/renderer/src/views/GameSettings.tsx
+++ b/src/renderer/src/views/GameSettings.tsx
@@ -142,9 +142,9 @@ export const GameSettings: FC<{ active?: boolean; pageId?: string }> = ({ active
   return (
     <Page active={active} pageId={pageId} scrollable={false}>
       <PageHeader
-        pictogramName="preferences"
+        pictogramName="settings"
         subtitle={t("Settings specific to the game you are managing.")}
-        title={t("Preferences")}
+        title={t("Game settings")}
       />
 
       <PageScroll className="space-y-6 p-6">


### PR DESCRIPTION
The sidebar item was renamed to "Game settings" in fba98ff39, but only the page registration changed - the page it opened still showed a "Preferences" header.

Sets the header title to "Game settings" and switches the pictogram to `settings` to match the global Settings page. Two lines in `GameSettings.tsx`.

<img width="1502" height="722" alt="image" src="https://github.com/user-attachments/assets/c2df7a5e-a9b9-4db5-b0e5-d79c120d2a21" />
