### PR TITLE
gamebryo-plugin-management: Fix plugin IDs for LOOT on case-sensitive filesystems

### DIFF
--- a/extensions/gamebryo-plugin-management/src/autosort.ts
+++ b/extensions/gamebryo-plugin-management/src/autosort.ts
@@ -18,6 +18,7 @@ import { gameDataPath, gameSupported, nativePlugins, pluginPath } from "./util/g
 import { missingGroupFixes } from "./util/groups";
 import { invalidPluginsFromError } from "./util/invalidPlugins";
 import { downloadMasterlist, downloadPrelude } from "./util/masterlist";
+import toLootPluginName from "./util/toLootPluginName";
 import toPluginId from "./util/toPluginId";
 
 const MAX_RESTARTS = 3;
@@ -578,7 +579,7 @@ class LootInterface {
     }
     try {
       await loot.loadPluginsAsync(
-        deployed.filter((id) => !invalid.has(id)).map((name) => toPluginId(name)),
+        deployed.filter((id) => !invalid.has(id)).map((id) => toLootPluginName(id, pluginList)),
         false,
       );
       pluginsLoaded = true;
@@ -908,6 +909,7 @@ class LootInterface {
           expectSuccess: true,
           env: {
             ELECTRON_RUN_AS_NODE: "1",
+            LD_LIBRARY_PATH: path.join(__dirname, ".."),
           },
         })
         .catch((err: Error) => {

--- a/extensions/gamebryo-plugin-management/src/util/toLootPluginName.test.ts
+++ b/extensions/gamebryo-plugin-management/src/util/toLootPluginName.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import toLootPluginName from "./toLootPluginName";
+
+describe("toLootPluginName", () => {
+  it("uses on-disk filename casing when file path is known", () => {
+    const pluginList = {
+      "myplugin.esp": {
+        filePath: "C:\\Games\\Data\\MyPlugin.esp",
+      },
+    } as any;
+
+    expect(toLootPluginName("myplugin.esp", pluginList)).toBe("MyPlugin.esp");
+  });
+
+  it("falls back to normalized plugin id when file path is missing", () => {
+    expect(toLootPluginName("MyPlugin.esp", {} as any)).toBe("myplugin.esp");
+  });
+});

--- a/extensions/gamebryo-plugin-management/src/util/toLootPluginName.ts
+++ b/extensions/gamebryo-plugin-management/src/util/toLootPluginName.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+
+import { IPlugins } from "../types/IPlugins";
+import toPluginId from "./toPluginId";
+
+function toLootPluginName(pluginId: string, pluginList: IPlugins): string {
+  const filePath = pluginList[pluginId]?.filePath;
+  if (filePath === undefined) {
+    return toPluginId(pluginId);
+  }
+  const base = path.basename(filePath);
+  return base === filePath ? path.win32.basename(filePath) : base;
+}
+
+export default toLootPluginName;


### PR DESCRIPTION
This tweaks the logic for deriving plugin names to pass to LOOT to preserve case so that it's able to actually load the plugin files on case-sensitive filesystems. I haven't tested this on Windows as I don't have an install readily available, so it would be very much appreciated if anyone is able to make sure this doesn't blow anything up there.