### PR TITLE
Upgrade React to 18.3.1 (legacy render)

### DIFF
--- a/AGENTS-FRONTEND.md
+++ b/AGENTS-FRONTEND.md
@@ -6,9 +6,11 @@ defaults when there's no local precedent.
 
 ## Stack
 
-- **React 16.14** — function components + hooks only. Do NOT use React 18+ APIs
-  (`useId`, `useSyncExternalStore`, `useTransition`, `createRoot`, automatic
-  batching guarantees). ESLint warns on new class components — don't add them.
+- **React 18.3.1 on the legacy `ReactDOM.render` root** (React 17-compatible
+  behavior) — function components + hooks only. Do NOT use `createRoot`,
+  concurrent features, or `StrictMode` yet — the createRoot flip is a separate,
+  later release. Class components, legacy context, and `findDOMNode` remain
+  functional but deprecated; do not introduce NEW usages.
 - **TypeScript** (type-checked ESLint). `import type { ... }` for types
   (`consistent-type-imports` is an error).
 - **Tailwind v4** for styling, **react-redux** for state, **react-i18next** for
@@ -117,7 +119,7 @@ defaults when there's no local precedent.
 
 ## Testing
 
-- `vitest` + `@testing-library/react` (v12), colocated with the component.
+- `vitest` + `@testing-library/react` (v16), colocated with the component.
 - Query by role/label/text (what a user sees), not test ids.
 
 ## Comments

--- a/AGENTS-FRONTEND.md
+++ b/AGENTS-FRONTEND.md
@@ -63,6 +63,10 @@ defaults when there's no local precedent.
 - `oxfmt` owns import grouping/ordering (external → `@/` alias → relative,
   alphabetical). Don't fight it — run `pnpm run format`.
 - Unused vars/args are errors unless prefixed `_`.
+- **React:** if a file already has `import * as React from "react"`, keep using
+  `React.*` references — don't mix styles within a file. In files without it,
+  import what you need by name (`import { useCallback, type ReactNode } from "react"`)
+  and never add a new `import * as React` / `import type * as React` line.
 
 ## Styling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgraded React from 17.0.2 to 18.3.1 (legacy rendering mode - no runtime behavior change; extension compatibility preserved)
+- Upgraded @testing-library/react from 12 to 16
+
 ## [2.5.0-beta.1] - 2026-07-29
 
 _First beta of the 2.5 release._

--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -89,12 +89,12 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | ps-list | 7.2.0 |
 | re-reselect | 4.0.1 |
 | re-resizable | 6.11.2 |
-| react | 17.0.2 |
+| react | 18.3.1 |
 | react-bootstrap | 0.33.1 |
 | react-datepicker | 3.8.0 |
 | react-dnd | 14.0.5 |
 | react-dnd-html5-backend | 14.1.0 |
