### PR TITLE
Health Check: better handling for errors and timeout

### DIFF
--- a/packages/nexus-api-v3/src/client.test.ts
+++ b/packages/nexus-api-v3/src/client.test.ts
@@ -240,3 +240,23 @@ describe("error fallback", () => {
     });
   });
 });
+
+describe("cancellation", () => {
+  // fetch is what honours the signal, so reaching it is the whole contract: an aborted
+  // signal has to reject the call without a request going out.
+  it("passes the client signal to fetch", async () => {
+    mockData({ mods: [] });
+
+    await expect(makeClient({ signal: AbortSignal.abort() }).getModsBatch(["1"])).rejects.toThrow(
+      /abort/i,
+    );
+    expect(fetchMocker.requests()).toHaveLength(0);
+  });
+
+  it("leaves requests alone when no signal is given", async () => {
+    mockData({ mods: [] });
+
+    await expect(makeClient().getModsBatch(["1"])).resolves.toEqual([]);
+    expect(fetchMocker.requests()).toHaveLength(1);
+  });
+});

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -10,6 +10,12 @@ export interface NexusV3ClientOptions {
   apiKey?: string;
   bearerToken?: string;
   middleware?: Middleware[];
+  /**
+   * Aborts every request made through this client, in flight included. Without one, a
+   * request to an endpoint that accepts the connection and then stops responding never
+   * settles: fetch has no timeout of its own.
+   */
+  signal?: AbortSignal;
 }
 
 export type NexusV3Client = ReturnType<typeof createNexusV3Client>;
@@ -30,6 +36,7 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
   const client = createClient<paths>({
     baseUrl: options.baseUrl,
     headers,
+    signal: options.signal,
   });
 
   for (const mw of options.middleware ?? []) {

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -703,3 +703,45 @@ describe("checkFileRequirements / resolution", () => {
     });
   });
 });
+
+describe("checkFileRequirements / abort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile.mockReturnValue({ gameId: "skyrimse" } as unknown as IProfile);
+    mockIsLoggedIn.mockReturnValue(true);
+    mockGatherDownloaded.mockResolvedValue([]);
+    mockDownloadedHydrator.mockReturnValue(() => undefined);
+  });
+
+  // Cancelling a request already in flight is the v3 client's job and is covered there. What
+  // matters here is that an aborted run leaves no report for the registry to store.
+  test("throws instead of returning a result when the signal is already aborted", async () => {
+    mockGather.mockResolvedValue([ref("ab_src")]);
+    mockHydrator.mockReturnValue((fileUID: string) => installedFile(fileUID, true));
+    mockCreateClient.mockReturnValue(
+      fakeClient(
+        { ab_src: { chain: "ab_srcChain", modId: "ab_srcMod" } },
+        [],
+      ) as unknown as ReturnType<typeof createVortexNexusV3Client>,
+    );
+
+    await expect(checkFileRequirements(api, AbortSignal.abort())).rejects.toThrow();
+  });
+
+  test("throws when the signal aborts partway through the run", async () => {
+    const controller = new AbortController();
+    mockGather.mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve([ref("ab2_src")]);
+    });
+    mockHydrator.mockReturnValue((fileUID: string) => installedFile(fileUID, true));
+    mockCreateClient.mockReturnValue(
+      fakeClient(
+        { ab2_src: { chain: "ab2_srcChain", modId: "ab2_srcMod" } },
+        [],
+      ) as unknown as ReturnType<typeof createVortexNexusV3Client>,
+    );
+
+    await expect(checkFileRequirements(api, controller.signal)).rejects.toThrow();
+  });
+});

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
@@ -57,7 +57,10 @@ function createResult(
 /**
  * Check the file-level requirements of installed mods for the active game
  */
-export async function checkFileRequirements(api: IExtensionApi): Promise<IHealthCheckResult> {
+export async function checkFileRequirements(
+  api: IExtensionApi,
+  signal?: AbortSignal,
+): Promise<IHealthCheckResult> {
   const startTime = Date.now();
   try {
     const state = api.getState();
@@ -78,7 +81,7 @@ export async function checkFileRequirements(api: IExtensionApi): Promise<IHealth
       );
     }
 
-    const metadata = await runFileLevelRequirements(api);
+    const metadata = await runFileLevelRequirements(api, signal);
 
     const sourcesWithRequirements = Object.values(metadata.fileRequirements);
     const totalRequirements = sourcesWithRequirements.reduce(
@@ -107,6 +110,10 @@ export async function checkFileRequirements(api: IExtensionApi): Promise<IHealth
       { metadata },
     );
   } catch (error) {
+    // The registry reports the timeout itself and discards this run's result.
+    if (signal?.aborted) {
+      throw error;
+    }
     log("error", "Failed to check file-level requirements", unknownToError(error));
     return createResult(
       startTime,
@@ -136,7 +143,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
   ],
-  check: async (api: IExtensionApi): Promise<IHealthCheckResult> => {
+  check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     // Reading the flag through FlagService reports an evaluation metric to the server.
     const flagEnabled = FlagService.instance.getFlag(FILE_REQUIREMENTS_FLAG) !== undefined;
     if (!flagEnabled || !isFileRequirementsUserEnabled(api.getState())) {
@@ -152,7 +159,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, true));
     try {
-      return await checkFileRequirements(api);
+      return await checkFileRequirements(api, signal);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -272,10 +272,11 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
         requirementsMap[uid] = requirements;
       }
     } catch (err) {
-      log("warn", "Failed to fetch mod requirements", {
-        error: (err as Error).message,
-      });
-      metadata.errors.push(`Failed to fetch requirements: ${(err as Error).message}`);
+      // Whatever the cache already held is still used below; the run is just incomplete,
+      // which the result status reflects rather than reporting a clean pass.
+      const message = getErrorMessageOrDefault(err);
+      log("warn", "Failed to fetch mod requirements", { error: message });
+      metadata.errors.push(`Failed to fetch requirements: ${message}`);
     }
 
     // Pre-fetch, batched and in parallel, the per-required-mod data the second pass
@@ -446,7 +447,22 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
     );
     const totalIssues = totalMissingMods + totalDlcRequirements;
 
