### PR TITLE
Add collision-aware Tooltip component (LAZ-538)

### DIFF
--- a/packages/e2e/src/selectors/loginPage.ts
+++ b/packages/e2e/src/selectors/loginPage.ts
@@ -35,8 +35,10 @@ export class LoginPage {
     this.authorisationSuccessTitle = page.locator("p.oauth__title", {
       hasText: /Authorisation successful!/i,
     });
+    // Logged in the button is named after the user, so fall back to the avatar image.
     this.profileButton = page
-      .locator("button[title='Profile'], button[title='Log in'], button:has(img[alt])")
+      .getByRole("button", { name: /^(profile|log in)$/i })
+      .or(page.locator("button:has(img[alt])"))
       .first();
     this.loggedInMenuItem = page.getByText(/view profile on web|logout/i).first();
   }

--- a/packages/e2e/src/selectors/spine.ts
+++ b/packages/e2e/src/selectors/spine.ts
@@ -7,10 +7,10 @@ export class Spine {
 
   constructor(page: Page) {
     this.page = page;
-    this.homeButton = page.getByTitle("Home", { exact: true }).first();
+    this.homeButton = page.getByRole("button", { name: "Home", exact: true }).first();
   }
 
   gameButton(gameName: string): Locator {
-    return this.page.getByTitle(gameName, { exact: true }).first();
+    return this.page.getByRole("button", { name: gameName, exact: true }).first();
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ catalogs:
     '@eslint/js':
       specifier: 10.0.1
       version: 10.0.1
+    '@floating-ui/react':
+      specifier: 0.27.20
+      version: 0.27.20
     '@headlessui/react':
       specifier: 1.7.19
       version: 1.7.19
@@ -4205,6 +4208,9 @@ importers:
       '@electron/remote':
         specifier: 'catalog:'
         version: 2.1.3(electron@43.0.0)
+      '@floating-ui/react':
+        specifier: 'catalog:'
+        version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
       '@headlessui/react':
         specifier: 'catalog:'
         version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
@@ -4732,6 +4738,9 @@ importers:
       '@electron/remote':
         specifier: 'catalog:'
         version: 2.1.3(electron@43.0.0)
+      '@floating-ui/react':
+        specifier: 'catalog:'
+        version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
       '@headlessui/react':
         specifier: 'catalog:'
         version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
@@ -6247,6 +6256,27 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.20':
+    resolution: {integrity: sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@headlessui/react@1.7.19':
     resolution: {integrity: sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==}
@@ -12130,6 +12160,9 @@ packages:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -14089,6 +14122,31 @@ snapshots:
       levn: 0.4.1
 
   '@fastify/busboy@2.1.1': {}
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/react@0.27.20(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1)(react@18.3.1)
+      '@floating-ui/utils': 0.2.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.5.0
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@headlessui/react@1.7.19(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
@@ -20191,6 +20249,8 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  tabbable@6.5.0: {}
 
   tagged-tag@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   "@electron/remote": 2.1.3
   "@eslint-react/eslint-plugin": 3.0.0
   "@eslint/js": 10.0.1
+  "@floating-ui/react": 0.27.20
   "@headlessui/react": 1.7.19
   "@hot-updater/bsdiff": 0.30.6
   "@iarna/toml": 2.2.5

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -231,6 +231,7 @@
   "dependencies": {
     "@duckdb/node-api": "catalog:",
     "@electron/remote": "catalog:",
+    "@floating-ui/react": "catalog:",
     "@headlessui/react": "catalog:",
     "@hot-updater/bsdiff": "catalog:",
     "@mdi/js": "catalog:",

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -62,6 +62,7 @@
     "@babel/preset-typescript": "catalog:",
     "@babel/register": "catalog:",
     "@electron/remote": "catalog:",
+    "@floating-ui/react": "catalog:",
     "@headlessui/react": "catalog:",
     "@hot-updater/bsdiff": "catalog:",
     "@mdi/js": "catalog:",

--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -29,6 +29,7 @@ import { TabPanel } from "@/ui/components/tabs/TabPanel";
 import { TabProvider } from "@/ui/components/tabs/Tabs.context";
 import { TabsDemo } from "@/ui/components/tabs/Tabs.demo";
 import { ToolbarDemo } from "@/ui/components/toolbar/Toolbar.demo";
+import { TooltipDemo } from "@/ui/components/tooltip/Tooltip.demo";
 import { TypographyDemo } from "@/ui/components/typography/Typography.demo";
 import { TypographyLinkDemo } from "@/ui/components/typography/TypographyLink.demo";
 import { Page } from "@/views/components/Page/Page";
@@ -82,6 +83,8 @@ export const DesignSystemPage = ({ active, api }: { active?: boolean; api: IExte
             <TabButton name="Collection Tile" panelId="collection-tile" />
 
             <TabButton name="Toolbar" panelId="toolbar" />
+
+            <TabButton name="Tooltip" panelId="tooltip" />
           </TabBar>
 
           <div className="mt-6">
@@ -237,6 +240,10 @@ export const DesignSystemPage = ({ active, api }: { active?: boolean; api: IExte
 
             <TabPanel id="toolbar">
               <ToolbarDemo />
+            </TabPanel>
+
+            <TabPanel id="tooltip">
+              <TooltipDemo />
             </TabPanel>
           </div>
         </TabProvider>

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 
 import type { Severity } from "@/extensions/health_check/utils/shared/severityStyles";
 import { Button } from "@/ui/components/button/Button";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
@@ -60,39 +62,47 @@ export function EntryActions({
         </Typography>
       )}
 
-      <Button
-        appearance={appearance}
-        brand="neutral"
-        disabled={givenFeedback}
-        leftIconPath={mdiThumbUpOutline}
-        size="sm"
-        title={t("common:::helpful")}
-        onClick={handle(() => {
-          trackFeedbackHelpful({ issue_type: issueType, resolution_type: resolutionType });
-          onHelpful();
-        })}
-      />
+      <TooltipDelayGroup>
+        <Tooltip content={t("common:::helpful")} placement="bottom">
+          <Button
+            appearance={appearance}
+            aria-label={t("common:::helpful")}
+            brand="neutral"
+            disabled={givenFeedback}
+            leftIconPath={mdiThumbUpOutline}
+            size="sm"
+            onClick={handle(() => {
+              trackFeedbackHelpful({ issue_type: issueType, resolution_type: resolutionType });
+              onHelpful();
+            })}
+          />
+        </Tooltip>
 
-      <Button
-        appearance={appearance}
-        brand="neutral"
-        disabled={givenFeedback}
-        leftIconPath={mdiThumbDownOutline}
-        size="sm"
-        title={t("common:::not_helpful")}
-        onClick={handle(() => setShowFeedbackModal(true))}
-      />
+        <Tooltip content={t("common:::not_helpful")} placement="bottom">
+          <Button
+            appearance={appearance}
+            aria-label={t("common:::not_helpful")}
+            brand="neutral"
+            disabled={givenFeedback}
+            leftIconPath={mdiThumbDownOutline}
+            size="sm"
+            onClick={handle(() => setShowFeedbackModal(true))}
+          />
+        </Tooltip>
 
-      {variant === "detail" && <div className="w-px self-stretch bg-stroke-weak" />}
+        {variant === "detail" && <div className="w-px self-stretch bg-stroke-weak" />}
 
-      <Button
-        appearance={appearance}
-        brand="neutral"
-        leftIconPath={isHidden ? mdiEyeOutline : mdiEyeOffOutline}
-        size="sm"
-        title={isHidden ? t("common:::unhide") : t("common:::hide")}
-        onClick={handle(onToggleHide)}
-      />
+        <Tooltip content={isHidden ? t("common:::unhide") : t("common:::hide")} placement="bottom">
+          <Button
+            appearance={appearance}
+            aria-label={isHidden ? t("common:::unhide") : t("common:::hide")}
+            brand="neutral"
+            leftIconPath={isHidden ? mdiEyeOutline : mdiEyeOffOutline}
+            size="sm"
+            onClick={handle(onToggleHide)}
+          />
+        </Tooltip>
+      </TooltipDelayGroup>
 
       <FeedbackModal
         isOpen={showFeedbackModal}

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -20,6 +20,8 @@ import { TabBar } from "@/ui/components/tabs/TabBar";
 import { TabButton } from "@/ui/components/tabs/TabButton";
 import { TabPanel } from "@/ui/components/tabs/TabPanel";
 import { TabProvider } from "@/ui/components/tabs/Tabs.context";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
 import { Typography } from "@/ui/components/typography/Typography";
 import { useRelativeTime } from "@/util/useRelativeTime";
 import { Page } from "@/views/components/Page/Page";
@@ -295,28 +297,34 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
           <div className="flex shrink-0 items-center gap-x-2">
             <LastUpdated />
 
-            <Button
-              appearance="subdued"
-              brand="neutral"
-              isLoading={isRefreshing}
-              leftIconPath={mdiRefresh}
-              size="sm"
-              title={t("common:::refresh")}
-              onClick={() => onRefresh?.()}
-            />
+            <TooltipDelayGroup>
+              <Tooltip content={t("common:::refresh")} placement="bottom">
+                <Button
+                  appearance="subdued"
+                  aria-label={t("common:::refresh")}
+                  brand="neutral"
+                  isLoading={isRefreshing}
+                  leftIconPath={mdiRefresh}
+                  size="sm"
+                  onClick={() => onRefresh?.()}
+                />
+              </Tooltip>
 
-            <Button
-              appearance="subdued"
-              brand="neutral"
-              leftIconPath={mdiCog}
-              size="sm"
-              title={t("common:::settings")}
-              onClick={() => {
-                trackSettingsOpened();
-                dispatch(setOpenMainPage("application_settings", false));
-                dispatch(setSettingsPage("Vortex"));
-              }}
-            />
+              <Tooltip content={t("common:::settings")} placement="bottom">
+                <Button
+                  appearance="subdued"
+                  aria-label={t("common:::settings")}
+                  brand="neutral"
+                  leftIconPath={mdiCog}
+                  size="sm"
+                  onClick={() => {
+                    trackSettingsOpened();
+                    dispatch(setOpenMainPage("application_settings", false));
+                    dispatch(setSettingsPage("Vortex"));
+                  }}
+                />
+              </Tooltip>
+            </TooltipDelayGroup>
           </div>
         </PageHeader>
 

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -33,6 +33,7 @@ ui/
 │   ├── table/           - Data table (sort, filter, group, column toggle, optional pagination)
 │   ├── tabs/            - Tabbed interface with context-based state
 │   ├── toolbar/         - Horizontal toolbar; groups collapse overflow into a kebab dropdown
+│   ├── tooltip/         - Rich, collision-aware tooltip (Floating UI)
 │   └── typography/      - Typography system (heading, title, body)
 ├── lib/
 │   └── icon_paths/      - 34 custom Nexus Mods SVG icon paths
@@ -347,6 +348,81 @@ import { mdiTune } from "@mdi/js";
 ```
 
 > **Positioning note:** the panel is positioned manually (absolute) until `@headlessui/react` reaches v2, which brings dynamic anchor positioning and proper z-index handling.
+
+### Tooltip
+
+Rich, collision-aware tooltip built on `@floating-ui/react`. `content` is arbitrary React — headings, lists, icons — not just a string. Position is resolved against the window continuously: it flips to the opposite side when the preferred one would overflow, slides along an edge when a corner would, and clamps its own width and height to the room that is left. It renders into the `#overlays` host, so tables, dashlets and scroll panes cannot clip it.
+
+**For new tooltips only.** The existing `controls/TooltipControls` components (`Button`, `IconButton`, `Icon`, `NavItem`) are untouched — don't migrate call sites to this without a deliberate decision to do so.
+
+**Defaults:** `placement="top"`, `delay={{ open: 300, close: 150 }}`, `showArrow`, non-interactive.
+
+```tsx
+import { Tooltip } from "../../ui/components/tooltip/Tooltip";
+
+// Plain label
+<Tooltip content="Deploys every enabled mod to the game folder">
+  <Button>Deploy</Button>
+</Tooltip>
+
+// Rich content — customContent gets no padding, so give it its own
+<Tooltip customContent={<ModHealthSummary mod={mod} />} placement="right">
+  <Button appearance="subdued" brand="neutral">Details</Button>
+</Tooltip>
+
+// Interactive — the pointer can travel in and use a link inside
+<Tooltip interactive customContent={<div className="px-4 py-3">…<TypographyLink>Manage it</TypographyLink></div>}>
+  <Button>Why is this hidden?</Button>
+</Tooltip>
+
+// Conditional — e.g. only explain the name when it's actually truncated
+<Tooltip content={mod.name} disabled={!isTruncated}>
+  <span className="truncate">{mod.name}</span>
+</Tooltip>
+```
+
+**Props:** `children` (the trigger), plus exactly one of `content` / `customContent`; `placement` (any Floating UI placement, e.g. `"top"`, `"right-start"`), `delay` (number, or `{ open, close }`), `disabled` (render the trigger with no tooltip), `interactive`, `showArrow`, `className` (applied to the tooltip bubble).
+
+**`content` is styled, `customContent` is not** — the same split as Button's `children`/`customContent`, and an `XOr`, so passing both (or neither) is a type error.
+
+| prop            | type        | styling                                                                     |
+| --------------- | ----------- | --------------------------------------------------------------------------- |
+| `content`       | `string`    | gets `.nxm-tooltip-content` — the tooltip's padding, font size, line height |
+| `customContent` | `ReactNode` | rendered unstyled; **you supply the padding**                               |
+
+Which prop you pass decides the styling, so the call site states its intent rather than the component sniffing the type. An always-present `.nxm-tooltip-body` wrapper carries the scroll clamp in both cases (it can't sit on `.nxm-tooltip` without clipping the arrow).
+
+> Because it's an `XOr`, a dynamically-built props object won't spread in — branch on the two cases instead. Static call sites are unaffected.
+
+Width is CSS, not a prop. `.nxm-tooltip` caps at 320px; pass a utility class to widen a specific tooltip — Tailwind sits in a higher layer than `components`, so it wins:
+
+```tsx
+<Tooltip className="max-w-lg" customContent={<LongChangelog />}>
+    …
+</Tooltip>
+```
+
+That only moves the design cap. The positioner around the bubble is still clamped to the space left in the window, so a wider cap can't push the tooltip off an edge.
+
+> **The trigger must forward a ref to a DOM node.** `Button` does; `Icon`, `Pill` and bare text do not — wrap those in a `<span className="inline-flex">`.
+
+`placement` is a preference, not a guarantee: the collision middleware treats it as the starting point and moves the tooltip if it wouldn't fit. Tooltips also open on keyboard focus and dismiss on Escape, and are non-interactive by default so they can never swallow a click aimed at what's underneath.
+
+#### TooltipDelayGroup
+
+Shares one hover delay across every `Tooltip` inside it. The first tooltip waits out the open delay; while one is showing, moving to a sibling swaps straight over. Wrap rows of icon buttons in this — without it, scanning a toolbar costs a fresh 300ms pause per button.
+
+```tsx
+import { TooltipDelayGroup } from "../../ui/components/tooltip/TooltipDelayGroup";
+
+<TooltipDelayGroup>
+    {actions.map((action) => (
+        <Tooltip key={action.label} content={action.label}>
+            <Button aria-label={action.label} leftIconPath={action.iconPath} />
+        </Tooltip>
+    ))}
+</TooltipDelayGroup>;
+```
 
 ### Listbox
 

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -355,7 +355,7 @@ Rich, collision-aware tooltip built on `@floating-ui/react`. `content` is arbitr
 
 **For new tooltips only.** The existing `controls/TooltipControls` components (`Button`, `IconButton`, `Icon`, `NavItem`) are untouched — don't migrate call sites to this without a deliberate decision to do so.
 
-**Defaults:** `placement="top"`, `delay={{ open: 300, close: 150 }}`, `showArrow`, non-interactive.
+**Defaults:** `placement="top"`, `delay={{ open: 250, close: 50 }}`, `showArrow`, non-interactive.
 
 ```tsx
 import { Tooltip } from "../../ui/components/tooltip/Tooltip";
@@ -410,7 +410,7 @@ That only moves the design cap. The positioner around the bubble is still clampe
 
 #### TooltipDelayGroup
 
-Shares one hover delay across every `Tooltip` inside it. The first tooltip waits out the open delay; while one is showing, moving to a sibling swaps straight over. Wrap rows of icon buttons in this — without it, scanning a toolbar costs a fresh 300ms pause per button.
+Shares one hover delay across every `Tooltip` inside it. The first tooltip waits out the open delay; while one is showing, moving to a sibling swaps straight over. Wrap rows of icon buttons in this — without it, scanning a toolbar costs a fresh 250ms pause per button.
 
 ```tsx
 import { TooltipDelayGroup } from "../../ui/components/tooltip/TooltipDelayGroup";
@@ -423,6 +423,20 @@ import { TooltipDelayGroup } from "../../ui/components/tooltip/TooltipDelayGroup
     ))}
 </TooltipDelayGroup>;
 ```
+
+It renders no DOM of its own. Where the row needs a layout element anyway, pass `as` and that element's props instead of nesting a second node inside:
+
+```tsx
+<TooltipDelayGroup as="div" className="flex items-center gap-x-1">
+    {actions.map((action) => (
+        <Tooltip key={action.label} content={action.label}>
+            <Button aria-label={action.label} leftIconPath={action.iconPath} />
+        </Tooltip>
+    ))}
+</TooltipDelayGroup>
+```
+
+`as` takes any element type and forwards the rest of the props to it. Props are typed as `HTMLAttributes`, so `className`, `style` and the like are covered — element-specific ones (`href`, say) are not, and are dropped with no wrapper to receive them if `as` is omitted.
 
 ### Listbox
 

--- a/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
@@ -1,0 +1,358 @@
+/**
+ * Tooltip Demo Component
+ * Demonstrates rich content, collision handling near the window edges, and delay grouping
+ */
+
+import {
+  mdiAlertCircleOutline,
+  mdiCheckCircleOutline,
+  mdiFolderOpenOutline,
+  mdiHistory,
+  mdiOpenInNew,
+  mdiRefresh,
+  mdiTune,
+} from "@mdi/js";
+import React from "react";
+
+import { Button } from "@/ui/components/button/Button";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Pill } from "@/ui/components/pill/Pill";
+import { Typography } from "@/ui/components/typography/Typography";
+import { TypographyLink } from "@/ui/components/typography/TypographyLink";
+
+import { Tooltip } from "./Tooltip";
+import { TooltipDelayGroup } from "./TooltipDelayGroup";
+
+const toolbarActions = [
+  { iconPath: mdiFolderOpenOutline, label: "Open mods folder" },
+  { iconPath: mdiHistory, label: "Deployment history" },
+  { iconPath: mdiRefresh, label: "Rescan mods" },
+  { iconPath: mdiTune, label: "Display options" },
+];
+
+/** Rich body: a heading, supporting copy, and a status list. */
+const ModHealthContent = () => (
+  <div className="space-y-2 p-3">
+    <Typography as="h4" typographyType="title-xs">
+      Unofficial Skyrim Patch
+    </Typography>
+
+    <Typography appearance="subdued" typographyType="body-sm">
+      Version 4.2.9b — installed 3 days ago. Two requirements resolved automatically.
+    </Typography>
+
+    <div className="space-y-1">
+      <div className="flex items-center gap-x-2">
+        <Icon className="text-success-strong" path={mdiCheckCircleOutline} size="xs" />
+
+        <Typography typographyType="body-sm">SKSE64 detected</Typography>
+      </div>
+
+      <div className="flex items-center gap-x-2">
+        <Icon className="text-warning-strong" path={mdiAlertCircleOutline} size="xs" />
+
+        <Typography typographyType="body-sm">Load order not yet sorted</Typography>
+      </div>
+    </div>
+  </div>
+);
+
+export const TooltipDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        Tooltip
+      </Typography>
+
+      <Typography appearance="subdued">
+        A collision-aware tooltip built on Floating UI. Content is arbitrary React, so it holds
+        headings, lists and icons rather than just a string. Position is resolved against the window
+        continuously: it flips to the opposite side when the preferred one would overflow, slides
+        along an edge when a corner would, and clamps its width and height to the space left. It
+        renders into the overlay host, so it escapes the `overflow: hidden` of tables and scroll
+        panes.
+      </Typography>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Plain and rich content
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        Pass a string for a simple label, or any node for a rich one. Both use the same component.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Tooltip content="Deploys every enabled mod to the game folder">
+          <Button>Deploy</Button>
+        </Tooltip>
+
+        <Tooltip customContent={<ModHealthContent />}>
+          <Button appearance="subdued" brand="neutral">
+            Rich content
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Wraps at the 320px cap set on .nxm-tooltip instead of stretching into one long line that runs the full width of the window and becomes unreadable.">
+          <Button appearance="subdued" brand="neutral">
+            Long text
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          className="max-w-lg"
+          content="Widened with a max-w-lg utility class rather than a prop. The positioner still clamps to the window, so a wider cap cannot push it off an edge."
+        >
+          <Button appearance="subdued" brand="neutral">
+            Wider cap
+          </Button>
+        </Tooltip>
+
+        <Tooltip disabled content="Never shown">
+          <Button appearance="weak" brand="neutral">
+            Disabled tooltip
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Triggers that do not forward a ref
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        The trigger has to hand a DOM node to the tooltip. `Button` forwards its ref, but plenty of
+        components (`Icon`, `Pill`) and bare text do not — wrap those in a `span`.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Tooltip content="Two of this mod's requirements are not installed yet" placement="right">
+          <span className="inline-flex">
+            <Icon className="text-warning-strong" path={mdiAlertCircleOutline} size="sm" />
+          </span>
+        </Tooltip>
+
+        <Tooltip content="Hidden from the mod list until its game is managed">
+          <span className="inline-flex">
+            <Pill>Pill trigger</Pill>
+          </span>
+        </Tooltip>
+
+        <Tooltip content="Any element works — this one is a plain span of text">
+          <span className="underline decoration-dotted">Inline text</span>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Placement
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        The placement you set is a preference, not a guarantee — it is the starting point the
+        collision middleware works from.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Tooltip content="Placed above" placement="top">
+          <Button appearance="subdued" brand="neutral">
+            Top
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Placed to the right" placement="right">
+          <Button appearance="subdued" brand="neutral">
+            Right
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Placed below" placement="bottom">
+          <Button appearance="subdued" brand="neutral">
+            Bottom
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Placed to the left" placement="left">
+          <Button appearance="subdued" brand="neutral">
+            Left
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="No arrow, tighter against the trigger" showArrow={false}>
+          <Button appearance="subdued" brand="neutral">
+            No arrow
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Collision handling
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        Every trigger below asks for the one placement that cannot fit. The left and right ones ask
+        to be placed outward and get slid back inside instead. Scroll this page so the row sits near
+        the top or bottom of the window and the top/bottom ones flip to the opposite side.
+      </Typography>
+
+      <div className="flex items-center justify-between gap-4">
+        <Tooltip
+          content="Asked for left placement with no room to the left, so it slides back into view rather than off the edge."
+          placement="left"
+        >
+          <Button appearance="subdued" brand="neutral">
+            Left edge
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Asked for top placement. Scroll until this button is near the top of the window and it flips underneath."
+          placement="top"
+        >
+          <Button appearance="subdued" brand="neutral">
+            Flips vertically
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Asked for right placement with no room to the right, so it slides back into view rather than off the edge."
+          placement="right"
+        >
+          <Button appearance="subdued" brand="neutral">
+            Right edge
+          </Button>
+        </Tooltip>
+      </div>
+
+      <div className="h-40 overflow-auto rounded-sm border border-stroke-weak bg-surface-low p-4">
+        <Typography appearance="subdued" typographyType="body-xs">
+          This box scrolls and clips its children. The tooltip below still escapes it, because it
+          renders into the overlay host rather than in place.
+        </Typography>
+
+        <div className="my-24">
+          <Tooltip content="Rendered outside the scroll container, so nothing clips it.">
+            <Button appearance="subdued" brand="neutral">
+              Inside a clipping container
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Delay grouping
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        The first row shares one delay: the first tooltip waits, then moving along the row swaps
+        instantly. The second row has no group, so every button waits out its own 300ms.
+      </Typography>
+
+      <TooltipDelayGroup>
+        <div className="flex items-center gap-x-1">
+          {toolbarActions.map((action) => (
+            <Tooltip content={action.label} key={action.label}>
+              <Button
+                appearance="weak"
+                aria-label={action.label}
+                brand="neutral"
+                leftIconPath={action.iconPath}
+                size="sm"
+              />
+            </Tooltip>
+          ))}
+        </div>
+      </TooltipDelayGroup>
+
+      <div className="flex items-center gap-x-1">
+        {toolbarActions.map((action) => (
+          <Tooltip content={action.label} key={action.label}>
+            <Button
+              appearance="weak"
+              aria-label={action.label}
+              brand="neutral"
+              leftIconPath={action.iconPath}
+              size="sm"
+            />
+          </Tooltip>
+        ))}
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Interactive content
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        With `interactive`, the pointer can travel from the trigger into the tooltip along a safe
+        path and use what is inside. Without it the tooltip ignores the pointer entirely.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Tooltip
+          interactive
+          customContent={
+            <div className="space-y-2 px-4 py-3">
+              <Typography typographyType="body-xs">
+                This mod is hidden because its game is not managed yet.
+              </Typography>
+
+              <TypographyLink
+                brand="primary"
+                rightIconPath={mdiOpenInNew}
+                typographyType="body-xs"
+                onClick={() => undefined}
+              >
+                Manage this game
+              </TypographyLink>
+            </div>
+          }
+        >
+          <Button appearance="subdued" brand="neutral">
+            Interactive
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Try to click the link — the pointer never reaches it.">
+          <Button appearance="subdued" brand="neutral">
+            Non-interactive
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Design Notes
+      </Typography>
+
+      <Typography appearance="subdued" as="ul" className="list-inside list-disc space-y-2">
+        <li>
+          For new tooltips only — the existing `controls/TooltipControls` components are unchanged
+        </li>
+
+        <li>
+          Flips, slides and clamps against the window; `placement` is a preference, not a guarantee
+        </li>
+
+        <li>Portals into the overlay host, so tables and scroll panes cannot clip it</li>
+
+        <li>Shows on focus as well as hover, and dismisses on Escape</li>
+
+        <li>
+          Non-interactive by default, so it never intercepts a click; opt in with `interactive`
+        </li>
+
+        <li>Wrap groups of triggers in `TooltipDelayGroup` so scanning a row feels instant</li>
+      </Typography>
+    </div>
+  </div>
+);

--- a/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
@@ -255,20 +255,18 @@ export const TooltipDemo = () => (
         instantly. The second row has no group, so every button waits out its own 300ms.
       </Typography>
 
-      <TooltipDelayGroup>
-        <div className="flex items-center gap-x-1">
-          {toolbarActions.map((action) => (
-            <Tooltip content={action.label} key={action.label}>
-              <Button
-                appearance="weak"
-                aria-label={action.label}
-                brand="neutral"
-                leftIconPath={action.iconPath}
-                size="sm"
-              />
-            </Tooltip>
-          ))}
-        </div>
+      <TooltipDelayGroup as="div" className="flex items-center gap-x-1">
+        {toolbarActions.map((action) => (
+          <Tooltip content={action.label} key={action.label}>
+            <Button
+              appearance="weak"
+              aria-label={action.label}
+              brand="neutral"
+              leftIconPath={action.iconPath}
+              size="sm"
+            />
+          </Tooltip>
+        ))}
       </TooltipDelayGroup>
 
       <div className="flex items-center gap-x-1">

--- a/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
@@ -1,16 +1,12 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { Tooltip, type ITooltipPlacement } from "./Tooltip";
 import { TooltipDelayGroup } from "./TooltipDelayGroup";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 interface IRenderOptions {
   content?: string;

--- a/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
@@ -1,0 +1,170 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Tooltip, type ITooltipPlacement } from "./Tooltip";
+
+// --- Helpers ---
+
+afterEach(() => {
+  cleanup();
+});
+
+interface IRenderOptions {
+  content?: string;
+  customContent?: React.ReactNode;
+  disabled?: boolean;
+  interactive?: boolean;
+  placement?: ITooltipPlacement;
+}
+
+// delay={0} throughout: the 300ms default would mean fake timers in every test.
+// content and customContent are mutually exclusive in the type, so the two cases
+// are rendered as separate branches — a spread of a dynamic object won't satisfy
+// XOr. `in` rather than a nullish check, so an explicitly-undefined content still
+// reaches the component instead of picking up the default below.
+const renderComponent = (options: IRenderOptions = {}) => {
+  const { content, customContent, ...rest } = options;
+  const triggerNode = <button type="button">Deploy</button>;
+
+  render(
+    "customContent" in options ? (
+      <Tooltip customContent={customContent} delay={0} {...rest}>
+        {triggerNode}
+      </Tooltip>
+    ) : (
+      <Tooltip
+        // Cast covers the guard test, which deliberately passes undefined.
+        content={("content" in options ? content : "Deploys every enabled mod") as string}
+        delay={0}
+        {...rest}
+      >
+        {triggerNode}
+      </Tooltip>
+    ),
+  );
+
+  return { trigger: screen.getByRole("button", { name: "Deploy" }) };
+};
+
+// --- Tests ---
+
+describe("Tooltip", () => {
+  it("renders the trigger", () => {
+    const { trigger } = renderComponent();
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it("does not show the content until hovered", () => {
+    renderComponent();
+    expect(screen.queryByText("Deploys every enabled mod")).not.toBeInTheDocument();
+  });
+
+  it("shows the content on hover", async () => {
+    const { trigger } = renderComponent();
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Deploys every enabled mod");
+    });
+  });
+
+  it("hides the content again when the pointer leaves", async () => {
+    const { trigger } = renderComponent();
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.unhover(trigger);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("shows the content on keyboard focus", async () => {
+    const { trigger } = renderComponent();
+    trigger.focus();
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+  });
+
+  it("describes the trigger while open, for screen readers", async () => {
+    const { trigger } = renderComponent();
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute("aria-describedby", screen.getByRole("tooltip").id);
+    });
+  });
+
+  it("dismisses on Escape", async () => {
+    const { trigger } = renderComponent();
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("gives string content the tooltip's own padding and type styles", async () => {
+    const { trigger } = renderComponent();
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+    expect(document.querySelector(".nxm-tooltip-body")).toHaveClass("nxm-tooltip-content");
+  });
+
+  it("leaves customContent unstyled so it owns its own layout", async () => {
+    const { trigger } = renderComponent({
+      customContent: <div data-testid="custom">Custom layout</div>,
+    });
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(screen.getByTestId("custom")).toBeInTheDocument());
+
+    const body = document.querySelector(".nxm-tooltip-body");
+    // The wrapper stays (it carries the scroll clamp) but must not add padding.
+    expect(body).toBeInTheDocument();
+    expect(body).not.toHaveClass("nxm-tooltip-content");
+  });
+
+  it("renders rich customContent, not just strings", async () => {
+    const { trigger } = renderComponent({
+      customContent: (
+        <div>
+          <h4>Unofficial Skyrim Patch</h4>
+
+          <p>Version 4.2.9b</p>
+        </div>
+      ),
+    });
+
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Unofficial Skyrim Patch" })).toBeInTheDocument();
+    });
+  });
+
+  it("renders the trigger untouched when disabled", async () => {
+    const { trigger } = renderComponent({ disabled: true });
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+
+    await userEvent.hover(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("attaches nothing when the body resolves to nothing", async () => {
+    // The XOr type normally prevents this; the runtime guard covers a caller
+    // passing `content={someMaybeUndefinedValue}`.
+    const { trigger } = renderComponent({ content: undefined as unknown as string });
+    await userEvent.hover(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("escapes clipping ancestors by rendering outside them", async () => {
+    render(
+      <div data-testid="clipper" style={{ overflow: "hidden" }}>
+        <Tooltip content="Not clipped" delay={0}>
+          <button type="button">Clipped trigger</button>
+        </Tooltip>
+      </div>,
+    );
+
+    await userEvent.hover(screen.getByRole("button", { name: "Clipped trigger" }));
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+    expect(screen.getByTestId("clipper")).not.toContainElement(screen.getByRole("tooltip"));
+  });
+});

--- a/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { Tooltip, type ITooltipPlacement } from "./Tooltip";
+import { TooltipDelayGroup } from "./TooltipDelayGroup";
 
 // --- Helpers ---
 
@@ -166,5 +167,46 @@ describe("Tooltip", () => {
     await userEvent.hover(screen.getByRole("button", { name: "Clipped trigger" }));
     await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
     expect(screen.getByTestId("clipper")).not.toContainElement(screen.getByRole("tooltip"));
+  });
+});
+
+describe("TooltipDelayGroup", () => {
+  const renderGroup = (props: Parameters<typeof TooltipDelayGroup>[0] = {}) =>
+    render(
+      <div data-testid="host">
+        <TooltipDelayGroup {...props}>
+          <button type="button">Deploy</button>
+        </TooltipDelayGroup>
+      </div>,
+    );
+
+  it("renders no element of its own by default", () => {
+    renderGroup();
+    expect(screen.getByTestId("host").children).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Deploy" }).parentElement).toBe(
+      screen.getByTestId("host"),
+    );
+  });
+
+  it("renders the element given by `as`, with its props, around the group", () => {
+    renderGroup({ as: "div", className: "flex gap-x-2" });
+
+    const wrapper = screen.getByRole("button", { name: "Deploy" }).parentElement;
+    expect(wrapper?.tagName).toBe("DIV");
+    expect(wrapper).toHaveClass("flex", "gap-x-2");
+    expect(screen.getByTestId("host")).toContainElement(wrapper);
+  });
+
+  it("still shares its delay with the tooltips inside a wrapper", async () => {
+    render(
+      <TooltipDelayGroup as="div" delay={0}>
+        <Tooltip content="Deploys every enabled mod">
+          <button type="button">Deploy</button>
+        </Tooltip>
+      </TooltipDelayGroup>,
+    );
+
+    await userEvent.hover(screen.getByRole("button", { name: "Deploy" }));
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
   });
 });

--- a/src/renderer/src/ui/components/tooltip/Tooltip.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.tsx
@@ -1,0 +1,205 @@
+import {
+  arrow,
+  autoUpdate,
+  flip,
+  FloatingArrow,
+  FloatingPortal,
+  limitShift,
+  offset,
+  type Placement,
+  safePolygon,
+  shift,
+  size,
+  useDelayGroup,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+  useTransitionStyles,
+} from "@floating-ui/react";
+import React, {
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  useRef,
+  useState,
+} from "react";
+
+import { joinClasses } from "@/ui/utils/joinClasses";
+import type { XOr } from "@/ui/utils/types";
+
+/** Portalling here is what lets tooltips escape `overflow: hidden` ancestors. */
+const OVERLAY_HOST_ID = "overlays";
+
+const TRIGGER_GAP = 8;
+/** Gap kept between the tooltip and the window edges. */
+const COLLISION_PADDING = 8;
+/** Floor for the reported height, so a cramped corner scrolls rather than collapses. */
+const MIN_AVAILABLE_HEIGHT = 96;
+const ARROW_HEIGHT = 8;
+const ARROW_WIDTH = 12;
+/** Keeps the arrow off the tooltip's rounded corners. */
+const ARROW_PADDING = 8;
+/** FloatingArrow doubles and clips this, so 1 renders as a 1px edge. */
+const ARROW_STROKE_WIDTH = 1;
+const TRANSITION_MS = 150;
+
+export type ITooltipPlacement = Placement;
+
+export type ITooltipDelay = number | { close?: number; open?: number };
+
+interface ITooltipBaseProps {
+  /** The trigger. Must forward a ref to a DOM node — wrap bare text in a `span`. */
+  children: ReactElement;
+  className?: string;
+  /** Hover delays in ms. A single number sets both open and close. */
+  delay?: ITooltipDelay;
+  /** Renders the trigger untouched, with no tooltip attached. */
+  disabled?: boolean;
+  /** Lets the pointer travel into the tooltip and use its content. */
+  interactive?: boolean;
+  /** Preferred side. Flips and slides automatically when it would overflow. */
+  placement?: ITooltipPlacement;
+  showArrow?: boolean;
+}
+
+export type ITooltipProps = ITooltipBaseProps &
+  XOr<{ content: string }, { customContent: ReactNode }>;
+
+/**
+ * Collision-aware tooltip: flips, slides and clamps against the window, and
+ * renders into the overlay host so nothing clips it.
+ */
+export const Tooltip = ({
+  children,
+  className,
+  content,
+  customContent,
+  delay = { close: 150, open: 300 },
+  disabled = false,
+  interactive = false,
+  placement = "top",
+  showArrow = true,
+}: ITooltipProps) => {
+  const [open, setOpen] = useState(false);
+  const arrowRef = useRef<SVGSVGElement>(null);
+
+  const { context, floatingStyles, refs } = useFloating({
+    middleware: [
+      offset(showArrow ? TRIGGER_GAP + ARROW_HEIGHT : TRIGGER_GAP),
+      // Swap sides rather than overflow.
+      flip({ fallbackAxisSideDirection: "start", padding: COLLISION_PADDING }),
+      // Slide along the edge; limitShift stops it detaching from the trigger.
+      shift({ limiter: limitShift(), padding: COLLISION_PADDING }),
+      size({
+        // Annotated because pnpm keeps @floating-ui/dom out of reach here, so the
+        // re-exported middleware options widen to `any`.
+        apply({
+          availableHeight,
+          availableWidth,
+          elements,
+        }: {
+          availableHeight: number;
+          availableWidth: number;
+          elements: { floating: HTMLElement };
+        }) {
+          // Hard limits only. The design cap is `max-width` on .nxm-tooltip
+          // inside this element, so the narrower of the two wins on its own.
+          Object.assign(elements.floating.style, {
+            maxHeight: `${Math.max(availableHeight, MIN_AVAILABLE_HEIGHT)}px`,
+            maxWidth: `${availableWidth}px`,
+          });
+        },
+        padding: COLLISION_PADDING,
+      }),
+      showArrow ? arrow({ element: arrowRef, padding: ARROW_PADDING }) : null,
+    ],
+    open,
+    placement,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+  });
+
+  // Inside a TooltipDelayGroup the group owns the timing once something is open,
+  // so moving along a row swaps instantly. Standalone, currentId stays null.
+  const groupContext = useDelayGroup(context);
+  const hoverDelay = groupContext.currentId === null ? delay : groupContext.delay;
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: groupContext.isInstantPhase
+      ? { close: groupContext.currentId === context.floatingId ? TRANSITION_MS : 0, open: 0 }
+      : TRANSITION_MS,
+    initial: { opacity: 0, transform: "scale(0.96)" },
+  });
+
+  const interactions = useInteractions([
+    useHover(context, {
+      delay: hoverDelay,
+      handleClose: interactive ? safePolygon({ blockPointerEvents: false }) : null,
+      // Enter only, or nudging the pointer reopens what Escape just dismissed.
+      move: false,
+    }),
+    useFocus(context),
+    useDismiss(context),
+    useRole(context, { role: "tooltip" }),
+  ]);
+
+  // React 17 types leave `props` as unknown once isValidElement narrows, so widen
+  // once here. Merging refs keeps any the caller already set on the trigger.
+  const trigger = children as ReactElement<Record<string, unknown>> & { ref?: Ref<unknown> };
+  const triggerRef = useMergeRefs([refs.setReference, trigger.ref]);
+
+  // Guarded despite the types, so `content={maybeUndefined}` gives a bare trigger.
+  const body = customContent ?? content;
+
+  if (disabled || !isValidElement(children) || body === null || body === undefined) {
+    return children;
+  }
+
+  return (
+    <>
+      {cloneElement(trigger, interactions.getReferenceProps({ ref: triggerRef, ...trigger.props }))}
+
+      {isMounted && (
+        <FloatingPortal id={OVERLAY_HOST_ID}>
+          <div
+            className={joinClasses("nxm-tooltip-positioner", {
+              "nxm-tooltip-positioner-interactive": interactive,
+            })}
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...interactions.getFloatingProps()}
+          >
+            <div className={joinClasses(["nxm-tooltip", className])} style={transitionStyles}>
+              {/* The wrapper stays for both: it carries the scroll clamp, which
+                  can't sit on .nxm-tooltip without clipping the arrow. */}
+              <div
+                className={joinClasses("nxm-tooltip-body", {
+                  "nxm-tooltip-content": customContent === undefined,
+                })}
+              >
+                {body}
+              </div>
+
+              {showArrow && (
+                <FloatingArrow
+                  className="nxm-tooltip-arrow"
+                  context={context}
+                  height={ARROW_HEIGHT}
+                  ref={arrowRef}
+                  strokeWidth={ARROW_STROKE_WIDTH}
+                  width={ARROW_WIDTH}
+                />
+              )}
+            </div>
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};

--- a/src/renderer/src/ui/components/tooltip/Tooltip.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.tsx
@@ -151,8 +151,8 @@ export const Tooltip = ({
     useRole(context, { role: "tooltip" }),
   ]);
 
-  // React 17 types leave `props` as unknown once isValidElement narrows, so widen
-  // once here. Merging refs keeps any the caller already set on the trigger.
+  // `ref` isn't on ReactElement until React 19, and isValidElement leaves `props` as
+  // any, so pin both once here. Merging refs keeps any the caller set on the trigger.
   const trigger = children as ReactElement<Record<string, unknown>> & { ref?: Ref<unknown> };
   const triggerRef = useMergeRefs([refs.setReference, trigger.ref]);
 

--- a/src/renderer/src/ui/components/tooltip/Tooltip.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.tsx
@@ -47,7 +47,7 @@ const ARROW_WIDTH = 12;
 const ARROW_PADDING = 8;
 /** FloatingArrow doubles and clips this, so 1 renders as a 1px edge. */
 const ARROW_STROKE_WIDTH = 1;
-const TRANSITION_MS = 150;
+const TRANSITION_MS = 30;
 
 export type ITooltipPlacement = Placement;
 
@@ -80,7 +80,7 @@ export const Tooltip = ({
   className,
   content,
   customContent,
-  delay = { close: 150, open: 300 },
+  delay = { close: 50, open: 250 },
   disabled = false,
   interactive = false,
   placement = "top",
@@ -92,8 +92,10 @@ export const Tooltip = ({
   const { context, floatingStyles, refs } = useFloating({
     middleware: [
       offset(showArrow ? TRIGGER_GAP + ARROW_HEIGHT : TRIGGER_GAP),
-      // Swap sides rather than overflow.
-      flip({ fallbackAxisSideDirection: "start", padding: COLLISION_PADDING }),
+      // Swap sides rather than overflow. crossAxis is off so shift handles the
+      // other axis — otherwise a trigger near an edge flips to an unasked-for
+      // side when sliding a pixel would have done.
+      flip({ crossAxis: false, fallbackAxisSideDirection: "start", padding: COLLISION_PADDING }),
       // Slide along the edge; limitShift stops it detaching from the trigger.
       shift({ limiter: limitShift(), padding: COLLISION_PADDING }),
       size({
@@ -134,7 +136,7 @@ export const Tooltip = ({
     duration: groupContext.isInstantPhase
       ? { close: groupContext.currentId === context.floatingId ? TRANSITION_MS : 0, open: 0 }
       : TRANSITION_MS,
-    initial: { opacity: 0, transform: "scale(0.96)" },
+    initial: { opacity: 0, transform: "scale(0.90)" },
   });
 
   const interactions = useInteractions([

--- a/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
+++ b/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
@@ -1,0 +1,19 @@
+import { FloatingDelayGroup } from "@floating-ui/react";
+import React, { type ReactNode } from "react";
+
+import type { ITooltipDelay } from "@/ui/components/tooltip/Tooltip";
+
+interface ITooltipDelayGroupProps {
+  children?: ReactNode;
+  /** Shared hover delays in ms. A single number sets both open and close. */
+  delay?: ITooltipDelay;
+}
+
+/**
+ * Shares one hover delay across every `Tooltip` inside. The first waits; while
+ * one is showing, moving to a sibling swaps straight over. Wrap rows of icons.
+ */
+export const TooltipDelayGroup = ({
+  children,
+  delay = { close: 150, open: 300 },
+}: ITooltipDelayGroupProps) => <FloatingDelayGroup delay={delay}>{children}</FloatingDelayGroup>;

--- a/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
+++ b/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
@@ -1,9 +1,10 @@
 import { FloatingDelayGroup } from "@floating-ui/react";
-import React, { type ReactNode } from "react";
+import React, { type ElementType, type HTMLAttributes, type ReactNode } from "react";
 
 import type { ITooltipDelay } from "@/ui/components/tooltip/Tooltip";
 
-interface ITooltipDelayGroupProps {
+interface ITooltipDelayGroupProps extends HTMLAttributes<HTMLElement> {
+  as?: ElementType;
   children?: ReactNode;
   /** Shared hover delays in ms. A single number sets both open and close. */
   delay?: ITooltipDelay;
@@ -12,8 +13,17 @@ interface ITooltipDelayGroupProps {
 /**
  * Shares one hover delay across every `Tooltip` inside. The first waits; while
  * one is showing, moving to a sibling swaps straight over. Wrap rows of icons.
+ *
+ * Renders no DOM of its own. Where the row needs a layout element anyway, pass
+ * `as` and its props so the group and that element are one node, not two.
  */
 export const TooltipDelayGroup = ({
+  as: Wrapper,
   children,
-  delay = { close: 150, open: 300 },
-}: ITooltipDelayGroupProps) => <FloatingDelayGroup delay={delay}>{children}</FloatingDelayGroup>;
+  delay = { close: 50, open: 250 },
+  ...props
+}: ITooltipDelayGroupProps) => (
+  <FloatingDelayGroup delay={delay}>
+    {Wrapper ? <Wrapper {...props}>{children}</Wrapper> : children}
+  </FloatingDelayGroup>
+);

--- a/src/renderer/src/views/components/Header/IconButton.tsx
+++ b/src/renderer/src/views/components/Header/IconButton.tsx
@@ -1,14 +1,17 @@
 import React, { forwardRef, type ButtonHTMLAttributes } from "react";
 
-import { Icon } from "../../../ui/components/icon/Icon";
-import { Typography } from "../../../ui/components/typography/Typography";
-import { joinClasses } from "../../../ui/utils/joinClasses";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Tooltip, type ITooltipPlacement } from "@/ui/components/tooltip/Tooltip";
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
 
 interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
   appearance?: "primary" | "secondary";
   className?: string;
   iconPath: string;
   itemCount?: number;
+  placement?: ITooltipPlacement;
+  title: string;
 }
 
 const appearanceMap: Record<IconButtonProps["appearance"], string> = {
@@ -17,28 +20,42 @@ const appearanceMap: Record<IconButtonProps["appearance"], string> = {
 };
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ appearance = "primary", className, iconPath, itemCount, ...props }, ref) => (
-    <button
-      className={joinClasses([
-        "group/icon-button relative flex size-7 items-center justify-center rounded-sm transition-colors hover:bg-surface-translucent-mid aria-expanded:bg-surface-translucent-mid",
-        appearanceMap[appearance],
-        className,
-      ])}
-      ref={ref}
-      {...props}
-    >
-      <Icon className="size-5" path={iconPath} size="none" />
+  (
+    {
+      appearance = "primary",
+      className,
+      iconPath,
+      itemCount,
+      placement = "bottom",
+      title,
+      ...props
+    },
+    ref,
+  ) => (
+    <Tooltip content={title} placement={placement}>
+      <button
+        aria-label={title}
+        className={joinClasses([
+          "group/icon-button relative flex size-7 items-center justify-center rounded-sm transition-colors hover:bg-surface-translucent-mid aria-expanded:bg-surface-translucent-mid",
+          appearanceMap[appearance],
+          className,
+        ])}
+        ref={ref}
+        {...props}
+      >
+        <Icon className="size-5" path={iconPath} size="none" />
 
-      {!!itemCount && (
-        <Typography
-          appearance="inverted"
-          as="span"
-          className="absolute -top-1 -right-1 flex h-4.5 min-w-4.5 items-center justify-center rounded-full border-2 border-neutral-inverted bg-primary-moderate px-1 leading-none font-semibold transition-colors group-hover/icon-button:bg-primary-strong group-aria-expanded/icon-button:bg-primary-strong"
-          typographyType="body-xs"
-        >
-          {itemCount > 9 ? "9+" : itemCount}
-        </Typography>
-      )}
-    </button>
+        {!!itemCount && (
+          <Typography
+            appearance="inverted"
+            as="span"
+            className="absolute -top-1 -right-1 flex h-4.5 min-w-4.5 items-center justify-center rounded-full border-2 border-neutral-inverted bg-primary-moderate px-1 leading-none font-semibold transition-colors group-hover/icon-button:bg-primary-strong group-aria-expanded/icon-button:bg-primary-strong"
+            typographyType="body-xs"
+          >
+            {itemCount > 9 ? "9+" : itemCount}
+          </Typography>
+        )}
+      </button>
+    </Tooltip>
   ),
 );

--- a/src/renderer/src/views/components/Header/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/ProfileSection.tsx
@@ -16,6 +16,7 @@ import { DropdownDivider } from "../../../ui/components/dropdown/DropdownDivider
 import { DropdownItem } from "../../../ui/components/dropdown/DropdownItem";
 import { DropdownItems } from "../../../ui/components/dropdown/DropdownItems";
 import { Icon } from "../../../ui/components/icon/Icon";
+import { Tooltip } from "../../../ui/components/tooltip/Tooltip";
 import { UserCanceled } from "../../../util/CustomErrors";
 import opn from "../../../util/opn";
 import {
@@ -25,22 +26,26 @@ import {
 
 interface ActionButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   imageSrc?: string;
+  title: string;
   username?: string;
 }
 
 const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
-  ({ imageSrc, username, ...props }, ref) => (
-    <button
-      className="hover-overlay relative flex size-7 items-center justify-center overflow-hidden rounded-full"
-      ref={ref}
-      {...props}
-    >
-      {imageSrc ? (
-        <img alt={username} className="size-6 rounded-full" src={imageSrc} />
-      ) : (
-        <Icon className="size-6 text-neutral-moderate" path={mdiAccountCircle} size="none" />
-      )}
-    </button>
+  ({ imageSrc, title, username, ...props }, ref) => (
+    <Tooltip content={title} placement="bottom">
+      <button
+        aria-label={title}
+        className="hover-overlay relative flex size-7 items-center justify-center overflow-hidden rounded-full"
+        ref={ref}
+        {...props}
+      >
+        {imageSrc ? (
+          <img alt={username} className="size-6 rounded-full" src={imageSrc} />
+        ) : (
+          <Icon className="size-6 text-neutral-moderate" path={mdiAccountCircle} size="none" />
+        )}
+      </button>
+    </Tooltip>
   ),
 );
 

--- a/src/renderer/src/views/components/Header/WindowControls.tsx
+++ b/src/renderer/src/views/components/Header/WindowControls.tsx
@@ -3,34 +3,41 @@ import React, { type ButtonHTMLAttributes, type FC } from "react";
 
 import { close, minimize, toggleMaximize, useIsMaximized } from "../../../hooks";
 import { Icon } from "../../../ui/components/icon/Icon";
+import { Tooltip } from "../../../ui/components/tooltip/Tooltip";
+import { TooltipDelayGroup } from "../../../ui/components/tooltip/TooltipDelayGroup";
 import { joinClasses } from "../../../ui/utils/joinClasses";
 
 interface WindowControlButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
   iconPath: string;
+  title: string;
 }
 
 const WindowControlButton: FC<React.PropsWithChildren<WindowControlButtonProps>> = ({
   className,
   iconPath,
+  title,
   ...props
 }) => (
-  <button
-    className={joinClasses([
-      "flex size-11 items-center justify-center text-neutral-subdued -outline-offset-2 transition-colors hover:text-neutral-strong",
-      className,
-    ])}
-    {...props}
-  >
-    <Icon path={iconPath} size="sm" />
-  </button>
+  <Tooltip content={title} placement="bottom">
+    <button
+      aria-label={title}
+      className={joinClasses([
+        "flex size-11 items-center justify-center text-neutral-subdued -outline-offset-2 transition-colors hover:text-neutral-strong",
+        className,
+      ])}
+      {...props}
+    >
+      <Icon path={iconPath} size="sm" />
+    </button>
+  </Tooltip>
 );
 
 export const WindowControls: FC<React.PropsWithChildren<unknown>> = () => {
   const isMaximized = useIsMaximized();
 
   return (
-    <div className="flex">
+    <TooltipDelayGroup as="div" className="flex">
       <WindowControlButton
         className="hover:bg-surface-mid"
         iconPath={mdiWindowMinimize}
@@ -51,6 +58,6 @@ export const WindowControls: FC<React.PropsWithChildren<unknown>> = () => {
         title="Close"
         onClick={close}
       />
-    </div>
+    </TooltipDelayGroup>
   );
 };

--- a/src/renderer/src/views/components/Header/index.tsx
+++ b/src/renderer/src/views/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import { useWindowContext } from "../../../contexts";
+import { TooltipDelayGroup } from "../../../ui/components/tooltip/TooltipDelayGroup";
 import { Typography } from "../../../ui/components/typography/Typography";
 import { nxmPanelClose, nxmPanelOpen } from "../../../ui/icon-paths";
 import {
@@ -59,6 +60,7 @@ export const Header: FC<React.PropsWithChildren<unknown>> = () => {
         <IconButton
           appearance="secondary"
           iconPath={menuIsCollapsed ? nxmPanelOpen : nxmPanelClose}
+          placement="right"
           style={{ WebkitAppRegion: "no-drag" }}
           title={menuIsCollapsed ? "Open menu" : "Collapse menu"}
           onClick={handleToggleMenu}
@@ -81,13 +83,13 @@ export const Header: FC<React.PropsWithChildren<unknown>> = () => {
         <VersionIndicator />
         <PremiumIndicator />
 
-        <div className="flex gap-x-2">
+        <TooltipDelayGroup as="div" className="flex gap-x-2">
           <Notifications />
 
           <HelpSection />
 
           <ProfileSection />
-        </div>
+        </TooltipDelayGroup>
 
         <div className="h-6 w-px bg-stroke-weak" />
 

--- a/src/renderer/src/views/components/Menu/DownloadsMenuContent.tsx
+++ b/src/renderer/src/views/components/Menu/DownloadsMenuContent.tsx
@@ -3,8 +3,10 @@ import React, { type FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
+import { useWindowContext } from "../../../contexts";
 import type { IGameStored } from "../../../extensions/gamemode_management/types/IGameStored";
 import type { IState } from "../../../types/IState";
+import { Tooltip } from "../../../ui/components/tooltip/Tooltip";
 import { Typography } from "../../../ui/components/typography/Typography";
 import { joinClasses } from "../../../ui/utils/joinClasses";
 import { discovered as discoveredGamesSelector } from "../../../util/selectors";
@@ -45,47 +47,53 @@ const GameMenuEntry: FC<
     onClick: () => void;
   }>
 > = ({ game, isActive, onClick }) => {
+  const { menuIsCollapsed } = useWindowContext();
   const discoveredGames = useSelector(discoveredGamesSelector);
   const { cacheKey, sources, preferred } = getGameImageUrls(game, discoveredGames[game.id]);
   const { src, exhausted, onError, onLoad } = useGameImage(cacheKey, sources, preferred);
 
   return (
-    <button
-      className={joinClasses([
-        "flex h-10 items-center gap-x-3 rounded-lg px-3 transition-colors hover:bg-surface-mid hover:text-neutral-moderate",
-        isActive ? "bg-surface-low text-neutral-moderate" : "text-neutral-subdued",
-      ])}
-      title={formatGameDisplayName(game.name)}
-      onClick={onClick}
+    <Tooltip
+      content={formatGameDisplayName(game.name)}
+      disabled={!menuIsCollapsed}
+      placement="right"
     >
-      {exhausted ? (
-        <span
-          className="flex size-4 shrink-0 items-center justify-center rounded-sm text-xs font-bold text-white"
-          style={{
-            backgroundColor: `hsl(${stringToHue(game.name)}, 40%, 35%)`,
-          }}
-        >
-          {game.name.charAt(0).toUpperCase()}
-        </span>
-      ) : (
-        <img
-          alt=""
-          className="size-4 shrink-0 rounded-sm object-cover"
-          src={src}
-          onError={onError}
-          onLoad={onLoad}
-        />
-      )}
-
-      <Typography
-        as="span"
-        brand="none"
-        className="truncate font-semibold"
-        typographyType="body-sm"
+      <button
+        className={joinClasses([
+          "flex h-10 items-center gap-x-3 rounded-lg px-3 transition-colors hover:bg-surface-mid hover:text-neutral-moderate",
+          isActive ? "bg-surface-low text-neutral-moderate" : "text-neutral-subdued",
+        ])}
+        onClick={onClick}
       >
-        {game.name}
-      </Typography>
-    </button>
+        {exhausted ? (
+          <span
+            className="flex size-4 shrink-0 items-center justify-center rounded-sm text-xs font-bold text-white"
+            style={{
+              backgroundColor: `hsl(${stringToHue(game.name)}, 40%, 35%)`,
+            }}
+          >
+            {game.name.charAt(0).toUpperCase()}
+          </span>
+        ) : (
+          <img
+            alt=""
+            className="size-4 shrink-0 rounded-sm object-cover"
+            src={src}
+            onError={onError}
+            onLoad={onLoad}
+          />
+        )}
+
+        <Typography
+          as="span"
+          brand="none"
+          className="truncate font-semibold"
+          typographyType="body-sm"
+        >
+          {game.name}
+        </Typography>
+      </button>
+    </Tooltip>
   );
 };
 

--- a/src/renderer/src/views/components/Menu/MenuButton.tsx
+++ b/src/renderer/src/views/components/Menu/MenuButton.tsx
@@ -2,6 +2,7 @@ import React, { type ButtonHTMLAttributes, type ComponentType, type FC } from "r
 
 import { useWindowContext } from "@/contexts";
 import { Icon } from "@/ui/components/icon/Icon";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
@@ -22,27 +23,28 @@ export const MenuButton: FC<React.PropsWithChildren<MenuButtonProps>> = ({
   const { menuIsCollapsed } = useWindowContext();
 
   return (
-    <button
-      className={joinClasses([
-        "relative flex h-10 items-center gap-x-3 rounded-lg px-3 text-left transition-colors",
-        "hover:bg-surface-mid hover:text-neutral-moderate focus-visible:z-1",
-        isActive ? "bg-surface-low text-neutral-moderate" : "text-neutral-subdued",
-      ])}
-      {...(menuIsCollapsed ? { title: children } : {})}
-      {...props}
-    >
-      <Icon className="shrink-0" path={iconPath} size="sm" />
-
-      <Typography
-        as="span"
-        brand="none"
-        className="grow truncate font-semibold"
-        typographyType="body-sm"
+    <Tooltip content={children} disabled={!menuIsCollapsed} placement="right">
+      <button
+        className={joinClasses([
+          "relative flex h-10 items-center gap-x-3 rounded-lg px-3 text-left transition-colors",
+          "hover:bg-surface-mid hover:text-neutral-moderate focus-visible:z-1",
+          isActive ? "bg-surface-low text-neutral-moderate" : "text-neutral-subdued",
+        ])}
+        {...props}
       >
-        {children}
-      </Typography>
+        <Icon className="shrink-0" path={iconPath} size="sm" />
 
-      {Badge && <Badge />}
-    </button>
+        <Typography
+          as="span"
+          brand="none"
+          className="grow truncate font-semibold"
+          typographyType="body-sm"
+        >
+          {children}
+        </Typography>
+
+        {Badge && <Badge />}
+      </button>
+    </Tooltip>
   );
 };

--- a/src/renderer/src/views/components/Menu/ToolButton.tsx
+++ b/src/renderer/src/views/components/Menu/ToolButton.tsx
@@ -3,7 +3,9 @@ import { pathToFileURL } from "url";
 import { mdiCircleOutline, mdiLoading, mdiPlay } from "@mdi/js";
 import React, { type ButtonHTMLAttributes, type FC, useMemo } from "react";
 
+import { useWindowContext } from "../../../contexts";
 import { Icon } from "../../../ui/components/icon/Icon";
+import { Tooltip } from "../../../ui/components/tooltip/Tooltip";
 import { Typography } from "../../../ui/components/typography/Typography";
 import { joinClasses } from "../../../ui/utils/joinClasses";
 import type { IStarterInfo } from "../../../util/StarterInfo";
@@ -23,6 +25,8 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
   isRunning = false,
   ...props
 }) => {
+  const { menuIsCollapsed } = useWindowContext();
+
   const imageSrc = useMemo(() => {
     try {
       const iconPath = StarterInfo.getIconPath(starter);
@@ -36,66 +40,71 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
   }, [starter]);
 
   return (
-    <button
-      className={joinClasses("group/tool-button relative size-8 shrink-0 rounded-sm", {
-        "pointer-events-none cursor-not-allowed": isRunning,
-      })}
-      title={isValid ? starter.name : `${starter.name} (Not configured)`}
-      {...props}
+    <Tooltip
+      content={isValid ? starter.name : `${starter.name} (Not configured)`}
+      placement={menuIsCollapsed ? "right" : "top"}
     >
-      {imageSrc ? (
-        <img
-          alt={starter.name}
-          className={joinClasses("absolute inset-0 size-full rounded-sm object-cover", {
-            "opacity-40 grayscale": !isValid,
-          })}
-          src={imageSrc}
-        />
-      ) : (
-        <Typography
-          appearance="moderate"
-          as="span"
-          className={joinClasses(
-            "absolute inset-0 flex items-center justify-center bg-surface-high leading-none",
-            { "opacity-40": !isValid },
-          )}
-          typographyType="body-lg"
-        >
-          {starter.name?.charAt(0)?.toUpperCase() || "?"}
-        </Typography>
-      )}
-
-      <span
-        className={joinClasses(
-          [
-            "absolute inset-0 z-1 flex items-center justify-center rounded-sm border border-stroke-moderate transition-colors",
-            "group-hover/tool-button:border-stroke-strong group-hover/tool-button:bg-translucent-600",
-            "group-focus-visible/tool-button:border-stroke-strong group-focus-visible/tool-button:bg-translucent-600",
-          ],
-          { "border-stroke-strong bg-translucent-600": isRunning },
-        )}
+      <button
+        aria-label={starter.name}
+        className={joinClasses("group/tool-button relative size-8 shrink-0 rounded-sm", {
+          "pointer-events-none cursor-not-allowed": isRunning,
+        })}
+        {...props}
       >
+        {imageSrc ? (
+          <img
+            alt={starter.name}
+            className={joinClasses("absolute inset-0 size-full rounded-sm object-cover", {
+              "opacity-40 grayscale": !isValid,
+            })}
+            src={imageSrc}
+          />
+        ) : (
+          <Typography
+            appearance="moderate"
+            as="span"
+            className={joinClasses(
+              "absolute inset-0 flex items-center justify-center bg-surface-high leading-none",
+              { "opacity-40": !isValid },
+            )}
+            typographyType="body-lg"
+          >
+            {starter.name?.charAt(0)?.toUpperCase() || "?"}
+          </Typography>
+        )}
+
         <span
           className={joinClasses(
             [
-              "relative text-neutral-inverted opacity-0 transition-opacity",
-              "group-hover/tool-button:opacity-100",
-              "group-focus-visible/tool-button:opacity-100",
+              "absolute inset-0 z-1 flex items-center justify-center rounded-sm border border-stroke-moderate transition-colors",
+              "group-hover/tool-button:border-stroke-strong group-hover/tool-button:bg-translucent-600",
+              "group-focus-visible/tool-button:border-stroke-strong group-focus-visible/tool-button:bg-translucent-600",
             ],
-            { "animate-spin opacity-100": isRunning },
+            { "border-stroke-strong bg-translucent-600": isRunning },
           )}
         >
-          {isRunning ? (
-            <>
-              <Icon className="opacity-40" path={mdiCircleOutline} />
+          <span
+            className={joinClasses(
+              [
+                "relative text-neutral-inverted opacity-0 transition-opacity",
+                "group-hover/tool-button:opacity-100",
+                "group-focus-visible/tool-button:opacity-100",
+              ],
+              { "animate-spin opacity-100": isRunning },
+            )}
+          >
+            {isRunning ? (
+              <>
+                <Icon className="opacity-40" path={mdiCircleOutline} />
 
-              <Icon className="absolute inset-0" path={mdiLoading} />
-            </>
-          ) : (
-            <Icon path={mdiPlay} />
-          )}
+                <Icon className="absolute inset-0" path={mdiLoading} />
+              </>
+            ) : (
+              <Icon path={mdiPlay} />
+            )}
+          </span>
         </span>
-      </span>
-    </button>
+      </button>
+    </Tooltip>
   );
 };

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -4,11 +4,13 @@ import { mdiPlay } from "@mdi/js";
 import React, { type FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useWindowContext } from "../../../contexts";
-import { Button } from "../../../ui/components/button/Button";
-import { joinClasses } from "../../../ui/utils/joinClasses";
-import type { IStarterInfo } from "../../../util/StarterInfo";
-import StarterInfo from "../../../util/StarterInfo";
+import { useWindowContext } from "@/contexts";
+import { Button } from "@/ui/components/button/Button";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { joinClasses } from "@/ui/utils/joinClasses";
+import type { IStarterInfo } from "@/util/StarterInfo";
+import StarterInfo from "@/util/StarterInfo";
+
 import { useSpineContext } from "../Spine/SpineContext";
 import { ToolButton } from "./ToolButton";
 import { useToolsContext } from "./ToolsContext";
@@ -43,22 +45,24 @@ const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
     return undefined;
   }, [primaryStarter, isCollapsed]);
 
-  const label = !isCollapsed ? (isPrimaryRunning ? t("Running...") : t("Play")) : undefined;
+  const label = isPrimaryRunning ? t("Running...") : t("Play");
 
   return (
     <div className="relative w-full">
-      <Button
-        brand="neutral"
-        appearance="strong"
-        className="w-full transition-all"
-        disabled={disabled}
-        leftIconPath={mdiPlay}
-        onClick={onClick}
-      >
-        {label}
-      </Button>
+      <Tooltip content={label} disabled={!isCollapsed} placement="right">
+        <Button
+          aria-label={isCollapsed ? label : undefined}
+          brand="neutral"
+          className="w-full transition-all"
+          disabled={disabled}
+          leftIconPath={mdiPlay}
+          onClick={onClick}
+        >
+          {!isCollapsed && label}
+        </Button>
+      </Tooltip>
 
-      {launcherIconSrc && (
+      {!!launcherIconSrc && (
         <div className="pointer-events-none absolute inset-0 z-2 flex items-center p-1">
           <img alt="" className="size-7 rounded-xs object-cover" src={launcherIconSrc} />
         </div>
@@ -72,7 +76,6 @@ interface ToolsSectionProps {
 }
 
 export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ isAnimating }) => {
-  const { t } = useTranslation();
   const { menuIsCollapsed } = useWindowContext();
   const { selection } = useSpineContext();
   const {

--- a/src/renderer/src/views/components/Menu/index.tsx
+++ b/src/renderer/src/views/components/Menu/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 
 import { setOpenMainPage } from "../../../actions";
 import { usePagesContext, useWindowContext } from "../../../contexts";
+import { TooltipDelayGroup } from "../../../ui/components/tooltip/TooltipDelayGroup";
 import { joinClasses } from "../../../ui/utils/joinClasses";
 import { getIconPath } from "../iconMap";
 import { useSpineContext } from "../Spine/SpineContext";
@@ -53,7 +54,8 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
   }, [menuIsCollapsed]);
 
   return (
-    <div
+    <TooltipDelayGroup
+      as="div"
       className={joinClasses([
         "relative -mt-1 flex shrink-0 flex-col pr-0.5 transition-[width]",
         menuIsCollapsed ? "w-16" : "w-56",
@@ -100,7 +102,7 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
       <ToolsSection isAnimating={isAnimating} />
 
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-1 h-6 bg-linear-to-t from-surface-base to-transparent" />
-    </div>
+    </TooltipDelayGroup>
   );
 };
 

--- a/src/renderer/src/views/components/Spine/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/DownloadButton.tsx
@@ -2,11 +2,13 @@ import { mdiDownload } from "@mdi/js";
 import React, { type FC } from "react";
 import { useSelector } from "react-redux";
 
-import type { DownloadState } from "../../../extensions/download_management/types/IDownload";
-import type { IState } from "../../../types/IState";
-import { Icon } from "../../../ui/components/icon/Icon";
-import { Typography } from "../../../ui/components/typography/Typography";
-import { joinClasses } from "../../../ui/utils/joinClasses";
+import type { DownloadState } from "@/extensions/download_management/types/IDownload";
+import type { IState } from "@/types/IState";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
 import { useSpineContext } from "./SpineContext";
 
 const ACTIVE_DOWNLOAD_STATES: DownloadState[] = ["init", "started", "finalizing"];
@@ -128,44 +130,46 @@ export const DownloadButton: FC<React.PropsWithChildren<unknown>> = () => {
   const isTime = false;
 
   return (
-    <button
-      className={joinClasses(
-        [
-          "group/download relative flex size-12 shrink-0 flex-col items-center justify-center gap-y-0.5 rounded-full transition-colors",
-          "hover:bg-surface-translucent-high",
-          isPaused || isDownloading
-            ? ""
-            : isActive
-              ? "border-2 border-neutral-strong"
-              : "border-2 border-stroke-weak hover:border-neutral-strong",
-        ],
-        { "bg-surface-translucent-low": isActive },
-      )}
-      title="Downloads"
-      onClick={() => selectDownloads()}
-    >
-      {isPaused || isDownloading ? (
-        <>
-          {!isPaused && (
-            <Typography
-              as="span"
-              brand="none"
-              className="leading-none font-semibold"
-              type="body-sm"
-            >
-              {isTime ? Math.ceil(estimatedMins) : speedMBps.toFixed(1)}
-            </Typography>
-          )}
+    <Tooltip content="Downloads" placement="right">
+      <button
+        aria-label="Downloads"
+        className={joinClasses(
+          [
+            "group/download relative flex size-12 shrink-0 flex-col items-center justify-center gap-y-0.5 rounded-full transition-colors",
+            "hover:bg-surface-translucent-high",
+            isPaused || isDownloading
+              ? ""
+              : isActive
+                ? "border-2 border-neutral-strong"
+                : "border-2 border-stroke-weak hover:border-neutral-strong",
+          ],
+          { "bg-surface-translucent-low": isActive },
+        )}
+        onClick={() => selectDownloads()}
+      >
+        {isPaused || isDownloading ? (
+          <>
+            {!isPaused && (
+              <Typography
+                as="span"
+                brand="none"
+                className="leading-none font-semibold"
+                type="body-sm"
+              >
+                {isTime ? Math.ceil(estimatedMins) : speedMBps.toFixed(1)}
+              </Typography>
+            )}
 
-          <span className="text-[0.375rem] leading-none tracking-[1px] uppercase">
-            {isPaused ? "paused" : isTime ? "mins" : "mb/s"}
-          </span>
+            <span className="text-[0.375rem] leading-none tracking-[1px] uppercase">
+              {isPaused ? "paused" : isTime ? "mins" : "mb/s"}
+            </span>
 
-          <ProgressRing isActive={isActive} isPaused={isPaused} progress={progress} />
-        </>
-      ) : (
-        <Icon className="transition-colors" path={mdiDownload} size="lg" />
-      )}
-    </button>
+            <ProgressRing isActive={isActive} isPaused={isPaused} progress={progress} />
+          </>
+        ) : (
+          <Icon className="transition-colors" path={mdiDownload} size="lg" />
+        )}
+      </button>
+    </Tooltip>
   );
 };

--- a/src/renderer/src/views/components/Spine/GameButton.tsx
+++ b/src/renderer/src/views/components/Spine/GameButton.tsx
@@ -1,8 +1,10 @@
 import { mdiGog, mdiMicrosoftXbox, mdiHelp, mdiSteam, mdiUbisoft } from "@mdi/js";
 import React, { type ButtonHTMLAttributes, type FC } from "react";
 
-import { nxmElectronicArts, nxmEpicGames } from "../../../ui/icon-paths";
-import { joinClasses } from "../../../ui/utils/joinClasses";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { nxmElectronicArts, nxmEpicGames } from "@/ui/icon-paths";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
 import { useGameImage } from "./utils";
 
 // Fallback for stores without specific icons
@@ -37,6 +39,7 @@ interface GameButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   preferred?: string;
   sources?: string[];
   store?: string;
+  title: string;
 }
 
 export const GameButton: FC<React.PropsWithChildren<GameButtonProps>> = ({
@@ -54,47 +57,49 @@ export const GameButton: FC<React.PropsWithChildren<GameButtonProps>> = ({
   const { src, exhausted, onError, onLoad } = useGameImage(cacheKey, sources, preferred);
 
   return (
-    <button
-      className={joinClasses("group relative size-12 shrink-0 overflow-hidden rounded-lg", {
-        "outline-2 outline-offset-2 outline-neutral-strong focus-visible:outline-info-subdued":
-          isActive,
-      })}
-      title={title}
-      {...props}
-    >
-      {exhausted ? (
-        <span
-          className="absolute inset-0 flex items-center justify-center text-xl font-bold text-white"
-          style={{
-            backgroundColor: `hsl(${stringToHue(title ?? "")}, 40%, 35%)`,
-          }}
-        >
-          {title?.charAt(0)?.toUpperCase() ?? "?"}
-        </span>
-      ) : (
-        <img
-          alt=""
-          className="absolute inset-0 size-full object-cover"
-          src={src}
-          onError={onError}
-          onLoad={onLoad}
-        />
-      )}
-
-      <span
-        className={joinClasses("absolute inset-0 z-1 rounded-lg transition-colors", {
-          "border border-stroke-weak group-hover:border-2 group-hover:border-neutral-strong group-hover:bg-translucent-200":
-            !isActive,
+    <Tooltip content={title} placement="right">
+      <button
+        aria-label={title}
+        className={joinClasses("group relative size-12 shrink-0 overflow-hidden rounded-lg", {
+          "outline-2 outline-offset-2 outline-neutral-strong focus-visible:outline-info-subdued":
+            isActive,
         })}
-      />
+        {...props}
+      >
+        {exhausted ? (
+          <span
+            className="absolute inset-0 flex items-center justify-center text-xl font-bold text-white"
+            style={{
+              backgroundColor: `hsl(${stringToHue(title)}, 40%, 35%)`,
+            }}
+          >
+            {title.charAt(0).toUpperCase() || "?"}
+          </span>
+        ) : (
+          <img
+            alt=""
+            className="absolute inset-0 size-full object-cover"
+            src={src}
+            onError={onError}
+            onLoad={onLoad}
+          />
+        )}
 
-      {/* TODO: Re-enable store icon
-      {storeIcon !== null && (
-        <span className="absolute top-0 left-0 z-2 flex size-4 items-center justify-center rounded-br-md bg-black/70 opacity-0 transition-opacity group-hover:opacity-100">
-          <Icon className="text-white" path={storeIcon} size="xs" />
-        </span>
-      )}
-      */}
-    </button>
+        <span
+          className={joinClasses("absolute inset-0 z-1 rounded-lg transition-colors", {
+            "border border-stroke-weak group-hover:border-2 group-hover:border-neutral-strong group-hover:bg-translucent-200":
+              !isActive,
+          })}
+        />
+
+        {/* TODO: Re-enable store icon
+        {storeIcon !== null && (
+          <span className="absolute top-0 left-0 z-2 flex size-4 items-center justify-center rounded-br-md bg-black/70 opacity-0 transition-opacity group-hover:opacity-100">
+            <Icon className="text-white" path={storeIcon} size="xs" />
+          </span>
+        )}
+        */}
+      </button>
+    </Tooltip>
   );
 };

--- a/src/renderer/src/views/components/Spine/SpineButton.tsx
+++ b/src/renderer/src/views/components/Spine/SpineButton.tsx
@@ -1,31 +1,37 @@
 import React, { type ButtonHTMLAttributes, type FC } from "react";
 
-import { Icon } from "../../../ui/components/icon/Icon";
-import { joinClasses } from "../../../ui/utils/joinClasses";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { joinClasses } from "@/ui/utils/joinClasses";
 
 interface SpineButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
   iconPath: string;
   isActive?: boolean;
+  title: string;
 }
 
 export const SpineButton: FC<React.PropsWithChildren<SpineButtonProps>> = ({
   className,
   iconPath,
   isActive,
+  title,
   ...props
 }) => (
-  <button
-    className={joinClasses([
-      className,
-      "flex size-12 shrink-0 items-center justify-center rounded-lg transition-colors",
-      "hover:border-neutral-strong hover:bg-surface-translucent-high hover:text-neutral-strong",
-      isActive
-        ? "border-neutral-strong bg-surface-translucent-low text-neutral-strong"
-        : "border-stroke-weak text-neutral-moderate",
-    ])}
-    {...props}
-  >
-    <Icon className="transition-colors" path={iconPath} size="lg" />
-  </button>
+  <Tooltip content={title} placement="right">
+    <button
+      aria-label={title}
+      className={joinClasses([
+        className,
+        "flex size-12 shrink-0 items-center justify-center rounded-lg transition-colors",
+        "hover:border-neutral-strong hover:bg-surface-translucent-high hover:text-neutral-strong",
+        isActive
+          ? "border-neutral-strong bg-surface-translucent-low text-neutral-strong"
+          : "border-stroke-weak text-neutral-moderate",
+      ])}
+      {...props}
+    >
+      <Icon className="transition-colors" path={iconPath} size="lg" />
+    </button>
+  </Tooltip>
 );

--- a/src/renderer/src/views/components/Spine/index.tsx
+++ b/src/renderer/src/views/components/Spine/index.tsx
@@ -2,6 +2,8 @@ import { mdiHome, mdiPlus } from "@mdi/js";
 import React, { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
+
 import {
   discovered as discoveredGamesSelector,
   knownGames as knownGamesSelector,
@@ -61,7 +63,10 @@ export const Spine: FC<React.PropsWithChildren<unknown>> = () => {
   }, [scrollRef]);
 
   return (
-    <div className="box-content flex w-18 shrink-0 flex-col items-center justify-between border-r border-stroke-weak py-3">
+    <TooltipDelayGroup
+      as="div"
+      className="box-content flex w-18 shrink-0 flex-col items-center justify-between border-r border-stroke-weak py-3"
+    >
       <SpineButton
         className="border-2"
         iconPath={mdiHome}
@@ -109,6 +114,6 @@ export const Spine: FC<React.PropsWithChildren<unknown>> = () => {
       </div>
 
       <DownloadButton />
-    </div>
+    </TooltipDelayGroup>
   );
 };

--- a/src/renderer/vitest.config.mts
+++ b/src/renderer/vitest.config.mts
@@ -17,24 +17,11 @@ export default defineConfig({
     setupFiles: ["./test-setup.ts"],
 
     include: ["src/**/*.test.{ts,tsx,js,jsx}"],
-
-    server: {
-      deps: {
-        // Inline so Vite transforms it and the react/jsx-runtime alias below
-        // applies; left external, Node resolves the bare specifier and fails
-        // against React 17's exports-less package.
-        inline: ["@floating-ui/react"],
-      },
-    },
   },
   resolve: {
     tsconfigPaths: true,
     alias: {
       "original-fs": "fs",
-      // React 17 ships no `exports` map, so Vite cannot resolve the bare
-      // `react/jsx-runtime` specifier that ESM deps (@floating-ui/react) import.
-      // Webpack resolves it fine; this only affects the vitest runner.
-      "react/jsx-runtime": "react/jsx-runtime.js",
       "modmeta-db": path.resolve(
         __dirname,
         "../../extensions/nmm-import-tool/node_modules/modmeta-db/lib/index.js",

--- a/src/renderer/vitest.config.mts
+++ b/src/renderer/vitest.config.mts
@@ -17,11 +17,24 @@ export default defineConfig({
     setupFiles: ["./test-setup.ts"],
 
     include: ["src/**/*.test.{ts,tsx,js,jsx}"],
+
+    server: {
+      deps: {
+        // Inline so Vite transforms it and the react/jsx-runtime alias below
+        // applies; left external, Node resolves the bare specifier and fails
+        // against React 17's exports-less package.
+        inline: ["@floating-ui/react"],
+      },
+    },
   },
   resolve: {
     tsconfigPaths: true,
     alias: {
       "original-fs": "fs",
+      // React 17 ships no `exports` map, so Vite cannot resolve the bare
+      // `react/jsx-runtime` specifier that ESM deps (@floating-ui/react) import.
+      // Webpack resolves it fine; this only affects the vitest runner.
+      "react/jsx-runtime": "react/jsx-runtime.js",
       "modmeta-db": path.resolve(
         __dirname,
         "../../extensions/nmm-import-tool/node_modules/modmeta-db/lib/index.js",

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -12,3 +12,4 @@
 @import "./table.css";
 @import "./tab.css";
 @import "./toolbar.css";
+@import "./tooltip.css";

--- a/src/stylesheets/ui/elements/tooltip.css
+++ b/src/stylesheets/ui/elements/tooltip.css
@@ -1,0 +1,47 @@
+@layer components {
+    .nxm-tooltip-positioner {
+        width: max-content;
+        pointer-events: none;
+        z-index: var(--z-index-tooltip);
+    }
+
+    .nxm-tooltip-positioner-interactive {
+        pointer-events: auto;
+    }
+
+    .nxm-tooltip {
+        position: relative;
+        max-height: inherit;
+        box-shadow: var(--shadow-md);
+        border-radius: var(--radius-sm);
+        color: var(--color-neutral-strong);
+        max-width: calc(var(--spacing) * 80);
+        border: solid 1px var(--color-stroke-weak);
+        background-color: var(--color-surface-mid);
+    }
+
+    .nxm-tooltip-body {
+        overflow-y: auto;
+        max-height: inherit;
+    }
+
+    .nxm-tooltip-content {
+        font-size: var(--text-body-sm);
+        padding-block: calc(var(--spacing) * 1.5);
+        padding-inline: calc(var(--spacing) * 2);
+        line-height: var(--text-body-sm--line-height);
+        letter-spacing: var(--text-body-sm--letter-spacing);
+    }
+
+    .nxm-tooltip-arrow {
+        fill: var(--color-surface-mid);
+
+        path[clip-path] {
+            stroke: var(--color-stroke-subdued);
+        }
+
+        path:not([clip-path]) {
+            stroke: var(--color-surface-mid);
+        }
+    }
+}

--- a/src/stylesheets/ui/elements/tooltip.css
+++ b/src/stylesheets/ui/elements/tooltip.css
@@ -16,8 +16,8 @@
         border-radius: var(--radius-sm);
         color: var(--color-neutral-strong);
         max-width: calc(var(--spacing) * 80);
-        border: solid 1px var(--color-stroke-weak);
         background-color: var(--color-surface-mid);
+        border: solid 1px var(--color-surface-high);
     }
 
     .nxm-tooltip-body {
@@ -37,7 +37,7 @@
         fill: var(--color-surface-mid);
 
         path[clip-path] {
-            stroke: var(--color-stroke-subdued);
+            stroke: var(--color-surface-high);
         }
 
         path:not([clip-path]) {


### PR DESCRIPTION
Adds a `Tooltip` built on `@floating-ui/react`, giving us collision-aware positioning so tooltips can't render off screen. Unblocked by LAZ-198 — `@floating-ui/react` has a `react >=17` peer, so this wasn't possible on 16.

### Scope

The component, plus every native `title` in the app chrome: the spine, the app header, the main menu and tools tray, and the Health Check page. `controls/TooltipControls` is untouched — existing call sites aren't migrated.

### What's in it

- `ui/components/tooltip/` — `Tooltip` + `TooltipDelayGroup`                                                 
- Portals into `#overlays`, so tables, dashlets and scroll panes can't clip it — collision handling alone doesn't fix clipping by an ancestor
- Opens on hover **and** focus, dismisses on Escape, `pointer-events: none` unless `interactive`, so it can't swallow a click
- `TooltipDelayGroup` shares one delay across a row, so scanning a toolbar doesn't cost 250ms per button. Takes an `as` prop so the group can *be* the row's layout element instead of nesting inside one
- Icon-only triggers gain an `aria-label`, leaving the tooltip to contribute only `aria-describedby` — the collapsed play button had no accessible name at all before
- E2E spine and profile selectors move off `getByTitle`, which these buttons no longer have
- Demo on the Design System page (new **Tooltip** tab) 