-| react-dom | 17.0.2 |
+| react-dom | 18.3.1 |
 | react-hot-toast | 2.6.0 |
 | react-i18next | 11.18.6 |
 | react-markdown | 6.0.3 |

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -476,8 +476,8 @@ class Archive {
 // @public (undocumented)
 type ArchiveHandlerCreator = (fileName: string, options: IArchiveOptions) => Promise_2<IArchiveHandler>;
 
-// @public (undocumented)
-class ArgumentInvalid extends Error {
+// @public @deprecated (undocumented)
+class ArgumentInvalid extends VortexError<"argument-invalid"> {
     constructor(argument: string);
 }
 
@@ -842,8 +842,8 @@ function currentGame_2(store: Redux.Store<any>): Promise_2<IGameStored>;
 // @public
 function currentGameDiscovery(state: any): IDiscoveryResult;
 
-// @public (undocumented)
-class CycleError extends Error {
+// @public @deprecated (undocumented)
+class CycleError extends VortexError<"cycle-error"> {
     constructor(cycles: string[][]);
     // (undocumented)
     get cycles(): string[][];
@@ -857,8 +857,8 @@ export class Dashlet extends React_2.Component<IDashletProps, {}> {
     render(): JSX.Element;
 }
 
-// @public (undocumented)
-class DataInvalid extends Error {
+// @public @deprecated (undocumented)
+class DataInvalid extends VortexError<"data-invalid"> {
     constructor(message: string);
 }
 
@@ -1116,6 +1116,11 @@ function extractExeIcon(exePath: string, destPath: string): Promise<void>;
 function fileMD5(input: string | Buffer, progress?: (bytesProcessed: number, totalBytes: number) => void): Promise<string>;
 
 // @public
+export type FileSystemErrorData = OsErrorData & {
+    path: string;
+};
+
+// @public
 const finalizingDownload: ComplexActionCreator1<string, {
 id: string;
 }, {}>;
@@ -1331,11 +1336,11 @@ type GameLaunchType = "gamestore" | "commandline";
 // @public (undocumented)
 function gameName(state: any, gameId: string): string;
 
-// @public (undocumented)
-class GameNotFound extends Error {
+// @public @deprecated (undocumented)
+class GameNotFound extends VortexError<"game-not-found"> {
     constructor(search: string);
     // (undocumented)
-    get search(): any;
+    get search(): string;
 }
 
 // @public (undocumented)
@@ -1881,6 +1886,7 @@ interface ICollectionInstallSession {
     };
     profileId: string;
     sessionId: string;
+    stalled?: boolean;
     totalOptional: number;
     totalRequired: number;
 }
@@ -3744,6 +3750,9 @@ interface IRunParameters {
     options: IRunOptions;
 }
 
+// @public
+const isActiveSessionStalled: (state: IState) => boolean;
+
 // @public (undocumented)
 const isAnalyticsEnabled: (state: any) => boolean;
 
@@ -4704,8 +4713,8 @@ type MergeTest = (game: IGame, gameDiscovery: IDiscoveryResult) => IMergeFilter;
 // @public (undocumented)
 type Method = "GET" | "POST" | "PUT";
 
-// @public (undocumented)
-class MissingInterpreter extends Error {
+// @public @deprecated (undocumented)
+class MissingInterpreter extends VortexError<"missing-interpreter"> {
     constructor(message: string, url?: string);
     // (undocumented)
     get url(): string | undefined;
@@ -4861,8 +4870,8 @@ type Normalize = (input: string) => string;
 // @public
 function normalizeStoreQuery(raw: IQueryArgEntry | undefined): IStoreQuery[];
 
-// @public (undocumented)
-class NotFound extends Error {
+// @public @deprecated (undocumented)
+class NotFound extends VortexError<"not-found"> {
     constructor(what: string);
 }
 
@@ -4875,8 +4884,8 @@ const notifications: (state: IState) => INotification[];
 // @public (undocumented)
 type NotificationType = "activity" | "global" | "success" | "info" | "warning" | "error" | "silent";
 
-// @public (undocumented)
-class NotSupportedError extends Error {
+// @public @deprecated (undocumented)
+class NotSupportedError extends VortexError<"not-supported"> {
     constructor();
 }
 
@@ -4907,6 +4916,13 @@ export class OptionsFilter implements ITableFilter {
     // (undocumented)
     raw: boolean;
 }
+
+// @public
+export type OsErrorData = {
+    originalCode: string;
+    errno: number;
+    syscall: string;
+};
 
 // Warning: (ae-forgotten-export) The symbol "IProps_6" needs to be exported by the entry point api.d.ts
 //
@@ -4998,8 +5014,8 @@ function prettifyNodeErrorMessage(err: any, options?: IErrorOptions, fileName?: 
 // @public (undocumented)
 type ProblemSeverity = "warning" | "error" | "fatal";
 
-// @public (undocumented)
-class ProcessCanceled extends Error {
+// @public @deprecated (undocumented)
+class ProcessCanceled extends VortexError<"process-canceled"> {
     constructor(message: string, extraInfo?: unknown);
     // (undocumented)
     get extraInfo(): unknown;
@@ -5310,6 +5326,7 @@ declare namespace selectors {
         isAnalyticsEnabled,
         isTelemetryEnabled,
         getCollectionActiveSession,
+        isActiveSessionStalled,
         getCollectionLastActiveSessionId,
         getCollectionSessionHistory,
         getCollectionSessionById,
@@ -5898,8 +5915,8 @@ mayCancel: boolean;
 // @public
 const setUpdateChannel: reduxAct.ComplexActionCreator1<unknown, unknown, {}>;
 
-// @public (undocumented)
-class SetupError extends Error {
+// @public @deprecated (undocumented)
+class SetupError extends VortexError<"setup-error"> {
     constructor(message: string, component?: string);
     // (undocumented)
     get component(): string | undefined;
@@ -6540,8 +6557,8 @@ function upload(targetUrl: string, dataStream: Readable, dataSize: number): Prom
 // @public (undocumented)
 export const Usage: React_2.ComponentClass<IUsageProps>;
 
-// @public (undocumented)
-class UserCanceled extends Error {
+// @public @deprecated (undocumented)
+class UserCanceled extends VortexError<"user-canceled"> {
     constructor(skipped?: boolean);
     // (undocumented)
     skipped: boolean;
@@ -6749,6 +6766,103 @@ export class VisibilityProxy extends React_2.PureComponent<any, {}> {
     componentWillUnmount(): void;
     // (undocumented)
     render(): JSX.Element;
+}
+
+// @public
+export class VortexError<out K extends VortexErrorKind = VortexErrorKind> extends Error {
+    constructor(message: string, data: { [P in K]: {
+            kind: P;
+        } & VortexErrorKindMap[P] }[K], meta?: {
+        isTransient?: boolean;
+        cause?: unknown;
+    });
+    readonly data: { [P in K]: {
+            kind: P;
+        } & VortexErrorKindMap[P] }[K];
+    readonly isTransient: boolean;
+}
+
+// @public
+export type VortexErrorData = { [K in VortexErrorKind]: {
+        kind: K;
+    } & VortexErrorKindMap[K] }[VortexErrorKind];
+
+// @public
+export type VortexErrorKind = keyof VortexErrorKindMap;
+
+// @public
+export interface VortexErrorKindMap {
+    "argument-invalid": {
+        argument: string;
+    };
+    "cycle-error": {
+        cycles: string[][];
+    };
+    "data-invalid": {
+        field?: string;
+    };
+    "download:is-html": {
+        url: string;
+    };
+    "download:resolver-error": {};
+    // (undocumented)
+    "fs:already-exists": FileSystemErrorData;
+    // (undocumented)
+    "fs:directory-not-empty": FileSystemErrorData;
+    // (undocumented)
+    "fs:no-permissions": FileSystemErrorData;
+    // (undocumented)
+    "fs:no-space": FileSystemErrorData;
+    // (undocumented)
+    "fs:not-a-directory": FileSystemErrorData;
+    // (undocumented)
+    "fs:not-a-file": FileSystemErrorData;
+    // (undocumented)
+    "fs:not-found": FileSystemErrorData;
+    "game-not-found": {
+        gameId: string;
+    };
+    // (undocumented)
+    "http:bad-status": {
+        url: string;
+        statusCode: number;
+    };
+    "http:generic": {
+        url: string;
+    } & Partial<OsErrorData>;
+    // (undocumented)
+    "http:precondition-failed": {
+        url: string;
+    };
+    // (undocumented)
+    "http:protocol-violation": {
+        url: string;
+    };
+    // (undocumented)
+    "http:timeout": {
+        url: string;
+    };
+    "missing-interpreter": {
+        url?: string;
+    };
+    "not-found": {
+        resourceType?: string;
+    };
+    "not-supported": {
+        feature?: string;
+    };
+    "os:generic": OsErrorData;
+    "os:unsupported": {};
+    "process-canceled": {
+        extraInfo?: unknown;
+    };
+    "setup-error": {
+        component?: string;
+    };
+    "user-canceled": {
+        skipped: boolean;
+    };
+    unknown: Record<string, unknown>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWalkOptions" needs to be exported by the entry point api.d.ts

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -1199,6 +1199,12 @@ export class FormCheckboxItem extends React_2.Component<IFormItemProps, {}> {
 // @public (undocumented)
 export class FormFeedback extends React_2.Component<IFormFeedbackProps, {}> {
     // (undocumented)
+    context: {
+        $bs_formGroup?: {
+            validationState?: string;
+        };
+    };
+    // (undocumented)
     static contextTypes: React_2.ValidationMap<any>;
     // (undocumented)
     static defaultProps: {
@@ -4734,6 +4740,8 @@ export class Modal extends React_2.PureComponent<typeof Modal_2.prototype.props,
     static Body: typeof ModalBody;
     // (undocumented)
     static childContextTypes: React_2.ValidationMap<any>;
+    // (undocumented)
+    context: Partial<IComponentContext>;
     // (undocumented)
     static Footer: typeof ModalFooter;
     // (undocumented)

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -419,7 +419,7 @@ function addReducer<ActionT, StateT>(action: ActionT, handler: (state: StateT, p
 function addUniqueSafe<T>(state: T, path: Array<string | number>, value: any): T;
 
 // @public (undocumented)
-export const Advanced: React_2.ComponentType<{}>;
+export const Advanced: React_2.ComponentType<React_2.PropsWithChildren<{}>>;
 
 // @public
 type ApiEventArgs<TEvent extends ApiEventName> = Readonly<Parameters<ApiEvents[TEvent]>>;
@@ -949,7 +949,7 @@ itemId: string;
 // Warning: (ae-forgotten-export) The symbol "IDNDContainerProps" needs to be exported by the entry point api.d.ts
 //
 // @public
-export const DNDContainer: FC<IDNDContainerProps>;
+export const DNDContainer: FC<React_3.PropsWithChildren<IDNDContainerProps>>;
 
 // @public (undocumented)
 const downloadPath: (state: IState) => string;
@@ -1686,7 +1686,7 @@ interface IActionDefinition {
     // (undocumented)
     action?: (instanceId: string | string[], data?: any) => void;
     // (undocumented)
-    component?: React_2.ComponentType<any>;
+    component?: React_2.ComponentType<React_2.PropsWithChildren<any>>;
     // (undocumented)
     condition?: (instanceId: string | string[], data?: any) => boolean | string;
     // (undocumented)
@@ -1942,7 +1942,7 @@ interface IComponentContext {
 // Warning: (ae-forgotten-export) The symbol "IIconProps" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
-export const Icon: FC<IIconProps>;
+export const Icon: FC<React_3.PropsWithChildren<IIconProps>>;
 
 // @public
 class Icon_2 extends React_2.Component<IconProps, {}> {
@@ -2417,7 +2417,7 @@ interface IExtensionApiExtension extends INexusAPIExtension, IModsAPIExtension, 
     // (undocumented)
     showHistory?: (stack: string) => void;
     // (undocumented)
-    showOverlay?: (id: string, title: string, content: string | React_2.ComponentType<any>, pos?: IPosition, options?: IOverlayOptions) => void;
+    showOverlay?: (id: string, title: string, content: string | React_2.ComponentType<React_2.PropsWithChildren<any>>, pos?: IPosition, options?: IOverlayOptions) => void;
 }
 
 // @public
@@ -2553,6 +2553,8 @@ interface IFileListItem {
 interface IFilterProps {
     // (undocumented)
     attributeId: string;
+    // (undocumented)
+    children?: React_2.ReactNode;
     // (undocumented)
     domRef: (ref: HTMLElement) => void;
     // (undocumented)
@@ -3027,11 +3029,11 @@ interface ILoadOrderEntry_2<T = any> {
 interface ILoadOrderGameInfo {
     clearStateOnPurge?: boolean;
     condition?: () => boolean;
-    customItemRenderer?: React.ComponentType<{
+    customItemRenderer?: React.ComponentType<React.PropsWithChildren<{
         className?: string;
         item: IItemRendererProps;
         forwardedRef?: (ref: any) => void;
-    }>;
+    }>>;
     deserializeLoadOrder: () => Promise<LoadOrder>;
     // (undocumented)
     gameId: string;
@@ -3039,7 +3041,7 @@ interface ILoadOrderGameInfo {
     serializeLoadOrder: (loadOrder: LoadOrder, prev: LoadOrder) => Promise<void>;
     toggleableEntries?: boolean;
     uniformRowHeight?: boolean;
-    usageInstructions?: string | React.ComponentType<{}>;
+    usageInstructions?: string | React.ComponentType<React.PropsWithChildren<{}>>;
     validate: (prev: LoadOrder, current: LoadOrder) => Promise<IValidationResult>;
 }
 
@@ -3080,7 +3082,7 @@ interface IMainPageOptions {
     isModernOnly?: boolean;
     // (undocumented)
     mdi?: string;
-    menuBadge?: React_2.ComponentType;
+    menuBadge?: React_2.ComponentType<React_2.PropsWithChildren<unknown>>;
     newLayout?: boolean;
     // (undocumented)
     onReset?: () => void;
@@ -4293,7 +4295,7 @@ interface ITableAttribute<T = any> {
 // @public (undocumented)
 interface ITableFilter {
     // (undocumented)
-    component: React.ComponentType<IFilterProps>;
+    component: React_2.ComponentType<React_2.PropsWithChildren<IFilterProps>>;
     dataId?: string;
     isEmpty?: (filter: any) => boolean;
     matches: (filter: any, value: any, state: any) => boolean;
@@ -5121,33 +5123,33 @@ class ReduxProp<T> {
 }
 
 // @public (undocumented)
-type RegisterAction = (group: string, position: number, iconOrComponent: string | React_2.ComponentType<any>, options: IActionOptions, titleOrProps?: string | PropsCallback, actionOrCondition?: (instanceIds?: string[]) => void | boolean, condition?: (instanceIds?: string[]) => boolean | string) => void;
+type RegisterAction = (group: string, position: number, iconOrComponent: string | React_2.ComponentType<React_2.PropsWithChildren<any>>, options: IActionOptions, titleOrProps?: string | PropsCallback, actionOrCondition?: (instanceIds?: string[]) => void | boolean, condition?: (instanceIds?: string[]) => boolean | string) => void;
 
 // Warning: (ae-forgotten-export) The symbol "IBannerOptions" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
-type RegisterBanner = (group: string, component: React_2.ComponentType<any>, options: IBannerOptions) => void;
+type RegisterBanner = (group: string, component: React_2.ComponentType<React_2.PropsWithChildren<any>>, options: IBannerOptions) => void;
 
 // @public (undocumented)
-type RegisterControlWrapper = (group: string, priority: number, wrapper: React_2.ComponentType<any>) => void;
+type RegisterControlWrapper = (group: string, priority: number, wrapper: React_2.ComponentType<React_2.PropsWithChildren<any>>) => void;
 
 // @public (undocumented)
-type RegisterDashlet = (title: string, width: 1 | 2 | 3, height: 1 | 2 | 3 | 4 | 5 | 6, position: number, component: React_2.ComponentClass<any> | React_2.FunctionComponent<any>, isVisible: (state: any) => boolean, props: PropsCallback, options: IDashletOptions) => void;
+type RegisterDashlet = (title: string, width: 1 | 2 | 3, height: 1 | 2 | 3 | 4 | 5 | 6, position: number, component: React_2.ComponentClass<any> | React_2.FunctionComponent<React_2.PropsWithChildren<any>>, isVisible: (state: any) => boolean, props: PropsCallback, options: IDashletOptions) => void;
 
 // @public (undocumented)
-type RegisterDialog = (id: string, element: React_2.ComponentType<any>, props?: PropsCallback) => void;
+type RegisterDialog = (id: string, element: React_2.ComponentType<React_2.PropsWithChildren<any>>, props?: PropsCallback) => void;
 
 // @public (undocumented)
 type RegisterFooter = (id: string, element: React_2.ComponentClass<any>, props?: PropsCallback) => void;
 
 // @public (undocumented)
-type RegisterMainPage = (icon: string, title: string, element: React_2.ComponentType<any>, options: IMainPageOptions) => void;
+type RegisterMainPage = (icon: string, title: string, element: React_2.ComponentType<React_2.PropsWithChildren<any>>, options: IMainPageOptions) => void;
 
 // @public (undocumented)
-type RegisterOverlay = (id: string, element: React_2.ComponentType<any>, props?: PropsCallback) => void;
+type RegisterOverlay = (id: string, element: React_2.ComponentType<React_2.PropsWithChildren<any>>, props?: PropsCallback) => void;
 
 // @public (undocumented)
-type RegisterSettings = (title: string, element: React_2.ComponentClass<any> | React_2.StatelessComponent<any>, props?: PropsCallback, visible?: () => boolean, priority?: number) => void;
+type RegisterSettings = (title: string, element: React_2.ComponentClass<any> | React_2.FunctionComponent<React_2.PropsWithChildren<any>>, props?: PropsCallback, visible?: () => boolean, priority?: number) => void;
 
 // @public (undocumented)
 type RegisterToDo = (id: string, type: ToDoType, props: (state: any) => any, icon: ((props: any) => JSX.Element) | string, text: ((t: TFunction, props: any) => JSX.Element) | string, action: (props: any) => void, condition: (props: any) => boolean, value: ((t: TFunction, props: any) => JSX.Element) | string, priority: number) => void;
@@ -6117,7 +6119,7 @@ const symlinkAsync: (srcpath: string, dstpath: string, type?: string) => Promise
 // Warning: (ae-forgotten-export) The symbol "IExtensibleProps" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
-export const Table: React_2.ComponentType<IBaseProps_11 & IExtensibleProps>;
+export const Table: React_2.ComponentType<React_2.PropsWithChildren<IBaseProps_11 & IExtensibleProps>>;
 
 // @public (undocumented)
 export class TableDateTimeFilter implements ITableFilter {

--- a/packages/vortex-api/CHANGELOG.md
+++ b/packages/vortex-api/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the vortex-api will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- React peer dependency upgraded to 18.3.1; `@types/react` and `@types/react-dom` peer dependencies are now 18. Extension source may need type-level fixes on next rebuild (explicit `children` props, removed type aliases) - see the [React 18 section of the migration guide](./docs/MIGRATION.md#vortex-2x-react-18)
+- `IExtensionContext` registration surfaces and `IMainPage` now use `React.FC` instead of the removed `React.StatelessComponent` (source-compatible)
+
 ## [v2.0.0]
 
 ### Added

--- a/packages/vortex-api/docs/MIGRATION.md
+++ b/packages/vortex-api/docs/MIGRATION.md
@@ -368,3 +368,57 @@ context.registerMainPage("savegame", "Save games", MySavegamePage, {
 - [ ] Replace `yarn`/`npx` commands with `pnpm`/`pnpm exec` in build scripts
 - [ ] Remove runtime packages from `devDependencies` (now provided by `vortex-api` peer dependencies)
 - [ ] Adapt `resolutions` field from `package.json`
+
+---
+
+## Vortex 2.x: React 18
+
+Vortex now runs React **18.3.1** (previously 17.0.2). The renderer still uses React's legacy rendering mode, which behaves identically to React 17 at runtime.
+
+**If your extension is already published: no action needed.** Compiled extensions continue to work unmodified - Vortex supplies React at runtime and the runtime behavior is unchanged.
+
+**When you next rebuild your extension**, your `@nexusmods/vortex-api` peer dependencies will pull in `@types/react` 18, and you may see new TypeScript errors. They are type-level only; here is the complete list with fixes:
+
+### 1. `Property 'children' does not exist on type ...`
+
+`@types/react` 18 removed the implicit `children` prop. Declare it explicitly on any component props that accept children:
+
+```ts
+// before
+interface IMyPanelProps {
+    title: string;
+}
+
+// after
+interface IMyPanelProps {
+    title: string;
+    children?: React.ReactNode;
+}
+```
+
+For function components typed with `React.FC`, you can instead use `React.FC<React.PropsWithChildren<IMyPanelProps>>`.
+
+### 2. `Type '...' is not assignable to type 'ReactNode'`
+
+`ReactNode` is stricter in the 18 types - plain objects and component _instances_ no longer qualify. If you were passing something unusual as a child, render it explicitly or cast at the call site:
+
+```tsx
+// before
+<div>{someObject}</div>
+// after
+<div>{String(someObject)}</div> // or render it properly
+```
+
+### 3. Removed type aliases
+
+| Removed in @types/react 18                     | Replace with                             |
+| ---------------------------------------------- | ---------------------------------------- |
+| `React.StatelessComponent<P>` / `React.SFC<P>` | `React.FC<P>`                            |
+| `React.ReactText`                              | `string \| number`                       |
+| `React.ReactChild`                             | `React.ReactElement \| string \| number` |
+
+> **Note:** Two Vortex API types (`IExtensionContext` registration surfaces and `IMainPage`) that previously referenced `StatelessComponent` now use `React.FC` - this is source-compatible; no change needed unless you aliased those types yourself.
+
+### Deprecated-but-working APIs (heads-up only)
+
+`ReactDOM.render`, `ReactDOM.findDOMNode`, and the legacy context API (`contextTypes` / `childContextTypes`) continue to work in Vortex's React 18. React logs deprecation warnings for them in development builds. They will be removed by React in a future major version, so migrating away when convenient is recommended - but nothing breaks today.

--- a/packages/vortex-api/docs/MIGRATION.md
+++ b/packages/vortex-api/docs/MIGRATION.md
@@ -419,6 +419,14 @@ For function components typed with `React.FC`, you can instead use `React.FC<Rea
 
 > **Note:** Two Vortex API types (`IExtensionContext` registration surfaces and `IMainPage`) that previously referenced `StatelessComponent` now use `React.FC` - this is source-compatible; no change needed unless you aliased those types yourself.
 
+### If `npm install` fails with ERESOLVE
+
+Some of Vortex's pinned dependencies (notably `react-select@1.3.0`) declare a React peer range capped below 18, which strict npm resolution rejects. Install with:
+
+    npm install --legacy-peer-deps
+
+or add the equivalent override for your package manager (pnpm: `peerDependencyRules.allowedVersions`; yarn: `resolutions`). Vortex itself supplies these packages at runtime, so the peer warning has no runtime effect.
+
 ### Deprecated-but-working APIs (heads-up only)
 
 `ReactDOM.render`, `ReactDOM.findDOMNode`, and the legacy context API (`contextTypes` / `childContextTypes`) continue to work in Vortex's React 18. React logs deprecation warnings for them in development builds. They will be removed by React in a future major version, so migrating away when convenient is recommended - but nothing breaks today.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ catalogs:
       specifier: 6.9.1
       version: 6.9.1
     '@testing-library/react':
-      specifier: 12.1.5
-      version: 12.1.5
+      specifier: 16.3.0
+      version: 16.3.0
     '@testing-library/user-event':
       specifier: 14.6.1
       version: 14.6.1
@@ -4791,7 +4791,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 12.1.5(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -7483,20 +7483,24 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
-  '@testing-library/dom@8.20.1':
-    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
-    engines: {node: '>=12'}
-
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
-  '@testing-library/react@12.1.5':
-    resolution: {integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==}
-    engines: {node: '>=12'}
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: <18.0.0
-      react-dom: <18.0.0
+      '@testing-library/dom': ^10.0.0
+      '@types/react': '18'
+      '@types/react-dom': '18'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -8257,18 +8261,11 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-query@5.1.3:
-    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
-
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
-
-  array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
   array-flatten@1.1.1:
@@ -8322,10 +8319,6 @@ packages:
   autogypi@0.2.2:
     resolution: {integrity: sha512-NkDsjbybxo98NEUpvDULvV6w4OxhnX8owBptd8/GlQLhi81TZrh7siRYX9zVEoAYpYaX5QrRuIZAtgYD9PGDXg==}
     hasBin: true
-
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
 
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
@@ -9009,10 +9002,6 @@ packages:
     resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
     engines: {node: '>= 0.4'}
 
-  deep-equal@2.2.3:
-    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
-    engines: {node: '>= 0.4'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -9299,9 +9288,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -9618,10 +9604,6 @@ packages:
   font-scanner@0.2.1:
     resolution: {integrity: sha512-YP+EZZ0hjOdJABdDzMdv1nKMhueZQJUQU86lka4HIVesPDVxW5hd9Gz9zGgwDE0G/UjRwmhlBB3FxYtPgkh/cg==}
 
-  for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -9810,10 +9792,6 @@ packages:
     engines: {node: '>=6'}
     deprecated: this library is no longer supported
 
-  has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
-
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -9986,10 +9964,6 @@ packages:
   inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
 
-  internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
@@ -10024,28 +9998,12 @@ packages:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
 
-  is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
-
-  is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
 
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
@@ -10094,14 +10052,6 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -10122,14 +10072,6 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
-
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
@@ -10138,28 +10080,12 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
-  is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
-
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -11119,10 +11045,6 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -11367,10 +11289,6 @@ packages:
   popper.js@1.16.1:
     resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
     deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
-
-  possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -11879,10 +11797,6 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -12107,10 +12021,6 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
-
-  stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -12876,18 +12786,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
-    engines: {node: '>= 0.4'}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -15243,17 +15141,6 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/dom@8.20.1':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.29.2
-      '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      pretty-format: 27.5.1
-
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
@@ -15263,15 +15150,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@12.1.5(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@testing-library/dom': 8.20.1
-      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+      '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -16180,20 +16067,11 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-query@5.1.3:
-    dependencies:
-      deep-equal: 2.2.3
-
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
-
-  array-buffer-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      is-array-buffer: 3.0.5
 
   array-flatten@1.1.1: {}
 
@@ -16240,10 +16118,6 @@ snapshots:
       bluebird: 3.7.2
       commander: 2.9.0
       resolve: 1.1.7
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
 
   aws-sign2@0.7.0: {}
 
@@ -16975,27 +16849,6 @@ snapshots:
       object-keys: 1.1.1
       regexp.prototype.flags: 1.5.4
 
-  deep-equal@2.2.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
-      es-get-iterator: 1.1.3
-      get-intrinsic: 1.3.0
-      is-arguments: 1.2.0
-      is-array-buffer: 3.0.5
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.4
-      isarray: 2.0.5
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      regexp.prototype.flags: 1.5.4
-      side-channel: 1.1.0
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.20
-
   deep-extend@0.6.0: {}
 
   deep-freeze-strict@1.1.1: {}
@@ -17314,18 +17167,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-get-iterator@1.1.3:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      is-arguments: 1.2.0
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
 
   es-module-lexer@2.1.0: {}
 
@@ -17760,10 +17601,6 @@ snapshots:
     dependencies:
       node-addon-api: 8.5.0
 
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -18004,8 +17841,6 @@ snapshots:
       ajv: 6.14.0
       har-schema: 2.0.0
 
-  has-bigints@1.1.0: {}
-
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
@@ -18162,12 +17997,6 @@ snapshots:
 
   inline-style-parser@0.1.1: {}
 
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.4
-      side-channel: 1.1.0
-
   internmap@2.0.3: {}
 
   interpret@3.1.1: {}
@@ -18199,26 +18028,9 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-array-buffer@3.0.5:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
   is-arrayish@0.2.1: {}
 
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.1.0
-
-  is-boolean-object@1.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-buffer@2.0.5: {}
-
-  is-callable@1.2.7: {}
 
   is-ci@3.0.1:
     dependencies:
@@ -18257,13 +18069,6 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-map@2.0.3: {}
-
-  is-number-object@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-number@7.0.0: {}
 
   is-plain-obj@1.1.0: {}
@@ -18281,37 +18086,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.4:
-    dependencies:
-      call-bound: 1.0.4
-
   is-stream@1.1.0: {}
 
   is-stream@4.0.1: {}
 
-  is-string@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@0.1.0: {}
-
-  is-weakmap@2.0.2: {}
-
-  is-weakset@2.0.4:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
 
   is-wsl@2.2.0:
     dependencies:
@@ -19157,15 +18938,6 @@ snapshots:
 
   object-keys@1.1.1: {}
 
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
   obug@2.1.3: {}
 
   octokit@5.0.5:
@@ -19444,8 +19216,6 @@ snapshots:
   pluralize@8.0.0: {}
 
   popper.js@1.16.1: {}
-
-  possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.16:
     dependencies:
@@ -20069,12 +19839,6 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
   safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
@@ -20324,11 +20088,6 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
-
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
 
   string-argv@0.3.2: {}
 
@@ -21032,31 +20791,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-boxed-primitive@1.1.1:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.2
-      is-number-object: 1.1.1
-      is-string: 1.1.1
-      is-symbol: 1.1.1
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.4
-
-  which-typed-array@1.1.20:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which@1.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,8 +792,8 @@ catalogs:
       specifier: 6.11.2
       version: 6.11.2
     react:
-      specifier: 17.0.2
-      version: 17.0.2
+      specifier: 18.3.1
+      version: 18.3.1
     react-bootstrap:
       specifier: 0.33.1
       version: 0.33.1
@@ -807,8 +807,8 @@ catalogs:
       specifier: 14.1.0
       version: 14.1.0
     react-dom:
-      specifier: 17.0.2
-      version: 17.0.2
+      specifier: 18.3.1
+      version: 18.3.1
     react-hot-toast:
       specifier: 2.6.0
       version: 2.6.0
@@ -985,8 +985,8 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  '@types/react': '17'
-  '@types/react-dom': '17'
+  '@types/react': '18'
+  '@types/react-dom': '18'
   node-addon-api: 8.5.0
   node-gyp: 12.3.0
   '@types/node': 24.12.2
@@ -1047,7 +1047,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 10.6.0(jiti@2.7.0)
+        version: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: 'catalog:'
         version: 10.1.8(eslint@10.6.0)
@@ -1125,7 +1125,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+        version: 8.62.1(eslint@10.6.0)(supports-color@10.2.2)(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.23.0)(yaml@2.9.0)
@@ -1195,14 +1195,14 @@ importers:
         specifier: 'catalog:'
         version: 3.5.20
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1220,13 +1220,13 @@ importers:
         version: 4.17.23
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-markdown:
         specifier: 'catalog:'
-        version: 6.0.3(@types/react@17.0.93)(react@17.0.2)
+        version: 6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1246,8 +1246,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -1282,8 +1282,8 @@ importers:
         specifier: 'catalog:'
         version: 4.17.24
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -1298,13 +1298,13 @@ importers:
         version: 4.17.23
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1321,8 +1321,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -1340,7 +1340,7 @@ importers:
         version: 5.2.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1363,8 +1363,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vortex-api
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -1394,10 +1394,10 @@ importers:
         version: 1.4.0
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1426,14 +1426,14 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1460,16 +1460,16 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1514,7 +1514,7 @@ importers:
         version: 2.4.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1531,14 +1531,14 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -1562,16 +1562,16 @@ importers:
         version: 0.5.7
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1648,14 +1648,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vortex-api
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -1688,7 +1688,7 @@ importers:
         version: 0.5.7
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1705,14 +1705,14 @@ importers:
         specifier: 'catalog:'
         version: 4.0.9
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-faux-dom':
         specifier: 'catalog:'
         version: 4.1.8
@@ -1751,7 +1751,7 @@ importers:
         version: 2.30.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       exe-version:
         specifier: workspace:*
         version: link:../../packages/exe-version
@@ -1784,25 +1784,25 @@ importers:
         version: 15.8.1
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-dnd-html5-backend:
         specifier: 'catalog:'
         version: 14.1.0
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-markdown:
         specifier: 'catalog:'
-        version: 6.0.3(@types/react@17.0.93)(react@17.0.2)
+        version: 6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2)
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1836,14 +1836,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vortex-api
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -1876,19 +1876,19 @@ importers:
         version: 15.8.1
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1927,16 +1927,16 @@ importers:
         version: 0.5.7
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -1966,16 +1966,16 @@ importers:
         version: 19.9.2
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
 
   extensions/games/game-7daystodie:
     devDependencies:
@@ -2296,14 +2296,14 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -2321,16 +2321,16 @@ importers:
         version: 2.4.1
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -2426,16 +2426,16 @@ importers:
         version: link:../../../src/shared
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -2459,8 +2459,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -2478,7 +2478,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       modmeta-db:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
@@ -2749,7 +2749,7 @@ importers:
     dependencies:
       simple-git:
         specifier: 'catalog:'
-        version: 3.33.0
+        version: 3.33.0(supports-color@10.2.2)
     devDependencies:
       '@nexusmods/vortex-api':
         specifier: workspace:*
@@ -2758,8 +2758,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -2774,13 +2774,13 @@ importers:
         version: 2.4.1
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2800,14 +2800,14 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -2822,13 +2822,13 @@ importers:
         version: 4.17.23
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-markdown:
         specifier: 'catalog:'
-        version: 6.0.3(@types/react@17.0.93)(react@17.0.2)
+        version: 6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -2864,16 +2864,16 @@ importers:
         version: 0.5.7
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -2893,14 +2893,14 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -2927,10 +2927,10 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -2950,14 +2950,14 @@ importers:
         specifier: 'catalog:'
         version: 12.1.0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -2984,16 +2984,16 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3022,8 +3022,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -3047,10 +3047,10 @@ importers:
         version: 19.9.2
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3065,10 +3065,10 @@ importers:
         version: link:../../packages/vortex-api
       '@nosferatu500/react-sortable-tree':
         specifier: 'catalog:'
-        version: 4.4.0(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.4.0(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)
       '@nosferatu500/theme-file-explorer':
         specifier: 'catalog:'
-        version: 3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -3076,14 +3076,14 @@ importers:
         specifier: 'catalog:'
         version: 2.0.29
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -3131,28 +3131,28 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-dnd-html5-backend:
         specifier: 'catalog:'
         version: 14.1.0
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3181,8 +3181,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vortex-api
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -3197,13 +3197,13 @@ importers:
         version: 2.4.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -3227,7 +3227,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       turbowalk:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
@@ -3248,8 +3248,8 @@ importers:
         specifier: 'catalog:'
         version: 12.1.0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -3270,10 +3270,10 @@ importers:
         version: 4.17.23
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -3387,8 +3387,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vortex-api
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -3406,10 +3406,10 @@ importers:
         version: 19.9.2
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3429,14 +3429,14 @@ importers:
         specifier: 'catalog:'
         version: 12.1.0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -3463,10 +3463,10 @@ importers:
         version: 3.1.1
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -3486,8 +3486,8 @@ importers:
         specifier: 'catalog:'
         version: 12.1.0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -3499,10 +3499,10 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       shortid:
         specifier: 'catalog:'
         version: 2.2.17
@@ -3543,14 +3543,14 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -3583,16 +3583,16 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3651,8 +3651,8 @@ importers:
         specifier: 'catalog:'
         version: 12.1.0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -3673,10 +3673,10 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
 
   extensions/script-extender-error-check:
     devDependencies:
@@ -3693,11 +3693,11 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -3712,10 +3712,10 @@ importers:
         version: 19.9.2
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       turbowalk:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
@@ -3752,7 +3752,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       exe-version:
         specifier: workspace:*
         version: link:../../packages/exe-version
@@ -3764,10 +3764,10 @@ importers:
         version: '@nexusmods/nexus-api@https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/ac96897d5ea4eb1288dae4ed43a01ce9cdc075c0'
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3806,16 +3806,16 @@ importers:
         version: 0.5.7
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -3854,7 +3854,7 @@ importers:
         version: 19.9.2
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       turbowalk:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
@@ -3871,17 +3871,17 @@ importers:
         specifier: 'catalog:'
         version: 3.5.20
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
       '@types/react-color':
         specifier: 'catalog:'
-        version: 2.17.12(@types/react@17.0.93)
+        version: 2.17.12(@types/react@18.3.31)
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -3908,19 +3908,19 @@ importers:
         version: 15.8.1
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-color:
         specifier: 'catalog:'
-        version: 2.19.3(react@17.0.2)
+        version: 2.19.3(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3943,8 +3943,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -3956,10 +3956,10 @@ importers:
         version: 5.2.1
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4010,7 +4010,7 @@ importers:
         version: 24.12.2
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       enquirer:
         specifier: 'catalog:'
         version: 2.4.1
@@ -4119,19 +4119,19 @@ importers:
         version: 3.1.5
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       redux-act:
         specifier: 'catalog:'
         version: 1.8.0
@@ -4158,11 +4158,11 @@ importers:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/ac96897d5ea4eb1288dae4ed43a01ce9cdc075c0
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -4171,7 +4171,7 @@ importers:
         version: 2.30.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       i18next:
         specifier: 'catalog:'
         version: 19.9.2
@@ -4186,7 +4186,7 @@ importers:
         version: 4.0.1(reselect@4.1.8)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4207,7 +4207,7 @@ importers:
         version: 2.1.3(electron@43.0.0)
       '@headlessui/react':
         specifier: 'catalog:'
-        version: 1.7.19(react-dom@17.0.2)(react@17.0.2)
+        version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
       '@hot-updater/bsdiff':
         specifier: 'catalog:'
         version: 0.30.6
@@ -4234,10 +4234,10 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/ac96897d5ea4eb1288dae4ed43a01ce9cdc075c0
       '@nosferatu500/react-sortable-tree':
         specifier: 'catalog:'
-        version: 4.4.0(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.4.0(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)
       '@nosferatu500/theme-file-explorer':
         specifier: 'catalog:'
-        version: 3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -4276,7 +4276,7 @@ importers:
         version: link:../shared
       bbcode-to-react:
         specifier: 'catalog:'
-        version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@17.0.2)
+        version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@18.3.1)
       big.js:
         specifier: 'catalog:'
         version: 5.2.2
@@ -4330,7 +4330,7 @@ importers:
         version: https://codeload.github.com/TanninOne/electron-redux/tar.gz/66bbd9d389579806e8c4ebd87bd513a668cc64a8
       electron-updater:
         specifier: 'catalog:'
-        version: 4.6.5
+        version: 4.6.5(supports-color@10.2.2)
       encoding-down:
         specifier: 'catalog:'
         version: 6.3.0
@@ -4375,7 +4375,7 @@ importers:
         version: 6.0.0
       interweave:
         specifier: 'catalog:'
-        version: 12.9.0(react@17.0.2)
+        version: 12.9.0(react@18.3.1)
       is-admin:
         specifier: 'catalog:'
         version: 3.0.0
@@ -4441,46 +4441,46 @@ importers:
         version: 4.0.1(reselect@4.1.8)
       re-resizable:
         specifier: 'catalog:'
-        version: 6.11.2(react-dom@17.0.2)(react@17.0.2)
+        version: 6.11.2(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-datepicker:
         specifier: 'catalog:'
-        version: 3.8.0(react-dom@17.0.2)(react@17.0.2)
+        version: 3.8.0(react-dom@18.3.1)(react@18.3.1)
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-dnd-html5-backend:
         specifier: 'catalog:'
         version: 14.1.0
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-hot-toast:
         specifier: 'catalog:'
-        version: 2.6.0(react-dom@17.0.2)(react@17.0.2)
+        version: 2.6.0(react-dom@18.3.1)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-markdown:
         specifier: 'catalog:'
-        version: 6.0.3(@types/react@17.0.93)(react@17.0.2)
+        version: 6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2)
       react-overlays:
         specifier: 'catalog:'
-        version: 1.2.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.2.0(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       recharts:
         specifier: 'catalog:'
-        version: 2.15.4(react-dom@17.0.2)(react@17.0.2)
+        version: 2.15.4(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4537,7 +4537,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
       universal-analytics:
         specifier: 'catalog:'
-        version: 0.4.23
+        version: 0.4.23(supports-color@10.2.2)
       uuid:
         specifier: 'catalog:'
         version: 3.4.0
@@ -4571,7 +4571,7 @@ importers:
     devDependencies:
       '@electron/rebuild':
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 4.1.0(supports-color@10.2.2)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 'catalog:'
         version: 0.6.2(react-refresh@0.18.0)(type-fest@5.6.0)(webpack@5.108.4)
@@ -4627,11 +4627,11 @@ importers:
         specifier: 'catalog:'
         version: 15.7.15
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -4670,13 +4670,13 @@ importers:
         version: 0.4.14
       '@welldone-software/why-did-you-render':
         specifier: 'catalog:'
-        version: 7.0.1(react@17.0.2)
+        version: 7.0.1(react@18.3.1)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       electron-builder:
         specifier: 'catalog:'
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
@@ -4703,7 +4703,7 @@ importers:
         version: link:../shared
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
 
   src/renderer:
     dependencies:
@@ -4713,13 +4713,13 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
-        version: 7.29.7
+        version: 7.29.7(supports-color@10.2.2)
       '@babel/polyfill':
         specifier: 'catalog:'
         version: 7.12.1
       '@babel/preset-env':
         specifier: 'catalog:'
-        version: 7.29.2(@babel/core@7.29.7)
+        version: 7.29.2(@babel/core@7.29.7)(supports-color@10.2.2)
       '@babel/preset-react':
         specifier: 'catalog:'
         version: 7.28.5(@babel/core@7.29.7)
@@ -4734,7 +4734,7 @@ importers:
         version: 2.1.3(electron@43.0.0)
       '@headlessui/react':
         specifier: 'catalog:'
-        version: 1.7.19(react-dom@17.0.2)(react@17.0.2)
+        version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
       '@hot-updater/bsdiff':
         specifier: 'catalog:'
         version: 0.30.6
@@ -4761,7 +4761,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/ac96897d5ea4eb1288dae4ed43a01ce9cdc075c0
       '@nosferatu500/react-sortable-tree':
         specifier: 'catalog:'
-        version: 4.4.0(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.4.0(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -4791,7 +4791,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 12.1.5(@types/react@17.0.93)(react-dom@17.0.2)(react@17.0.2)
+        version: 12.1.5(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -4853,8 +4853,8 @@ importers:
         specifier: 'catalog:'
         version: 15.7.15
       '@types/react':
-        specifier: '17'
-        version: 17.0.93
+        specifier: '18'
+        version: 18.3.31
       '@types/react-bootstrap':
         specifier: 'catalog:'
         version: 0.32.37
@@ -4862,8 +4862,8 @@ importers:
         specifier: 'catalog:'
         version: 2.11.1
       '@types/react-dom':
-        specifier: '17'
-        version: 17.0.26(@types/react@17.0.93)
+        specifier: '18'
+        version: 18.3.7(@types/react@18.3.31)
       '@types/react-redux':
         specifier: 'catalog:'
         version: 7.1.34
@@ -4872,7 +4872,7 @@ importers:
         version: 1.3.6
       '@types/react-transition-group':
         specifier: 'catalog:'
-        version: 4.4.12(@types/react@17.0.93)
+        version: 4.4.12(@types/react@18.3.31)
       '@types/redux':
         specifier: 'catalog:'
         version: 3.6.0
@@ -4926,13 +4926,13 @@ importers:
         version: link:../shared
       '@welldone-software/why-did-you-render':
         specifier: 'catalog:'
-        version: 7.0.1(react@17.0.2)
+        version: 7.0.1(react@18.3.1)
       babel-loader:
         specifier: 'catalog:'
         version: 10.1.1(@babel/core@7.29.7)(webpack@5.108.4)
       bbcode-to-react:
         specifier: 'catalog:'
-        version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@17.0.2)
+        version: https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@18.3.1)
       big.js:
         specifier: 'catalog:'
         version: 5.2.2
@@ -4983,7 +4983,7 @@ importers:
         version: https://codeload.github.com/TanninOne/drivelist/tar.gz/720d1890db11482ec05fc0f6aa176cfa6e6844dd
       electron:
         specifier: 'catalog:'
-        version: 43.0.0
+        version: 43.0.0(supports-color@10.2.2)
       electron-context-menu:
         specifier: 'catalog:'
         version: 3.6.1
@@ -4992,7 +4992,7 @@ importers:
         version: https://codeload.github.com/TanninOne/electron-redux/tar.gz/66bbd9d389579806e8c4ebd87bd513a668cc64a8
       electron-updater:
         specifier: 'catalog:'
-        version: 4.6.5
+        version: 4.6.5(supports-color@10.2.2)
       encoding-down:
         specifier: 'catalog:'
         version: 6.3.0
@@ -5034,7 +5034,7 @@ importers:
         version: 3.1.1
       interweave:
         specifier: 'catalog:'
-        version: 12.9.0(react@17.0.2)
+        version: 12.9.0(react@18.3.1)
       is-admin:
         specifier: 'catalog:'
         version: 3.0.0
@@ -5091,49 +5091,49 @@ importers:
         version: 4.0.1(reselect@4.1.8)
       re-resizable:
         specifier: 'catalog:'
-        version: 6.11.2(react-dom@17.0.2)(react@17.0.2)
+        version: 6.11.2(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: 'catalog:'
-        version: 17.0.2
+        version: 18.3.1
       react-bootstrap:
         specifier: 'catalog:'
-        version: 0.33.1(react-dom@17.0.2)(react@17.0.2)
+        version: 0.33.1(react-dom@18.3.1)(react@18.3.1)
       react-datepicker:
         specifier: 'catalog:'
-        version: 3.8.0(react-dom@17.0.2)(react@17.0.2)
+        version: 3.8.0(react-dom@18.3.1)(react@18.3.1)
       react-dnd:
         specifier: 14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-dnd-html5-backend:
         specifier: 'catalog:'
         version: 14.1.0
       react-dom:
         specifier: 'catalog:'
-        version: 17.0.2(react@17.0.2)
+        version: 18.3.1(react@18.3.1)
       react-hot-toast:
         specifier: 'catalog:'
-        version: 2.6.0(react-dom@17.0.2)(react@17.0.2)
+        version: 2.6.0(react-dom@18.3.1)(react@18.3.1)
       react-i18next:
         specifier: 'catalog:'
-        version: 11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2)
+        version: 11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1)
       react-markdown:
         specifier: 'catalog:'
-        version: 6.0.3(@types/react@17.0.93)(react@17.0.2)
+        version: 6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2)
       react-overlays:
         specifier: 'catalog:'
-        version: 1.2.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.2.0(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: 'catalog:'
-        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
+        version: 7.2.9(react-dom@18.3.1)(react@18.3.1)
       react-refresh:
         specifier: 'catalog:'
         version: 0.18.0
       react-select:
         specifier: 'catalog:'
-        version: 1.3.0(react-dom@17.0.2)(react@17.0.2)
+        version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       recharts:
         specifier: 'catalog:'
-        version: 2.15.4(react-dom@17.0.2)(react@17.0.2)
+        version: 2.15.4(react-dom@18.3.1)(react@18.3.1)
       redux:
         specifier: 'catalog:'
         version: 4.2.1
@@ -5190,7 +5190,7 @@ importers:
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
       universal-analytics:
         specifier: 'catalog:'
-        version: 0.4.23
+        version: 0.4.23(supports-color@10.2.2)
       uuid:
         specifier: 'catalog:'
         version: 3.4.0
@@ -7713,7 +7713,7 @@ packages:
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -7797,15 +7797,15 @@ packages:
   '@types/react-color@2.17.12':
     resolution: {integrity: sha512-QFGzyXqUFtIQsVsjd4PG3Ks+4DBCYDwd0rV/tdS4nnvPf/pzZrEtM1uwZZfjwg3dVrrJ2J3hWR3KzkEVOI0I/g==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
 
   '@types/react-datepicker@2.11.1':
     resolution: {integrity: sha512-MVz1vcv3ButoDfKPUA40lSxPBGsT1f05zqvUsP4t5997TX9C4btlYyREJ+h9sRw9R10EpokkS08GFK4XI+Q0Qg==}
 
-  '@types/react-dom@17.0.26':
-    resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
 
   '@types/react-faux-dom@4.1.8':
     resolution: {integrity: sha512-jP9uLEjIaqXptKrUckGm5JKSNMpiHzFLbO0Bb06WSYOOvhj6EsEFc2iLu3dNyYT1oKwyLIMCCsyrjrbxC+C7Qw==}
@@ -7822,15 +7822,15 @@ packages:
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
 
-  '@types/react@17.0.93':
-    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@types/reactcss@1.2.13':
     resolution: {integrity: sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
 
   '@types/redux-devtools-log-monitor@1.0.35':
     resolution: {integrity: sha512-HjtupMQ6uoJbbyxqwr2FZl5Qp0uI7YFH3tc5/Mg7ZiOKO2ortTVpV34OKzNoHgs1qaB1bOc7SXsKZFfX65UB4g==}
@@ -7854,9 +7854,6 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -11522,7 +11519,7 @@ packages:
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
       '@types/node': 24.12.2
-      '@types/react': '17'
+      '@types/react': '18'
       react: '>= 16.14'
     peerDependenciesMeta:
       '@types/hoist-non-react-statics':
@@ -11532,10 +11529,10 @@ packages:
       '@types/react':
         optional: true
 
-  react-dom@17.0.2:
-    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: 17.0.2
+      react: ^18.3.1
 
   react-hot-toast@2.6.0:
     resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
@@ -11577,7 +11574,7 @@ packages:
   react-markdown@6.0.3:
     resolution: {integrity: sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==}
     peerDependencies:
-      '@types/react': '17'
+      '@types/react': '18'
       react: '>=16'
 
   react-onclickoutside@6.13.2:
@@ -11654,8 +11651,8 @@ packages:
       react: '>=16 || >=17 || >= 18 || >= 19'
       react-dom: '>=16 || >=17 || >= 18 || >=19'
 
-  react@17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   reactcss@1.2.3:
@@ -11904,8 +11901,8 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
-  scheduler@0.20.2:
-    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -13104,7 +13101,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -13113,7 +13110,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -13155,27 +13152,27 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@10.2.2)
@@ -13188,24 +13185,24 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -13217,25 +13214,25 @@ snapshots:
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -13253,7 +13250,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -13273,25 +13270,25 @@ snapshots:
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
@@ -13300,59 +13297,59 @@ snapshots:
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
 
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
@@ -13361,17 +13358,17 @@ snapshots:
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13379,7 +13376,7 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13387,55 +13384,55 @@ snapshots:
 
   '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -13443,17 +13440,17 @@ snapshots:
 
   '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -13461,36 +13458,36 @@ snapshots:
 
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13498,7 +13495,7 @@ snapshots:
 
   '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13506,17 +13503,17 @@ snapshots:
 
   '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13524,39 +13521,39 @@ snapshots:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -13564,12 +13561,12 @@ snapshots:
 
   '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -13577,12 +13574,12 @@ snapshots:
 
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
@@ -13590,7 +13587,7 @@ snapshots:
 
   '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
@@ -13599,24 +13596,24 @@ snapshots:
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
@@ -13627,34 +13624,34 @@ snapshots:
 
   '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -13662,22 +13659,22 @@ snapshots:
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
@@ -13688,24 +13685,24 @@ snapshots:
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
@@ -13714,10 +13711,10 @@ snapshots:
       core-js: 2.6.12
       regenerator-runtime: 0.13.11
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.7)':
+  '@babel/preset-env@7.29.2(@babel/core@7.29.7)(supports-color@10.2.2)':
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.29.7
@@ -13782,7 +13779,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@10.2.2)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
@@ -13792,14 +13789,14 @@ snapshots:
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.7)
@@ -13811,7 +13808,7 @@ snapshots:
 
   '@babel/preset-typescript@7.16.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
@@ -13820,7 +13817,7 @@ snapshots:
 
   '@babel/register@7.16.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -13839,7 +13836,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -13923,14 +13920,14 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  '@electron/get@5.0.0':
+  '@electron/get@5.0.0(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
       semver: 7.8.5
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@10.2.2)
     optionalDependencies:
       undici: 7.24.6
     transitivePeerDependencies:
@@ -13955,20 +13952,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@4.1.0':
+  '@electron/rebuild@4.1.0(supports-color@10.2.2)':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
       node-abi: 4.31.0
       node-api-version: 0.2.1
       node-gyp: 12.3.0
-      read-binary-file-arch: 1.0.6
+      read-binary-file-arch: 1.0.6(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   '@electron/remote@2.1.3(electron@43.0.0)':
     dependencies:
-      electron: 43.0.0
+      electron: 43.0.0(supports-color@10.2.2)
 
   '@electron/universal@1.5.1':
     dependencies:
@@ -14090,7 +14087,7 @@ snapshots:
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.6.0)':
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -14100,7 +14097,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       string-ts: 2.3.1
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14114,7 +14111,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14127,7 +14124,7 @@ snapshots:
       '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-react-dom: 3.0.0(eslint@10.6.0)(typescript@6.0.3)
       eslint-plugin-react-naming-convention: 3.0.0(eslint@10.6.0)(typescript@6.0.3)
       eslint-plugin-react-rsc: 3.0.0(eslint@10.6.0)(typescript@6.0.3)
@@ -14141,7 +14138,7 @@ snapshots:
   '@eslint-react/shared@3.0.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
       zod: 4.4.3
@@ -14155,13 +14152,13 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@10.2.2)
@@ -14184,7 +14181,7 @@ snapshots:
 
   '@eslint/js@10.0.1(eslint@10.6.0)':
     optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -14195,12 +14192,12 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@headlessui/react@1.7.19(react-dom@17.0.2)(react@17.0.2)':
+  '@headlessui/react@1.7.19(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@tanstack/react-virtual': 3.13.23(react-dom@17.0.2)(react@17.0.2)
+      '@tanstack/react-virtual': 3.13.23(react-dom@18.3.1)(react@18.3.1)
       client-only: 0.0.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@hot-updater/bsdiff@0.30.6': {}
 
@@ -14215,18 +14212,18 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@hypnosphi/create-react-context@0.3.1(prop-types@15.8.1)(react@17.0.2)':
+  '@hypnosphi/create-react-context@0.3.1(prop-types@15.8.1)(react@18.3.1)':
     dependencies:
       gud: 1.0.0
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 18.3.1
       warning: 4.0.3
 
   '@iarna/toml@2.2.5': {}
 
-  '@icons/material@0.2.4(react@17.0.2)':
+  '@icons/material@0.2.4(react@18.3.1)':
     dependencies:
-      react: 17.0.2
+      react: 18.3.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -14271,7 +14268,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -14391,31 +14388,31 @@ snapshots:
       string-template: 1.0.0
       typed-emitter: 1.4.0
 
-  '@nosferatu500/react-dnd-scrollzone@2.0.10(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)':
+  '@nosferatu500/react-dnd-scrollzone@2.0.10(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       hoist-non-react-statics: 3.3.2
       lodash.throttle: 4.1.1
-      react: 17.0.2
-      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
 
-  '@nosferatu500/react-sortable-tree@4.4.0(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)':
+  '@nosferatu500/react-sortable-tree@4.4.0(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@nosferatu500/react-dnd-scrollzone': 2.0.10(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)
+      '@nosferatu500/react-dnd-scrollzone': 2.0.10(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)
       lodash.isequal: 4.5.0
-      react: 17.0.2
-      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
       react-dnd-html5-backend: 14.1.0
-      react-dom: 17.0.2(react@17.0.2)
-      react-virtuoso: 4.18.11(react-dom@17.0.2)(react@17.0.2)
+      react-dom: 18.3.1(react@18.3.1)
+      react-virtuoso: 4.18.11(react-dom@18.3.1)(react@18.3.1)
 
-  '@nosferatu500/theme-file-explorer@3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react-dom@17.0.2)(react@17.0.2)':
+  '@nosferatu500/theme-file-explorer@3.0.21(@nosferatu500/react-sortable-tree@4.4.0)(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@nosferatu500/react-sortable-tree': 4.4.0(react-dnd@14.0.5)(react-dom@17.0.2)(react@17.0.2)
+      '@nosferatu500/react-sortable-tree': 4.4.0(react-dnd@14.0.5)(react-dom@18.3.1)(react@18.3.1)
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/hoist-non-react-statics'
       - '@types/node'
@@ -15150,7 +15147,7 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
       '@typescript-eslint/types': 8.62.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -15227,11 +15224,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tanstack/react-virtual@3.13.23(react-dom@17.0.2)(react@17.0.2)':
+  '@tanstack/react-virtual@3.13.23(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@tanstack/virtual-core': 3.13.23
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@tanstack/virtual-core@3.13.23': {}
 
@@ -15266,13 +15263,13 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@12.1.5(@types/react@17.0.93)(react-dom@17.0.2)(react@17.0.2)':
+  '@testing-library/react@12.1.5(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 8.20.1
-      '@types/react-dom': 17.0.26(@types/react@17.0.93)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -15332,7 +15329,7 @@ snapshots:
 
   '@types/bbcode-to-react@0.2.4':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/big.js@6.2.2': {}
 
@@ -15513,9 +15510,9 @@ snapshots:
 
   '@types/history@2.0.51': {}
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@17.0.93)':
+  '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
 
   '@types/http-cache-semantics@4.2.0': {}
@@ -15593,61 +15590,60 @@ snapshots:
 
   '@types/react-bootstrap@0.32.37':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
-  '@types/react-color@2.17.12(@types/react@17.0.93)':
+  '@types/react-color@2.17.12(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 17.0.93
-      '@types/reactcss': 1.2.13(@types/react@17.0.93)
+      '@types/react': 18.3.31
+      '@types/reactcss': 1.2.13(@types/react@18.3.31)
 
   '@types/react-datepicker@2.11.1':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
       date-fns: 2.30.0
       popper.js: 1.16.1
 
-  '@types/react-dom@17.0.26(@types/react@17.0.93)':
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/react-faux-dom@4.1.8':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/react-redux@7.1.34':
     dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@17.0.93)
-      '@types/react': 17.0.93
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.31)
+      '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
   '@types/react-router@2.0.61':
     dependencies:
       '@types/history': 2.0.51
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/react-select@1.3.6':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
-  '@types/react-transition-group@4.4.12(@types/react@17.0.93)':
+  '@types/react-transition-group@4.4.12(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
-  '@types/react@17.0.93':
+  '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
-      '@types/scheduler': 0.16.8
       csstype: 3.2.3
 
-  '@types/reactcss@1.2.13(@types/react@17.0.93)':
+  '@types/reactcss@1.2.13(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/redux-devtools-log-monitor@1.0.35':
     dependencies:
       '@types/base16': 1.0.5
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
   '@types/redux-thunk@2.1.0(redux@4.2.1)':
     dependencies:
@@ -15671,8 +15667,6 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.12.2
-
-  '@types/scheduler@0.16.8': {}
 
   '@types/semver@7.7.1': {}
 
@@ -15737,12 +15731,12 @@ snapshots:
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1)(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -15750,14 +15744,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@10.6.0)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -15786,7 +15780,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -15815,7 +15809,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -15976,10 +15970,10 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@welldone-software/why-did-you-render@7.0.1(react@17.0.2)':
+  '@welldone-software/why-did-you-render@7.0.1(react@18.3.1)':
     dependencies:
       lodash: 4.17.23
-      react: 17.0.2
+      react: 18.3.1
 
   '@xmldom/xmldom@0.8.11': {}
 
@@ -16265,32 +16259,32 @@ snapshots:
 
   babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.108.4):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       find-up: 5.0.0
     optionalDependencies:
       webpack: 5.108.4(esbuild@0.28.0)(webpack-cli@7.2.1)
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7)(supports-color@10.2.2):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@10.2.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@10.2.2)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16312,9 +16306,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.11: {}
 
-  bbcode-to-react@https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@17.0.2):
+  bbcode-to-react@https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d(react@18.3.1):
     dependencies:
-      react: 17.0.2
+      react: 18.3.1
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -16420,7 +16414,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builder-util-runtime@8.9.2:
+  builder-util-runtime@8.9.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       sax: 1.6.0
@@ -17205,7 +17199,7 @@ snapshots:
 
   electron-extension-installer@2.0.1(electron@43.0.0):
     dependencies:
-      electron: 43.0.0
+      electron: 43.0.0(supports-color@10.2.2)
       jszip: 3.10.1
 
   electron-is-dev@2.0.0: {}
@@ -17232,10 +17226,10 @@ snapshots:
 
   electron-to-chromium@1.5.325: {}
 
-  electron-updater@4.6.5:
+  electron-updater@4.6.5(supports-color@10.2.2):
     dependencies:
       '@types/semver': 7.7.1
-      builder-util-runtime: 8.9.2
+      builder-util-runtime: 8.9.2(supports-color@10.2.2)
       fs-extra: 10.1.0
       js-yaml: 4.1.1
       lazy-val: 1.0.5
@@ -17245,10 +17239,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.0.0:
+  electron@43.0.0(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
-      '@electron/get': 5.0.0
+      '@electron/get': 5.0.0(supports-color@10.2.2)
       '@types/node': 24.12.2
     transitivePeerDependencies:
       - supports-color
@@ -17387,7 +17381,7 @@ snapshots:
 
   eslint-config-prettier@10.1.8(eslint@10.6.0):
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
 
   eslint-plugin-better-tailwindcss@4.6.1(eslint@10.6.0)(oxlint@1.72.0)(tailwindcss@4.3.2)(typescript@6.0.3):
     dependencies:
@@ -17401,7 +17395,7 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       valibot: 1.4.2(typescript@6.0.3)
     optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       oxlint: 1.72.0(oxlint-tsgolint@0.24.0)
     transitivePeerDependencies:
       - '@eslint/css'
@@ -17410,7 +17404,7 @@ snapshots:
   eslint-plugin-perfectionist@5.9.1(eslint@10.6.0)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17426,7 +17420,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17443,7 +17437,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       string-ts: 2.3.1
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -17459,7 +17453,7 @@ snapshots:
       '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17475,7 +17469,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       birecord: 0.1.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17492,7 +17486,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       string-ts: 2.3.1
       ts-api-utils: 2.5.0(typescript@6.0.3)
       ts-pattern: 5.9.0
@@ -17518,11 +17512,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.6.0(jiti@2.7.0):
+  eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -18178,10 +18172,10 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  interweave@12.9.0(react@17.0.2):
+  interweave@12.9.0(react@18.3.1):
     dependencies:
       escape-html: 1.0.3
-      react: 17.0.2
+      react: 18.3.1
 
   invariant@2.2.4:
     dependencies:
@@ -18747,11 +18741,11 @@ snapshots:
     dependencies:
       unist-util-visit: 2.0.3
 
-  mdast-util-from-markdown@0.8.5:
+  mdast-util-from-markdown@0.8.5(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@10.2.2)
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
@@ -18788,7 +18782,7 @@ snapshots:
 
   methods@1.1.2: {}
 
-  micromark@2.11.4:
+  micromark@2.11.4(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       parse-entities: 2.0.0
@@ -19509,9 +19503,9 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
-  prop-types-extra@1.1.1(react@17.0.2):
+  prop-types-extra@1.1.1(react@18.3.1):
     dependencies:
-      react: 17.0.2
+      react: 18.3.1
       react-is: 16.13.1
       warning: 4.0.3
 
@@ -19581,12 +19575,12 @@ snapshots:
     dependencies:
       reselect: 4.1.8
 
-  re-resizable@6.11.2(react-dom@17.0.2)(react@17.0.2):
+  re-resizable@6.11.2(react-dom@18.3.1)(react@18.3.1):
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-bootstrap@0.33.1(react-dom@17.0.2)(react@17.0.2):
+  react-bootstrap@0.33.1(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime-corejs2': 7.29.2
       classnames: 2.5.1
@@ -19594,84 +19588,83 @@ snapshots:
       invariant: 2.2.4
       keycode: 2.2.1
       prop-types: 15.8.1
-      prop-types-extra: 1.1.1(react@17.0.2)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-overlays: 0.9.3(react-dom@17.0.2)(react@17.0.2)
-      react-prop-types: 0.4.0(react@17.0.2)
-      react-transition-group: 2.9.0(react-dom@17.0.2)(react@17.0.2)
-      uncontrollable: 7.2.1(react@17.0.2)
+      prop-types-extra: 1.1.1(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-overlays: 0.9.3(react-dom@18.3.1)(react@18.3.1)
+      react-prop-types: 0.4.0(react@18.3.1)
+      react-transition-group: 2.9.0(react-dom@18.3.1)(react@18.3.1)
+      uncontrollable: 7.2.1(react@18.3.1)
       warning: 3.0.0
 
-  react-color@2.19.3(react@17.0.2):
+  react-color@2.19.3(react@18.3.1):
     dependencies:
-      '@icons/material': 0.2.4(react@17.0.2)
+      '@icons/material': 0.2.4(react@18.3.1)
       lodash: 4.17.23
       lodash-es: 4.17.23
       material-colors: 1.2.6
       prop-types: 15.8.1
-      react: 17.0.2
-      reactcss: 1.2.3(react@17.0.2)
+      react: 18.3.1
+      reactcss: 1.2.3(react@18.3.1)
       tinycolor2: 1.6.0
 
-  react-context-toolbox@2.0.2(react@17.0.2):
+  react-context-toolbox@2.0.2(react@18.3.1):
     dependencies:
-      react: 17.0.2
+      react: 18.3.1
 
-  react-datepicker@3.8.0(react-dom@17.0.2)(react@17.0.2):
+  react-datepicker@3.8.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       date-fns: 2.30.0
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-onclickoutside: 6.13.2(react-dom@17.0.2)(react@17.0.2)
-      react-popper: 1.3.11(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-onclickoutside: 6.13.2(react-dom@18.3.1)(react@18.3.1)
+      react-popper: 1.3.11(react@18.3.1)
 
   react-dnd-html5-backend@14.1.0:
     dependencies:
       dnd-core: 14.0.1
 
-  react-dnd@14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@17.0.93)(react@17.0.2):
+  react-dnd@14.0.5(@types/hoist-non-react-statics@3.3.7)(@types/node@24.12.2)(@types/react@18.3.31)(react@18.3.1):
     dependencies:
       '@react-dnd/invariant': 2.0.0
       '@react-dnd/shallowequal': 2.0.0
       dnd-core: 14.0.1
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
-      react: 17.0.2
+      react: 18.3.1
     optionalDependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@17.0.93)
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.31)
       '@types/node': 24.12.2
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
 
-  react-dom@17.0.2(react@17.0.2):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
+      react: 18.3.1
+      scheduler: 0.23.2
 
-  react-hot-toast@2.6.0(react-dom@17.0.2)(react@17.0.2):
+  react-hot-toast@2.6.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       csstype: 3.2.3
       goober: 2.1.18(csstype@3.2.3)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-i18next@11.18.6(i18next@19.9.2)(react-dom@17.0.2)(react@17.0.2):
+  react-i18next@11.18.6(i18next@19.9.2)(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
       i18next: 19.9.2
-      react: 17.0.2
+      react: 18.3.1
     optionalDependencies:
-      react-dom: 17.0.2(react@17.0.2)
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-input-autosize@2.2.2(react@17.0.2):
+  react-input-autosize@2.2.2(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 18.3.1
 
   react-is@16.13.1: {}
 
@@ -19681,17 +19674,17 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-markdown@6.0.3(@types/react@17.0.93)(react@17.0.2):
+  react-markdown@6.0.3(@types/react@18.3.31)(react@18.3.1)(supports-color@10.2.2):
     dependencies:
       '@types/hast': 2.3.10
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
       '@types/unist': 2.0.11
       comma-separated-tokens: 1.0.8
       prop-types: 15.8.1
       property-information: 5.6.0
-      react: 17.0.2
+      react: 18.3.1
       react-is: 17.0.2
-      remark-parse: 9.0.0
+      remark-parse: 9.0.0(supports-color@10.2.2)
       remark-rehype: 8.1.0
       space-separated-tokens: 1.1.5
       style-to-object: 0.3.0
@@ -19701,115 +19694,114 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-onclickoutside@6.13.2(react-dom@17.0.2)(react@17.0.2):
+  react-onclickoutside@6.13.2(react-dom@18.3.1)(react@18.3.1):
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-overlays@0.9.3(react-dom@17.0.2)(react@17.0.2):
+  react-overlays@0.9.3(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       dom-helpers: 3.4.0
       prop-types: 15.8.1
-      prop-types-extra: 1.1.1(react@17.0.2)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-transition-group: 2.9.0(react-dom@17.0.2)(react@17.0.2)
+      prop-types-extra: 1.1.1(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 2.9.0(react-dom@18.3.1)(react@18.3.1)
       warning: 3.0.0
 
-  react-overlays@1.2.0(react-dom@17.0.2)(react@17.0.2):
+  react-overlays@1.2.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       dom-helpers: 3.4.0
       prop-types: 15.8.1
-      prop-types-extra: 1.1.1(react@17.0.2)
-      react: 17.0.2
-      react-context-toolbox: 2.0.2(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
-      react-popper: 1.3.11(react@17.0.2)
-      uncontrollable: 6.2.3(react@17.0.2)
+      prop-types-extra: 1.1.1(react@18.3.1)
+      react: 18.3.1
+      react-context-toolbox: 2.0.2(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-popper: 1.3.11(react@18.3.1)
+      uncontrollable: 6.2.3(react@18.3.1)
       warning: 4.0.3
 
-  react-popper@1.3.11(react@17.0.2):
+  react-popper@1.3.11(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@hypnosphi/create-react-context': 0.3.1(prop-types@15.8.1)(react@17.0.2)
+      '@hypnosphi/create-react-context': 0.3.1(prop-types@15.8.1)(react@18.3.1)
       deep-equal: 1.1.2
       popper.js: 1.16.1
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 18.3.1
       typed-styles: 0.0.7
       warning: 4.0.3
 
-  react-prop-types@0.4.0(react@17.0.2):
+  react-prop-types@0.4.0(react@18.3.1):
     dependencies:
-      react: 17.0.2
+      react: 18.3.1
       warning: 3.0.0
 
-  react-redux@7.2.9(react-dom@17.0.2)(react@17.0.2):
+  react-redux@7.2.9(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       '@types/react-redux': 7.1.34
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 18.3.1
       react-is: 17.0.2
     optionalDependencies:
-      react-dom: 17.0.2(react@17.0.2)
+      react-dom: 18.3.1(react@18.3.1)
 
   react-refresh@0.18.0: {}
 
-  react-select@1.3.0(react-dom@17.0.2)(react@17.0.2):
+  react-select@1.3.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-input-autosize: 2.2.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-input-autosize: 2.2.2(react@18.3.1)
 
-  react-smooth@4.0.4(react-dom@17.0.2)(react@17.0.2):
+  react-smooth@4.0.4(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       fast-equals: 5.4.1
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-transition-group: 4.4.5(react-dom@17.0.2)(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
 
-  react-transition-group@2.9.0(react-dom@17.0.2)(react@17.0.2):
+  react-transition-group@2.9.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-lifecycles-compat: 3.0.4
 
-  react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
+  react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-virtuoso@4.18.11(react-dom@17.0.2)(react@17.0.2):
+  react-virtuoso@4.18.11(react-dom@18.3.1)(react@18.3.1):
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react@17.0.2:
+  react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-      object-assign: 4.1.1
 
-  reactcss@1.2.3(react@17.0.2):
+  reactcss@1.2.3(react@18.3.1):
     dependencies:
       lodash: 4.17.23
-      react: 17.0.2
+      react: 18.3.1
 
-  read-binary-file-arch@1.0.6:
+  read-binary-file-arch@1.0.6(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -19859,15 +19851,15 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.15.4(react-dom@17.0.2)(react@17.0.2):
+  recharts@2.15.4(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
       lodash: 4.17.23
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
-      react-smooth: 4.0.4(react-dom@17.0.2)(react@17.0.2)
+      react-smooth: 4.0.4(react-dom@18.3.1)(react@18.3.1)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
@@ -19947,9 +19939,9 @@ snapshots:
       chalk: 2.4.2
       commander: 2.20.3
 
-  remark-parse@9.0.0:
+  remark-parse@9.0.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 0.8.5
+      mdast-util-from-markdown: 0.8.5(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -20101,10 +20093,9 @@ snapshots:
 
   sax@1.6.0: {}
 
-  scheduler@0.20.2:
+  scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-      object-assign: 4.1.1
 
   schema-utils@3.3.0:
     dependencies:
@@ -20240,9 +20231,9 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@3.33.0:
+  simple-git@3.33.0(supports-color@10.2.2):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@10.2.2)
       '@kwsites/promise-deferred': 1.1.1
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -20414,7 +20405,7 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  sumchecker@3.0.1:
+  sumchecker@3.0.1(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -20689,13 +20680,13 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.62.1(eslint@10.6.0)(typescript@6.0.3):
+  typescript-eslint@8.62.1(eslint@10.6.0)(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1)(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -20715,18 +20706,18 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
-  uncontrollable@6.2.3(react@17.0.2):
+  uncontrollable@6.2.3(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       invariant: 2.2.4
-      react: 17.0.2
+      react: 18.3.1
 
-  uncontrollable@7.2.1(react@17.0.2):
+  uncontrollable@7.2.1(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@types/react': 17.0.93
+      '@types/react': 18.3.31
       invariant: 2.2.4
-      react: 17.0.2
+      react: 18.3.1
       react-lifecycles-compat: 3.0.4
 
   undici-types@7.16.0: {}
@@ -20792,7 +20783,7 @@ snapshots:
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
 
-  universal-analytics@0.4.23:
+  universal-analytics@0.4.23(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       request: 2.88.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,11 +84,11 @@ catalog:
   "@types/numeral": 2.0.5
   "@types/packery": 1.4.37
   "@types/prop-types": 15.7.15
-  "@types/react": ^17.0.93
+  "@types/react": ^18.3.0
   "@types/react-bootstrap": 0.32.37
   "@types/react-color": 2.17.12
   "@types/react-datepicker": 2.11.1
-  "@types/react-dom": ~17.0.26
+  "@types/react-dom": ~18.3.0
   "@types/react-faux-dom": 4.1.8
   "@types/react-redux": 7.1.34
   "@types/react-router": 2.0.61
@@ -212,13 +212,13 @@ catalog:
   ps-list: 7.2.0
   re-reselect: 4.0.1
   re-resizable: 6.11.2
-  react: 17.0.2
+  react: 18.3.1
   react-bootstrap: 0.33.1
   react-color: 2.19.3
   react-datepicker: 3.8.0
   react-dnd: 14.0.5
   react-dnd-html5-backend: 14.1.0
-  react-dom: 17.0.2
+  react-dom: 18.3.1
   react-hot-toast: 2.6.0
   react-i18next: 11.18.6
   react-markdown: 6.0.3
@@ -296,20 +296,20 @@ peerDependencyRules:
   allowedVersions:
     # bbcode-to-react (git fork) peers cap at ^16; uses only createElement-era
     # APIs unchanged in React 17
-    "bbcode-to-react>react": "17"
+    "bbcode-to-react>react": "18"
     # react-select@1.3.0 peers cap at ^16; it is API-frozen and remapped to
     # ReactSelectWrap for extensions (LAZ-200). Verified working on React 17.
-    "react-select>react": "17"
-    "react-select>react-dom": "17"
+    "react-select>react": "18"
+    "react-select>react-dom": "18"
     # react-select's own dependency react-input-autosize@2.2.2 also caps at ^16
     # (react peer only, no react-dom peer)
-    "react-input-autosize>react": "17"
+    "react-input-autosize>react": "18"
     "@nosferatu500/react-sortable-tree>react-dnd": "14"
     "@nosferatu500/react-dnd-scrollzone>react-dnd": "14"
 
 overrides:
-  "@types/react": "17"
-  "@types/react-dom": "17"
+  "@types/react": "18"
+  "@types/react-dom": "18"
   node-addon-api: 8.5.0
   node-gyp: 12.3.0
   # @types/node is a peer of react-dnd; differing versions across the tree fork

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ catalog:
   "@tailwindcss/cli": 4.3.2
   "@testing-library/dom": 10.4.1
   "@testing-library/jest-dom": 6.9.1
-  "@testing-library/react": 12.1.5
+  "@testing-library/react": 16.3.0
   "@testing-library/user-event": 14.6.1
   "@types/babel__preset-env": 7.10.0
   "@types/babel__register": 7.17.3

--- a/src/renderer/src/ExtensionProvider.ts
+++ b/src/renderer/src/ExtensionProvider.ts
@@ -89,8 +89,10 @@ export function extend(
   groupProp?: string,
   addExtInfo?: boolean,
 ): <P extends IExtendedProps>(
-  component: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof IExtendedProps> & IExtensibleProps> {
+  component: React.ComponentType<React.PropsWithChildren<P>>,
+) => React.ComponentType<
+  React.PropsWithChildren<Omit<P, keyof IExtendedProps> & IExtensibleProps>
+> {
   ExtensionManager.registerUIAPI(registerFunc.name);
   const extensions: { [group: string]: any } = {};
 
@@ -109,8 +111,8 @@ export function extend(
   };
 
   return <P extends IExtendedProps, S>(
-    ComponentToWrap: React.ComponentType<P>,
-  ): React.ComponentType<Omit<P, keyof IExtendedProps>> => {
+    ComponentToWrap: React.ComponentType<React.PropsWithChildren<P>>,
+  ): React.ComponentType<React.PropsWithChildren<Omit<P, keyof IExtendedProps>>> => {
     type PropsT = Omit<P, keyof IExtendedProps> & IExtensibleProps;
     // eslint-disable-next-line @eslint-react/component-hook-factories
     return class __ExtendedComponent extends React.Component<PropsT, S> {
@@ -121,7 +123,7 @@ export function extend(
       public UNSAFE_componentWillReceiveProps(nextProps: any) {
         if (this.props[groupProp] !== nextProps[groupProp]) {
           if (extensions[nextProps[groupProp]] === undefined) {
-            updateExtensions(nextProps, this.context);
+            updateExtensions(nextProps, this.context as ExtensionManager);
           }
         }
         if (this.props.staticElements !== nextProps.staticElements) {
@@ -133,7 +135,7 @@ export function extend(
         const { children, staticElements } = this.props;
 
         if (extensions[this.props[groupProp]] === undefined) {
-          updateExtensions(this.props, this.context);
+          updateExtensions(this.props, this.context as ExtensionManager);
         }
 
         if (this.mObjects === undefined) {

--- a/src/renderer/src/ExtensionProvider.ts
+++ b/src/renderer/src/ExtensionProvider.ts
@@ -118,12 +118,14 @@ export function extend(
     return class __ExtendedComponent extends React.Component<PropsT, S> {
       public static contextType = ExtensionContext;
 
+      declare public context: ExtensionManager;
+
       private mObjects: any[];
 
       public UNSAFE_componentWillReceiveProps(nextProps: any) {
         if (this.props[groupProp] !== nextProps[groupProp]) {
           if (extensions[nextProps[groupProp]] === undefined) {
-            updateExtensions(nextProps, this.context as ExtensionManager);
+            updateExtensions(nextProps, this.context);
           }
         }
         if (this.props.staticElements !== nextProps.staticElements) {
@@ -135,7 +137,7 @@ export function extend(
         const { children, staticElements } = this.props;
 
         if (extensions[this.props[groupProp]] === undefined) {
-          updateExtensions(this.props, this.context as ExtensionManager);
+          updateExtensions(this.props, this.context);
         }
 
         if (this.mObjects === undefined) {

--- a/src/renderer/src/contexts/FlagsContext.tsx
+++ b/src/renderer/src/contexts/FlagsContext.tsx
@@ -30,7 +30,7 @@ export interface IFlagsProviderProps {
   children: ReactNode;
 }
 
-export const FlagsProvider: FC<IFlagsProviderProps> = ({ children }) => {
+export const FlagsProvider: FC<React.PropsWithChildren<IFlagsProviderProps>> = ({ children }) => {
   const [flags, setFlags] = useState<ReadonlyMap<KnownFlagName, FeatureFlag>>(
     () => FlagService.instance.flags,
   );

--- a/src/renderer/src/contexts/MainContext.tsx
+++ b/src/renderer/src/contexts/MainContext.tsx
@@ -37,7 +37,7 @@ export interface IMainProviderProps {
   children: ReactNode;
 }
 
-export const MainProvider: FC<IMainProviderProps> = ({ children }) => {
+export const MainProvider: FC<React.PropsWithChildren<IMainProviderProps>> = ({ children }) => {
   const extensions = useExtensionContext();
   const api = extensions.getApi();
 

--- a/src/renderer/src/contexts/MenuLayerContext.tsx
+++ b/src/renderer/src/contexts/MenuLayerContext.tsx
@@ -28,7 +28,9 @@ export interface IMenuLayerProviderProps {
   children: ReactNode;
 }
 
-export const MenuLayerProvider: FC<IMenuLayerProviderProps> = ({ children }) => {
+export const MenuLayerProvider: FC<React.PropsWithChildren<IMenuLayerProviderProps>> = ({
+  children,
+}) => {
   const [menuLayerOpen, setMenuLayerOpen] = useState(false);
   const [menuLayerElement, setMenuLayerElement] = useState<HTMLDivElement | null>(null);
   const menuObserverRef = useRef<MutationObserver | undefined>(undefined);

--- a/src/renderer/src/contexts/PagesContext.tsx
+++ b/src/renderer/src/contexts/PagesContext.tsx
@@ -43,7 +43,7 @@ const isPageVisible = (page: IMainPage): boolean => {
   }
 };
 
-export const PagesProvider: FC<IPagesProviderProps> = ({ children }) => {
+export const PagesProvider: FC<React.PropsWithChildren<IPagesProviderProps>> = ({ children }) => {
   const dispatch = useDispatch();
   const mainPages = useMainPages();
   const mainPage = useSelector(mainPageSelector);

--- a/src/renderer/src/contexts/WindowContext.tsx
+++ b/src/renderer/src/contexts/WindowContext.tsx
@@ -39,7 +39,7 @@ export interface IWindowProviderProps {
   children: ReactNode;
 }
 
-export const WindowProvider: FC<IWindowProviderProps> = ({ children }) => {
+export const WindowProvider: FC<React.PropsWithChildren<IWindowProviderProps>> = ({ children }) => {
   const dispatch = useDispatch();
   const tabsMinimized = useSelector((state: IState) => state.settings.window.tabsMinimized);
 

--- a/src/renderer/src/controls/ActionControl.tsx
+++ b/src/renderer/src/controls/ActionControl.tsx
@@ -10,6 +10,7 @@ export interface IActionControlProps {
   instanceId?: string | string[];
   filter?: (action: IActionDefinition) => boolean;
   showAll?: boolean;
+  children?: React.ReactNode;
 }
 
 export interface IExtensionProps {

--- a/src/renderer/src/controls/Advanced.tsx
+++ b/src/renderer/src/controls/Advanced.tsx
@@ -5,6 +5,7 @@ import { ComponentEx, connect } from "./ComponentEx";
 
 interface IConnectedProps {
   advancedMode: boolean;
+  children?: React.ReactNode;
 }
 
 type IProps = IConnectedProps;
@@ -51,4 +52,6 @@ function mapStateToProps(state: IState): IConnectedProps {
   };
 }
 
-export default connect(mapStateToProps)(Advanced) as React.ComponentType<{}>;
+export default connect(mapStateToProps)(Advanced) as React.ComponentType<
+  React.PropsWithChildren<{}>
+>;

--- a/src/renderer/src/controls/Collapse.tsx
+++ b/src/renderer/src/controls/Collapse.tsx
@@ -6,6 +6,7 @@ import { PureComponentEx, translate } from "./ComponentEx";
 export interface ICollapseProps extends WithTranslation {
   showText?: string;
   hideText?: string;
+  children?: React.ReactNode;
 }
 
 interface ICollapseState {

--- a/src/renderer/src/controls/ContextMenu.tsx
+++ b/src/renderer/src/controls/ContextMenu.tsx
@@ -154,7 +154,10 @@ function MenuAction(props: IMenuActionProps) {
   );
 }
 
-class RootCloseWrapper extends React.Component<{ onClose: () => void }, {}> {
+class RootCloseWrapper extends React.Component<
+  { onClose: () => void; children?: React.ReactNode },
+  {}
+> {
   // React 17 delegates events at the react root instead of document, so this
   // component mounts while the click/contextmenu that opened the menu is
   // still bubbling toward document; registering the close listeners
@@ -201,6 +204,7 @@ export interface IContextMenuProps {
   actions?: IActionDefinitionEx[];
   className?: string;
   onTrigger?: () => void;
+  children?: React.ReactNode;
 }
 
 type IProps = IContextMenuProps;

--- a/src/renderer/src/controls/Dashlet.tsx
+++ b/src/renderer/src/controls/Dashlet.tsx
@@ -5,6 +5,7 @@ import { truthy } from "../util/util";
 export interface IDashletProps {
   className: string;
   title: string;
+  children?: React.ReactNode;
 }
 
 class Dashlet extends React.Component<IDashletProps, {}> {

--- a/src/renderer/src/controls/DraggableList.test.tsx
+++ b/src/renderer/src/controls/DraggableList.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
   cleanup();
 });
 
-const Row: React.FC<{ item: { id: string } }> = ({ item }) => (
+const Row: React.FC<React.PropsWithChildren<{ item: { id: string } }>> = ({ item }) => (
   <div data-testid="lo-row">{item.id}</div>
 );
 
@@ -35,7 +35,7 @@ const renderComponent = (itemCount: number, virtualized: boolean) => {
         id="test-lo"
         itemTypeId="test-lo-item"
         items={items}
-        itemRenderer={Row as React.ComponentType<{ item: any }>}
+        itemRenderer={Row as React.ComponentType<React.PropsWithChildren<{ item: any }>>}
         idFunc={(item) => item.id}
         apply={() => undefined}
         virtualized={virtualized}

--- a/src/renderer/src/controls/DraggableList.tsx
+++ b/src/renderer/src/controls/DraggableList.tsx
@@ -21,7 +21,7 @@ export interface IDraggableListProps {
   items: any[];
   isLocked?: (item: any) => boolean;
   idFunc?: (item: any) => string;
-  itemRenderer: React.ComponentType<{ item: any }>;
+  itemRenderer: React.ComponentType<React.PropsWithChildren<{ item: any }>>;
   apply: (ordered: any[]) => void;
   style?: React.CSSProperties;
   className?: string;

--- a/src/renderer/src/controls/DraggableListItem.tsx
+++ b/src/renderer/src/controls/DraggableListItem.tsx
@@ -9,11 +9,13 @@ export interface IDraggableListItemProps {
   index: number;
   item: any;
   isLocked: boolean;
-  itemRenderer: React.ComponentType<{
-    className?: string;
-    item: any;
-    forwardedRef?: any;
-  }>;
+  itemRenderer: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: any;
+      forwardedRef?: any;
+    }>
+  >;
   containerId: string;
   isSelected: boolean;
   selectedItems: any[];
@@ -31,7 +33,7 @@ export interface IDraggableListItemProps {
   onDragStart: (items: any[]) => void;
 }
 
-const DraggableItem: React.FC<IDraggableListItemProps> = ({
+const DraggableItem: React.FC<React.PropsWithChildren<IDraggableListItemProps>> = ({
   disabled,
   index,
   item,

--- a/src/renderer/src/controls/Dropzone.tsx
+++ b/src/renderer/src/controls/Dropzone.tsx
@@ -34,6 +34,7 @@ export interface IBaseProps {
   dialogDefault?: string;
   style?: React.CSSProperties;
   dragOverlay?: JSX.Element;
+  children?: React.ReactNode;
 }
 
 interface IConnectedProps {}

--- a/src/renderer/src/controls/DynamicProps.tsx
+++ b/src/renderer/src/controls/DynamicProps.tsx
@@ -11,7 +11,8 @@ function ignoreFunction(lhs: any, rhs: any): boolean {
 export interface IBaseProps {
   dynamicProps: () => any;
   staticProps: any;
-  component: React.ComponentClass<any> | React.StatelessComponent<any>;
+  component: React.ComponentClass<any> | React.FunctionComponent<React.PropsWithChildren<any>>;
+  children?: React.ReactNode;
 }
 
 /**

--- a/src/renderer/src/controls/ErrorBoundary.tsx
+++ b/src/renderer/src/controls/ErrorBoundary.tsx
@@ -27,6 +27,7 @@ export interface IBaseProps {
   onHide?: () => void;
   className?: string;
   canDisplayError?: boolean;
+  children?: React.ReactNode;
 }
 
 export interface IErrorBoundaryProps extends IBaseProps, WithTranslation {}
@@ -182,8 +183,8 @@ export default translate(["common"])(ErrorBoundary);
  * so that they get reported properly instead of remaining unhandled.
  */
 export function safeCallbacks<T, S>(
-  ComponentToWrap: React.ComponentType<React.PropsWithChildren<T>>,
-): React.ComponentType<Omit<T, keyof IErrorContext>> {
+  ComponentToWrap: React.ComponentType<React.PropsWithChildren<React.PropsWithChildren<T>>>,
+): React.ComponentType<React.PropsWithChildren<Omit<T, keyof IErrorContext>>> {
   // tslint:disable-next-line:class-name
   // return class __SafeCallbackComponent extends React.Component<T, S> {
   const cache: { [key: string]: { cb: CBFunction; depList: any[] } } = {};

--- a/src/renderer/src/controls/ExtensibleControl.tsx
+++ b/src/renderer/src/controls/ExtensibleControl.tsx
@@ -8,7 +8,7 @@ export interface IExtensibleControlProps {
 
 interface IWrapperProps {
   priority: number;
-  wrapper: React.ComponentType<{}>;
+  wrapper: React.ComponentType<React.PropsWithChildren<{}>>;
 }
 
 interface IExtensionProps {
@@ -33,7 +33,7 @@ function registerControlWrapper(
   instanceGroup: string,
   group: string,
   priority: number,
-  wrapper: React.ComponentType<{}>,
+  wrapper: React.ComponentType<React.PropsWithChildren<{}>>,
 ) {
   if (instanceGroup === group) {
     return { priority, wrapper };

--- a/src/renderer/src/controls/ExtensionGate.tsx
+++ b/src/renderer/src/controls/ExtensionGate.tsx
@@ -22,7 +22,7 @@ import { Icon } from "./TooltipControls";
  * @class ExtensionGate
  * @extends {React.Component<{}, {}>}
  */
-class ExtensionGate extends React.Component<{ id: string }, {}> {
+class ExtensionGate extends React.Component<{ id: string; children?: React.ReactNode }, {}> {
   private mWrappers: { [key: string]: any } = {};
   private mValid: boolean;
 

--- a/src/renderer/src/controls/FormFeedback.tsx
+++ b/src/renderer/src/controls/FormFeedback.tsx
@@ -16,12 +16,14 @@ class FormFeedback extends React.Component<IFormFeedbackProps, {}> {
     $bs_formGroup: PropTypes.object,
   };
 
+  declare public context: { $bs_formGroup?: { validationState?: string } };
+
   public static defaultProps = {
     bsRole: "feedback",
   };
 
   public render(): JSX.Element {
-    const formGroup = (this.context as any).$bs_formGroup;
+    const formGroup = this.context.$bs_formGroup;
     const { className } = this.props;
 
     const classes = ["form-control-feedback", "feedback-awesome"];

--- a/src/renderer/src/controls/FormFeedback.tsx
+++ b/src/renderer/src/controls/FormFeedback.tsx
@@ -21,7 +21,7 @@ class FormFeedback extends React.Component<IFormFeedbackProps, {}> {
   };
 
   public render(): JSX.Element {
-    const formGroup = this.context.$bs_formGroup;
+    const formGroup = (this.context as any).$bs_formGroup;
     const { className } = this.props;
 
     const classes = ["form-control-feedback", "feedback-awesome"];

--- a/src/renderer/src/controls/Icon.tsx
+++ b/src/renderer/src/controls/Icon.tsx
@@ -115,7 +115,7 @@ const checkMissingIcon = (set: string, name: string): void => {
   });
 };
 
-export const Icon: FC<IIconProps> = ({
+export const Icon: FC<React.PropsWithChildren<IIconProps>> = ({
   id,
   className,
   style,

--- a/src/renderer/src/controls/Modal.tsx
+++ b/src/renderer/src/controls/Modal.tsx
@@ -21,7 +21,7 @@ class MyModal extends React.PureComponent<typeof Modal.prototype.props, {}> {
   private mMenuLayer: Element = null;
 
   public getChildContext(): any {
-    return { ...this.context, menuLayer: this.mMenuLayer };
+    return { ...(this.context as any), menuLayer: this.mMenuLayer };
   }
 
   public render(): JSX.Element {

--- a/src/renderer/src/controls/Modal.tsx
+++ b/src/renderer/src/controls/Modal.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import type { ModalBody, ModalFooter, ModalHeader, ModalTitle } from "react-bootstrap";
 import { Modal } from "react-bootstrap";
 
+import type { IComponentContext } from "../types/IComponentContext";
 import { MutexWrapper } from "../util/MutexContext";
 
 class MyModal extends React.PureComponent<typeof Modal.prototype.props, {}> {
@@ -16,12 +17,14 @@ class MyModal extends React.PureComponent<typeof Modal.prototype.props, {}> {
     menuLayer: PropTypes.object,
   };
 
+  declare public context: Partial<IComponentContext>;
+
   private getContainer = memoizeOne(() => this.getContainerImpl());
 
   private mMenuLayer: Element = null;
 
   public getChildContext(): any {
-    return { ...(this.context as any), menuLayer: this.mMenuLayer };
+    return { ...this.context, menuLayer: this.mMenuLayer };
   }
 
   public render(): JSX.Element {

--- a/src/renderer/src/controls/PortalMenu.tsx
+++ b/src/renderer/src/controls/PortalMenu.tsx
@@ -14,6 +14,7 @@ interface IPortalMenuProps {
   useMousePosition?: boolean | { x: number; y: number };
   bsRole?: string;
   placement?: "top" | "bottom" | "left" | "right";
+  children?: React.ReactNode;
 }
 
 function nop() {

--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -63,6 +63,7 @@ export interface IBaseProps {
   showDetails?: boolean;
   hasActions?: boolean;
   onChangeSelection?: (ids: string[]) => void;
+  children?: React.ReactNode;
 }
 
 interface IConnectedProps {
@@ -1971,4 +1972,4 @@ export default translate(["common"])(
     registerTableAttribute,
     "tableId",
   )(connect(mapStateToProps, mapDispatchToProps)(SuperTable)),
-) as React.ComponentType<IBaseProps & IExtensibleProps>;
+) as React.ComponentType<React.PropsWithChildren<IBaseProps & IExtensibleProps>>;

--- a/src/renderer/src/controls/ToolbarIcon.tsx
+++ b/src/renderer/src/controls/ToolbarIcon.tsx
@@ -18,6 +18,7 @@ export interface IToolbarIconProps {
   className?: string;
   stroke?: boolean;
   hollow?: boolean;
+  children?: React.ReactNode;
 }
 
 class ToolbarIcon extends React.PureComponent<IToolbarIconProps, {}> {

--- a/src/renderer/src/controls/TooltipControls.tsx
+++ b/src/renderer/src/controls/TooltipControls.tsx
@@ -184,7 +184,9 @@ export class ToggleButton extends React.Component<ToggleButtonProps, {}> {
         </BootstrapButton>
       );
     } else {
-      const tooltip = <Popover id={this.props.id}>{tooltipText as React.ReactNode}</Popover>;
+      // offTooltip is declared as React.Component, but callers pass elements
+      const tooltipContent = React.isValidElement(tooltipText) ? tooltipText : null;
+      const tooltip = <Popover id={this.props.id}>{tooltipContent}</Popover>;
       return (
         <OverlayTrigger
           overlay={tooltip}
@@ -195,7 +197,7 @@ export class ToggleButton extends React.Component<ToggleButtonProps, {}> {
           <BootstrapButton {...(relayProps as any)}>
             {["icon", "both"].indexOf(bType) !== -1 ? <SvgIcon name={icon} /> : null}
             {["text", "both"].indexOf(bType) !== -1 ? (
-              <p className="button-text">{tooltipText as React.ReactNode}</p>
+              <p className="button-text">{tooltipContent}</p>
             ) : null}
             {this.props.children}
           </BootstrapButton>

--- a/src/renderer/src/controls/TooltipControls.tsx
+++ b/src/renderer/src/controls/TooltipControls.tsx
@@ -184,7 +184,7 @@ export class ToggleButton extends React.Component<ToggleButtonProps, {}> {
         </BootstrapButton>
       );
     } else {
-      const tooltip = <Popover id={this.props.id}>{tooltipText}</Popover>;
+      const tooltip = <Popover id={this.props.id}>{tooltipText as React.ReactNode}</Popover>;
       return (
         <OverlayTrigger
           overlay={tooltip}
@@ -195,7 +195,7 @@ export class ToggleButton extends React.Component<ToggleButtonProps, {}> {
           <BootstrapButton {...(relayProps as any)}>
             {["icon", "both"].indexOf(bType) !== -1 ? <SvgIcon name={icon} /> : null}
             {["text", "both"].indexOf(bType) !== -1 ? (
-              <p className="button-text">{tooltipText}</p>
+              <p className="button-text">{tooltipText as React.ReactNode}</p>
             ) : null}
             {this.props.children}
           </BootstrapButton>

--- a/src/renderer/src/controls/TriStateCheckbox.tsx
+++ b/src/renderer/src/controls/TriStateCheckbox.tsx
@@ -11,6 +11,7 @@ export interface ITriCheckboxProps {
   disabled: boolean;
   onChangeCB?: (evt: React.ChangeEvent<HTMLInputElement>, value: CheckboxState) => void;
   onContextMenu?: (checkboxState: CheckboxState) => void;
+  children?: React.ReactNode;
 }
 
 interface ITriCheckboxState {

--- a/src/renderer/src/controls/Usage.tsx
+++ b/src/renderer/src/controls/Usage.tsx
@@ -13,6 +13,7 @@ export interface IUsageProps {
   persistent?: boolean;
   className?: string;
   opaque?: boolean;
+  children?: React.ReactNode;
 }
 
 interface IConnectedProps {

--- a/src/renderer/src/controls/ZoomableImage.tsx
+++ b/src/renderer/src/controls/ZoomableImage.tsx
@@ -23,6 +23,7 @@ export interface IZoomableImageProps {
   url: string;
   container?: JSX.Element;
   overlayClass?: string;
+  children?: React.ReactNode;
 }
 
 class ZoomableImage extends React.Component<IZoomableImageProps, { showOverlay: boolean }> {

--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -1099,7 +1099,7 @@ function register(context: IExtensionContext, collectionsCB: ICallbackMap) {
     clone: (gameId: string, collection: ICollection, from: IMod, to: IMod) => Promise<void>,
     title: (t: TFunction) => string,
     condition?: (state: IState, gameId: string) => boolean,
-    editComponent?: React.ComponentType<IExtendedInterfaceProps>,
+    editComponent?: React.ComponentType<React.PropsWithChildren<IExtendedInterfaceProps>>,
   ) => {
     addExtension({
       id,

--- a/src/renderer/src/extensions/collections/util/extension.ts
+++ b/src/renderer/src/extensions/collections/util/extension.ts
@@ -11,7 +11,7 @@ export interface IExtensionFeature {
   clone: (gameId: string, collection: ICollection, from: IMod, to: IMod) => Promise<void>;
   title: (t: TFunction) => string;
   condition?: (state: IState, gameId: string) => boolean;
-  editComponent?: React.ComponentType<IExtendedInterfaceProps>;
+  editComponent?: React.ComponentType<React.PropsWithChildren<IExtendedInterfaceProps>>;
 }
 
 const features: IExtensionFeature[] = [];

--- a/src/renderer/src/extensions/collections/util/gameSupport/index.ts
+++ b/src/renderer/src/extensions/collections/util/gameSupport/index.ts
@@ -91,7 +91,9 @@ export function parseGameSpecifics(
   }
 }
 
-export function getInterface(gameId: string): React.ComponentType<IExtendedInterfaceProps> {
+export function getInterface(
+  gameId: string,
+): React.ComponentType<React.PropsWithChildren<IExtendedInterfaceProps>> {
   if (gameSupport[gameId] === undefined) {
     return null;
   } else {

--- a/src/renderer/src/extensions/collections/views/CollectionModsPageAttributeRenderer.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionModsPageAttributeRenderer.tsx
@@ -77,4 +77,6 @@ function CollectionModsPageAttributeRenderer(props: IProps) {
   ) : null;
 }
 
-export default CollectionModsPageAttributeRenderer as React.ComponentType<IBaseProps>;
+export default CollectionModsPageAttributeRenderer as React.ComponentType<
+  React.PropsWithChildren<IBaseProps>
+>;

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
@@ -1124,4 +1124,4 @@ function mapDispatchToProps(dispatch: Redux.Dispatch): IActionProps {
 export default connect(
   makeMapStateToProps,
   mapDispatchToProps,
-)(CollectionPage) as any as React.ComponentType<ICollectionPageProps>;
+)(CollectionPage) as any as React.ComponentType<React.PropsWithChildren<ICollectionPageProps>>;

--- a/src/renderer/src/extensions/collections/views/CollectionTile/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionTile/index.tsx
@@ -479,4 +479,4 @@ function mapDispatchToProps(dispatch: Redux.Dispatch): IActionProps {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(CollectionThumbnail) as any as React.ComponentType<IBaseProps>;
+)(CollectionThumbnail) as any as React.ComponentType<React.PropsWithChildren<IBaseProps>>;

--- a/src/renderer/src/extensions/collections/views/IniTweaks.tsx
+++ b/src/renderer/src/extensions/collections/views/IniTweaks.tsx
@@ -290,6 +290,6 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IState, null, Redux.Action>)
 
 const TweakListConnected = withTranslation([NAMESPACE, "common"])(
   connect(mapStateToProps, mapDispatchToProps)(TweakList) as any,
-) as React.ComponentType<IBaseProps>;
+) as React.ComponentType<React.PropsWithChildren<IBaseProps>>;
 
 export default TweakListConnected;

--- a/src/renderer/src/extensions/dashboard/views/PackeryGrid.tsx
+++ b/src/renderer/src/extensions/dashboard/views/PackeryGrid.tsx
@@ -16,6 +16,7 @@ export interface IProps {
   onChangeLayout: (items: string[]) => void;
   settings: any;
   items: string[];
+  children?: React.ReactNode;
 }
 
 function setEqual(lhs: Set<any>, rhs: Set<any>) {

--- a/src/renderer/src/extensions/dashboard/views/PackeryItem.tsx
+++ b/src/renderer/src/extensions/dashboard/views/PackeryItem.tsx
@@ -31,6 +31,7 @@ export interface IPackeryItemProps {
   onSetWidth?: (id: string, width: number) => void;
   onSetHeight?: (id: string, height: number) => void;
   onUpdateLayout?: () => void;
+  children?: React.ReactNode;
 }
 
 interface IPackeryItemState {

--- a/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
@@ -21,7 +21,9 @@ vi.mock("../../../controls/ErrorBoundary", () => ({
 }));
 
 vi.mock("react-redux", () => ({
-  connect: () => (component: React.ComponentType<Record<string, unknown>>) => component,
+  connect:
+    () => (component: React.ComponentType<React.PropsWithChildren<Record<string, unknown>>>) =>
+      component,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -47,11 +49,13 @@ vi.mock("recharts", () => ({
 
 import DownloadGraph from "./DownloadGraph";
 
-const Graph = DownloadGraph as unknown as React.ComponentType<{
-  t: (key: string) => string;
-  maxBandwidth: number;
-  speeds: number[];
-}>;
+const Graph = DownloadGraph as unknown as React.ComponentType<
+  React.PropsWithChildren<{
+    t: (key: string) => string;
+    maxBandwidth: number;
+    speeds: number[];
+  }>
+>;
 
 const t = (key: string) => key;
 

--- a/src/renderer/src/extensions/file_based_loadorder/types/types.ts
+++ b/src/renderer/src/extensions/file_based_loadorder/types/types.ts
@@ -108,17 +108,19 @@ export interface ILoadOrderGameInfo {
    *  in the load order page alongside the load order panel.
    *  Default instructions will be provided if custom instructions aren't provided.
    */
-  usageInstructions?: string | React.ComponentType<{}>;
+  usageInstructions?: string | React.ComponentType<React.PropsWithChildren<{}>>;
 
   /**
    * Extension developers are able to provide a custom item renderer for the
    *  load order page. This will get rendered instead of the default one.
    */
-  customItemRenderer?: React.ComponentType<{
-    className?: string;
-    item: IItemRendererProps;
-    forwardedRef?: (ref: any) => void;
-  }>;
+  customItemRenderer?: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: IItemRendererProps;
+      forwardedRef?: (ref: any) => void;
+    }>
+  >;
 
   /**
    * Set to true if a custom item renderer produces rows of a single, uniform

--- a/src/renderer/src/extensions/file_based_loadorder/views/FilterBox.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/FilterBox.tsx
@@ -9,7 +9,10 @@ interface IProps {
   setFilter(value: string): void;
 }
 
-const FilterBox: React.FC<IProps> = ({ currentFilterValue, setFilter }) => {
+const FilterBox: React.FC<React.PropsWithChildren<IProps>> = ({
+  currentFilterValue,
+  setFilter,
+}) => {
   const [t] = useTranslation("common");
   const applyFilter = React.useCallback((value: string) => setFilter(value), [setFilter]);
   return (

--- a/src/renderer/src/extensions/file_based_loadorder/views/InfoPanel.tsx
+++ b/src/renderer/src/extensions/file_based_loadorder/views/InfoPanel.tsx
@@ -7,7 +7,7 @@ import FlexLayout from "../../../controls/FlexLayout";
 import type { LoadOrderValidationError } from "../types/types";
 
 interface IProps {
-  info: string | React.ComponentType<{}>;
+  info: string | React.ComponentType<React.PropsWithChildren<{}>>;
   validationError: LoadOrderValidationError;
 }
 
@@ -73,5 +73,5 @@ class InfoPanel extends ComponentEx<IProps, {}> {
 
 export default withTranslation(["common"])(InfoPanel as any) as React.ComponentClass<{
   validationError: LoadOrderValidationError;
-  info: string | React.ComponentType<{}>;
+  info: string | React.ComponentType<React.PropsWithChildren<{}>>;
 }>;

--- a/src/renderer/src/extensions/health_check/views/SettingsHealthCheck.tsx
+++ b/src/renderer/src/extensions/health_check/views/SettingsHealthCheck.tsx
@@ -10,7 +10,7 @@ import { setModRequirementsEnabled, setFileRequirementsEnabled } from "../action
 import { FILE_REQUIREMENTS_FLAG } from "../checks/fileRequirementsCheck";
 import { isModRequirementsEnabled, isFileRequirementsUserEnabled } from "../selectors";
 
-const SettingsHealthCheck: React.FC = () => {
+const SettingsHealthCheck: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation(["health_check"]);
   const dispatch = useDispatch();
   const modRequirementsEnabled = useSelector(isModRequirementsEnabled);

--- a/src/renderer/src/extensions/health_check/views/content/types.ts
+++ b/src/renderer/src/extensions/health_check/views/content/types.ts
@@ -72,9 +72,9 @@ export interface IHealthCheckContent {
   /** Map this check's result (from state) into listing entries. */
   selectEntries: (state: IState) => IHealthCheckEntry[];
   /** Renders a listing row for one of this check's entries. */
-  ListingRow: FC<IListingRowProps>;
+  ListingRow: FC<React.PropsWithChildren<IListingRowProps>>;
   /** Renders the detail body (below the shared chrome) for one entry. */
-  DetailView: FC<IDetailViewProps>;
+  DetailView: FC<React.PropsWithChildren<IDetailViewProps>>;
   /** Whether the shell offers hide controls (tabs / hide-all) for this check. */
   supportsHide?: boolean;
   /** Whether the given entry is currently hidden (provider-owned state). */

--- a/src/renderer/src/extensions/instructions_overlay/index.ts
+++ b/src/renderer/src/extensions/instructions_overlay/index.ts
@@ -6,11 +6,16 @@ import Reducer from "./reducer";
 
 const componentRegistry = new Map<string, React.ComponentType<any>>();
 
-function registerOverlayComponent(id: string, component: React.ComponentType<any>): void {
+function registerOverlayComponent(
+  id: string,
+  component: React.ComponentType<React.PropsWithChildren<any>>,
+): void {
   componentRegistry.set(id, component);
 }
 
-function getOverlayComponent(id: string): React.ComponentType<any> | undefined {
+function getOverlayComponent(
+  id: string,
+): React.ComponentType<React.PropsWithChildren<any>> | undefined {
   return componentRegistry.get(id);
 }
 
@@ -36,7 +41,7 @@ function init(context: IExtensionContext): boolean {
     (
       id: string,
       title: string,
-      content: string | React.ComponentType<any>,
+      content: string | React.ComponentType<React.PropsWithChildren<any>>,
       pos: IPosition = undefined,
       options: IOverlayOptions,
     ) => {

--- a/src/renderer/src/extensions/mod_load_order/types/types.ts
+++ b/src/renderer/src/extensions/mod_load_order/types/types.ts
@@ -150,7 +150,9 @@ export interface IGameLoadOrderEntry {
   // Provides game extensions with relevant props that the extension writer
   //  can use to build the information panel. Providing a string here instead
   //  of a react component will create a default component instead.
-  createInfoPanel: (props: IInfoPanelProps) => string | React.ComponentType;
+  createInfoPanel: (
+    props: IInfoPanelProps,
+  ) => string | React.ComponentType<React.PropsWithChildren<unknown>>;
 
   // Give the game extension the opportunity to modify the load order
   //  before we start sorting the mods.
@@ -170,9 +172,11 @@ export interface IGameLoadOrderEntry {
 
   // Add option to provide a custom item renderer if wanted.
   //  Default item renderer will be used if left undefined.
-  itemRenderer?: React.ComponentType<{
-    className?: string;
-    item: ILoadOrderDisplayItem;
-    onRef: (ref: any) => any;
-  }>;
+  itemRenderer?: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: ILoadOrderDisplayItem;
+      onRef: (ref: any) => any;
+    }>
+  >;
 }

--- a/src/renderer/src/extensions/mod_load_order/views/DraggableList.tsx
+++ b/src/renderer/src/extensions/mod_load_order/views/DraggableList.tsx
@@ -24,12 +24,14 @@ interface IItemBaseProps {
   index: number;
   item: ILoadOrderDisplayItem;
   isLocked: boolean;
-  itemRenderer: React.ComponentType<{
-    className?: string;
-    item: ILoadOrderDisplayItem;
-    onRef: (ref: any) => any;
-    onContextMenu?: (evt: any) => any;
-  }>;
+  itemRenderer: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: ILoadOrderDisplayItem;
+      onRef: (ref: any) => any;
+      onContextMenu?: (evt: any) => any;
+    }>
+  >;
   containerId: string;
   take: (item: ILoadOrderDisplayItem, list: ILoadOrderDisplayItem[]) => any;
   onChangeIndex: (
@@ -164,11 +166,13 @@ interface IBaseProps {
   id: string;
   items: ILoadOrderDisplayItem[];
   loadOrder: ILoadOrder;
-  itemRenderer: React.ComponentType<{
-    className?: string;
-    item: ILoadOrderDisplayItem;
-    onRef: (ref: any) => any;
-  }>;
+  itemRenderer: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: ILoadOrderDisplayItem;
+      onRef: (ref: any) => any;
+    }>
+  >;
   apply: (ordered: ILoadOrderDisplayItem[]) => void;
 }
 
@@ -365,4 +369,4 @@ export default DropTarget(
   DND_TYPE,
   containerTarget,
   containerCollect,
-)(DraggableList) as React.ComponentType<IBaseProps>;
+)(DraggableList) as React.ComponentType<React.PropsWithChildren<IBaseProps>>;

--- a/src/renderer/src/extensions/mod_load_order/views/LoadOrderPage.tsx
+++ b/src/renderer/src/extensions/mod_load_order/views/LoadOrderPage.tsx
@@ -33,11 +33,13 @@ interface IBaseState {
   loading: boolean;
   updating: boolean;
   sortType: SortType;
-  itemRenderer: React.ComponentType<{
-    className?: string;
-    item: ILoadOrderDisplayItem;
-    onRef: (ref: any) => any;
-  }>;
+  itemRenderer: React.ComponentType<
+    React.PropsWithChildren<{
+      className?: string;
+      item: ILoadOrderDisplayItem;
+      onRef: (ref: any) => any;
+    }>
+  >;
 }
 
 export interface IBaseProps {
@@ -422,7 +424,7 @@ class LoadOrderPage extends ComponentEx<IProps, IComponentState> {
                       apply={this.onApply}
                     />
                   </FlexLayout.Flex>
-                  <FlexLayout.Flex>{infoPanel}</FlexLayout.Flex>
+                  <FlexLayout.Flex>{infoPanel as React.ReactNode}</FlexLayout.Flex>
                 </FlexLayout>
               </DNDContainer>
             </PanelX.Body>

--- a/src/renderer/src/extensions/mod_load_order/views/LoadOrderPage.tsx
+++ b/src/renderer/src/extensions/mod_load_order/views/LoadOrderPage.tsx
@@ -394,7 +394,16 @@ class LoadOrderPage extends ComponentEx<IProps, IComponentState> {
       refresh: () => this.mForceUpdateDebouncer.schedule(),
     });
 
-    const infoPanel = typeof res === "string" ? <DefaultInfoPanel infoText={res} /> : res;
+    // The declared return type of createInfoPanel is string | ComponentType, but
+    // extensions in the wild return ready-made elements, so handle all three shapes.
+    const infoPanel =
+      typeof res === "string" ? (
+        <DefaultInfoPanel infoText={res} />
+      ) : typeof res === "function" ? (
+        React.createElement(res)
+      ) : (
+        res
+      );
 
     const sorted =
       this.state.sortType === "ascending"
@@ -424,7 +433,7 @@ class LoadOrderPage extends ComponentEx<IProps, IComponentState> {
                       apply={this.onApply}
                     />
                   </FlexLayout.Flex>
-                  <FlexLayout.Flex>{infoPanel as React.ReactNode}</FlexLayout.Flex>
+                  <FlexLayout.Flex>{infoPanel}</FlexLayout.Flex>
                 </FlexLayout>
               </DNDContainer>
             </PanelX.Body>

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -1309,7 +1309,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
   callbacks.forEach((cb) => cb(nexus));
 }
 
-function toolbarBanner(t: TFunction): React.FunctionComponent<any> {
+function toolbarBanner(t: TFunction): React.FunctionComponent<React.PropsWithChildren<any>> {
   return () => {
     const context = React.useContext<IComponentContext>(MainContext);
     const premiumPictogramPath = "assets/pictograms/premium-pictogram.svg";

--- a/src/renderer/src/extensions/starter_dashlet/BoxWithHandle.tsx
+++ b/src/renderer/src/extensions/starter_dashlet/BoxWithHandle.tsx
@@ -13,7 +13,7 @@ interface IProps {
   onMoveItem: (id: string, id2: string) => void;
 }
 
-export const BoxWithHandle: FC<IProps> = (props: IProps) => {
+export const BoxWithHandle: FC<React.PropsWithChildren<IProps>> = (props: IProps) => {
   const [{ opacity, isDragging }, drag, dragPreview] = useDrag({
     type: "TOOL",
     item: { idx: props.index, id: props.item.id },

--- a/src/renderer/src/hooks/useMainPages.ts
+++ b/src/renderer/src/hooks/useMainPages.ts
@@ -14,7 +14,7 @@ const registerMainPage = (
   extInfo: Partial<IRegisteredExtension>,
   icon: string,
   title: string,
-  component: ComponentType,
+  component: ComponentType<React.PropsWithChildren<unknown>>,
   options: IMainPageOptions,
 ): IMainPage => {
   return {

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -59,6 +59,9 @@ const REACT_DEPRECATION_WARNINGS = [
   "ReactDOM.render is no longer supported",
   "uses the legacy contextTypes API",
   "uses the legacy childContextTypes API",
+  // emitted by legacy deps (react-bootstrap 0.33, react-i18next 11) on 18
+  "findDOMNode is deprecated",
+  "renderSubtreeIntoContainer() is no longer supported",
 ];
 
 // turn all error logs into a single parameter. The reason is that (at least in production)

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -49,11 +49,30 @@ process.on("exit", (code: number) => {
   }
 });
 
+// React 18 emits these deprecation warnings via console.error in development
+// builds (production react-dom strips them). They fire during the very first
+// render — before show-window — where a console.error arms the
+// "Vortex failed to start" terminate timer in MainWindow. Demote them to
+// console.warn: still visible in devtools and the log, but not treated as
+// errors. Everything else must keep flowing through console.error unchanged.
+const REACT_DEPRECATION_WARNINGS = [
+  "ReactDOM.render is no longer supported",
+  "uses the legacy contextTypes API",
+  "uses the legacy childContextTypes API",
+];
+
 // turn all error logs into a single parameter. The reason is that (at least in production)
 // these only get reported by the main process and due to a "bug" only one parameter gets
 // relayed.
 const oldErr = console.error;
 console.error = (...args) => {
+  if (
+    typeof args[0] === "string" &&
+    REACT_DEPRECATION_WARNINGS.some((sig) => args[0].includes(sig))
+  ) {
+    console.warn(args.concat(" ") + "\n" + new Error().stack);
+    return;
+  }
   oldErr(args.concat(" ") + "\n" + new Error().stack);
 };
 

--- a/src/renderer/src/types/IActionDefinition.ts
+++ b/src/renderer/src/types/IActionDefinition.ts
@@ -20,7 +20,7 @@ export interface IActionDefinition {
   icon?: string;
   title?: string;
   data?: any;
-  component?: React.ComponentType<any>;
+  component?: React.ComponentType<React.PropsWithChildren<any>>;
   props?: () => any;
   action?: (instanceId: string | string[], data?: any) => void;
   subMenus?: IActionDefinition[] | ActionFunc;

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -141,7 +141,7 @@ export type CheckFunction = () => PromiseLike<ITestResult>;
 
 export type RegisterSettings = (
   title: string,
-  element: React.ComponentClass<any> | React.StatelessComponent<any>,
+  element: React.ComponentClass<any> | React.FunctionComponent<React.PropsWithChildren<any>>,
   props?: PropsCallback,
   visible?: () => boolean,
   priority?: number,
@@ -150,7 +150,7 @@ export type RegisterSettings = (
 export type RegisterAction = (
   group: string,
   position: number,
-  iconOrComponent: string | React.ComponentType<any>,
+  iconOrComponent: string | React.ComponentType<React.PropsWithChildren<any>>,
   options: IActionOptions,
   titleOrProps?: string | PropsCallback,
   actionOrCondition?: (instanceIds?: string[]) => void | boolean,
@@ -160,7 +160,7 @@ export type RegisterAction = (
 export type RegisterControlWrapper = (
   group: string,
   priority: number,
-  wrapper: React.ComponentType<any>,
+  wrapper: React.ComponentType<React.PropsWithChildren<any>>,
 ) => void;
 
 export type RegisterFooter = (
@@ -171,7 +171,7 @@ export type RegisterFooter = (
 
 export type RegisterBanner = (
   group: string,
-  component: React.ComponentType<any>,
+  component: React.ComponentType<React.PropsWithChildren<any>>,
   options: IBannerOptions,
 ) => void;
 
@@ -217,13 +217,13 @@ export interface IMainPageOptions {
   onReset?: () => void;
   mdi?: string;
   /** Self-subscribing status badge shown on this page's left-menu item. */
-  menuBadge?: React.ComponentType;
+  menuBadge?: React.ComponentType<React.PropsWithChildren<unknown>>;
 }
 
 export type RegisterMainPage = (
   icon: string,
   title: string,
-  element: React.ComponentType<any>,
+  element: React.ComponentType<React.PropsWithChildren<any>>,
   options: IMainPageOptions,
 ) => void;
 
@@ -241,7 +241,7 @@ export type RegisterDashlet = (
   width: 1 | 2 | 3,
   height: 1 | 2 | 3 | 4 | 5 | 6,
   position: number,
-  component: React.ComponentClass<any> | React.FunctionComponent<any>,
+  component: React.ComponentClass<any> | React.FunctionComponent<React.PropsWithChildren<any>>,
   isVisible: (state) => boolean,
   props: PropsCallback,
   options: IDashletOptions,
@@ -249,13 +249,13 @@ export type RegisterDashlet = (
 
 export type RegisterDialog = (
   id: string,
-  element: React.ComponentType<any>,
+  element: React.ComponentType<React.PropsWithChildren<any>>,
   props?: PropsCallback,
 ) => void;
 
 export type RegisterOverlay = (
   id: string,
-  element: React.ComponentType<any>,
+  element: React.ComponentType<React.PropsWithChildren<any>>,
   props?: PropsCallback,
 ) => void;
 
@@ -503,7 +503,7 @@ export interface IExtensionApiExtension
   showOverlay?: (
     id: string,
     title: string,
-    content: string | React.ComponentType<any>,
+    content: string | React.ComponentType<React.PropsWithChildren<any>>,
     pos?: IPosition,
     options?: IOverlayOptions,
   ) => void;

--- a/src/renderer/src/types/IExtensionProvider.ts
+++ b/src/renderer/src/types/IExtensionProvider.ts
@@ -1,9 +1,9 @@
-import type * as React from "react";
+import type { ReactNode } from "react";
 
 export interface IExtensibleProps {
   group?: string;
   staticElements?: any[];
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export interface IExtendedProps {

--- a/src/renderer/src/types/IExtensionProvider.ts
+++ b/src/renderer/src/types/IExtensionProvider.ts
@@ -1,6 +1,9 @@
+import type * as React from "react";
+
 export interface IExtensibleProps {
   group?: string;
   staticElements?: any[];
+  children?: React.ReactNode;
 }
 
 export interface IExtendedProps {

--- a/src/renderer/src/types/IMainPage.ts
+++ b/src/renderer/src/types/IMainPage.ts
@@ -15,7 +15,7 @@ export interface IMainPage {
   icon: string;
   mdi?: string;
   title: string;
-  component: React.ComponentClass<any> | React.StatelessComponent<any>;
+  component: React.ComponentClass<any> | React.FunctionComponent<React.PropsWithChildren<any>>;
   propsFunc: () => any;
   visible: () => boolean;
   group: "global" | "per-game" | "support" | "hidden" | "dashboard";
@@ -33,5 +33,5 @@ export interface IMainPage {
   activity?: ReduxProp<boolean>;
   namespace?: string;
   onReset?: () => void;
-  menuBadge?: React.ComponentType;
+  menuBadge?: React.ComponentType<React.PropsWithChildren<unknown>>;
 }

--- a/src/renderer/src/types/ITableAttribute.ts
+++ b/src/renderer/src/types/ITableAttribute.ts
@@ -1,3 +1,5 @@
+import type * as React from "react";
+
 import type { ITString, TFunction } from "../util/i18n";
 
 export type AttributeRenderer = "progress";
@@ -24,6 +26,7 @@ export interface IFilterProps {
   t: TFunction;
   onSetFilter: (attributeId: string, value: any) => void;
   domRef: (ref: HTMLElement) => void;
+  children?: React.ReactNode;
 }
 
 export interface ITableFilter {
@@ -55,7 +58,7 @@ export interface ITableFilter {
    * for possible values
    */
   raw: string | boolean;
-  component: React.ComponentType<IFilterProps>;
+  component: React.ComponentType<React.PropsWithChildren<IFilterProps>>;
   /**
    * specifies which property of the object to filter on, meaning that obj[dataId] will be passed
    * to the "matches" function as the value to filter by.

--- a/src/renderer/src/ui/components/collection_tile/CollectionTile.demo.tsx
+++ b/src/renderer/src/ui/components/collection_tile/CollectionTile.demo.tsx
@@ -14,7 +14,9 @@ import { CollectionTile } from "./CollectionTile";
 export interface ICollectionTileDemoProps {
   api: IExtensionApi;
 }
-export const CollectionTileDemo: ComponentType<ICollectionTileDemoProps> = ({ api }) => {
+export const CollectionTileDemo: ComponentType<
+  React.PropsWithChildren<ICollectionTileDemoProps>
+> = ({ api }) => {
   const handleAddCollection = (title: string) => {
     console.log("Add collection:", title);
   };

--- a/src/renderer/src/ui/components/collection_tile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collection_tile/CollectionTile.tsx
@@ -66,7 +66,7 @@ const Stat = ({ children, iconPath }: PropsWithChildren<{ iconPath: string }>) =
   </div>
 );
 
-export const CollectionTile: ComponentType<ICollectionTileProps> = ({
+export const CollectionTile: ComponentType<React.PropsWithChildren<ICollectionTileProps>> = ({
   api,
   collection,
   isLoggedIn = true,

--- a/src/renderer/src/ui/components/listing/Listing.tsx
+++ b/src/renderer/src/ui/components/listing/Listing.tsx
@@ -25,7 +25,7 @@ export const Listing = ({
   skeletonCount = 4,
   SkeletonTile,
 }: PropsWithChildren<{
-  SkeletonTile?: ComponentType;
+  SkeletonTile?: ComponentType<React.PropsWithChildren<unknown>>;
   additionalContent?: ReactNode;
   appendLoader?: boolean;
   className?: string;

--- a/src/renderer/src/ui/components/listing_loader/ListingLoader.tsx
+++ b/src/renderer/src/ui/components/listing_loader/ListingLoader.tsx
@@ -8,7 +8,7 @@ export const ListingLoader = ({
   skeletonCount,
   SkeletonTile,
 }: PropsWithChildren<{
-  SkeletonTile?: ComponentType;
+  SkeletonTile?: ComponentType<React.PropsWithChildren<unknown>>;
   append?: boolean;
   className?: string;
   isLoading?: boolean;

--- a/src/renderer/src/util/MutexContext.ts
+++ b/src/renderer/src/util/MutexContext.ts
@@ -43,7 +43,9 @@ export interface IMutexProviderProps {
   children: React.ReactNode;
 }
 
-export const MutexProvider: React.FC<IMutexProviderProps> = ({ children }) => {
+export const MutexProvider: React.FC<React.PropsWithChildren<IMutexProviderProps>> = ({
+  children,
+}) => {
   const queueRef = React.useRef<MutexContextValue>();
   if (queueRef.current === undefined) {
     queueRef.current = new MutexContextValue();

--- a/src/renderer/src/views/AppLayout.tsx
+++ b/src/renderer/src/views/AppLayout.tsx
@@ -42,7 +42,7 @@ export interface IBaseProps {
   className?: string;
 }
 
-export const AppLayout: FC<IBaseProps> = () => {
+export const AppLayout: FC<React.PropsWithChildren<IBaseProps>> = () => {
   const useModernLayout = useSelector((state: IState) => state.settings.window.useModernLayout);
 
   return (

--- a/src/renderer/src/views/DNDContainer.tsx
+++ b/src/renderer/src/views/DNDContainer.tsx
@@ -10,7 +10,7 @@ interface IDNDContainerProps {
  * up to the parent, but I'll have to admit I don't understand 100% how "context" and
  * "manager" work in react-dnd and what changed in its api since we needed this.
  */
-export const DNDContainer: FC<IDNDContainerProps> = (props) => {
+export const DNDContainer: FC<React.PropsWithChildren<IDNDContainerProps>> = (props) => {
   const { children, style } = props;
 
   // Return null if no children provided

--- a/src/renderer/src/views/Dialog.tsx
+++ b/src/renderer/src/views/Dialog.tsx
@@ -47,7 +47,7 @@ interface IActionProps {
   isDisabled: boolean;
 }
 
-const Action: React.FC<IActionProps> = (props) => {
+const Action: React.FC<React.PropsWithChildren<IActionProps>> = (props) => {
   const { action, isDefault, isDisabled, onDismiss } = props;
 
   const { t } = useTranslation(["common"]);
@@ -69,7 +69,7 @@ const Action: React.FC<IActionProps> = (props) => {
   );
 };
 
-export const Dialog: React.FC = () => {
+export const Dialog: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation(["common"]);
   const dispatch = useDispatch();
 

--- a/src/renderer/src/views/DialogContainer.tsx
+++ b/src/renderer/src/views/DialogContainer.tsx
@@ -12,14 +12,14 @@ export interface IBaseProps {
 
 interface IExtDialog {
   id: string;
-  component: React.ComponentType<IErrorBoundaryProps>;
+  component: React.ComponentType<React.PropsWithChildren<IErrorBoundaryProps>>;
   props: PropsCallbackTyped<IErrorBoundaryProps>;
 }
 
 const registerDialog = (
   _instanceGroup: undefined,
   id: string,
-  component: React.ComponentType<IErrorBoundaryProps>,
+  component: React.ComponentType<React.PropsWithChildren<IErrorBoundaryProps>>,
   props?: PropsCallbackTyped<IErrorBoundaryProps>,
 ): IExtDialog => {
   return { id, component, props };
@@ -31,7 +31,7 @@ interface IRenderDialogProps {
   onHideDialog: () => void;
 }
 
-const RenderDialog: FC<IRenderDialogProps> = ({
+const RenderDialog: FC<React.PropsWithChildren<IRenderDialogProps>> = ({
   dialog,
   visibleDialog,
   onHideDialog,
@@ -52,7 +52,10 @@ const RenderDialog: FC<IRenderDialogProps> = ({
   );
 };
 
-export const DialogContainer: React.FC<IBaseProps> = ({ visibleDialog, onHideDialog }) => {
+export const DialogContainer: React.FC<React.PropsWithChildren<IBaseProps>> = ({
+  visibleDialog,
+  onHideDialog,
+}) => {
   const dialogs = useExtensionObjects<IExtDialog>(registerDialog);
 
   return (

--- a/src/renderer/src/views/GameSettings.tsx
+++ b/src/renderer/src/views/GameSettings.tsx
@@ -20,7 +20,7 @@ import { PageScroll } from "@/views/components/Page/PageScroll";
 
 interface ISettingsPage {
   title: string;
-  component: React.ComponentType<IBaseProps>;
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>;
   props: PropsCallbackTyped<IBaseProps>;
   visible: () => boolean;
   priority: number;
@@ -35,7 +35,7 @@ interface ICombinedSettingsPage {
 const registerSettings = (
   _instanceGroup: undefined,
   title: string,
-  component: React.ComponentType<IBaseProps>,
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>,
   props: PropsCallbackTyped<IBaseProps>,
   visible: () => boolean,
   priority?: number,
@@ -43,7 +43,10 @@ const registerSettings = (
   return { title, component, props, visible, priority: priority || 100 };
 };
 
-export const GameSettings: FC<{ active?: boolean; pageId?: string }> = ({ active, pageId }) => {
+export const GameSettings: FC<React.PropsWithChildren<{ active?: boolean; pageId?: string }>> = ({
+  active,
+  pageId,
+}) => {
   const { t } = useTranslation(["common"]);
   const dispatch = useDispatch();
 

--- a/src/renderer/src/views/LoadingScreen.tsx
+++ b/src/renderer/src/views/LoadingScreen.tsx
@@ -17,7 +17,7 @@ const readable = (input: string): string => {
     .join(" ");
 };
 
-export const LoadingScreen: React.FC<ILoadingScreenProps> = (props) => {
+export const LoadingScreen: React.FC<React.PropsWithChildren<ILoadingScreenProps>> = (props) => {
   const { extensions } = props;
 
   const [currentlyLoading, setCurrentlyLoading] = React.useState("");

--- a/src/renderer/src/views/MainFooter.tsx
+++ b/src/renderer/src/views/MainFooter.tsx
@@ -9,14 +9,14 @@ export interface IBaseProps {
 
 interface IFooter {
   id: string;
-  component: React.ComponentType<IBaseProps>;
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>;
   props: PropsCallbackTyped<IBaseProps>;
 }
 
 const registerFooter = (
   _instanceGroup: undefined,
   id: string,
-  component: React.ComponentType<IBaseProps>,
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>,
   props: PropsCallbackTyped<IBaseProps>,
 ): IFooter => {
   return { id, component, props };
@@ -25,7 +25,7 @@ const registerFooter = (
 /**
  * Footer on the main window. Can be extended
  */
-export const MainFooter: FC<IBaseProps> = ({ slim }) => {
+export const MainFooter: FC<React.PropsWithChildren<IBaseProps>> = ({ slim }) => {
   const footers = useExtensionObjects<IFooter>(registerFooter);
 
   const renderFooter = (footer: IFooter): JSX.Element => {

--- a/src/renderer/src/views/MainPageContainer.tsx
+++ b/src/renderer/src/views/MainPageContainer.tsx
@@ -88,7 +88,13 @@ interface IErrorFallbackProps {
   onRetry: () => void;
 }
 
-const ErrorFallback: FC<IErrorFallbackProps> = ({ pageId, classes, error, errorInfo, onRetry }) => {
+const ErrorFallback: FC<React.PropsWithChildren<IErrorFallbackProps>> = ({
+  pageId,
+  classes,
+  error,
+  errorInfo,
+  onRetry,
+}) => {
   const { t } = useTranslation(["common"]);
   const context = useMainContext();
 
@@ -129,7 +135,11 @@ ComponentStack:
   );
 };
 
-export const MainPageContainer: React.FC<IBaseProps> = ({ page, active, secondary }) => {
+export const MainPageContainer: React.FC<React.PropsWithChildren<IBaseProps>> = ({
+  page,
+  active,
+  secondary,
+}) => {
   const { t } = useTranslation(["common"]);
   const [headerRef, setHeaderRef] = useState<HTMLElement | null>(null);
 

--- a/src/renderer/src/views/MainPageHeader.tsx
+++ b/src/renderer/src/views/MainPageHeader.tsx
@@ -9,7 +9,7 @@ export interface IProps {
   children?: ReactNode;
 }
 
-export const MainPageHeader: FC<IProps> = ({ children }) => {
+export const MainPageHeader: FC<React.PropsWithChildren<IProps>> = ({ children }) => {
   const mainPage = useSelector(mainPageSelector);
   const { headerPortal, page } = useContext(PageHeaderContext);
 

--- a/src/renderer/src/views/Notification.tsx
+++ b/src/renderer/src/views/Notification.tsx
@@ -16,7 +16,7 @@ interface IActionProps {
   onTrigger: (actionTitle: string) => void;
 }
 
-const Action: FC<IActionProps> = (props) => {
+const Action: FC<React.PropsWithChildren<IActionProps>> = (props) => {
   const { count, icon, title, onTrigger } = props;
 
   const { t } = useTranslation(["common"]);
@@ -75,7 +75,7 @@ const typeToIcon = (type: NotificationType): JSX.Element | null => {
   }
 };
 
-export const Notification: FC<IProps> = (props) => {
+export const Notification: FC<React.PropsWithChildren<IProps>> = (props) => {
   const { collapsed, onDismiss, onExpand, onSuppress, onTriggerAction, params } = props;
   const { actions, id, message, noDismiss, progress, title, type } = params;
 

--- a/src/renderer/src/views/NotificationButton.tsx
+++ b/src/renderer/src/views/NotificationButton.tsx
@@ -56,7 +56,7 @@ const displayTime = (item: INotification): number | null => {
   return NOTIFICATION_TIMEOUTS[item.type] ?? 10000;
 };
 
-export const NotificationButton: React.FC<IBaseProps> = ({ hide }) => {
+export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> = ({ hide }) => {
   const { t } = useTranslation(["common"]);
   const dispatch = useDispatch();
   const extensions = useExtensionContext();

--- a/src/renderer/src/views/OverlayContainer.tsx
+++ b/src/renderer/src/views/OverlayContainer.tsx
@@ -7,20 +7,20 @@ import type { PropsCallback } from "../types/IExtensionContext";
 
 interface IExtOverlay {
   id: string;
-  component: React.ComponentType;
+  component: React.ComponentType<React.PropsWithChildren<unknown>>;
   props?: PropsCallback;
 }
 
 const registerOverlay = (
   _instanceGroup: undefined,
   id: string,
-  component: React.ComponentType,
+  component: React.ComponentType<React.PropsWithChildren<unknown>>,
   props?: PropsCallback,
 ): IExtOverlay => {
   return { id, component, props };
 };
 
-const renderOverlay: FC<IExtOverlay> = (overlay) => {
+const renderOverlay: FC<React.PropsWithChildren<IExtOverlay>> = (overlay) => {
   const props = overlay.props ? overlay.props() : {};
   return (
     <ErrorBoundary className="errorboundary-overlay" key={overlay.id}>
@@ -31,7 +31,7 @@ const renderOverlay: FC<IExtOverlay> = (overlay) => {
   );
 };
 
-export const OverlayContainer: FC = () => {
+export const OverlayContainer: FC<React.PropsWithChildren<unknown>> = () => {
   const overlays = useExtensionObjects<IExtOverlay>(registerOverlay);
 
   return <div>{overlays.map((overlay) => renderOverlay(overlay))}</div>;

--- a/src/renderer/src/views/PageButton.tsx
+++ b/src/renderer/src/views/PageButton.tsx
@@ -12,7 +12,7 @@ interface IPageButtonProps {
   namespace: string;
 }
 
-export const PageButton: FC<IPageButtonProps> = (props) => {
+export const PageButton: FC<React.PropsWithChildren<IPageButtonProps>> = (props) => {
   const { namespace, page } = props;
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 

--- a/src/renderer/src/views/QuickLauncher.tsx
+++ b/src/renderer/src/views/QuickLauncher.tsx
@@ -29,7 +29,7 @@ import { truthy } from "../util/util";
 
 type IGameIconCache = { [gameId: string]: { icon: string; game: IGameStored } };
 
-export const QuickLauncher: React.FC = () => {
+export const QuickLauncher: React.FC<React.PropsWithChildren<unknown>> = () => {
   const dispatch = useDispatch();
   const extensions = useExtensionContext();
   const api = extensions.getApi();

--- a/src/renderer/src/views/Settings.tsx
+++ b/src/renderer/src/views/Settings.tsx
@@ -26,7 +26,7 @@ const startupSettings = lazyRequire<typeof startupSettingsT>(
 
 interface ISettingsPage {
   title: string;
-  component: React.ComponentType<IBaseProps>;
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>;
   props: PropsCallbackTyped<IBaseProps>;
   visible: () => boolean;
   priority: number;
@@ -41,7 +41,7 @@ interface ICombinedSettingsPage {
 const registerSettings = (
   _instanceGroup: undefined,
   title: string,
-  component: React.ComponentType<IBaseProps>,
+  component: React.ComponentType<React.PropsWithChildren<IBaseProps>>,
   props: PropsCallbackTyped<IBaseProps>,
   visible: () => boolean,
   priority?: number,
@@ -49,7 +49,10 @@ const registerSettings = (
   return { title, component, props, visible, priority: priority || 100 };
 };
 
-export const Settings: React.FC<{ active?: boolean; pageId?: string }> = ({ active, pageId }) => {
+export const Settings: React.FC<React.PropsWithChildren<{ active?: boolean; pageId?: string }>> = ({
+  active,
+  pageId,
+}) => {
   const { t } = useTranslation(["common"]);
   const dispatch = useDispatch();
 

--- a/src/renderer/src/views/WindowControls.tsx
+++ b/src/renderer/src/views/WindowControls.tsx
@@ -3,7 +3,7 @@ import React, { type FC } from "react";
 import { IconButton } from "../controls/TooltipControls";
 import { close, minimize, toggleMaximize, useIsMaximized } from "../hooks/windowControls";
 
-export const WindowControls: FC = () => {
+export const WindowControls: FC<React.PropsWithChildren<unknown>> = () => {
   const isMaximized = useIsMaximized();
 
   return (

--- a/src/renderer/src/views/components/ContentPane.tsx
+++ b/src/renderer/src/views/components/ContentPane.tsx
@@ -4,7 +4,7 @@ import { usePagesContext } from "../../contexts";
 import { usePageRendering } from "../../hooks";
 import { DNDContainer } from "../DNDContainer";
 
-export const ModernContentPane: FC = () => {
+export const ModernContentPane: FC<React.PropsWithChildren<unknown>> = () => {
   const { mainPages } = usePagesContext();
 
   const { renderPage } = usePageRendering();

--- a/src/renderer/src/views/components/Header/HelpSection.tsx
+++ b/src/renderer/src/views/components/Header/HelpSection.tsx
@@ -28,7 +28,7 @@ const builtInActionIcons: Record<string, string> = {
   bug: mdiBugOutline,
 };
 
-export const HelpSection: FC = () => {
+export const HelpSection: FC<React.PropsWithChildren<unknown>> = () => {
   const dispatch = useDispatch();
   const extensions = useExtensionContext();
   const api = extensions.getApi();

--- a/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
@@ -11,7 +11,7 @@ interface NotificationActionsProps {
   onExpand?: () => void;
 }
 
-export const NotificationActions: FC<NotificationActionsProps> = ({
+export const NotificationActions: FC<React.PropsWithChildren<NotificationActionsProps>> = ({
   actions,
   collapsed,
   onActionClick,

--- a/src/renderer/src/views/components/Header/Notifications/NotificationContent.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationContent.tsx
@@ -7,7 +7,10 @@ interface NotificationContentProps {
   lines: string[];
 }
 
-export const NotificationContent: FC<NotificationContentProps> = ({ title, lines }) => {
+export const NotificationContent: FC<React.PropsWithChildren<NotificationContentProps>> = ({
+  title,
+  lines,
+}) => {
   return (
     <Typography appearance="moderate" as="div" typographyType="body-sm">
       {!!title && <p className="font-semibold">{title}</p>}

--- a/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
@@ -12,7 +12,7 @@ interface NotificationControlsProps {
   onSuppress: (e: MouseEvent) => void;
 }
 
-export const NotificationControls: FC<NotificationControlsProps> = ({
+export const NotificationControls: FC<React.PropsWithChildren<NotificationControlsProps>> = ({
   noDismiss,
   allowSuppress,
   collapsed,

--- a/src/renderer/src/views/components/Header/Notifications/NotificationItem.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationItem.tsx
@@ -39,7 +39,7 @@ interface INotificationItemProps {
   onExpand?: (groupId: string) => void;
 }
 
-export const NotificationItem: FC<INotificationItemProps> = ({
+export const NotificationItem: FC<React.PropsWithChildren<INotificationItemProps>> = ({
   notification,
   collapsed,
   onDismiss,

--- a/src/renderer/src/views/components/Header/Notifications/index.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/index.tsx
@@ -16,7 +16,9 @@ import { useNotificationItems } from "./useNotificationItems";
  * react to it directly. The outer component just manages the Popover state.
  * This allows us to reset expand state and trigger auto-open when new notifications arrive.
  */
-const NotificationsContent: React.FC<{ popoverOpen: boolean }> = ({ popoverOpen }) => {
+const NotificationsContent: React.FC<React.PropsWithChildren<{ popoverOpen: boolean }>> = ({
+  popoverOpen,
+}) => {
   const extensions = useExtensionContext();
   const api = extensions.getApi();
 

--- a/src/renderer/src/views/components/Header/PremiumIndicator.tsx
+++ b/src/renderer/src/views/components/Header/PremiumIndicator.tsx
@@ -13,7 +13,7 @@ import { Typography } from "../../../ui/components/typography/Typography";
 import opn from "../../../util/opn";
 import { Campaign, Content, nexusModsURL, Section } from "../../../util/util";
 
-export const PremiumIndicator: FC = () => {
+export const PremiumIndicator: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
 
   const showAd = useSelector(shouldShowPremiumAd);

--- a/src/renderer/src/views/components/Header/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/ProfileSection.tsx
@@ -44,7 +44,7 @@ const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
   ),
 );
 
-export const ProfileSection: FC = () => {
+export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
   const dispatch = useDispatch();
   const extensions = useExtensionContext();
   const api = extensions.getApi();

--- a/src/renderer/src/views/components/Header/StagingIndicator.tsx
+++ b/src/renderer/src/views/components/Header/StagingIndicator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { Pill } from "../../../ui/components/pill/Pill";
 
-export const StagingIndicator: FC = () => {
+export const StagingIndicator: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
 
   if (process.env.IS_VORTEX_PREVIEW !== "true") {

--- a/src/renderer/src/views/components/Header/VersionIndicator.tsx
+++ b/src/renderer/src/views/components/Header/VersionIndicator.tsx
@@ -3,7 +3,7 @@ import React, { type FC } from "react";
 import { Typography } from "../../../ui/components/typography/Typography";
 import { getApplication } from "../../../util/application";
 
-export const VersionIndicator: FC = () => {
+export const VersionIndicator: FC<React.PropsWithChildren<unknown>> = () => {
   const version = getApplication().version;
   const formattedVersion = `v${version}`;
 

--- a/src/renderer/src/views/components/Header/WindowControls.tsx
+++ b/src/renderer/src/views/components/Header/WindowControls.tsx
@@ -10,7 +10,11 @@ interface WindowControlButtonProps extends ButtonHTMLAttributes<HTMLButtonElemen
   iconPath: string;
 }
 
-const WindowControlButton: FC<WindowControlButtonProps> = ({ className, iconPath, ...props }) => (
+const WindowControlButton: FC<React.PropsWithChildren<WindowControlButtonProps>> = ({
+  className,
+  iconPath,
+  ...props
+}) => (
   <button
     className={joinClasses([
       "flex size-11 items-center justify-center text-neutral-subdued -outline-offset-2 transition-colors hover:text-neutral-strong",
@@ -22,7 +26,7 @@ const WindowControlButton: FC<WindowControlButtonProps> = ({ className, iconPath
   </button>
 );
 
-export const WindowControls: FC = () => {
+export const WindowControls: FC<React.PropsWithChildren<unknown>> = () => {
   const isMaximized = useIsMaximized();
 
   return (

--- a/src/renderer/src/views/components/Header/index.tsx
+++ b/src/renderer/src/views/components/Header/index.tsx
@@ -20,7 +20,7 @@ import { StagingIndicator } from "./StagingIndicator";
 import { VersionIndicator } from "./VersionIndicator";
 import { WindowControls } from "./WindowControls";
 
-export const Header: FC = () => {
+export const Header: FC<React.PropsWithChildren<unknown>> = () => {
   const { menuIsCollapsed, setMenuIsCollapsed } = useWindowContext();
   const { t } = useTranslation();
   const { selection } = useSpineContext();

--- a/src/renderer/src/views/components/Menu/DownloadsMenuContent.tsx
+++ b/src/renderer/src/views/components/Menu/DownloadsMenuContent.tsx
@@ -38,11 +38,13 @@ function useManagedGameIds(): string[] {
   }, [discoveredGames, allProfiles]);
 }
 
-const GameMenuEntry: FC<{
-  game: IGameStored;
-  isActive: boolean;
-  onClick: () => void;
-}> = ({ game, isActive, onClick }) => {
+const GameMenuEntry: FC<
+  React.PropsWithChildren<{
+    game: IGameStored;
+    isActive: boolean;
+    onClick: () => void;
+  }>
+> = ({ game, isActive, onClick }) => {
   const discoveredGames = useSelector(discoveredGamesSelector);
   const { cacheKey, sources, preferred } = getGameImageUrls(game, discoveredGames[game.id]);
   const { src, exhausted, onError, onLoad } = useGameImage(cacheKey, sources, preferred);
@@ -87,7 +89,7 @@ const GameMenuEntry: FC<{
   );
 };
 
-export const DownloadsMenuContent: FC = () => {
+export const DownloadsMenuContent: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const { downloadGameFilter, setDownloadGameFilter } = useSpineContext();
   const managedGameIds = useManagedGameIds();

--- a/src/renderer/src/views/components/Menu/MenuButton.tsx
+++ b/src/renderer/src/views/components/Menu/MenuButton.tsx
@@ -9,10 +9,10 @@ interface MenuButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: string;
   iconPath: string;
   isActive?: boolean;
-  Badge?: ComponentType;
+  Badge?: ComponentType<React.PropsWithChildren<unknown>>;
 }
 
-export const MenuButton: FC<MenuButtonProps> = ({
+export const MenuButton: FC<React.PropsWithChildren<MenuButtonProps>> = ({
   children,
   iconPath,
   isActive,

--- a/src/renderer/src/views/components/Menu/ToolButton.tsx
+++ b/src/renderer/src/views/components/Menu/ToolButton.tsx
@@ -16,7 +16,7 @@ interface ToolButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isRunning?: boolean;
 }
 
-export const ToolButton: FC<ToolButtonProps> = ({
+export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
   starter,
   isPrimary = false,
   isValid = true,

--- a/src/renderer/src/views/components/Menu/ToolsContext.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsContext.tsx
@@ -21,7 +21,7 @@ interface ToolsProviderProps {
   children: ReactNode;
 }
 
-export const ToolsProvider: FC<ToolsProviderProps> = ({ children }) => {
+export const ToolsProvider: FC<React.PropsWithChildren<ToolsProviderProps>> = ({ children }) => {
   const { api } = useMainContext();
   const dispatch = useDispatch();
 

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -21,7 +21,7 @@ interface PlayButtonProps {
   onClick: () => void;
 }
 
-const PlayButton: FC<PlayButtonProps> = ({
+const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
   primaryStarter,
   isPrimaryRunning,
   isCollapsed,
@@ -71,7 +71,7 @@ interface ToolsSectionProps {
   isAnimating: boolean;
 }
 
-export const ToolsSection: FC<ToolsSectionProps> = ({ isAnimating }) => {
+export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ isAnimating }) => {
   const { t } = useTranslation();
   const { menuIsCollapsed } = useWindowContext();
   const { selection } = useSpineContext();

--- a/src/renderer/src/views/components/Menu/index.tsx
+++ b/src/renderer/src/views/components/Menu/index.tsx
@@ -20,7 +20,7 @@ const toolPadding = {
   5: "pb-66",
 };
 
-const MenuContent: FC = () => {
+const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const { menuIsCollapsed } = useWindowContext();
   const { selection, visiblePages } = useSpineContext();
@@ -104,7 +104,7 @@ const MenuContent: FC = () => {
   );
 };
 
-export const Menu: FC = () => {
+export const Menu: FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <ToolsProvider>
       <MenuContent />

--- a/src/renderer/src/views/components/Spine/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/DownloadButton.tsx
@@ -70,11 +70,13 @@ function useDownloadProgress(): DownloadProgress {
   });
 }
 
-const ProgressRing: FC<{
-  isActive: boolean;
-  isPaused: boolean;
-  progress: number;
-}> = ({ isActive, isPaused, progress }) => {
+const ProgressRing: FC<
+  React.PropsWithChildren<{
+    isActive: boolean;
+    isPaused: boolean;
+    progress: number;
+  }>
+> = ({ isActive, isPaused, progress }) => {
   const size = 48;
   const strokeWidth = 4;
   const radius = (size - strokeWidth) / 2;
@@ -115,7 +117,7 @@ const ProgressRing: FC<{
   );
 };
 
-export const DownloadButton: FC = () => {
+export const DownloadButton: FC<React.PropsWithChildren<unknown>> = () => {
   const { selection, selectDownloads } = useSpineContext();
 
   const isActive = selection.type === "downloads";

--- a/src/renderer/src/views/components/Spine/GameButton.tsx
+++ b/src/renderer/src/views/components/Spine/GameButton.tsx
@@ -39,7 +39,7 @@ interface GameButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   store?: string;
 }
 
-export const GameButton: FC<GameButtonProps> = ({
+export const GameButton: FC<React.PropsWithChildren<GameButtonProps>> = ({
   cacheKey,
   isActive,
   preferred,

--- a/src/renderer/src/views/components/Spine/SpineButton.tsx
+++ b/src/renderer/src/views/components/Spine/SpineButton.tsx
@@ -9,7 +9,12 @@ interface SpineButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isActive?: boolean;
 }
 
-export const SpineButton: FC<SpineButtonProps> = ({ className, iconPath, isActive, ...props }) => (
+export const SpineButton: FC<React.PropsWithChildren<SpineButtonProps>> = ({
+  className,
+  iconPath,
+  isActive,
+  ...props
+}) => (
   <button
     className={joinClasses([
       className,

--- a/src/renderer/src/views/components/Spine/SpineContext.tsx
+++ b/src/renderer/src/views/components/Spine/SpineContext.tsx
@@ -57,7 +57,11 @@ interface ISpineContext {
 
 const SpineContext = createContext<ISpineContext | undefined>(undefined);
 
-export const SpineProvider: FC = ({ children }: { children: ReactNode }) => {
+export const SpineProvider: FC<React.PropsWithChildren<unknown>> = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
   const { api } = useMainContext();
   const { mainPages } = usePagesContext();
   const dispatch = useDispatch();

--- a/src/renderer/src/views/components/Spine/index.tsx
+++ b/src/renderer/src/views/components/Spine/index.tsx
@@ -13,7 +13,7 @@ import { SpineButton } from "./SpineButton";
 import { useSpineContext } from "./SpineContext";
 import { formatGameDisplayName, getGameImageUrls } from "./utils";
 
-export const Spine: FC = () => {
+export const Spine: FC<React.PropsWithChildren<unknown>> = () => {
   const { selection, selectHome, selectGame, selectGlobalPage } = useSpineContext();
 
   const [canScrollUp, setCanScrollUp] = useState(false);

--- a/src/renderer/src/views/layout/ClassicLayout.tsx
+++ b/src/renderer/src/views/layout/ClassicLayout.tsx
@@ -13,7 +13,7 @@ import { ToastContainer } from "./ToastContainer";
 import { Toolbar } from "./Toolbar";
 import { UIBlocker } from "./UIBlocker";
 
-export const ClassicLayout: FC = () => {
+export const ClassicLayout: FC<React.PropsWithChildren<unknown>> = () => {
   const customTitlebar = useSelector((state: IState) => state.settings.window.customTitlebar);
   const switchingProfile = useSwitchingProfile();
 

--- a/src/renderer/src/views/layout/ContentPane.tsx
+++ b/src/renderer/src/views/layout/ContentPane.tsx
@@ -7,7 +7,7 @@ import { DNDContainer } from "../DNDContainer";
  * Content pane component.
  * For Classic layout.
  */
-export const ContentPane: FC = ({ children }) => {
+export const ContentPane: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <FlexLayout.Flex fill={true} id="main-window-pane">
       <DNDContainer

--- a/src/renderer/src/views/layout/DialogLayer.tsx
+++ b/src/renderer/src/views/layout/DialogLayer.tsx
@@ -11,7 +11,7 @@ import { OverlayContainer } from "../OverlayContainer";
  * Provides a dialog system layer.
  * For both layouts.
  */
-export const DialogLayer: FC = (): JSX.Element => {
+export const DialogLayer: FC<React.PropsWithChildren<unknown>> = (): JSX.Element => {
   const dispatch = useDispatch();
 
   const visibleDialog = useSelector(

--- a/src/renderer/src/views/layout/LayoutContainer.tsx
+++ b/src/renderer/src/views/layout/LayoutContainer.tsx
@@ -15,7 +15,10 @@ export interface ILayoutContainerProps {
  * Provides the main container for the layout, applying necessary classes and refs.
  * For both layouts.
  */
-export const LayoutContainer: FC<ILayoutContainerProps> = ({ children, className }) => {
+export const LayoutContainer: FC<React.PropsWithChildren<ILayoutContainerProps>> = ({
+  children,
+  className,
+}) => {
   const { isFocused, isHidpi } = useWindowContext();
   const { menuLayerOpen, setMenuLayerRef } = useMenuLayerContext();
 

--- a/src/renderer/src/views/layout/MainLayout.tsx
+++ b/src/renderer/src/views/layout/MainLayout.tsx
@@ -11,7 +11,7 @@ import { ContentPane, Sidebar } from "./index";
  * Provides main layout with a Sidebar and ContentPane.
  * For Classic layout.
  */
-export const MainLayout: FC = () => {
+export const MainLayout: FC<React.PropsWithChildren<unknown>> = () => {
   const { mainPages, mainPage } = usePagesContext();
 
   const dispatch = useDispatch();

--- a/src/renderer/src/views/layout/ModernLayout.tsx
+++ b/src/renderer/src/views/layout/ModernLayout.tsx
@@ -12,7 +12,7 @@ import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ToastContainer } from "./ToastContainer";
 import { UIBlocker } from "./UIBlocker";
 
-export const ModernLayout: FC = () => {
+export const ModernLayout: FC<React.PropsWithChildren<unknown>> = () => {
   const switchingProfile = useSwitchingProfile();
 
   return (

--- a/src/renderer/src/views/layout/PageGroup.tsx
+++ b/src/renderer/src/views/layout/PageGroup.tsx
@@ -22,7 +22,7 @@ export interface IPageGroupProps {
  * Provides a page group in the sidebar.
  * For Classic layout.
  */
-export const PageGroup: FC<IPageGroupProps> = memo((props) => {
+export const PageGroup: FC<React.PropsWithChildren<IPageGroupProps>> = memo((props) => {
   const { title, groupKey, pages, mainPage, secondaryPage, tabsMinimized, onClickPage } = props;
 
   const { t } = useTranslation();

--- a/src/renderer/src/views/layout/ProfileSwitcher.tsx
+++ b/src/renderer/src/views/layout/ProfileSwitcher.tsx
@@ -17,7 +17,7 @@ import { DialogContainer } from "../DialogContainer";
  * Provides a profile switcher component.
  * For both layouts.
  */
-export const ProfileSwitcher: FC = () => {
+export const ProfileSwitcher: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 

--- a/src/renderer/src/views/layout/Sidebar.tsx
+++ b/src/renderer/src/views/layout/Sidebar.tsx
@@ -27,7 +27,7 @@ export interface ISidebarProps {
  * Provides the sidebar component.
  * For Classic layout.
  */
-export const Sidebar: FC<ISidebarProps> = (props) => {
+export const Sidebar: FC<React.PropsWithChildren<ISidebarProps>> = (props) => {
   const { pages, onClickPage, onToggleMenu, onSidebarRef } = props;
 
   const { t } = useTranslation();

--- a/src/renderer/src/views/layout/ToastContainer.tsx
+++ b/src/renderer/src/views/layout/ToastContainer.tsx
@@ -48,7 +48,7 @@ class ToastErrorBoundary extends Component<{ children: ReactNode }, IToastBounda
   }
 }
 
-export const ToastContainer: FC = memo(() => (
+export const ToastContainer: FC<React.PropsWithChildren<unknown>> = memo(() => (
   <ToastErrorBoundary>
     <Toaster
       position="bottom-center"

--- a/src/renderer/src/views/layout/Toolbar.tsx
+++ b/src/renderer/src/views/layout/Toolbar.tsx
@@ -19,7 +19,7 @@ import { QuickLauncher } from "../QuickLauncher";
 const applicationButtons: IActionDefinition[] = [];
 const globalButtons: IActionDefinition[] = [];
 
-export const Toolbar: FC = () => {
+export const Toolbar: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const customTitlebar = useSelector((state: IState) => state.settings.window.customTitlebar);
   const version = useSelector((state: IState) => state.app.appVersion);

--- a/src/renderer/src/views/layout/UIBlocker.tsx
+++ b/src/renderer/src/views/layout/UIBlocker.tsx
@@ -14,7 +14,7 @@ import type { IState } from "../../types/IState";
  * Used during profile switching, game discovery, or other long-running tasks.
  * For both layouts.
  */
-export const UIBlocker: FC = () => {
+export const UIBlocker: FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { api } = useMainContext();

--- a/src/renderer/src/views/pages/Tools/ToolRow.tsx
+++ b/src/renderer/src/views/pages/Tools/ToolRow.tsx
@@ -47,7 +47,7 @@ export interface ToolRowProps {
   onMoveDown?: (starter: IStarterInfo) => void;
 }
 
-export const ToolRow: FC<ToolRowProps> = ({
+export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
   starter,
   counter,
   isValid,

--- a/src/renderer/src/views/pages/Tools/index.tsx
+++ b/src/renderer/src/views/pages/Tools/index.tsx
@@ -45,7 +45,7 @@ const Panel = ({
   </div>
 );
 
-export const ToolsPage: FC<{ active?: boolean }> = ({ active }) => {
+export const ToolsPage: FC<React.PropsWithChildren<{ active?: boolean }>> = ({ active }) => {
   const { t } = useTranslation();
   const {
     gameMode,

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,3 +1,6 @@
+// React 18: opt tests into act() environment (required by RTL 13+)
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
 // NOTE(erri120): yes, the library is called "jest-dom" but it works for vitest as well with this import:
 // https://www.npmjs.com/package/@testing-library/jest-dom#with-vitest
 import os from "node:os";

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,6 +1,3 @@
-// React 18: opt tests into act() environment (required by RTL 13+)
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
-
 // NOTE(erri120): yes, the library is called "jest-dom" but it works for vitest as well with this import:
 // https://www.npmjs.com/package/@testing-library/jest-dom#with-vitest
 import os from "node:os";

--- a/src/renderer/vitest.config.mts
+++ b/src/renderer/vitest.config.mts
@@ -10,6 +10,10 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "happy-dom",
+    // Expose beforeAll/afterEach/... as globals so @testing-library/react can
+    // self-register its hooks (act environment + auto-cleanup). Tests should
+    // still import from "vitest" explicitly.
+    globals: true,
     setupFiles: ["./test-setup.ts"],
 
     include: ["src/**/*.test.{ts,tsx,js,jsx}"],


### PR DESCRIPTION
## Summary

This went a lot smoother than expected. The reason is that React 18 has a built-in compatibility mode: keep rendering through the old `ReactDOM.render`, which we do, and the app runs with React 17 behavior, bug for bug. No concurrent rendering, no `createRoot`, no `StrictMode`, no timing changes. This PR swaps which React we ship without changing how anything renders. The flip to `createRoot`, where the actual new behavior lives, is a separate later release so we never land a new React and new rendering semantics in the same update.

This is the lightest touch possible. The real refactor work (replacing `findDOMNode`, migrating off legacy context, dealing with react-bootstrap) is what React 19 will eventually force, and none of it is in here. Being current on 18 makes 19 less urgent: we can schedule that work instead of doing it under pressure.

It was also quick because the React 17 upgrade did the structural work. There is one shared React copy for the host and every extension (extensions don't bundle their own), one version catalog, and the peer rules were already tamed. Flipping the catalog to 18.3.1 installed clean on the first try.

For extensions: published extensions keep working, unmodified. Unlike the React 17 upgrade, nothing was added to or removed from the set of modules extensions can require. I verified this at runtime with three third-party extensions. Authors will notice one thing, which is that their next `npm install` pulls `@types/react` 18 and may surface a few TypeScript errors on rebuild (mostly "declare your `children` prop"). All three error classes with fixes are documented in a new MIGRATION.md section. At runtime, nothing changes for them.

Why bother at all: React 18 unblocks `@headlessui/react` v2 for frontend work, keeps us on supported versions, and 18.3's dev-mode warnings point at exactly the code React 19 would break. Free early warning while we run 18.

## Changes

1. Regenerate stale API report (first commit). `etc/vortex.api.md` had drifted on master; regenerating it separately keeps this branch's API diff purely React-driven.
2. Catalog bump: `react`/`react-dom` → 18.3.1, `@types/react` ^18.3.0 / `@types/react-dom` ~18.3.0, overrides in lockstep, the four React-17 peer escape hatches re-pointed at 18. Zero new escape hatches needed; single React instance and no 17 residue in the lockfile.
3. @testing-library/react 12 → 16 (12 caps at React 17), plus `IS_REACT_ACT_ENVIRONMENT` in the vitest setup. The whole renderer suite passed without touching a single test.
4. @types/react 18 fallout, smaller than feared: the implicit-`children` removal boils down to `children?: React.ReactNode` on 14 shared props interfaces, `StatelessComponent` → `React.FC` (3 sites), and a few `ReactNode` casts. All 50 extension projects compiled clean with zero changes.
5. Typed class `context` declarations. React 18 types `Component.context` as `unknown`; `ExtensionProvider`, `FormFeedback`, and `Modal` now declare their context shape instead of casting.
6. API report regenerated. The React-driven public API delta is ~19 lines, all loosening (`ComponentType<PropsWithChildren<...>>` on registration surfaces). Nothing an existing extension compiles against breaks.
7. Known React 18 deprecation warnings demoted to `console.warn` (dev builds only; production React strips them). Besides log noise, an un-demoted `console.error` during first render would arm the "Vortex failed to start" terminate timer in `MainWindow` before the window shows.
8. Docs: MIGRATION.md "React 18" section for extension authors (with an npm `--legacy-peer-deps` note for react-select's stale peer range), and AGENTS-FRONTEND.md updated (it still said React 16.14).

## Verification

- Build, lint, and typecheck green across all 152 projects. 3305/3305 tests across 253 files. Playwright e2e: 23 passed, and the 3 failures are all confirmed pre-existing on master (stale selectors; the code involved is byte-identical on both branches).
- A from-scratch sample extension compiled against the new types produces zero React-18-introduced errors. The identical setup on React 17's types has one more.
- Full manual smoke (15 areas, log-monitored throughout): boot and game switching, mods table batch ops, downloads, a FOMOD wizard, a complete collection install, deploy/purge, every drag-and-drop surface (gamebryo load order, dependency lines, groups editor, BUTR load order), dialogs including menus inside modals, notifications, profiles, dashboard, live HMR. Community extensions exercised for real: Bannerlord (BUTR), Support Stats, Subnautica 2.
- Log audit over the whole session: three deduped React warnings, all known and benign (`defaultProps` from react-markdown, `unmountComponentAtNode`, and `validateDOMNesting`, which predates React 17). Zero React 18 regressions found.

## Known items / follow-ups

- createRoot is not in this PR on purpose. It's where React 18's real behavior change lives (auto-batching), and it gets its own later release with a focused audit. A spike confirmed the app boots and runs under `createRoot`, and RTL 16 already renders the entire test suite through it.
- The `renderer:api` script has undeclared build prerequisites (`@vortex/shared`, `exe-version`, `icon-extract`); it needs an nx task dependency.
- react-markdown 6.0.3 triggers React's `defaultProps` deprecation; it goes on the React 19 dependency-sweep list.