-    if (totalIssues === 0 && metadata.errors.length === 0) {
+    const details = buildDetailsString(modsWithIssues, metadata.errors);
+
+    // An incomplete run cannot claim the loadout is fine: with the fetch failed we don't
+    // know what we didn't see. Whatever was resolved from cache is still reported, so the
+    // metadata rides along and the listing keeps showing it.
+    if (metadata.errors.length > 0) {
+      return createResult(
+        startTime,
+        "error",
+        HealthCheckSeverity.Error,
+        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalIssues} issues found in ${metadata.modsChecked} mods checked`,
+        { details, metadata },
+      );
+    }
+
+    if (totalIssues === 0) {
       return createResult(
         startTime,
         "passed",
@@ -456,7 +472,6 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       );
     }
 
-    const details = buildDetailsString(modsWithIssues, metadata.errors);
     const severity = totalMissingMods > 0 ? HealthCheckSeverity.Warning : HealthCheckSeverity.Info;
     const status = totalMissingMods > 0 ? "warning" : "passed";
 

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -182,7 +182,10 @@ function resolveModUID(mod: IMod, gameId: string): string | undefined {
  * Check Nexus mod requirements
  * Fetches requirements from Nexus API and checks if they are satisfied
  */
-export async function checkModRequirements(api: IExtensionApi): Promise<IHealthCheckResult> {
+export async function checkModRequirements(
+  api: IExtensionApi,
+  signal?: AbortSignal,
+): Promise<IHealthCheckResult> {
   const startTime = Date.now();
   try {
     const state = api.getState();
@@ -253,6 +256,8 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       [uid: string]: Partial<IModRequirements> | undefined;
     } = {};
 
+    signal?.throwIfAborted();
+
     try {
       const resolved = await resolveCached(
         [...modsByUid.keys()],
@@ -311,16 +316,19 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
     // One batched mod-details call instead of one per required mod.
     const detailUids = [...requiredTargets.keys()];
     if (detailUids.length > 0) {
+      signal?.throwIfAborted();
       try {
-        await getModDetails(api, detailUids);
+        await getModDetails(api, detailUids, signal);
       } catch (err) {
-        log("warn", "Failed to batch mod details", { error: (err as Error).message });
+        signal?.throwIfAborted();
+        log("warn", "Failed to batch mod details", { error: getErrorMessageOrDefault(err) });
       }
     }
 
     // File-list lookups, fanned out in bounded-concurrency waves.
     const filesByRequiredUid = new Map<string, IModFileInfo[]>();
     for (const wave of chunked([...requiredTargets], FILE_LOOKUP_CONCURRENCY)) {
+      signal?.throwIfAborted();
       const fetched = await Promise.all(
         wave.map(async ([uid, target]) => {
           const files = await getModFilesWithCache(api, target.gameId, target.modId).catch(
@@ -483,6 +491,10 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       { details, metadata },
     );
   } catch (error) {
+    // The registry reports the timeout itself and discards this run's result.
+    if (signal?.aborted) {
+      throw error;
+    }
     log("error", "Failed to check Nexus mod requirements", unknownToError(error));
     return createResult(
       startTime,
@@ -512,7 +524,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
   ],
-  check: async (api: IExtensionApi): Promise<IHealthCheckResult> => {
+  check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     if (!isModRequirementsEnabled(api.getState())) {
       return {
         checkId: MOD_REQUIREMENTS_CHECK_ID,
@@ -526,7 +538,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, true));
     try {
-      return await checkModRequirements(api);
+      return await checkModRequirements(api, signal);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
@@ -48,6 +48,21 @@ describe("HealthCheckRegistry timeout handling", () => {
     expect(parked.starts()).toBe(1);
   });
 
+  test("tells the user the check gave up", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck();
+    const notify = vi.spyOn(harness.api, "sendNotification");
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });
+
+    await harness.run(parked.id);
+
+    // Keyed on the check, so repeated timeouts replace rather than stack.
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "health-check-timeout-slow-check", type: "warning" }),
+    );
+
+    await vi.waitFor(() => expect(parked.hasSettled()).toBe(true), SETTLE);
+  });
+
   test("runs again once the abandoned body has finished", async ({ makeHealthCheck }) => {
     const harness = makeHealthCheck();
     const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
@@ -247,6 +247,12 @@ export class HealthCheckRegistry {
         return undefined;
       }
 
+      // A timeout clears the check's previous result, so without this the page just empties
+      // with no explanation.
+      if (timedOut) {
+        this.notifyTimeout(entry.healthCheck);
+      }
+
       log("warn", "Health check failed", {
         id: checkId,
         error: err.message || "Unknown error",
@@ -263,6 +269,20 @@ export class HealthCheckRegistry {
         this.mExecutionQueue.delete(checkId);
       }
     }
+  }
+
+  /**
+   * Report a check that gave up. Keyed on the check so a repeatedly timing-out check replaces
+   * its own notification instead of stacking one per trigger.
+   */
+  private notifyTimeout(healthCheck: IHealthCheckEntry["healthCheck"]): void {
+    this.mApi.sendNotification?.({
+      id: `health-check-timeout-${healthCheck.id}`,
+      type: "warning",
+      title: "Health check timed out",
+      message: `${healthCheck.name} took too long and was stopped. Refresh to try again.`,
+      displayMS: 10000,
+    });
   }
 
   /** Whether this check names a game other than the active one. */

--- a/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
@@ -44,13 +44,17 @@ export function useModRequirementActions(
 
   // 1-click install is a Premium feature; free users get the upgrade prompt
   // (which routes them to the mod page) instead of an in-app download.
+  // onDownloadRequirement reports its own failures and never rejects, so the
+  // fire-and-forget call sites have nothing to catch; a failed install leaves the
+  // detail page open rather than navigating away from the issue.
   const installInApp = useCallback(async () => {
     if (showPremiumAd) {
       setShowPremiumModal(true);
       return;
     }
-    await onDownloadRequirement(api, mod, undefined, identity);
-    onInstalled?.();
+    if (await onDownloadRequirement(api, mod, undefined, identity)) {
+      onInstalled?.();
+    }
   }, [api, mod, identity, showPremiumAd, onInstalled]);
 
   // Persistence only — EntryActions owns the feedback analytics, so both thumbs record

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
@@ -121,9 +121,12 @@ const detailCache: KeyedCache<FileVersionDetail> = createKeyedCache(CACHE_TTL_MS
  * Build the resolver ports for the active session. Candidate and version detail
  * data come from the Nexus v3 batch endpoints (chunked, paged and cached here);
  * mod details go through the shared, v3-backed getModDetails accessor.
+ *
+ * The resolver takes no signal of its own, so an abort reaches it through the client, which
+ * carries the signal into every request and so cancels one already in flight.
  */
-export function createResolverPorts(api: IExtensionApi): ResolverPorts {
-  const client = createVortexNexusV3Client(api);
+export function createResolverPorts(api: IExtensionApi, signal?: AbortSignal): ResolverPorts {
+  const client = createVortexNexusV3Client(api, { signal });
 
   return {
     async fetchCandidates(fileVersionUids) {
@@ -142,7 +145,7 @@ export function createResolverPorts(api: IExtensionApi): ResolverPorts {
     },
 
     async fetchModDetails(modUids) {
-      const details = await getModDetails(api, modUids);
+      const details = await getModDetails(api, modUids, signal);
       return details.map(
         (detail): ModDetail => ({
           modUid: detail.modUID,

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -85,6 +85,7 @@ function surfacedModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
  */
 export async function runFileLevelRequirements(
   api: IExtensionApi,
+  signal?: AbortSignal,
 ): Promise<IFileRequirementsCheckMetadata> {
   const gameId = activeProfile(api.getState())?.gameId ?? "";
 
@@ -106,8 +107,10 @@ export async function runFileLevelRequirements(
   const report = await checkFileLevelRequirements({
     installedFiles,
     uninstalledFileVersionUids: new Set(downloadedRefs.map((ref) => ref.fileUID)),
-    ports: createResolverPorts(api),
+    ports: createResolverPorts(api, signal),
   });
+
+  signal?.throwIfAborted();
 
   const buildHydrate = (modDetailsByUID: Map<string, IModDetails>): HydrateFile => {
     const hydrateInstalled = makeInstalledFileHydrator(api, installedRefs, modDetailsByUID);
@@ -133,7 +136,8 @@ export async function runFileLevelRequirements(
 
   // Backfill display data (thumbnail, summary, adult flag) via the batched, cached
   // mod-details endpoint, then re-map with it. See toDownloadedFile / toInstalledFile.
-  const details = await getModDetails(api, modUIDs).catch((err: unknown): IModDetails[] => {
+  const details = await getModDetails(api, modUIDs, signal).catch((err: unknown): IModDetails[] => {
+    signal?.throwIfAborted();
     log("warn", "failed to fetch mod details for file requirements", {
       count: modUIDs.length,
       error: getErrorMessage(unknownToError(err)),

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
@@ -6,7 +6,7 @@ import {
 } from "@/extensions/nexus_integration/util/convertGameId";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import type { IGame } from "@/types/IGame";
-import { getGame, toPromise } from "@/util/api";
+import { getGame } from "@/util/api";
 
 import { trackedInstall } from "../shared/installTracking";
 import type { IssueAnalyticsIdentity } from "../shared/tracking";
@@ -83,24 +83,30 @@ export async function onDownloadRequirement(
         mod_version: targetFile.version,
       },
       async () => {
-        const dlId = await toPromise<string>((cb) =>
-          api.events.emit(
+        const dlId = await new Promise<string>((resolve, reject) =>
+          api.events.emit<"start-download">(
             "start-download",
             [nxmUrl],
             { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
             undefined,
-            cb,
+            (err, id?) =>
+              err !== null || id === undefined
+                ? reject(err ?? new Error("download did not report an id"))
+                : resolve(id),
             undefined,
             { allowInstall: false },
           ),
         );
 
-        await toPromise<string>((cb) =>
-          api.events.emit(
+        await new Promise<string>((resolve, reject) =>
+          api.events.emit<"start-install-download">(
             "start-install-download",
             dlId,
             { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
-            cb,
+            (err, modId) =>
+              err !== null || modId === undefined
+                ? reject(err ?? new Error("install did not report a mod id"))
+                : resolve(modId),
           ),
         );
       },

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
@@ -13,21 +13,26 @@ import type { IssueAnalyticsIdentity } from "../shared/tracking";
 import { getModFilesWithCache } from "./modFiles";
 
 /**
- * Download and install missing mod requirements from Nexus
+ * Download and install missing mod requirements from Nexus. Resolves to whether the
+ * requirement was installed; every failure is reported to the user here rather than
+ * thrown, mirroring downloadFileRequirement, because the call sites are fire-and-forget
+ * click handlers with nowhere to catch.
  */
 export async function onDownloadRequirement(
   api: IExtensionApi,
   mod: IModRequirementExt,
   file?: IModFileInfo,
   identity?: IssueAnalyticsIdentity,
-): Promise<void> {
+): Promise<boolean> {
+  const modLabel = mod.modName || `mod ID ${mod.modId}`;
+
   if (!Number.isInteger(mod.modId) || mod.modId <= 0) {
     api.showErrorNotification(
       `Cannot download requirement "${mod.modName}"`,
       "This requirement does not have a valid Nexus Mods ID.",
       { allowReport: false },
     );
-    return;
+    return false;
   }
 
   const getFileIds = async (): Promise<IModFileInfo[]> => {
@@ -51,54 +56,64 @@ export async function onDownloadRequirement(
     return files;
   };
 
-  const fileIds = await getFileIds();
-  if (fileIds.length === 0) {
-    return;
+  try {
+    const fileIds = await getFileIds();
+    if (fileIds.length === 0) {
+      return false;
+    }
+
+    const gameId = mod.gameId;
+    const modId = mod.modId;
+    const targetFile = fileIds[0];
+
+    const game: IGame = getGame(gameId);
+    const nexusDomainName = nexusGameId(game, gameId);
+    const nxmUrl = `nxm://${nexusDomainName}/mods/${modId}/files/${targetFile.fileId}`;
+    // mod.gameId is the Nexus domain (e.g. "skyrimspecialedition"); the downloader and
+    // download.game records key on the internal id ("skyrimse"). Convert before emitting
+    // so the file lands in the same folder the install handler later looks in.
+    const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
+
+    await trackedInstall(
+      api,
+      {
+        ...identity,
+        mod_id: modId,
+        mod_name: mod.modName,
+        mod_version: targetFile.version,
+      },
+      async () => {
+        const dlId = await toPromise<string>((cb) =>
+          api.events.emit(
+            "start-download",
+            [nxmUrl],
+            { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
+            undefined,
+            cb,
+            undefined,
+            { allowInstall: false },
+          ),
+        );
+
+        await toPromise<string>((cb) =>
+          api.events.emit(
+            "start-install-download",
+            dlId,
+            { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
+            cb,
+          ),
+        );
+      },
+    );
+  } catch (err) {
+    // trackedInstall re-throws so the caller owns the user-facing handling; this is that
+    // caller. The file-list lookup is inside the same try because it can fail the same way.
+    api.showErrorNotification(`Failed to install requirement: ${modLabel}`, err, {
+      allowReport: false,
+    });
+
+    return false;
   }
-
-  const gameId = mod.gameId;
-  const modId = mod.modId;
-  const targetFile = fileIds[0];
-
-  const game: IGame = getGame(gameId);
-  const nexusDomainName = nexusGameId(game, gameId);
-  const nxmUrl = `nxm://${nexusDomainName}/mods/${modId}/files/${targetFile.fileId}`;
-  // mod.gameId is the Nexus domain (e.g. "skyrimspecialedition"); the downloader and
-  // download.game records key on the internal id ("skyrimse"). Convert before emitting
-  // so the file lands in the same folder the install handler later looks in.
-  const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
-
-  await trackedInstall(
-    api,
-    {
-      ...identity,
-      mod_id: modId,
-      mod_name: mod.modName,
-      mod_version: targetFile.version,
-    },
-    async () => {
-      const dlId = await toPromise<string>((cb) =>
-        api.events.emit(
-          "start-download",
-          [nxmUrl],
-          { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
-          undefined,
-          cb,
-          undefined,
-          { allowInstall: false },
-        ),
-      );
-
-      await toPromise<string>((cb) =>
-        api.events.emit(
-          "start-install-download",
-          dlId,
-          { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
-          cb,
-        ),
-      );
-    },
-  );
 
   api.sendNotification({
     type: "success",
@@ -106,4 +121,6 @@ export async function onDownloadRequirement(
     displayMS: 5000,
     id: "health-check:nexus-requirements-download-finished",
   });
+
+  return true;
 }

--- a/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
@@ -40,12 +40,16 @@ async function fetchModDetailRows(client: V3Client, modUIDs: string[]): Promise<
  * /mods/batch endpoint, chunked to the per-request id limit and cached by uid
  * so re-runs only fetch the misses. Shared by the mod- and file-level checks.
  */
-export async function getModDetails(api: IExtensionApi, modUIDs: string[]): Promise<IModDetails[]> {
+export async function getModDetails(
+  api: IExtensionApi,
+  modUIDs: string[],
+  signal?: AbortSignal,
+): Promise<IModDetails[]> {
   if (modUIDs.length === 0) {
     return [];
   }
 
-  const client = createVortexNexusV3Client(api);
+  const client = createVortexNexusV3Client(api, { signal });
   const byUid = await resolveCached(modUIDs, modDetailCache, async (missing) => {
     const details = (await fetchModDetailRows(client, missing)).map(toModDetails);
     return new Map(details.map((detail) => [detail.modUID, detail]));

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -147,6 +147,17 @@ interface IAppContext {
   isProfileChanging: boolean;
 }
 
+declare module "../../types/IExtensionContext" {
+  interface ApiEvents {
+    "start-install-download": (
+      downloadId: string,
+      // legacy callers pass a bare allowAutoEnable flag, normalized by the handler
+      options?: IInstallOptions | boolean,
+      callback?: (err: Error | null, modId?: string) => void,
+    ) => void;
+  }
+}
+
 const appContext: IAppContext = {
   isProfileChanging: false,
 };

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -939,7 +939,10 @@ export function onGetModRequirements(
             ...graphErrorContext(err),
           });
         }
-        return Bluebird.resolve({});
+        // Rethrow: resolving to {} made "this mod has no requirements" and "we could not
+        // ask" indistinguishable, so a rate limit or outage was reported to the user as a
+        // clean bill of health. The caller decides what an incomplete run means.
+        return Bluebird.reject(err);
       });
   };
 }

--- a/src/renderer/src/util/util.ts
+++ b/src/renderer/src/util/util.ts
@@ -659,6 +659,11 @@ function flattenInner(obj: any, key: string[], objStack: any[], options: IFlatte
   }, {});
 }
 
+/**
+ * @deprecated Wrap the call in a plain `new Promise` instead. This helper predates the typed
+ * `ApiEvents` registry and erases the callback signature, so the emit's arguments and result
+ * go unchecked.
+ */
 export function toPromise<ResT>(func: (cb) => void): Bluebird<ResT> {
   return new Bluebird((resolve, reject) => {
     const cb = (err: Error, res: ResT) => {


### PR DESCRIPTION
## Health check: fail visibly, and stop when timed out

Fixes health check behavior on timeout or errors.

- A failed mod-requirement install produced an unhandled rejection and no notification; it now reports its own errors like `downloadFileRequirement` does.
- `onGetModRequirements` swallowed every error and resolved `{}`, so an outage reported "passed"; it now propagates and the check reports `error`.
- Neither check honoured the registry's abort signal, so a run against an unresponsive endpoint held the check's slot and blocked every later trigger. Both now stop on their signal, the v3 client cancels in-flight requests, and the registry warns when a run gives up.
