### PR TITLE
Load Steam overlay when launching via Proton

### DIFF
--- a/src/renderer/src/util/linux/proton.ts
+++ b/src/renderer/src/util/linux/proton.ts
@@ -236,11 +236,16 @@ export function buildProtonEnvironment(
   steamPath: string,
   existingEnv?: Record<string, string>,
 ): Record<string, string> {
+  const preloads = [
+    path.join(steamPath, "ubuntu12_32", "gameoverlayrenderer.so"),
+    path.join(steamPath, "ubuntu12_64", "gameoverlayrenderer.so"),
+  ];
   return {
     ...existingEnv,
     STEAM_COMPAT_DATA_PATH: compatDataPath,
     STEAM_COMPAT_CLIENT_INSTALL_PATH: steamPath,
     WINEPREFIX: getWinePrefixPath(compatDataPath),
+    LD_PRELOAD: preloads.join(":"),
   };
 }
 


### PR DESCRIPTION
This adds the `gameoverlayrenderer.so` libraries to `LD_PRELOAD` when launching via Proton to make the Steam overlay functional in this scenario. I didn't add any similar logic for native Linux games, since that takes a completely different code path for launching and I felt it could be considered a different scope than this change.