### PR TITLE
Fix nxm:// URL handling on Linux

### DIFF
--- a/src/main/src/cli.ts
+++ b/src/main/src/cli.ts
@@ -193,6 +193,13 @@ export function parseCommandline(argv: string[], electronIsShitHack: boolean): I
     argv = electronIsShitArgumentSort(argv);
   }
 
+  if (process.platform === "linux") {
+    const nxmArg = argv.findIndex((arg) => arg.startsWith("nxm://"));
+    if (nxmArg !== -1 && !(nxmArg > 1 && argv[nxmArg - 1] === "-d")) {
+      argv.splice(nxmArg, 0, "-d");
+    }
+  }
+
   let version: string = "1.0.0";
   try {
     // won't happen in regular operation but lets us test this function outside vortex

--- a/src/main/src/main.ts
+++ b/src/main/src/main.ts
@@ -169,6 +169,15 @@ const handleError = (error: Error) => {
 };
 
 async function main(): Promise<void> {
+  if (process.env.VORTEX_E2E === "1") {
+    // Skip single-instance lock in e2e tests — each test worker runs its
+    // own Electron instance with an isolated user data directory.
+  } else if (!app.requestSingleInstanceLock()) {
+    app.disableHardwareAcceleration();
+    app.quit();
+    return;
+  }
+
   // important: The following has to be synchronous!
   const mainArgs = parseCommandline(process.argv, false);
 
@@ -308,17 +317,6 @@ async function main(): Promise<void> {
   initTelemetryIpcHandler();
 
   StylesheetCompiler.init();
-
-  if (process.env.VORTEX_E2E === "1") {
-    // Skip single-instance lock in e2e tests — each test worker runs its
-    // own Electron instance with an isolated user data directory.
-  } else if (!app.requestSingleInstanceLock()) {
-    app.disableHardwareAcceleration();
-    app.commandLine.appendSwitch("--in-process-gpu");
-    app.commandLine.appendSwitch("--disable-software-rasterizer");
-    app.quit();
-    return;
-  }
 
   // async code only allowed from here on out
 


### PR DESCRIPTION
This tweaks argument parsing on Linux by injecting a `-d` flag before an argument starting with `nxm://`. This allows the Vortex executable to be launched directly rather than needing to be proxied via a `run.sh` script.

This also modifies duplicate instance handling by exiting almost immediately in such a scenario. As far as I can tell there's no reason to proceed as far as it currently does, and in fact doing so triggers a segfault (at least on my system, Fedora 44 KDE).