### PR TITLE
Disable zod's eval-based JIT under the renderer CSP (LAZ-866)

### DIFF
--- a/src/renderer/src/index.html
+++ b/src/renderer/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta
             http-equiv="Content-Security-Policy"
-            content="script-src 'self' 'sha256-MCx+U3fU6hJNKvWqT8cJrZb2MfZlyUfg8oXORz+vn6M='"
+            content="script-src 'self' 'sha256-bFRIEmBXWkB30lOfVGw1yYX8VUoq6PSmi6cNnDehTqU='"
         />
         <title>Vortex</title>
         <link rel="stylesheet" href="assets/css/loadingScreen.css" />
@@ -33,6 +33,10 @@
     </body>
 
     <script>
+        // zod reads config from this global (shared by all copies); mutate the
+        // object zod bound at load, do not replace it. jitless keeps zod off
+        // new Function, which this page's CSP forbids.
+        (globalThis.__zod_globalConfig ??= {}).jitless = true;
         require("./renderer.js");
     </script>
 </html>

--- a/src/shared/.oxlintrc.json
+++ b/src/shared/.oxlintrc.json
@@ -2,6 +2,17 @@
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "extends": ["../../oxlint.base.config.json"],
   "rules": {
-    "vitest/require-mock-type-parameters": "warn"
+    "vitest/require-mock-type-parameters": "warn",
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["zod", "zod/**"],
+            "message": "Import { z } from the zodJitless wrapper: zod fixes the JIT decision per schema at construction, and the wrapper guarantees z.config({ jitless: true }) runs first."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/shared/src/errors/parser.ts
+++ b/src/shared/src/errors/parser.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-
+import { z } from "../zodJitless";
 import { VortexError } from "./base";
 
 /**

--- a/src/shared/src/types/flags.ts
+++ b/src/shared/src/types/flags.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "../zodJitless";
 
 // NOTE(erri120): explicit casting with `as z.ZodType<>` required for `--isolatedDeclarations` to work
 export const flagVariantSchemas = {

--- a/src/shared/src/zodJitless.ts
+++ b/src/shared/src/zodJitless.ts
@@ -1,0 +1,18 @@
+// oxlint-disable-next-line no-restricted-imports -- see below
+import { z } from "zod";
+
+// zod v4 compiles object-schema parsers with new Function on first parse and
+// decides per schema, at construction time, whether that JIT is available.
+// The probe backing the decision runs once per process and can sample a
+// context where eval is allowed (the preload loads this package before the
+// document CSP exists) while parsing later happens in the CSP-bound renderer
+// page, where new Function throws EvalError. jitless disables the JIT for
+// every schema constructed after this call.
+//
+// Get z from this module, never from "zod" directly (enforced by the
+// no-restricted-imports rule in this package's .oxlintrc.json): the import
+// graph then guarantees no schema in this package is constructed before the
+// config runs.
+z.config({ jitless: true });
+
+export { z };


### PR DESCRIPTION
zod v4 compiles object-schema parsers with new Function and decides per schema, at construction time, whether eval is available, via a once-per-process probe. The preload loads @vortex/shared before the document CSP exists, so the probe passes there and every object schema parsed later inside the CSP-bound page throws EvalError; the OAuth access-token parse made every login fail.

Two layers, each covering what the other cannot:
- index.html sets jitless on zod's globalThis config singleton before requiring the renderer, covering every schema the renderer constructs. The object is mutated, not replaced: zod already bound it while the preload loaded shared. The inline script change carries a recomputed CSP hash.
- @vortex/shared routes zod through a zodJitless wrapper (enforced by a no-restricted-imports lint rule), covering its own schemas, which are constructed during the preload before the page script runs.

closes LAZ-866
closes #23822

reference: https://github.com/colinhacks/zod/pull/5889

Note that I chose to fix this for v2.5 primarily instead of v2.4 as previous versions were not as broadly affected (@Aragas mentioned that some telemetry entries existed in the past)