### PR TITLE
Health Check: Correctness fixes

### DIFF
--- a/packages/nexus-api-v3/src/client.test.ts
+++ b/packages/nexus-api-v3/src/client.test.ts
@@ -240,3 +240,23 @@ describe("error fallback", () => {
     });
   });
 });
+
+describe("cancellation", () => {
+  // fetch is what honours the signal, so reaching it is the whole contract: an aborted
+  // signal has to reject the call without a request going out.
+  it("passes the client signal to fetch", async () => {
+    mockData({ mods: [] });
+
+    await expect(makeClient({ signal: AbortSignal.abort() }).getModsBatch(["1"])).rejects.toThrow(
+      /abort/i,
+    );
+    expect(fetchMocker.requests()).toHaveLength(0);
+  });
+
+  it("leaves requests alone when no signal is given", async () => {
+    mockData({ mods: [] });
+
+    await expect(makeClient().getModsBatch(["1"])).resolves.toEqual([]);
+    expect(fetchMocker.requests()).toHaveLength(1);
+  });
+});

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -10,6 +10,12 @@ export interface NexusV3ClientOptions {
   apiKey?: string;
   bearerToken?: string;
   middleware?: Middleware[];
+  /**
+   * Aborts every request made through this client, in flight included. Without one, a
+   * request to an endpoint that accepts the connection and then stops responding never
+   * settles: fetch has no timeout of its own.
+   */
+  signal?: AbortSignal;
 }
 
 export type NexusV3Client = ReturnType<typeof createNexusV3Client>;
@@ -30,6 +36,7 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
   const client = createClient<paths>({
     baseUrl: options.baseUrl,
     headers,
+    signal: options.signal,
   });
 
   for (const mw of options.middleware ?? []) {

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.test.ts
@@ -703,3 +703,45 @@ describe("checkFileRequirements / resolution", () => {
     });
   });
 });
