### PR TITLE
gamebryo-archive-check: Fix case for Data directory

### DIFF
--- a/extensions/gamebryo-archive-check/src/index.ts
+++ b/extensions/gamebryo-archive-check/src/index.ts
@@ -120,7 +120,7 @@ async function checkForErrors(api: types.IExtensionApi, pluginsObj: any) {
     undefined,
   );
 
-  const dataFolder = discovery ? path.join(discovery, "data") : undefined;
+  const dataFolder = discovery ? path.join(discovery, "Data") : undefined;
 
   const normalize = (fileName: string) => {
     const noExt = path.basename(fileName, path.extname(fileName)).toLowerCase();


### PR DESCRIPTION
This allows it to work correctly on machines with case-sensitive filesystems (i.e. Linux).