### PR TITLE
Build gamebryo-plugin-management on Linux

### DIFF
--- a/extensions/gamebryo-plugin-management/package.json
+++ b/extensions/gamebryo-plugin-management/package.json
@@ -4,9 +4,12 @@
   "description": "Management for Gamebryo plugins",
   "scripts": {
     "_assets": "copyfiles -u 1 -f ./src/stylesheets/plugin_management.scss ./src/language.json ./src/loot_icon.png dist",
-    "_native": "node ../copy-native.mjs ./node_modules/loot/build/Release/node-loot.node ./node_modules/loot/loot_api/libloot.dll ./node_modules/loot/async.js && node -e \"const fs=require('fs');const f='dist/async.js';let c=fs.readFileSync(f,'utf8');c=c.replace('./build/Release/node-loot','./node-loot');fs.writeFileSync(f,c);\"",
-    "_build": "node build.mjs && pnpm run _assets && pnpm run _native && pnpm extractInfo",
-    "build": "node -e \"if(process.platform==='win32')process.exit(1)\" || (pnpm run _build)",
+    "_native_common": "node ../copy-native.mjs ./node_modules/loot/build/Release/node-loot.node ./node_modules/loot/async.js && node -e \"const fs=require('fs');const f='dist/async.js';let c=fs.readFileSync(f,'utf8');c=c.replace('./build/Release/node-loot','./node-loot');fs.writeFileSync(f,c);\"",
+    "_native_os": "run-script-os",
+    "_native_os:windows": "node ../copy-native.mjs ./node_modules/loot/loot_api/libloot.dll",
+    "_native_os:linux": "node ../copy-native.mjs ./node_modules/loot/loot_api/libloot.so.0",
+    "_build": "node build.mjs && pnpm run _assets && pnpm run _native_os && pnpm run _native_common && pnpm extractInfo",
+    "build": "pnpm run _build",
     "typecheck": "pnpm tsc",
     "test": "pnpm exec vitest run"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,6 +863,9 @@ catalogs:
     rolldown:
       specifier: 1.1.4
       version: 1.1.4
+    run-script-os:
+      specifier: ^1.1.6
+      version: 1.1.6
     sass:
       specifier: 1.101.0
       version: 1.101.0
@@ -1815,6 +1818,9 @@ importers:
       reselect:
         specifier: 'catalog:'
         version: 4.1.8
+      run-script-os:
+        specifier: 'catalog:'
+        version: 1.1.6
       shortid:
         specifier: 'catalog:'
         version: 2.2.17
@@ -11873,6 +11879,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  run-script-os@1.1.6:
+    resolution: {integrity: sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==}
+    hasBin: true
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -20070,6 +20080,8 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.4
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  run-script-os@1.1.6: {}
 
   rw@1.3.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -237,6 +237,7 @@ catalog:
   resolve: 1.22.11
   rimraf: github:TanninOne/rimraf#7b8b70d4e8783cd233fca3283cf1f930af4e39c2
   rolldown: 1.1.4
+  run-script-os: ^1.1.6
   sass: 1.101.0
   semver: 7.7.4
   shortid: 2.2.17


### PR DESCRIPTION
This allows building `gamebryo-plugin-management` on Linux (which previously skipped building this extension). This depends on Linux support in `node-loot` which is [not yet merged](https://github.com/Nexus-Mods/node-loot/pull/20), so I'm creating this as a draft PR in the meantime.