### PR TITLE
Use default Proton version as configured in Steam and allow loading Proton from non-default Steam libraries

### DIFF
--- a/src/renderer/src/util/Steam.ts
+++ b/src/renderer/src/util/Steam.ts
@@ -333,7 +333,12 @@ class Steam implements IGameStore {
             return this.mBaseFolder.then((basePath) =>
               PromiseBB.map(entries, async (entry) => {
                 try {
-                  const protonInfo = await getProtonInfo(basePath, steamAppsPath, entry.appid);
+                  const protonInfo = await getProtonInfo(
+                    basePath,
+                    steamPaths,
+                    steamAppsPath,
+                    entry.appid,
+                  );
                   entry.usesProton = protonInfo.usesProton;
                   entry.compatDataPath = protonInfo.compatDataPath;
                   entry.protonPath = protonInfo.protonPath;

--- a/src/renderer/src/util/linux/proton.ts
+++ b/src/renderer/src/util/linux/proton.ts
@@ -122,8 +122,10 @@ function folderMatchesKeyword(folderName: string, keyword: string): boolean {
  *   - config.vdf: "proton_9"            -> folder: "Proton 9.0"
  *   - config.vdf: "GE-Proton10-28"      -> folder: "GE-Proton10-28" (exact match)
  *
- * Steam provides no direct mapping between these names. Custom tools (GE-Proton, etc.)
- * use matching names, but official Proton versions do not.
+ * Steam provides an indirect mapping between these names in appdata.vdf, but we
+ * don't currently have a mechanism for parsing binary VDF files and this approach
+ * works well enough for now.
+ * Custom tools (GE-Proton, etc.) use matching names, but official Proton versions do not.
  *
  * Resolution strategy (no hardcoded mappings):
  * 1. Custom tools: Check compatibilitytools.d/{name} - custom Proton builds
@@ -136,40 +138,47 @@ function folderMatchesKeyword(folderName: string, keyword: string): boolean {
  * releases new Proton versions.
  */
 export async function resolveProtonPath(
-  steamPath: string,
+  steamBasePath: string,
+  steamLibraryPaths: string[],
   protonName: string,
 ): Promise<string | undefined> {
   // 1. Check custom compatibility tools directory (GE-Proton, etc.)
   // Custom tools use their config name as the folder name directly
-  const customToolPath = path.join(steamPath, "compatibilitytools.d", protonName);
+  const customToolPath = path.join(steamBasePath, "compatibilitytools.d", protonName);
   if (await pathExists(customToolPath)) {
     return customToolPath;
   }
 
-  const commonPath = path.join(steamPath, "steamapps", "common");
-
   // 2. Check for exact match in steamapps/common
-  const exactPath = path.join(commonPath, protonName);
-  if (await pathExists(exactPath)) {
-    return exactPath;
+  for (const steamLibraryPath of steamLibraryPaths) {
+    const commonPath = path.join(steamLibraryPath, "steamapps", "common");
+
+    const exactPath = path.join(commonPath, protonName);
+    if (await pathExists(exactPath)) {
+      return exactPath;
+    }
   }
 
   // 3. Fuzzy match: scan Proton* folders and match by keyword
-  const keyword = extractProtonKeyword(protonName);
-  if (keyword) {
-    try {
-      const entries = await fs.readdirAsync(commonPath);
-      const protonDirs = entries.filter((e) => e.toLowerCase().startsWith("proton"));
+  for (const steamLibraryPath of steamLibraryPaths) {
+    const commonPath = path.join(steamLibraryPath, "steamapps", "common");
 
-      for (const dir of protonDirs) {
-        if (folderMatchesKeyword(dir, keyword)) {
-          return path.join(commonPath, dir);
+    const keyword = extractProtonKeyword(protonName);
+    if (keyword) {
+      try {
+        const entries = await fs.readdirAsync(commonPath);
+        const protonDirs = entries.filter((e) => e.toLowerCase().startsWith("proton"));
+
+        for (const dir of protonDirs) {
+          if (folderMatchesKeyword(dir, keyword)) {
+            return path.join(commonPath, dir);
+          }
         }
+      } catch (err: any) {
+        log("debug", `Could not scan ${commonPath} for Proton`, {
+          error: err?.message,
+        });
       }
-    } catch (err: any) {
-      log("debug", "Could not scan steamapps/common for Proton", {
-        error: err?.message,
-      });
     }
   }
 
@@ -179,23 +188,36 @@ export async function resolveProtonPath(
 /**
  * Find the latest installed Proton version (fallback)
  */
-export async function findLatestProton(steamPath: string): Promise<string | undefined> {
-  const commonPath = path.join(steamPath, "steamapps", "common");
+export async function findLatestProton(steamLibraryPaths: string[]): Promise<string | undefined> {
   try {
-    const entries = await fs.readdirAsync(commonPath);
-    const protonDirs = entries.filter((e) => e.toLowerCase().startsWith("proton"));
+    let protonDirs: string[] = [];
+    let protonDirPaths: { [key: string]: string } = {};
 
-    // Steam defaults to Proton Experimental - replicate this behavior
-    const protonExperimentalDir = protonDirs.find((e) => e.toLowerCase().endsWith("experimental"));
-    if (protonExperimentalDir) {
-      return path.join(commonPath, protonDirs[protonExperimentalDir]);
+    for (let libraryPath of steamLibraryPaths) {
+      const commonPath = path.join(libraryPath, "steamapps", "common");
+      const entries = await fs.readdirAsync(commonPath);
+      const curProtonDirs = entries.filter((e) => e.toLowerCase().startsWith("proton"));
+
+      // Steam defaults to Proton Experimental - replicate this behavior
+      const protonExperimentalDir = protonDirs.find((e) =>
+        e.toLowerCase().endsWith("experimental"),
+      );
+      if (protonExperimentalDir) {
+        return path.join(commonPath, protonDirs[protonExperimentalDir]);
+      }
+
+      protonDirs = protonDirs.concat(curProtonDirs);
+      for (let protonDir of curProtonDirs) {
+        protonDirPaths[protonDir] = path.join(commonPath, protonDir);
+      }
     }
 
     // Otherwise, fall back to the last version lexographically
     const sortedProtonDirs = protonDirs.sort().reverse();
 
     if (sortedProtonDirs.length > 0) {
-      return path.join(commonPath, sortedProtonDirs[0]);
+      const protonDir = sortedProtonDirs[0];
+      return protonDirPaths[protonDir];
     }
   } catch (err: any) {
     log("debug", "Could not scan for Proton versions", { error: err?.message });
@@ -207,7 +229,8 @@ export async function findLatestProton(steamPath: string): Promise<string | unde
  * Get full Proton info for a game
  */
 export async function getProtonInfo(
-  steamPath: string,
+  steamBasePath: string,
+  steamLibraryPaths: string[],
   steamAppsPath: string,
   appId: string,
 ): Promise<IProtonInfo> {
@@ -219,24 +242,24 @@ export async function getProtonInfo(
   const compatDataPath = getCompatDataPath(steamAppsPath, appId);
 
   // Try to get configured Proton, fall back to latest
-  const confProtonName = await getConfiguredProtonName(steamPath, appId);
+  const confProtonName = await getConfiguredProtonName(steamBasePath, appId);
   let protonPath: string | undefined;
 
   if (confProtonName) {
-    protonPath = await resolveProtonPath(steamPath, confProtonName);
+    protonPath = await resolveProtonPath(steamBasePath, steamLibraryPaths, confProtonName);
   }
 
   if (!protonPath) {
     // Game does not have Proton version override,
     // or we couldn't find the override version
-    const defProtonName = await getDefaultProtonName(steamPath);
-    protonPath = await resolveProtonPath(steamPath, defProtonName);
+    const defProtonName = await getDefaultProtonName(steamBasePath);
+    protonPath = await resolveProtonPath(steamBasePath, steamLibraryPaths, defProtonName);
   }
 
   if (!protonPath) {
     // config.vdf does not contain a default Proton version,
     // or the default version is not installed
-    protonPath = await findLatestProton(steamPath);
+    protonPath = await findLatestProton(steamLibraryPaths);
   }
 
   return { usesProton: true, compatDataPath, protonPath };

--- a/src/renderer/src/util/linux/proton.ts
+++ b/src/renderer/src/util/linux/proton.ts
@@ -58,6 +58,13 @@ export async function getConfiguredProtonName(
 }
 
 /**
+ * Find the default Proton version (fallback)
+ */
+export async function getDefaultProtonName(steamPath: string): Promise<string | undefined> {
+  return getConfiguredProtonName(steamPath, "0");
+}
+
+/**
  * Check if a path exists asynchronously
  */
 async function pathExists(filePath: string): Promise<boolean> {
@@ -176,13 +183,19 @@ export async function findLatestProton(steamPath: string): Promise<string | unde
   const commonPath = path.join(steamPath, "steamapps", "common");
   try {
     const entries = await fs.readdirAsync(commonPath);
-    const protonDirs = entries
-      .filter((e) => e.toLowerCase().startsWith("proton"))
-      .sort()
-      .reverse();
+    const protonDirs = entries.filter((e) => e.toLowerCase().startsWith("proton"));
 
-    if (protonDirs.length > 0) {
-      return path.join(commonPath, protonDirs[0]);
+    // Steam defaults to Proton Experimental - replicate this behavior
+    const protonExperimentalDir = protonDirs.find((e) => e.toLowerCase().endsWith("experimental"));
+    if (protonExperimentalDir) {
+      return path.join(commonPath, protonDirs[protonExperimentalDir]);
+    }
+
+    // Otherwise, fall back to the last version lexographically
+    const sortedProtonDirs = protonDirs.sort().reverse();
+
+    if (sortedProtonDirs.length > 0) {
+      return path.join(commonPath, sortedProtonDirs[0]);
     }
   } catch (err: any) {
     log("debug", "Could not scan for Proton versions", { error: err?.message });
@@ -206,14 +219,23 @@ export async function getProtonInfo(
   const compatDataPath = getCompatDataPath(steamAppsPath, appId);
 
   // Try to get configured Proton, fall back to latest
-  const protonName = await getConfiguredProtonName(steamPath, appId);
+  const confProtonName = await getConfiguredProtonName(steamPath, appId);
   let protonPath: string | undefined;
 
-  if (protonName) {
-    protonPath = await resolveProtonPath(steamPath, protonName);
+  if (confProtonName) {
+    protonPath = await resolveProtonPath(steamPath, confProtonName);
   }
 
   if (!protonPath) {
+    // Game does not have Proton version override,
+    // or we couldn't find the override version
+    const defProtonName = await getDefaultProtonName(steamPath);
+    protonPath = await resolveProtonPath(steamPath, defProtonName);
+  }
+
+  if (!protonPath) {
+    // config.vdf does not contain a default Proton version,
+    // or the default version is not installed
     protonPath = await findLatestProton(steamPath);
   }
 


### PR DESCRIPTION
This PR adds the following tweaks to Proton discovery:

First, Vortex now tries first to load the default Proton version as configured in Steam (associated with app ID `0` in `config.vdf`) before falling back to the existing lexographic-based selection in `findLatestProton`. The fallback is still necessary because Steam doesn't actually populate the default version until the Compatibility menu is opened - if the user hasn't opened it before then that entry won't exist. `findLatestProton` also now prefers Proton Experimental if found, since that's what Steam seems to default to.

Second, Vortex now attempts to discover installed Proton versions across all Steam library folders. This is especially important if the default library doesn't contain _any_ Proton versions, as previously this would cause Vortex to fall back to running the target .exe directly (which obviously doesn't work properly on Linux).

As a note: I believe the name-based heuristic currently in use for finding Proton installations is technically unnecessary as the Proton "keys" are associated with app IDs in `appinfo.vdf` which are in turn associated with a directory name, but this file is in binary VDF format and Vortex doesn't seem to be able to parse that without pulling in an additional dependency. I was also only able to find [a single Node package](https://github.com/cbartondock/node-binary-vdf) that can handle the latest format version, but it doesn't seem to be maintained and currently requires a tweak to work correctly.