### PR TITLE
Anchor Settings pickers left so their menus stay inside the pane

### DIFF
--- a/packages/e2e/src/tests/settings.spec.ts
+++ b/packages/e2e/src/tests/settings.spec.ts
@@ -26,6 +26,42 @@ test.describe("Settings - Interface Tab", () => {
     });
   });
 
+  test("language picker menu opens fully visible (not clipped by the settings pane)", async ({
+    vortexWindow,
+  }) => {
+    await test.step("Open the language picker", async () => {
+      await vortexWindow.getByRole("button", { name: "English" }).first().click();
+      await expect(vortexWindow.getByRole("listbox")).toBeVisible();
+    });
+
+    await test.step("Verify the open menu is hit-testable at its corners", async () => {
+      const hits = await vortexWindow.getByRole("listbox").evaluate((menu) => {
+        // the e2e tsconfig has no DOM lib; type the in-page APIs structurally
+        interface InPageElement {
+          getBoundingClientRect(): { left: number; top: number; right: number; bottom: number };
+          closest(selector: string): InPageElement | null;
+        }
+        const el = menu as unknown as InPageElement;
+        const doc = (
+          globalThis as unknown as {
+            document: { elementFromPoint(x: number, y: number): InPageElement | null };
+          }
+        ).document;
+        const r = el.getBoundingClientRect();
+        const points: Array<[number, number]> = [
+          [r.left + 4, r.top + 4],
+          [r.right - 4, r.top + 4],
+          [r.left + 4, Math.min(r.bottom - 4, r.top + 150)],
+        ];
+        return points.map(([x, y]) => {
+          const hit = doc.elementFromPoint(x, y);
+          return hit !== null && hit.closest('[role="listbox"]') !== null;
+        });
+      });
+      expect(hits).toEqual([true, true, true]);
+    });
+  });
+
   test("customisation toggles can be switched on and off", async ({ vortexWindow }) => {
     const settings = new SettingsPage(vortexWindow);
     const toggleCount = await settings.checkboxes.count();

--- a/src/renderer/src/extensions/settings_application/SettingsVortex.tsx
+++ b/src/renderer/src/extensions/settings_application/SettingsVortex.tsx
@@ -70,6 +70,7 @@ class SettingsVortex extends ComponentEx<IProps, IComponentState> {
                 { label: t("Shared"), value: "on" },
                 { label: t("Per-User"), value: "off" },
               ]}
+              placement="left"
               value={multiUser ? "on" : "off"}
               onChange={this.selectMode}
             />

--- a/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
+++ b/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
@@ -184,6 +184,7 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
                 label: option.label,
                 value: option.id,
               }))}
+              placement="left"
               value={selectedLanguageId}
               onChange={this.selectLanguage}
             />

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -124,6 +124,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
                   { label: t("Beta"), value: "beta" },
                   { label: t("No automatic updates"), value: "none" },
                 ]}
+                placement="left"
                 value={updateChannel}
                 onChange={this.selectChannel}
               />


### PR DESCRIPTION
The Picker default `placement="right"` opens its menu leftward, which the Settings pane's overflow clipping cuts off — the language, multi-user, and update-channel pickers appeared hidden behind the sidebar. Anchor them `left` (same idiom as the Design System demos); Headless UI v2's auto-positioning will retire the prop later.

Adds an e2e regression test that opens the language picker and hit-tests the menu's corners.

<img width="910" height="1158" alt="Screenshot 2026-07-29 212730" src="https://github.com/user-attachments/assets/fd833d6d-a164-487c-874a-339659235417" />

<img width="1226" height="816" alt="Screenshot 2026-07-29 212832" src="https://github.com/user-attachments/assets/3f8852a7-a089-48b1-a63e-6c36ab3b4d63" />
