### PR TITLE
fix: update analytics tracking events shape to support OR cases 

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -407,7 +407,7 @@ describe("checkFileRequirements / resolution", () => {
     const metadata = await runWith({
       // ord_g2_file is an acceptable version the user installed and then disabled, with no
       // wrong version enabled to explain it: enabling it would clear the OR, so the whole
-      // requirement stays hidden (LAZ-840).
+      // requirement stays hidden.
       refs: [ref("ord_src"), ref("ord_g2_file", false)],
       versions: {
         ord_src: { chain: "ord_srcChain", modId: "ord_srcMod" },

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -35,7 +35,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
   const {
     trackDetailViewed,
     trackOneClickInstallClicked,
-    trackPickOptionSelected,
     trackInstallAllInGroupClicked,
     trackInstallViaModPageClicked,
     trackViewModPageClicked,
@@ -142,25 +141,21 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               showPremiumAd,
               identity,
               requestDownload: (candidate) => downloadFileRequirement(api, candidate, identity),
-              onInstall: (candidate) =>
+              onInstall: (candidate, resolution) =>
                 trackOneClickInstallClicked({
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,
                   mod_name: candidate.modName,
                   mod_version: candidate.version,
                   is_adult_content: candidate.adultContent,
+                  requirement_state: resolution.requirementState,
+                  option_count: resolution.optionCount,
                 }),
-              onPickOption: (candidate, position, total) =>
-                trackPickOptionSelected({
-                  mod_id: decodeUID(candidate.modUID)?.id ?? 0,
-                  mod_name: candidate.modName,
-                  option_position: position,
-                  total_options: total,
-                }),
-              onInstallAll: (candidates) =>
+              onInstallAll: (candidates, requirementState) =>
                 trackInstallAllInGroupClicked({
                   mod_count: candidates.length,
+                  requirement_state: requirementState,
                 }),
-              onOpenModPage: (candidate) => {
+              onOpenModPage: (candidate, resolution) => {
                 const modPageProps = {
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,
                   mod_name: candidate.modName,
@@ -168,22 +163,33 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                 };
 
                 // Free users install via the website (a resolution action); premium users
-                // browsing to the mod page is informational.
+                // browsing to the mod page is informational, so it carries no resolution.
                 if (showPremiumAd) {
-                  trackInstallViaModPageClicked(modPageProps);
+                  trackInstallViaModPageClicked({
+                    ...modPageProps,
+                    requirement_state: resolution.requirementState,
+                    option_count: resolution.optionCount,
+                  });
                 } else {
                   trackViewModPageClicked(modPageProps);
                 }
               },
-              onEnable: (correctFile, enabledFile) => {
+              onEnable: (correctFile, enabledFile, resolution) => {
+                const resolutionProps = {
+                  requirement_state: resolution.requirementState,
+                  option_count: resolution.optionCount,
+                };
+
                 if (enabledFile) {
                   trackEnableThisVersionClicked({
+                    ...resolutionProps,
                     mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
                     required_version: correctFile.version,
                     current_version: enabledFile.version,
                   });
                 } else {
                   trackEnableClicked({
+                    ...resolutionProps,
                     mod_id: decodeUID(correctFile.modUID)?.id ?? 0,
                     mod_name: correctFile.modName,
                     mod_version: correctFile.version,
@@ -195,10 +201,11 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                   mod_id: decodeUID(file.modUID)?.id ?? 0,
                   mod_name: file.modName,
                 }),
-              onInstallDownloaded: (file) =>
+              onInstallDownloaded: (file, resolution) =>
                 trackInstallDownloadedClicked({
                   mod_id: decodeUID(file.modUID)?.id ?? 0,
-                  mod_count: 1,
+                  requirement_state: resolution.requirementState,
+                  option_count: resolution.optionCount,
                 }),
             }}
             report={report}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -17,6 +17,7 @@ import {
   uninstalledFiles,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IFileRequirementReport } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
+import { sharedRequirementState } from "@/extensions/health_check/utils/shared/tracking";
 import { decodeUID } from "@/extensions/nexus_integration/util/UIDs";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
@@ -42,9 +43,9 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   const {
     trackOneClickInstallClicked,
     trackInstallAllInGroupClicked,
-    trackPickModInstallClicked,
+    trackViewPickOptionsClicked,
     trackEnableThisVersionClicked,
-    trackInstallDownloadedClicked,
+    trackInstallAllDownloadedClicked,
     trackIssueHidden,
     trackIssueUnhidden,
   } = useIssueTracking();
@@ -78,6 +79,9 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
       ? `${names[0]} ${t("listing::item::more_count", { count: names.length - 1 })}`
       : names[0];
 
+  // A listing row is one category, so every requirement in it shares a state.
+  const requirementState = sharedRequirementState(report.requirements);
+
   const doQuickInstall = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (candidates.length === 1) {
@@ -88,10 +92,12 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
         mod_name: candidate.modName,
         mod_version: candidate.version,
         is_adult_content: candidate.adultContent,
+        requirement_state: requirementState,
       });
     } else {
       trackInstallAllInGroupClicked({
         mod_count: candidates.length,
+        requirement_state: requirementState,
       });
     }
 
@@ -128,9 +134,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                trackPickModInstallClicked({
-                  issue_type: issueType,
-                });
+                trackViewPickOptionsClicked({});
                 onOpen();
               }}
             >
@@ -148,6 +152,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                   mod_id: decodeUID(switches[0].correct.modUID)?.id ?? 0,
                   required_version: switches[0].correct.version,
                   current_version: switches[0].wrong.version,
+                  requirement_state: "disabled_wrong_enabled",
                 });
                 switchActiveVersions(api, switches);
               }}