+
+describe("checkFileRequirements / abort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile.mockReturnValue({ gameId: "skyrimse" } as unknown as IProfile);
+    mockIsLoggedIn.mockReturnValue(true);
+    mockGatherDownloaded.mockResolvedValue([]);
+    mockDownloadedHydrator.mockReturnValue(() => undefined);
+  });
+
+  // Cancelling a request already in flight is the v3 client's job and is covered there. What
+  // matters here is that an aborted run leaves no report for the registry to store.
+  test("throws instead of returning a result when the signal is already aborted", async () => {
+    mockGather.mockResolvedValue([ref("ab_src")]);
+    mockHydrator.mockReturnValue((fileUID: string) => installedFile(fileUID, true));
+    mockCreateClient.mockReturnValue(
+      fakeClient(
+        { ab_src: { chain: "ab_srcChain", modId: "ab_srcMod" } },
+        [],
+      ) as unknown as ReturnType<typeof createVortexNexusV3Client>,
+    );
+
+    await expect(checkFileRequirements(api, AbortSignal.abort())).rejects.toThrow();
+  });
+
+  test("throws when the signal aborts partway through the run", async () => {
+    const controller = new AbortController();
+    mockGather.mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve([ref("ab2_src")]);
+    });
+    mockHydrator.mockReturnValue((fileUID: string) => installedFile(fileUID, true));
+    mockCreateClient.mockReturnValue(
+      fakeClient(
+        { ab2_src: { chain: "ab2_srcChain", modId: "ab2_srcMod" } },
+        [],
+      ) as unknown as ReturnType<typeof createVortexNexusV3Client>,
+    );
+
+    await expect(checkFileRequirements(api, controller.signal)).rejects.toThrow();
+  });
+});

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
@@ -57,7 +57,10 @@ function createResult(
 /**
  * Check the file-level requirements of installed mods for the active game
  */
-export async function checkFileRequirements(api: IExtensionApi): Promise<IHealthCheckResult> {
+export async function checkFileRequirements(
+  api: IExtensionApi,
+  signal?: AbortSignal,
+): Promise<IHealthCheckResult> {
   const startTime = Date.now();
   try {
     const state = api.getState();
@@ -78,7 +81,7 @@ export async function checkFileRequirements(api: IExtensionApi): Promise<IHealth
       );
     }
 
-    const metadata = await runFileLevelRequirements(api);
+    const metadata = await runFileLevelRequirements(api, signal);
 
     const sourcesWithRequirements = Object.values(metadata.fileRequirements);
     const totalRequirements = sourcesWithRequirements.reduce(
@@ -107,6 +110,10 @@ export async function checkFileRequirements(api: IExtensionApi): Promise<IHealth
       { metadata },
     );
   } catch (error) {
+    // The registry reports the timeout itself and discards this run's result.
+    if (signal?.aborted) {
+      throw error;
+    }
     log("error", "Failed to check file-level requirements", unknownToError(error));
     return createResult(
       startTime,
@@ -136,7 +143,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
   ],
-  check: async (api: IExtensionApi): Promise<IHealthCheckResult> => {
+  check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     // Reading the flag through FlagService reports an evaluation metric to the server.
     const flagEnabled = FlagService.instance.getFlag(FILE_REQUIREMENTS_FLAG) !== undefined;
     if (!flagEnabled || !isFileRequirementsUserEnabled(api.getState())) {
@@ -152,7 +159,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, true));
     try {
-      return await checkFileRequirements(api);
+      return await checkFileRequirements(api, signal);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(FILE_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -272,10 +272,11 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
         requirementsMap[uid] = requirements;
       }
     } catch (err) {
-      log("warn", "Failed to fetch mod requirements", {
-        error: (err as Error).message,
-      });
-      metadata.errors.push(`Failed to fetch requirements: ${(err as Error).message}`);
+      // Whatever the cache already held is still used below; the run is just incomplete,
+      // which the result status reflects rather than reporting a clean pass.
+      const message = getErrorMessageOrDefault(err);
+      log("warn", "Failed to fetch mod requirements", { error: message });
+      metadata.errors.push(`Failed to fetch requirements: ${message}`);
     }
 
     // Pre-fetch, batched and in parallel, the per-required-mod data the second pass
@@ -446,7 +447,22 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
     );
     const totalIssues = totalMissingMods + totalDlcRequirements;
 
-    if (totalIssues === 0 && metadata.errors.length === 0) {
+    const details = buildDetailsString(modsWithIssues, metadata.errors);
+
+    // An incomplete run cannot claim the loadout is fine: with the fetch failed we don't
+    // know what we didn't see. Whatever was resolved from cache is still reported, so the
+    // metadata rides along and the listing keeps showing it.
+    if (metadata.errors.length > 0) {
+      return createResult(
+        startTime,
+        "error",
+        HealthCheckSeverity.Error,
+        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalIssues} issues found in ${metadata.modsChecked} mods checked`,
+        { details, metadata },
+      );
+    }
+
+    if (totalIssues === 0) {
       return createResult(
         startTime,
         "passed",
@@ -456,7 +472,6 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       );
     }
 
-    const details = buildDetailsString(modsWithIssues, metadata.errors);
     const severity = totalMissingMods > 0 ? HealthCheckSeverity.Warning : HealthCheckSeverity.Info;
     const status = totalMissingMods > 0 ? "warning" : "passed";
 

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -385,6 +385,15 @@ export async function checkModRequirements(
 
       // Check Nexus mod requirements
       if (requirements.nexusRequirements?.nodes) {
+        const { nodes, totalCount } = requirements.nexusRequirements;
+        if (totalCount > nodes.length) {
+          log("debug", "mod requirements truncated by the query page size", {
+            uid,
+            fetched: nodes.length,
+            totalCount,
+          });
+        }
+
         const requiredBy: IModRequirementExt["requiredBy"] = {
           modId,
           modName: getModName(),
@@ -393,7 +402,7 @@ export async function checkModRequirements(
             : undefined,
         };
 
-        for (const req of requirements.nexusRequirements.nodes) {
+        for (const req of nodes) {
           // External (non-Nexus) requirements are temporarily suppressed because there
           // is no way to invalidate them. They can't be auto-detected, so the only way
           // to clear one is for the user to confirm it's installed — which just hides

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -446,16 +446,13 @@ export async function checkModRequirements(
       }
     }
 
-    // Count totals
-    const modsWithIssues = Object.values(metadata.modRequirements);
-    const totalMissingMods = modsWithIssues.reduce((sum, m) => sum + m.missingMods.length, 0);
-    const totalDlcRequirements = modsWithIssues.reduce(
-      (sum, m) => sum + m.dlcRequirements.length,
-      0,
-    );
-    const totalIssues = totalMissingMods + totalDlcRequirements;
+    const modEntries = Object.values(metadata.modRequirements);
+    const details = buildDetailsString(modEntries, metadata.errors);
 
-    const details = buildDetailsString(modsWithIssues, metadata.errors);
+    // DLC requirements are collected into the metadata and the details, but no UI renders
+    // them yet, so counting them would report issues against a visibly empty page.
+    const modsWithMissing = modEntries.filter((mod) => mod.missingMods.length > 0);
+    const totalMissingMods = modsWithMissing.reduce((sum, mod) => sum + mod.missingMods.length, 0);
 
     // An incomplete run cannot claim the loadout is fine: with the fetch failed we don't
     // know what we didn't see. Whatever was resolved from cache is still reported, so the
@@ -465,12 +462,12 @@ export async function checkModRequirements(
         startTime,
         "error",
         HealthCheckSeverity.Error,
-        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalIssues} issues found in ${metadata.modsChecked} mods checked`,
+        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalMissingMods} issues found in ${metadata.modsChecked} mods checked`,
         { details, metadata },
       );
     }
 
-    if (totalIssues === 0) {
+    if (totalMissingMods === 0) {
       return createResult(
         startTime,
         "passed",
@@ -480,14 +477,11 @@ export async function checkModRequirements(
       );
     }
 
-    const severity = totalMissingMods > 0 ? HealthCheckSeverity.Warning : HealthCheckSeverity.Info;
-    const status = totalMissingMods > 0 ? "warning" : "passed";
-
     return createResult(
       startTime,
-      status,
-      severity,
-      `Found ${totalIssues} requirement issues (${totalMissingMods} mod, ${totalDlcRequirements} DLC) across ${modsWithIssues.length} mods`,
+      "warning",
+      HealthCheckSeverity.Warning,
+      `Found ${totalMissingMods} requirement issues across ${modsWithMissing.length} mods`,
       { details, metadata },
     );
   } catch (error) {

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -182,7 +182,10 @@ function resolveModUID(mod: IMod, gameId: string): string | undefined {
  * Check Nexus mod requirements
  * Fetches requirements from Nexus API and checks if they are satisfied
  */
-export async function checkModRequirements(api: IExtensionApi): Promise<IHealthCheckResult> {
+export async function checkModRequirements(
+  api: IExtensionApi,
+  signal?: AbortSignal,
+): Promise<IHealthCheckResult> {
   const startTime = Date.now();
   try {
     const state = api.getState();
@@ -253,6 +256,8 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       [uid: string]: Partial<IModRequirements> | undefined;
     } = {};
 
+    signal?.throwIfAborted();
+
     try {
       const resolved = await resolveCached(
         [...modsByUid.keys()],
@@ -311,16 +316,19 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
     // One batched mod-details call instead of one per required mod.
     const detailUids = [...requiredTargets.keys()];
     if (detailUids.length > 0) {
+      signal?.throwIfAborted();
       try {
-        await getModDetails(api, detailUids);
+        await getModDetails(api, detailUids, signal);
       } catch (err) {
-        log("warn", "Failed to batch mod details", { error: (err as Error).message });
+        signal?.throwIfAborted();
+        log("warn", "Failed to batch mod details", { error: getErrorMessageOrDefault(err) });
       }
     }
 
     // File-list lookups, fanned out in bounded-concurrency waves.
     const filesByRequiredUid = new Map<string, IModFileInfo[]>();
     for (const wave of chunked([...requiredTargets], FILE_LOOKUP_CONCURRENCY)) {
+      signal?.throwIfAborted();
       const fetched = await Promise.all(
         wave.map(async ([uid, target]) => {
           const files = await getModFilesWithCache(api, target.gameId, target.modId).catch(
@@ -483,6 +491,10 @@ export async function checkModRequirements(api: IExtensionApi): Promise<IHealthC
       { details, metadata },
     );
   } catch (error) {
+    // The registry reports the timeout itself and discards this run's result.
+    if (signal?.aborted) {
+      throw error;
+    }
     log("error", "Failed to check Nexus mod requirements", unknownToError(error));
     return createResult(
       startTime,
@@ -512,7 +524,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
   ],
-  check: async (api: IExtensionApi): Promise<IHealthCheckResult> => {
+  check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     if (!isModRequirementsEnabled(api.getState())) {
       return {
         checkId: MOD_REQUIREMENTS_CHECK_ID,
@@ -526,7 +538,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
 
     api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, true));
     try {
-      return await checkModRequirements(api);
+      return await checkModRequirements(api, signal);
     } finally {
       api.store?.dispatch(setHealthCheckRunning(MOD_REQUIREMENTS_CHECK_ID, false));
     }

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -140,7 +140,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               api,
               showPremiumAd,
               identity,
-              requestDownload: (candidate) => downloadFileRequirement(api, candidate, identity),
+              requestDownload: (candidate, enabledFile) =>
+                downloadFileRequirement(api, candidate, identity, enabledFile),
               onInstall: (candidate, resolution) =>
                 trackOneClickInstallClicked({
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   canQuickInstall,
-  downloadCandidates,
+  downloadTargets,
   requirementModName,
   switchTargets,
   uninstalledFiles,
@@ -51,7 +51,8 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   } = useIssueTracking();
 
   const { identity, issueType, resolutionType } = useIssue();
-  const candidates = downloadCandidates(report.requirements);
+  const targets = downloadTargets(report.requirements);
+  const candidates = targets.map((target) => target.candidate);
   const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
   const toInstall = uninstalledFiles(report.requirements);
@@ -106,7 +107,9 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
       return;
     }
 
-    candidates.forEach((candidate) => void downloadFileRequirement(api, candidate, identity));
+    targets.forEach(
+      (target) => void downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
+    );
   };
 
   return (

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -6,7 +6,7 @@ import type { IFileActionContext } from "@/extensions/health_check/utils/fileReq
 import { downloadFileRequirement } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   canQuickInstall,
-  downloadCandidates,
+  downloadTargets,
   type FileRequirementCategory,
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
@@ -86,11 +86,9 @@ export const RequirementBody = ({
   const title = t(groupTitleKey(report.category));
   const { requirements } = report;
 
-  const installAllCandidates = canQuickInstall(report.category)
-    ? downloadCandidates(requirements)
-    : [];
+  const installAllTargets = canQuickInstall(report.category) ? downloadTargets(requirements) : [];
 
-  const hasInstallAll = installAllCandidates.length > 1;
+  const hasInstallAll = installAllTargets.length > 1;
 
   // While "install all" runs, every card's install button also shows loading.
   const rowCtx: IFileActionContext = {
@@ -100,14 +98,19 @@ export const RequirementBody = ({
   };
 
   const installAll = () => {
-    ctx.onInstallAll(installAllCandidates, sharedRequirementState(requirements));
+    ctx.onInstallAll(
+      installAllTargets.map((target) => target.candidate),
+      sharedRequirementState(requirements),
+    );
     if (ctx.showPremiumAd) {
       setPremiumOpen(true);
       return;
     }
     setDownloadingAll(true);
     void Promise.all(
-      installAllCandidates.map((candidate) => downloadFileRequirement(api, candidate, identity)),
+      installAllTargets.map((target) =>
+        downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
+      ),
     ).then((results) => {
       // On full success the requirements clear and this view unmounts; only reset
       // when something failed and the buttons are still around.
@@ -129,7 +132,7 @@ export const RequirementBody = ({
     >
       {downloadingAll
         ? t("detail::item::downloading")
-        : t("actions::install_all", { count: installAllCandidates.length })}
+        : t("actions::install_all", { count: installAllTargets.length })}
     </Button>
   );
 
@@ -158,7 +161,7 @@ export const RequirementBody = ({
       <PremiumModal
         downloadScope="all"
         isOpen={premiumOpen}
-        modCount={installAllCandidates.length}
+        modCount={installAllTargets.length}
         trigger="batch_install"
         onClose={() => setPremiumOpen(false)}
         onDownload={() => setPremiumOpen(false)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -9,6 +9,7 @@ import {
   type IResolutionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { openModPage } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
+import type { IInstalledFile } from "@/extensions/health_check/utils/fileRequirements/installedFiles";
 import type { IFileRequirementCandidate } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
@@ -20,18 +21,21 @@ import { FileRequirement } from "../FileRequirement";
 export const CandidateCard = ({
   ctx,
   candidate,
+  enabledFile,
   resolution,
   isOr,
 }: {
   ctx: IFileActionContext;
   candidate: IFileRequirementCandidate;
+  /** The wrong version this download replaces, if any; disabled once the download installs. */
+  enabledFile?: IInstalledFile;
   resolution: IResolutionContext;
   isOr?: boolean;
 }) => {
   const { t } = useTranslation(["health_check", "common"]);
 
   const { isLoading, onClick } = useInstallButton(
-    () => ctx.requestDownload(candidate),
+    () => ctx.requestDownload(candidate, enabledFile),
     ctx.showPremiumAd,
   );
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
@@ -23,7 +23,13 @@ const branchCard = (
   switch (branch.kind) {
     case "download":
       return (
-        <CandidateCard candidate={branch.candidate} ctx={ctx} isOr={true} resolution={resolution} />
+        <CandidateCard
+          candidate={branch.candidate}
+          ctx={ctx}
+          enabledFile={branch.enabledFile}
+          isOr={true}
+          resolution={resolution}
+        />
       );
     case "install":
       return (

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -39,6 +39,7 @@ export const ReplaceRows = ({
         <CandidateCard
           candidate={requirement.candidate}
           ctx={ctx}
+          enabledFile={requirement.installedFile}
           resolution={{ requirementState: requirementStateFor(requirement) }}
         />
       </div>

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
@@ -48,6 +48,21 @@ describe("HealthCheckRegistry timeout handling", () => {
     expect(parked.starts()).toBe(1);
   });
 
+  test("tells the user the check gave up", async ({ makeHealthCheck }) => {
+    const harness = makeHealthCheck();
+    const notify = vi.spyOn(harness.api, "sendNotification");
+    const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });
+
+    await harness.run(parked.id);
+
+    // Keyed on the check, so repeated timeouts replace rather than stack.
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "health-check-timeout-slow-check", type: "warning" }),
+    );
+
+    await vi.waitFor(() => expect(parked.hasSettled()).toBe(true), SETTLE);
+  });
+
   test("runs again once the abandoned body has finished", async ({ makeHealthCheck }) => {
     const harness = makeHealthCheck();
     const parked = harness.parkCheck({ id: "slow-check", timeout: 50 });

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
@@ -247,6 +247,12 @@ export class HealthCheckRegistry {
         return undefined;
       }
 
+      // A timeout clears the check's previous result, so without this the page just empties
+      // with no explanation.
+      if (timedOut) {
+        this.notifyTimeout(entry.healthCheck);
+      }
+
       log("warn", "Health check failed", {
         id: checkId,
         error: err.message || "Unknown error",
@@ -263,6 +269,20 @@ export class HealthCheckRegistry {
         this.mExecutionQueue.delete(checkId);
       }
     }
+  }
+
+  /**
+   * Report a check that gave up. Keyed on the check so a repeatedly timing-out check replaces
+   * its own notification instead of stacking one per trigger.
+   */
+  private notifyTimeout(healthCheck: IHealthCheckEntry["healthCheck"]): void {
+    this.mApi.sendNotification?.({
+      id: `health-check-timeout-${healthCheck.id}`,
+      type: "warning",
+      title: "Health check timed out",
+      message: `${healthCheck.name} took too long and was stopped. Refresh to try again.`,
+      displayMS: 10000,
+    });
   }
 
   /** Whether this check names a game other than the active one. */

--- a/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/hooks/useModRequirementActions.ts
@@ -44,13 +44,17 @@ export function useModRequirementActions(
 
   // 1-click install is a Premium feature; free users get the upgrade prompt
   // (which routes them to the mod page) instead of an in-app download.
+  // onDownloadRequirement reports its own failures and never rejects, so the
+  // fire-and-forget call sites have nothing to catch; a failed install leaves the
+  // detail page open rather than navigating away from the issue.
   const installInApp = useCallback(async () => {
     if (showPremiumAd) {
       setShowPremiumModal(true);
       return;
     }
-    await onDownloadRequirement(api, mod, undefined, identity);
-    onInstalled?.();
+    if (await onDownloadRequirement(api, mod, undefined, identity)) {
+      onInstalled?.();
+    }
   }, [api, mod, identity, showPremiumAd, onInstalled]);
 
   // Persistence only — EntryActions owns the feedback analytics, so both thumbs record

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
@@ -46,8 +46,14 @@ export interface IFileActionContext {
   showPremiumAd: boolean;
   /** The issue these cards resolve, for the install funnel events. */
   identity: IssueAnalyticsIdentity;
-  /** Download a candidate, opening the premium upsell first for free users. Resolves to whether a download ran. */
-  requestDownload: (candidate: IFileRequirementCandidate) => Promise<boolean>;
+  /**
+   * Download a candidate, opening the premium upsell first for free users. `enabledFile` is
+   * the wrong version it replaces, if any. Resolves to whether a download ran.
+   */
+  requestDownload: (
+    candidate: IFileRequirementCandidate,
+    enabledFile?: IInstalledFile,
+  ) => Promise<boolean>;
   /** Appearance for a card's install button; demoted to "moderate" when an "install all" is shown. */
   installButtonAppearance?: "strong" | "moderate";
   /** True while "install all" is running; puts every card's install button into the loading state. */

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
@@ -121,9 +121,12 @@ const detailCache: KeyedCache<FileVersionDetail> = createKeyedCache(CACHE_TTL_MS
  * Build the resolver ports for the active session. Candidate and version detail
  * data come from the Nexus v3 batch endpoints (chunked, paged and cached here);
  * mod details go through the shared, v3-backed getModDetails accessor.
+ *
+ * The resolver takes no signal of its own, so an abort reaches it through the client, which
+ * carries the signal into every request and so cancels one already in flight.
  */
-export function createResolverPorts(api: IExtensionApi): ResolverPorts {
-  const client = createVortexNexusV3Client(api);
+export function createResolverPorts(api: IExtensionApi, signal?: AbortSignal): ResolverPorts {
+  const client = createVortexNexusV3Client(api, { signal });
 
   return {
     async fetchCandidates(fileVersionUids) {
@@ -142,7 +145,7 @@ export function createResolverPorts(api: IExtensionApi): ResolverPorts {
     },
 
     async fetchModDetails(modUids) {
-      const details = await getModDetails(api, modUids);
+      const details = await getModDetails(api, modUids, signal);
       return details.map(
         (detail): ModDetail => ({
           modUid: detail.modUID,

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// The action layer is tested against mocked boundaries: the store selectors, the
+// enable/disable action and the download events. What matters here is which mods end up
+// enabled and disabled, so `setModsEnabled` is the assertion surface.
+vi.mock("@/extensions/nexus_integration/selectors", () => ({ shouldShowPremiumAd: vi.fn() }));
+vi.mock("@/extensions/nexus_integration/util", () => ({ nexusGames: vi.fn(() => []) }));
+vi.mock("@/extensions/nexus_integration/util/convertGameId", () => ({
+  convertGameIdReverse: vi.fn(() => "skyrimse"),
+}));
+vi.mock("@/extensions/gamemode_management/selectors", () => ({ knownGames: vi.fn(() => []) }));
+vi.mock("@/extensions/profile_management/selectors", () => ({ activeProfile: vi.fn() }));
+vi.mock("@/extensions/profile_management/actions/profiles", () => ({
+  setModsEnabled: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/logging", () => ({ log: vi.fn() }));
+vi.mock("@/util/api", () => ({
+  opn: vi.fn(() => Promise.resolve()),
+  renderModName: vi.fn(() => "Mod"),
+  sanitizeCSSId: vi.fn((id: string) => id),
+}));
+vi.mock("../shared/installTracking", () => ({
+  trackedInstall: vi.fn((_api, _identity, run: () => Promise<void>) => run()),
+}));
+
+import { knownGames } from "@/extensions/gamemode_management/selectors";
+import { shouldShowPremiumAd } from "@/extensions/nexus_integration/selectors";
+import { nexusGames } from "@/extensions/nexus_integration/util";
+import { setModsEnabled } from "@/extensions/profile_management/actions/profiles";
+import { activeProfile } from "@/extensions/profile_management/selectors";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import { opn } from "@/util/api";
+
+import { trackedInstall } from "../shared/installTracking";
+import { downloadFileRequirement, installDownloadedFile } from "./fileRequirementActions";
+import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
+import type { IFileRequirementCandidate } from "./mapRequirementsReport";
+
+const mockPremiumAd = vi.mocked(shouldShowPremiumAd);
+const mockActiveProfile = vi.mocked(activeProfile);
+const mockSetModsEnabled = vi.mocked(setModsEnabled);
+const mockTrackedInstall = vi.mocked(trackedInstall);
+
+const NEXUS_GAME_ID = 1704;
+
+/** A composite UID as the Nexus API builds them: (gameId << 32) | id. */
+const uid = (id: number): string => ((BigInt(NEXUS_GAME_ID) << BigInt(32)) | BigInt(id)).toString();
+
+/** The mod id "start-install-download" reports for the freshly installed version. */
+const INSTALLED_MOD_ID = "correct-version";
+
+const CANDIDATE: IFileRequirementCandidate = {
+  fileUID: uid(9001),
+  modUID: uid(42),
+  modName: "Required Mod",
+  fileName: "required.zip",
+  version: "2.0",
+  adultContent: false,
+};
+
+const DOWNLOADED: IDownloadedFile = {
+  downloadId: "dl-1",
+  fileUID: uid(9001),
+  modUID: uid(42),
+  modName: "Required Mod",
+  fileName: "required.zip",
+  version: "2.0",
+  adultContent: false,
+};
+
+function installedFile(modId: string): IInstalledFile {
+  return {
+    modId,
+    fileUID: uid(9000),
+    modUID: uid(42),
+    modName: "Required Mod",
+    fileName: "required-old.zip",
+    version: "1.0",
+    adultContent: false,
+    enabled: true,
+  };
+}
+
+/** An api whose mod store holds the given mod ids, and whose download events succeed. */
+function makeApi(modIds: string[] = ["wrong-version", INSTALLED_MOD_ID]): IExtensionApi {
+  const mods = Object.fromEntries(modIds.map((id) => [id, { id }]));
+  return {
+    getState: () => ({ persistent: { mods: { skyrimse: mods } } }),
+    events: {
+      emit: (event: string, ...args: unknown[]) => {
+        // Both download events take a node-style callback; the id they report is all the
+        // action uses. "start-download" carries extra options before its callback.
+        const callback = args.find((arg) => typeof arg === "function") as (
+          err: Error | null,
+          res: string,
+        ) => void;
+        callback(null, event === "start-download" ? "dl-1" : INSTALLED_MOD_ID);
+      },
+    },
+    showErrorNotification: vi.fn(),
+  } as unknown as IExtensionApi;
+}
+
+/** The (modIds, enabled) pairs setModsEnabled was called with, in order. */
+const enableCalls = (): Array<[string[], boolean]> =>
+  mockSetModsEnabled.mock.calls.map((call) => [call[2], call[3]]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPremiumAd.mockReturnValue(false);
+  mockSetModsEnabled.mockReturnValue(Promise.resolve() as never);
+  mockTrackedInstall.mockImplementation((_api, _identity, run) => run());
+  vi.mocked(nexusGames).mockReturnValue([{ id: NEXUS_GAME_ID, domain_name: "skyrimse" }] as never);
+  vi.mocked(knownGames).mockReturnValue([] as never);
+  mockActiveProfile.mockReturnValue({ id: "profile-1", gameId: "skyrimse" } as never);
+});
+
+describe("downloadFileRequirement", () => {
+  test("disables the version it replaces before enabling the download", async () => {
+    const api = makeApi();
+
+    expect(
+      await downloadFileRequirement(api, CANDIDATE, undefined, installedFile("wrong-version")),
+    ).toBe(true);
+
+    // Disable first: leaving both enabled deploys two versions of the same mod.
+    expect(enableCalls()).toEqual([
+      [["wrong-version"], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the download replaces no installed version", async () => {
+    const api = makeApi();
+
+    expect(await downloadFileRequirement(api, CANDIDATE)).toBe(true);
+
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the install reused the replaced version's mod entry", async () => {
+    const api = makeApi();
+
+    await downloadFileRequirement(api, CANDIDATE, undefined, installedFile(INSTALLED_MOD_ID));
+
+    // Disabling it here would switch off the version just installed.
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the replaced version has left the mod store", async () => {
+    const api = makeApi([INSTALLED_MOD_ID]);
+
+    await downloadFileRequirement(api, CANDIDATE, undefined, installedFile("wrong-version"));
+
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("routes free users to the file page instead of downloading", async () => {
+    mockPremiumAd.mockReturnValue(true);
+
+    expect(await downloadFileRequirement(makeApi(), CANDIDATE)).toBe(false);
+
+    expect(opn).toHaveBeenCalledOnce();
+    expect(mockTrackedInstall).not.toHaveBeenCalled();
+    expect(mockSetModsEnabled).not.toHaveBeenCalled();
+  });
+
+  test("reports a failed install rather than throwing", async () => {
+    const api = makeApi();
+    mockTrackedInstall.mockRejectedValue(new Error("install failed"));
+
+    expect(await downloadFileRequirement(api, CANDIDATE)).toBe(false);
+    expect(api.showErrorNotification).toHaveBeenCalledOnce();
+  });
+});
+
+describe("installDownloadedFile", () => {
+  test("disables the version it replaces before enabling the install", async () => {
+    const api = makeApi();
+
+    expect(
+      await installDownloadedFile(api, DOWNLOADED, undefined, installedFile("wrong-version")),
+    ).toBe(true);
+
+    expect(enableCalls()).toEqual([
+      [["wrong-version"], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("installs a downloaded file for free users too", async () => {
+    mockPremiumAd.mockReturnValue(true);
+
+    expect(await installDownloadedFile(makeApi(), DOWNLOADED)).toBe(true);
+  });
+});

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -39,7 +39,8 @@ function modPageUrl(ref: INexusFileRef): string | undefined {
 }
 
 /**
- * Download and install a missing / wrong-version file, then make it the active version.
+ * Download and install a missing / wrong-version file, then make it the active version,
+ * disabling `enabledFile` when the download replaces a wrong version of the same chain.
  * Free users can't 1-click install, so open the file page instead (website download); the
  * premium upsell is out of MVP scope.
  */
@@ -47,6 +48,7 @@ export async function downloadFileRequirement(
   api: IExtensionApi,
   candidate: IFileRequirementCandidate,
   identity?: IssueAnalyticsIdentity,
+  enabledFile?: IInstalledFile,
 ): Promise<boolean> {
   if (shouldShowPremiumAd(api.getState())) {
     openFilePage(api, candidate);
@@ -100,7 +102,7 @@ export async function downloadFileRequirement(
           ),
         );
 
-        await activateInstalledVersion(api, modId);
+        await activateInstalledVersion(api, modId, enabledFile);
       },
     );
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
@@ -64,13 +64,21 @@ export const categoryOf = (requirement: IFileRequirement): FileRequirementCatego
   }
 };
 
+/** One file to download, with the wrong version it replaces when it is a version change. */
+export interface IFileDownloadTarget {
+  candidate: IFileRequirementCandidate;
+  /** The wrong version currently enabled, disabled once the download installs. */
+  enabledFile?: IInstalledFile;
+}
+
 /** Files to download for a report; OR/toggle/install-uninstalled need a user choice or different action. */
-export const downloadCandidates = (requirements: IFileRequirement[]): IFileRequirementCandidate[] =>
+export const downloadTargets = (requirements: IFileRequirement[]): IFileDownloadTarget[] =>
   requirements.flatMap((requirement) => {
     switch (requirement.kind) {
       case "missing":
+        return [{ candidate: requirement.candidate }];
       case "wrong-version-installed":
-        return [requirement.candidate];
+        return [{ candidate: requirement.candidate, enabledFile: requirement.installedFile }];
       default:
         return [];
     }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -5,6 +5,7 @@ import { nexusGamesProm } from "@/extensions/nexus_integration/util";
 import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import { activeProfile } from "@/extensions/profile_management/selectors";
 import type { IProfile } from "@/extensions/profile_management/types/IProfile";
+import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { getSafe } from "@/util/storeHelper";
 
@@ -285,10 +286,14 @@ export function makeDownloadedFileHydrator(
   const refByUID = new Map(refs.map((ref): [string, IDownloadedFileRef] => [ref.fileUID, ref]));
 
   return (fileUID) => {
+    // A ref miss is a normal negative lookup; callers try installed before downloaded.
     const ref = refByUID.get(fileUID);
     if (!ref) return undefined;
     const download = downloads[ref.downloadId];
-    if (!download) return undefined;
+    if (!download) {
+      log("debug", "unable to hydrate downloaded file", { fileUID, downloadId: ref.downloadId });
+      return undefined;
+    }
     return toDownloadedFile(ref, download, modDetailsByUID.get(ref.modUID));
   };
 }
@@ -352,12 +357,14 @@ export function makeInstalledFileHydrator(
   const refByUID = new Map(refs.map((ref): [string, IInstalledFileRef] => [ref.fileUID, ref]));
 
   return (fileUID) => {
+    // A ref miss is a normal negative lookup; callers try installed before downloaded.
     const ref = refByUID.get(fileUID);
     if (!ref) {
       return undefined;
     }
     const mod = mods[ref.modId];
     if (!mod) {
+      log("debug", "unable to hydrate installed file", { fileUID, modId: ref.modId });
       return undefined;
     }
     const modUID = resolveModUID(mod.attributes ?? {}, gameId);

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/runFileLevelRequirements.ts
@@ -85,6 +85,7 @@ function surfacedModUIDs(metadata: IFileRequirementsCheckMetadata): string[] {
  */
 export async function runFileLevelRequirements(
   api: IExtensionApi,
+  signal?: AbortSignal,
 ): Promise<IFileRequirementsCheckMetadata> {
   const gameId = activeProfile(api.getState())?.gameId ?? "";
 
@@ -106,8 +107,10 @@ export async function runFileLevelRequirements(
   const report = await checkFileLevelRequirements({
     installedFiles,
     uninstalledFileVersionUids: new Set(downloadedRefs.map((ref) => ref.fileUID)),
-    ports: createResolverPorts(api),
+    ports: createResolverPorts(api, signal),
   });
+
+  signal?.throwIfAborted();
 
   const buildHydrate = (modDetailsByUID: Map<string, IModDetails>): HydrateFile => {
     const hydrateInstalled = makeInstalledFileHydrator(api, installedRefs, modDetailsByUID);
@@ -133,7 +136,8 @@ export async function runFileLevelRequirements(
 
   // Backfill display data (thumbnail, summary, adult flag) via the batched, cached
   // mod-details endpoint, then re-map with it. See toDownloadedFile / toInstalledFile.
-  const details = await getModDetails(api, modUIDs).catch((err: unknown): IModDetails[] => {
+  const details = await getModDetails(api, modUIDs, signal).catch((err: unknown): IModDetails[] => {
+    signal?.throwIfAborted();
     log("warn", "failed to fetch mod details for file requirements", {
       count: modUIDs.length,
       error: getErrorMessage(unknownToError(err)),

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/onDownloadRequirement.ts
@@ -13,21 +13,26 @@ import type { IssueAnalyticsIdentity } from "../shared/tracking";
 import { getModFilesWithCache } from "./modFiles";
 
 /**
- * Download and install missing mod requirements from Nexus
+ * Download and install missing mod requirements from Nexus. Resolves to whether the
+ * requirement was installed; every failure is reported to the user here rather than
+ * thrown, mirroring downloadFileRequirement, because the call sites are fire-and-forget
+ * click handlers with nowhere to catch.
  */
 export async function onDownloadRequirement(
   api: IExtensionApi,
   mod: IModRequirementExt,
   file?: IModFileInfo,
   identity?: IssueAnalyticsIdentity,
-): Promise<void> {
+): Promise<boolean> {
+  const modLabel = mod.modName || `mod ID ${mod.modId}`;
+
   if (!Number.isInteger(mod.modId) || mod.modId <= 0) {
     api.showErrorNotification(
       `Cannot download requirement "${mod.modName}"`,
       "This requirement does not have a valid Nexus Mods ID.",
       { allowReport: false },
     );
-    return;
+    return false;
   }
 
   const getFileIds = async (): Promise<IModFileInfo[]> => {
@@ -51,54 +56,64 @@ export async function onDownloadRequirement(
     return files;
   };
 
-  const fileIds = await getFileIds();
-  if (fileIds.length === 0) {
-    return;
+  try {
+    const fileIds = await getFileIds();
+    if (fileIds.length === 0) {
+      return false;
+    }
+
+    const gameId = mod.gameId;
+    const modId = mod.modId;
+    const targetFile = fileIds[0];
+
+    const game: IGame = getGame(gameId);
+    const nexusDomainName = nexusGameId(game, gameId);
+    const nxmUrl = `nxm://${nexusDomainName}/mods/${modId}/files/${targetFile.fileId}`;
+    // mod.gameId is the Nexus domain (e.g. "skyrimspecialedition"); the downloader and
+    // download.game records key on the internal id ("skyrimse"). Convert before emitting
+    // so the file lands in the same folder the install handler later looks in.
+    const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
+
+    await trackedInstall(
+      api,
+      {
+        ...identity,
+        mod_id: modId,
+        mod_name: mod.modName,
+        mod_version: targetFile.version,
+      },
+      async () => {
+        const dlId = await toPromise<string>((cb) =>
+          api.events.emit(
+            "start-download",
+            [nxmUrl],
+            { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
+            undefined,
+            cb,
+            undefined,
+            { allowInstall: false },
+          ),
+        );
+
+        await toPromise<string>((cb) =>
+          api.events.emit(
+            "start-install-download",
+            dlId,
+            { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
+            cb,
+          ),
+        );
+      },
+    );
+  } catch (err) {
+    // trackedInstall re-throws so the caller owns the user-facing handling; this is that
+    // caller. The file-list lookup is inside the same try because it can fail the same way.
+    api.showErrorNotification(`Failed to install requirement: ${modLabel}`, err, {
+      allowReport: false,
+    });
+
+    return false;
   }
-
-  const gameId = mod.gameId;
-  const modId = mod.modId;
-  const targetFile = fileIds[0];
-
-  const game: IGame = getGame(gameId);
-  const nexusDomainName = nexusGameId(game, gameId);
-  const nxmUrl = `nxm://${nexusDomainName}/mods/${modId}/files/${targetFile.fileId}`;
-  // mod.gameId is the Nexus domain (e.g. "skyrimspecialedition"); the downloader and
-  // download.game records key on the internal id ("skyrimse"). Convert before emitting
-  // so the file lands in the same folder the install handler later looks in.
-  const internalGameId = convertGameIdReverse(knownGames(api.getState()), gameId) || gameId;
-
-  await trackedInstall(
-    api,
-    {
-      ...identity,
-      mod_id: modId,
-      mod_name: mod.modName,
-      mod_version: targetFile.version,
-    },
-    async () => {
-      const dlId = await toPromise<string>((cb) =>
-        api.events.emit(
-          "start-download",
-          [nxmUrl],
-          { game: internalGameId, name: targetFile.name, fileId: targetFile.fileId, modId },
-          undefined,
-          cb,
-          undefined,
-          { allowInstall: false },
-        ),
-      );
-
-      await toPromise<string>((cb) =>
-        api.events.emit(
-          "start-install-download",
-          dlId,
-          { allowAutoEnable: true }, // Auto-enable since user explicitly requested via requirements
-          cb,
-        ),
-      );
-    },
-  );
 
   api.sendNotification({
     type: "success",
@@ -106,4 +121,6 @@ export async function onDownloadRequirement(
     displayMS: 5000,
     id: "health-check:nexus-requirements-download-finished",
   });
+
+  return true;
 }

--- a/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
@@ -40,12 +40,16 @@ async function fetchModDetailRows(client: V3Client, modUIDs: string[]): Promise<
  * /mods/batch endpoint, chunked to the per-request id limit and cached by uid
  * so re-runs only fetch the misses. Shared by the mod- and file-level checks.
  */
-export async function getModDetails(api: IExtensionApi, modUIDs: string[]): Promise<IModDetails[]> {
+export async function getModDetails(
+  api: IExtensionApi,
+  modUIDs: string[],
+  signal?: AbortSignal,
+): Promise<IModDetails[]> {
   if (modUIDs.length === 0) {
     return [];
   }
 
-  const client = createVortexNexusV3Client(api);
+  const client = createVortexNexusV3Client(api, { signal });
   const byUid = await resolveCached(modUIDs, modDetailCache, async (missing) => {
     const details = (await fetchModDetailRows(client, missing)).map(toModDetails);
     return new Map(details.map((detail) => [detail.modUID, detail]));

--- a/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   categoryOf,
-  downloadCandidates,
+  downloadTargets,
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IExtensionApi } from "@/types/IExtensionContext";
@@ -76,10 +76,11 @@ export const fileRequirementsContent: IHealthCheckContent = {
           issue_id: fileIssueId(source.sourceFileUID, categoryOf(requirement)),
           check_id: checkId,
         };
-        for (const candidate of downloadCandidates([requirement])) {
+        for (const target of downloadTargets([requirement])) {
           items.push({
-            key: candidate.fileUID,
-            install: () => void downloadFileRequirement(api, candidate, identity),
+            key: target.candidate.fileUID,
+            install: () =>
+              void downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
           });
         }
         if (requirement.kind === "correct-version-uninstalled") {

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -939,7 +939,10 @@ export function onGetModRequirements(
             ...graphErrorContext(err),
           });
         }
-        return Bluebird.resolve({});
+        // Rethrow: resolving to {} made "this mod has no requirements" and "we could not
+        // ask" indistinguishable, so a rate limit or outage was reported to the user as a
+        // clean bill of health. The caller decides what an incomplete run means.
+        return Bluebird.reject(err);
       });
   };
 }


### PR DESCRIPTION
- A `download-replace` install left both versions enabled. The download now carries the version it replaces through to `activateInstalledVersion`, so the old one is disabled.
- DLC requirements were counted into the result message but no UI renders them, so a DLC-only mod reported issues against an empty page. They no longer count.
- Query-cap truncation and file hydration failures dropped requirements with no trace. Both now log at `debug`.
- First tests for `fileRequirementActions` (8), asserting which mods end up enabled and disabled.