### PR TITLE
Fix copying dotnetprobe binary to unpacked ASAR on Linux

### DIFF
--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -72,6 +72,7 @@
     "node_modules/json-socket",
     "node_modules/react-select/scss",
     "node_modules/@nexusmods/fomod-installer-ipc/dist/*.exe",
+    "assets/dotnetprobe*",
     "assets/*.exe",
     "assets/css/**",
     "**/*.node",


### PR DESCRIPTION
On Windows it's covered under `assets/*.exe`, but this doesn't work on Linux where the executable lacks an extension.