@@ -165,10 +170,7 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                 onClick={(e) => {
                   e.stopPropagation();
 
-                  trackInstallDownloadedClicked({
-                    mod_id: decodeUID(toInstall[0].uninstalledFile.modUID)?.id ?? 0,
-                    mod_count: toInstall.length,
-                  });
+                  trackInstallAllDownloadedClicked({ mod_count: toInstall.length });
 
                   toInstall.forEach(
                     (req) =>

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -11,6 +11,7 @@ import {
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { sharedRequirementState } from "@/extensions/health_check/utils/shared/tracking";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
@@ -99,7 +100,7 @@ export const RequirementBody = ({
   };
 
   const installAll = () => {
-    ctx.onInstallAll(installAllCandidates);
+    ctx.onInstallAll(installAllCandidates, sharedRequirementState(requirements));
     if (ctx.showPremiumAd) {
       setPremiumOpen(true);
       return;

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -6,6 +6,7 @@ import {
   candidateToFileData,
   fileWebLinks,
   type IFileActionContext,
+  type IResolutionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { openModPage } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirementCandidate } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
@@ -19,15 +20,13 @@ import { FileRequirement } from "../FileRequirement";
 export const CandidateCard = ({
   ctx,
   candidate,
+  resolution,
   isOr,
-  optionPosition,
-  optionCount,
 }: {
   ctx: IFileActionContext;
   candidate: IFileRequirementCandidate;
+  resolution: IResolutionContext;
   isOr?: boolean;
-  optionPosition?: number;
-  optionCount?: number;
 }) => {
   const { t } = useTranslation(["health_check", "common"]);
 
@@ -39,17 +38,12 @@ export const CandidateCard = ({
   const loading = isLoading || !!ctx.isDownloadingAll;
 
   const handleInstall = () => {
-    if (isOr) {
-      ctx.onPickOption(candidate, optionPosition ?? 0, optionCount ?? 0);
-    } else {
-      ctx.onInstall(candidate);
-    }
-
+    ctx.onInstall(candidate, resolution);
     onClick();
   };
 
   const handleModPage = () => {
-    ctx.onOpenModPage(candidate);
+    ctx.onOpenModPage(candidate, resolution);
     openModPage(ctx.api, candidate);
   };
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import {
   fileWebLinks,
   type IFileActionContext,
+  type IResolutionContext,
   installedToFileData,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import {
@@ -23,12 +24,14 @@ export const EnableCard = ({
   ctx,
   correctFile,
   enabledFile,
+  resolution,
   isOr,
 }: {
   ctx: IFileActionContext;
   correctFile: IInstalledFile;
   /** The wrong version to switch off, if any; absent means a plain enable. */
   enabledFile?: IInstalledFile;
+  resolution: IResolutionContext;
   isOr?: boolean;
 }) => {
   const { t } = useTranslation("health_check");
@@ -39,7 +42,7 @@ export const EnableCard = ({
   };
 
   const handleEnable = () => {
-    ctx.onEnable(correctFile, enabledFile);
+    ctx.onEnable(correctFile, enabledFile, resolution);
 
     if (enabledFile) {
       switchActiveVersion(ctx.api, enabledFile, correctFile);

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
@@ -6,6 +6,7 @@ import {
   downloadedToFileData,
   fileWebLinks,
   type IFileActionContext,
+  type IResolutionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import {
   installDownloadedFile,
@@ -29,12 +30,14 @@ export const InstallDownloadedCard = ({
   ctx,
   file,
   enabledFile,
+  resolution,
   isOr,
 }: {
   ctx: IFileActionContext;
   file: IDownloadedFile;
   /** The wrong version to switch off, if any; absent means a plain install. */
   enabledFile?: IInstalledFile;
+  resolution: IResolutionContext;
   isOr?: boolean;
 }) => {
   const { t } = useTranslation("health_check");
@@ -46,7 +49,7 @@ export const InstallDownloadedCard = ({
   const isSwitch = enabledFile !== undefined;
 
   const handleInstall = () => {
-    ctx.onInstallDownloaded(file);
+    ctx.onInstallDownloaded(file, resolution);
     onClick();
   };
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/DownloadRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/DownloadRows.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { IFileActionContext } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { requirementStateFor } from "@/extensions/health_check/utils/shared/tracking";
 
 import { CandidateCard } from "../cards/CandidateCard";
 
@@ -11,4 +12,10 @@ export const DownloadRows = ({
 }: {
   ctx: IFileActionContext;
   requirement: Extract<IFileRequirement, { kind: "missing" }>;
-}) => <CandidateCard candidate={requirement.candidate} ctx={ctx} />;
+}) => (
+  <CandidateCard
+    candidate={requirement.candidate}
+    ctx={ctx}
+    resolution={{ requirementState: requirementStateFor(requirement) }}
+  />
+);

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/InstallUninstalledRows.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { IFileActionContext } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { requirementStateFor } from "@/extensions/health_check/utils/shared/tracking";
 
 import { InstallDownloadedCard } from "../cards/InstallDownloadedCard";
 
@@ -16,5 +17,6 @@ export const InstallUninstalledRows = ({
     ctx={ctx}
     enabledFile={requirement.enabledFile}
     file={requirement.uninstalledFile}
+    resolution={{ requirementState: requirementStateFor(requirement) }}
   />
 );

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 
-import type { IFileActionContext } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
+import type {
+  IFileActionContext,
+  IResolutionContext,
+} from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import type {
   IFileRequirement,
   IFileRequirementBranch,
 } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { branchRequirementState } from "@/extensions/health_check/utils/shared/tracking";
 
 import { CandidateCard } from "../cards/CandidateCard";
 import { EnableCard } from "../cards/EnableCard";
@@ -14,19 +18,12 @@ import { InstallDownloadedCard } from "../cards/InstallDownloadedCard";
 const branchCard = (
   branch: IFileRequirementBranch,
   ctx: IFileActionContext,
-  optionPosition: number,
-  optionCount: number,
+  resolution: IResolutionContext,
 ) => {
   switch (branch.kind) {
     case "download":
       return (
-        <CandidateCard
-          candidate={branch.candidate}
-          ctx={ctx}
-          isOr={true}
-          optionCount={optionCount}
-          optionPosition={optionPosition}
-        />
+        <CandidateCard candidate={branch.candidate} ctx={ctx} isOr={true} resolution={resolution} />
       );
     case "install":
       return (
@@ -35,6 +32,7 @@ const branchCard = (
           enabledFile={branch.enabledFile}
           file={branch.uninstalledFile}
           isOr={true}
+          resolution={resolution}
         />
       );
     case "enable":
@@ -44,6 +42,7 @@ const branchCard = (
           ctx={ctx}
           enabledFile={branch.enabledFile}
           isOr={true}
+          resolution={resolution}
         />
       );
   }
@@ -57,9 +56,12 @@ export const OrRows = ({
   requirement: Extract<IFileRequirement, { kind: "or" }>;
 }) => (
   <>
-    {requirement.branches.map((branch, index) => (
+    {requirement.branches.map((branch) => (
       <React.Fragment key={branch.modFileId}>
-        {branchCard(branch, ctx, index + 1, requirement.branches.length)}
+        {branchCard(branch, ctx, {
+          requirementState: branchRequirementState(branch),
+          optionCount: requirement.branches.length,
+        })}
       </React.Fragment>
     ))}
   </>

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { viewInLoadout } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { requirementStateFor } from "@/extensions/health_check/utils/shared/tracking";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
 import { nxmModOutline } from "@/ui/icon-paths";
@@ -35,7 +36,11 @@ export const ReplaceRows = ({
           {t("detail::item::required_version")}
         </Typography>
 
-        <CandidateCard candidate={requirement.candidate} ctx={ctx} />
+        <CandidateCard
+          candidate={requirement.candidate}
+          ctx={ctx}
+          resolution={{ requirementState: requirementStateFor(requirement) }}
+        />
       </div>
 
       <div className="space-y-3 pt-6">

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { viewInLoadout } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IFileRequirement } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { requirementStateFor } from "@/extensions/health_check/utils/shared/tracking";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
 import { nxmModOutline } from "@/ui/icon-paths";
@@ -39,6 +40,7 @@ export const ToggleRows = ({
           correctFile={requirement.correctFile}
           ctx={ctx}
           enabledFile={requirement.enabledFile}
+          resolution={{ requirementState: requirementStateFor(requirement) }}
         />
       </div>
 

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
@@ -138,6 +138,49 @@ describe("createHealthCheckTracker", () => {
     expect(events[0].properties).not.toHaveProperty("issue_id");
   });
 
+  it("carries the requirement state, and option_count only for an OR pick", () => {
+    const { tracker, events } = harness();
+    const issue = { issue_id: "a-b", check_id: "file_requirements" } as const;
+
+    tracker.trackInstallDownloadedClicked({
+      ...issue,
+      mod_id: 42,
+      requirement_state: "downloaded_wrong_enabled",
+    });
+    tracker.trackInstallDownloadedClicked({
+      ...issue,
+      mod_id: 42,
+      requirement_state: "downloaded",
+      option_count: 2,
+    });
+
+    expect(events[0].eventName).toBe("health_check_install_downloaded_clicked");
+    expect(events[0].properties.requirement_state).toBe("downloaded_wrong_enabled");
+    expect(events[0].properties).not.toHaveProperty("option_count");
+    expect(events[1].properties.option_count).toBe(2);
+  });
+
+  it("names the pick flow after opening the options, not resolving them", () => {
+    const { tracker, events } = harness();
+    tracker.trackViewPickOptionsClicked({ issue_id: "a-b", check_id: "file_requirements" });
+    expect(events[0].eventName).toBe("health_check_view_pick_options_clicked");
+    expect(events[0].properties).toEqual({ issue_id: "a-b", check_id: "file_requirements" });
+  });
+
+  it("keeps the on-disk bulk install separate from the premium-gated group install", () => {
+    const { tracker, events } = harness();
+    const issue = { issue_id: "a-b", check_id: "file_requirements" } as const;
+
+    tracker.trackInstallAllDownloadedClicked({ ...issue, mod_count: 3 });
+    tracker.trackInstallAllInGroupClicked({ ...issue, mod_count: 3, requirement_state: "missing" });
+
+    expect(events.map((e) => e.eventName)).toEqual([
+      "health_check_install_all_downloaded_clicked",
+      "health_check_install_all_in_group_clicked",
+    ]);
+    expect(events[0].properties).not.toHaveProperty("requirement_state");
+  });
+
   it("strips undefined optional properties", () => {
     const { tracker, events } = harness();
     tracker.trackPremiumModalShown({ trigger: "single_install" });

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
@@ -8,11 +8,22 @@ import type {
   IssueAnalyticsIdentity,
   IssueType,
   OptionalIssueAnalyticsIdentity,
+  RequirementState,
   ResolutionType,
 } from "../utils/shared/tracking";
 
 /** Which free-user fallback the premium modal offered. */
 type PremiumFallbackType = "single_mod_page" | "batch_mod_pages";
+
+/**
+ * What the user was resolving. `option_count` is set only when the requirement offered
+ * alternatives, which is what marks a resolution as an OR pick. Both are optional because
+ * the mod-requirements check shares these events and has no versions, so no state to report.
+ */
+type ResolutionProps = {
+  requirement_state?: RequirementState;
+  option_count?: number;
+};
 
 /**
  * Build a Health Check analytics event. Returns the app-wide MixpanelEvent shape so it
@@ -102,12 +113,13 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     // Install flow
     trackOneClickInstallClicked: (
-      props: IssueAnalyticsIdentity & {
-        mod_id: number;
-        mod_name: string;
-        mod_version: string;
-        is_adult_content: boolean;
-      },
+      props: IssueAnalyticsIdentity &
+        ResolutionProps & {
+          mod_id: number;
+          mod_name: string;
+          mod_version: string;
+          is_adult_content: boolean;
+        },
     ) => track("health_check_one_click_install_clicked", props),
 
     // Install lifecycle, bracketing the actual download + install a health-check action
@@ -137,41 +149,42 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
     ) => track("health_check_install_failed", props),
 
     trackInstallDownloadedClicked: (
-      props: IssueAnalyticsIdentity & { mod_id: number; mod_count: number },
+      props: IssueAnalyticsIdentity & ResolutionProps & { mod_id: number },
     ) => track("health_check_install_downloaded_clicked", props),
 
-    trackInstallAllInGroupClicked: (props: IssueAnalyticsIdentity & { mod_count: number }) =>
-      track("health_check_install_all_in_group_clicked", props),
+    // The listing row's bulk install of files already on disk, so no premium gate - unlike
+    // install_all_in_group, which fetches from Nexus. Its items can mix requirement states.
+    trackInstallAllDownloadedClicked: (props: IssueAnalyticsIdentity & { mod_count: number }) =>
+      track("health_check_install_all_downloaded_clicked", props),
+
+    trackInstallAllInGroupClicked: (
+      props: IssueAnalyticsIdentity & { mod_count: number; requirement_state?: RequirementState },
+    ) => track("health_check_install_all_in_group_clicked", props),
 
     // Enable flow
     trackEnableClicked: (
-      props: IssueAnalyticsIdentity & { mod_id: number; mod_name: string; mod_version: string },
+      props: IssueAnalyticsIdentity &
+        ResolutionProps & { mod_id: number; mod_name: string; mod_version: string },
     ) => track("health_check_enable_clicked", props),
 
     trackEnableThisVersionClicked: (
-      props: IssueAnalyticsIdentity & {
-        mod_id: number;
-        required_version: string;
-        current_version: string;
-      },
+      props: IssueAnalyticsIdentity &
+        ResolutionProps & {
+          mod_id: number;
+          required_version: string;
+          current_version: string;
+        },
     ) => track("health_check_enable_this_version_clicked", props),
 
-    // Pick flow
-    trackPickModInstallClicked: (props: IssueAnalyticsIdentity & { issue_type: IssueType }) =>
-      track("health_check_pick_mod_install_clicked", props),
-
-    trackPickOptionSelected: (
-      props: IssueAnalyticsIdentity & {
-        mod_id: number;
-        mod_name: string;
-        option_position: number;
-        total_options: number;
-      },
-    ) => track("health_check_pick_option_selected", props),
+    // Pick flow. This is navigation to the alternatives; which one the user picks is reported
+    // by that resolution's own event, carrying option_count.
+    trackViewPickOptionsClicked: (props: IssueAnalyticsIdentity) =>
+      track("health_check_view_pick_options_clicked", props),
 
     // Navigation & external
     trackInstallViaModPageClicked: (
-      props: IssueAnalyticsIdentity & { mod_id: number; mod_name: string; mod_version: string },
+      props: IssueAnalyticsIdentity &
+        ResolutionProps & { mod_id: number; mod_name: string; mod_version: string },
     ) => track("health_check_install_via_mod_page_clicked", props),
 
     trackViewModPageClicked: (

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
@@ -1,6 +1,6 @@
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
-import type { IssueAnalyticsIdentity } from "../shared/tracking";
+import type { IssueAnalyticsIdentity, RequirementState } from "../shared/tracking";
 import { openFilePage, openModPage } from "./fileRequirementActions";
 import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
 import type { IFileRequirementCandidate } from "./mapRequirementsReport";
@@ -9,6 +9,15 @@ import type { IFileRequirementCandidate } from "./mapRequirementsReport";
 export interface ITrackedModRef {
   modUID: string;
   modName: string;
+}
+
+/**
+ * What a card resolves, for the analytics on its actions. `optionCount` is set only when the
+ * requirement offered alternatives, which is what marks the resolution as an OR pick.
+ */
+export interface IResolutionContext {
+  requirementState: RequirementState;
+  optionCount?: number;
 }
 
 // Helpers shared by the requirement cards: the mod-page / file-page open handlers,
@@ -43,21 +52,27 @@ export interface IFileActionContext {
   installButtonAppearance?: "strong" | "moderate";
   /** True while "install all" is running; puts every card's install button into the loading state. */
   isDownloadingAll?: boolean;
-  // Analytics intent — cards emit what the user did; the owner maps it to Mixpanel events.
+  // Analytics intent — cards emit what the user did and what they were resolving; the
+  // owner maps it to Mixpanel events.
   /** 1-click install of a single required candidate. */
-  onInstall: (candidate: IFileRequirementCandidate) => void;
-  /** Picking one of the "OR" alternatives (1-based position within the options). */
-  onPickOption: (candidate: IFileRequirementCandidate, position: number, total: number) => void;
-  /** The group-level "install all" button. */
-  onInstallAll: (candidates: IFileRequirementCandidate[]) => void;
+  onInstall: (candidate: IFileRequirementCandidate, resolution: IResolutionContext) => void;
+  /** The group-level "install all" button; its items share one state. */
+  onInstallAll: (
+    candidates: IFileRequirementCandidate[],
+    requirementState?: RequirementState,
+  ) => void;
   /** Opening a candidate's mod page (owner splits install-via vs view by user tier). */
-  onOpenModPage: (candidate: IFileRequirementCandidate) => void;
+  onOpenModPage: (candidate: IFileRequirementCandidate, resolution: IResolutionContext) => void;
   /** Enabling an installed version, optionally switching off the wrong one. */
-  onEnable: (correctFile: IInstalledFile, enabledFile?: IInstalledFile) => void;
+  onEnable: (
+    correctFile: IInstalledFile,
+    enabledFile: IInstalledFile | undefined,
+    resolution: IResolutionContext,
+  ) => void;
   /** Navigating to a mod in the local mods list. */
   onViewInMods: (file: ITrackedModRef) => void;
   /** Installing an already-downloaded file. */
-  onInstallDownloaded: (file: IDownloadedFile) => void;
+  onInstallDownloaded: (file: IDownloadedFile, resolution: IResolutionContext) => void;
 }
 
 /** Mod-page / file-page open handlers for a candidate or installed file. */

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -90,7 +90,7 @@ describe("makeDownloadedFileHydrator", () => {
       });
     });
 
-    test("takes the fetched adult flag over the download's own (LAZ-849)", () => {
+    test("takes the fetched adult flag over the download's own", () => {
       const dl = download({ nexus: { modInfo: { contains_adult_content: false } } });
       expect(hydrate(dl, DETAILS)?.adultContent).toBe(true);
     });

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/mapRequirementsReport.ts
@@ -79,6 +79,8 @@ export type IFileRequirementBranch =
       modFileId: string;
       /** The file to download for this alternative */
       candidate: IFileRequirementCandidate;
+      /** A wrong version of the same chain currently enabled, if any (makes it a version change) */
+      enabledFile?: IInstalledFile;
     }
   | {
       kind: "install";
@@ -214,9 +216,8 @@ function classifyDependency(
   if (branches.length > 1) {
     // A deliberately disabled alternative (nothing wrong enabled to explain it) counts as
     // satisfied - enabling it would clear the OR - matching the single-branch rule below.
-    // Drop this guard to surface it as an "enable this version" card instead.
-    // Deliberately on the resolver's state, not on hydrated display data: whether to
-    // surface the OR at all can't depend on whether a file we never render resolved.
+    // Drop this guard to surface it as an "enable this version" card instead. Keyed on the
+    // resolver's state, not hydrated data: it decides whether the issue is shown at all.
     if (branches.some((b) => b.satisfyingDisabled.length > 0 && b.wrongEnabled.length === 0)) {
       return undefined;
     }
@@ -337,6 +338,7 @@ function classifyOrBranch(
       kind: "download",
       modFileId: branch.modFileId,
       candidate: toCandidate(branch.recommended),
+      enabledFile: enabledWrongFile(branch, hydrate),
     };
   }
   return undefined;

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { issueTypeForCheck, resolutionTypeForCategory } from "./tracking";
+import type { IDownloadedFile, IInstalledFile } from "../fileRequirements/installedFiles";
+import type {
+  IFileRequirementCandidate,
+  IFileRequirement,
+} from "../fileRequirements/mapRequirementsReport";
+import {
+  branchRequirementState,
+  issueTypeForCheck,
+  requirementStateFor,
+  resolutionTypeForCategory,
+  sharedRequirementState,
+} from "./tracking";
+
+const candidate = {} as IFileRequirementCandidate;
+const installed = {} as IInstalledFile;
+const downloaded = {} as IDownloadedFile;
 
 describe("issueTypeForCheck", () => {
   it("maps the file-level check to warning", () => {
@@ -21,5 +36,92 @@ describe("resolutionTypeForCategory", () => {
     ["download-replace", "update"],
   ] as const)("maps %s to %s", (category, expected) => {
     expect(resolutionTypeForCategory(category)).toBe(expected);
+  });
+});
+
+describe("requirementStateFor", () => {
+  it.each([
+    [{ kind: "missing", requirementDefId: "d", candidate }, "missing"],
+    [
+      {
+        kind: "wrong-version-installed",
+        requirementDefId: "d",
+        installedFile: installed,
+        candidate,
+      },
+      "wrong_version_enabled",
+    ],
+    [
+      { kind: "correct-version-uninstalled", requirementDefId: "d", uninstalledFile: downloaded },
+      "downloaded",
+    ],
+    [
+      {
+        kind: "correct-version-uninstalled",
+        requirementDefId: "d",
+        uninstalledFile: downloaded,
+        enabledFile: installed,
+      },
+      "downloaded_wrong_enabled",
+    ],
+    [
+      {
+        kind: "wrong-version-enabled",
+        requirementDefId: "d",
+        enabledFile: installed,
+        correctFile: installed,
+      },
+      "disabled_wrong_enabled",
+    ],
+  ] as const)("maps a $0.kind requirement", (requirement, expected) => {
+    expect(requirementStateFor(requirement)).toBe(expected);
+  });
+});
+
+describe("branchRequirementState", () => {
+  it("separates a plain download from one that replaces an enabled wrong version", () => {
+    const download = { kind: "download", modFileId: "g", candidate } as const;
+
+    expect(branchRequirementState(download)).toBe("missing");
+    expect(branchRequirementState({ ...download, enabledFile: installed })).toBe(
+      "wrong_version_enabled",
+    );
+  });
+
+  it("separates an install and an enable from their switch variants", () => {
+    const install = { kind: "install", modFileId: "g", uninstalledFile: downloaded } as const;
+    const enable = { kind: "enable", modFileId: "g", correctFile: installed } as const;
+
+    expect(branchRequirementState(install)).toBe("downloaded");
+    expect(branchRequirementState({ ...install, enabledFile: installed })).toBe(
+      "downloaded_wrong_enabled",
+    );
+    expect(branchRequirementState(enable)).toBe("disabled");
+    expect(branchRequirementState({ ...enable, enabledFile: installed })).toBe(
+      "disabled_wrong_enabled",
+    );
+  });
+});
+
+describe("sharedRequirementState", () => {
+  const missing: IFileRequirement = { kind: "missing", requirementDefId: "a", candidate };
+  const or: IFileRequirement = { kind: "or", requirementDefId: "b", branches: [] };
+  const downloadedReq: IFileRequirement = {
+    kind: "correct-version-uninstalled",
+    requirementDefId: "c",
+    uninstalledFile: downloaded,
+  };
+
+  it("reports the state a group's items share", () => {
+    expect(sharedRequirementState([missing, { ...missing, requirementDefId: "a2" }])).toBe(
+      "missing",
+    );
+  });
+
+  it("reports nothing for an empty, mixed or OR group, rather than one item's state", () => {
+    expect(sharedRequirementState([])).toBeUndefined();
+    expect(sharedRequirementState([missing, downloadedReq])).toBeUndefined();
+    expect(sharedRequirementState([or])).toBeUndefined();
+    expect(sharedRequirementState([missing, or])).toBeUndefined();
   });
 });

--- a/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/tracking.ts
@@ -1,5 +1,9 @@
 import type { HealthCheckId } from "../../types";
 import type { FileRequirementCategory } from "../fileRequirements/fileRequirementReport";
+import type {
+  IFileRequirement,
+  IFileRequirementBranch,
+} from "../fileRequirements/mapRequirementsReport";
 
 /**
  * Shared analytics vocabulary for the Health Check tracking events (LAZ-551).
@@ -69,6 +73,63 @@ export type IssueAnalyticsIdentity = {
  * row or detail page) and page-wide, across both checks.
  */
 export type OptionalIssueAnalyticsIdentity = Partial<IssueAnalyticsIdentity>;
+
+/**
+ * What state a requirement was in when the user acted on it. `disabled` is never reported
+ * today: that state is suppressed as the user's deliberate choice.
+ */
+export type RequirementState =
+  | "missing"
+  | "wrong_version_enabled"
+  | "downloaded"
+  | "downloaded_wrong_enabled"
+  | "disabled_wrong_enabled"
+  | "disabled";
+
+/** An OR is excluded because it has no single state; use branchRequirementState per option. */
+export const requirementStateFor = (
+  requirement: Exclude<IFileRequirement, { kind: "or" }>,
+): RequirementState => {
+  switch (requirement.kind) {
+    case "missing":
+      return "missing";
+    case "wrong-version-installed":
+      return "wrong_version_enabled";
+    case "correct-version-uninstalled":
+      return requirement.enabledFile ? "downloaded_wrong_enabled" : "downloaded";
+    case "wrong-version-enabled":
+      return "disabled_wrong_enabled";
+  }
+};
+
+/** requirement_state for one of an OR's alternatives. */
+export const branchRequirementState = (branch: IFileRequirementBranch): RequirementState => {
+  switch (branch.kind) {
+    case "download":
+      return branch.enabledFile ? "wrong_version_enabled" : "missing";
+    case "install":
+      return branch.enabledFile ? "downloaded_wrong_enabled" : "downloaded";
+    case "enable":
+      return branch.enabledFile ? "disabled_wrong_enabled" : "disabled";
+  }
+};
+
+/**
+ * The state a group's items share — one category, so normally all of them. Undefined when
+ * they differ, so the property is left off rather than reporting one item's state for all.
+ */
+export const sharedRequirementState = (
+  requirements: IFileRequirement[],
+): RequirementState | undefined => {
+  const first = requirements[0];
+  if (first === undefined || first.kind === "or") {
+    return undefined;
+  }
+  const state = requirementStateFor(first);
+  return requirements.every((req) => req.kind !== "or" && requirementStateFor(req) === state)
+    ? state
+    : undefined;
+};
 
 /**
  * resolution_type for a file-requirement report category. Mod requirements are


### PR DESCRIPTION

# Health Check analytics: proposed amendments

## Changed

| Event | Change |
| --- | --- |
| `one_click_install_clicked` | **+ `requirement_state`**, **+ `option_count`** |
| `install_downloaded_clicked` | **+ `requirement_state`**, **+ `option_count`**, **− `mod_count`** — now always one card, one mod |
| `enable_this_version_clicked` | **+ `requirement_state`**, **+ `option_count`** |
| `enable_clicked` | **+ `requirement_state`**, **+ `option_count`** |
| `install_via_mod_page_clicked` | **+ `requirement_state`**, **+ `option_count`** |
| `install_all_in_group_clicked` | **+ `requirement_state`** — a listing row or detail group is one category, so all its items share a state |
| `pick_mod_install_clicked` | **renamed `view_pick_options_clicked`**, **− `issue_type`** (always `warning`) — it opens the details page rather than resolving anything |

`option_count` is set only when the requirement offered alternatives; that alone marks a resolution as an
OR pick. `option_position` is not tracked — alternatives render in whatever order the API returned them.

## Added

| Event | Properties | Reason |
| --- | --- | --- |
| `install_all_downloaded_clicked` | mod_count | "Install (N downloaded)" on a listing row, currently folded into the single-mod `install_downloaded_clicked` with the first mod's id. Distinct from `install_all_in_group_clicked`, which downloads its items from Nexus and is premium-gated; these are already on disk. No `requirement_state`: items may mix `downloaded` and `downloaded_wrong_enabled` |

## Dropped

| Event | Reason |
| --- | --- |
| `pick_option_selected` | Replaced by `option_count` on the resolution events. It currently fires *instead of* the action event and only from the download card, so OR picks are missing from the install funnel and install/enable alternatives record nothing |

## `requirement_state` values

| Value | Meaning |
| --- | --- |
| `missing` | nothing acceptable owned |
| `wrong_version_enabled` | wrong version enabled, nothing acceptable owned |
| `downloaded` | downloaded, not installed, nothing wrong enabled |
| `downloaded_wrong_enabled` | as above with a wrong version enabled — the install is a switch |
| `disabled_wrong_enabled` | installed but disabled, wrong version enabled |
| `disabled` | installed but disabled, nothing wrong enabled — suppressed today, reserved |

Inside an OR, `wrong_version_enabled` needs one line in `classifyOrBranch`: the download branch discards
`branch.wrongEnabled`, so the state currently reports as `missing`. A boolean is enough — OR cards show
no labels and no current-version card, so nothing renders it.
