### PR TITLE
Health Check Correctness Fixes

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -385,6 +385,15 @@ export async function checkModRequirements(
 
       // Check Nexus mod requirements
       if (requirements.nexusRequirements?.nodes) {
+        const { nodes, totalCount } = requirements.nexusRequirements;
+        if (totalCount > nodes.length) {
+          log("debug", "mod requirements truncated by the query page size", {
+            uid,
+            fetched: nodes.length,
+            totalCount,
+          });
+        }
+
         const requiredBy: IModRequirementExt["requiredBy"] = {
           modId,
           modName: getModName(),
@@ -393,7 +402,7 @@ export async function checkModRequirements(
             : undefined,
         };
 
-        for (const req of requirements.nexusRequirements.nodes) {
+        for (const req of nodes) {
           // External (non-Nexus) requirements are temporarily suppressed because there
           // is no way to invalidate them. They can't be auto-detected, so the only way
           // to clear one is for the user to confirm it's installed — which just hides

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -446,16 +446,13 @@ export async function checkModRequirements(
       }
     }
 
-    // Count totals
-    const modsWithIssues = Object.values(metadata.modRequirements);
-    const totalMissingMods = modsWithIssues.reduce((sum, m) => sum + m.missingMods.length, 0);
-    const totalDlcRequirements = modsWithIssues.reduce(
-      (sum, m) => sum + m.dlcRequirements.length,
-      0,
-    );
-    const totalIssues = totalMissingMods + totalDlcRequirements;
+    const modEntries = Object.values(metadata.modRequirements);
+    const details = buildDetailsString(modEntries, metadata.errors);
 
-    const details = buildDetailsString(modsWithIssues, metadata.errors);
+    // DLC requirements are collected into the metadata and the details, but no UI renders
+    // them yet, so counting them would report issues against a visibly empty page.
+    const modsWithMissing = modEntries.filter((mod) => mod.missingMods.length > 0);
+    const totalMissingMods = modsWithMissing.reduce((sum, mod) => sum + mod.missingMods.length, 0);
 
     // An incomplete run cannot claim the loadout is fine: with the fetch failed we don't
     // know what we didn't see. Whatever was resolved from cache is still reported, so the
@@ -465,12 +462,12 @@ export async function checkModRequirements(
         startTime,
         "error",
         HealthCheckSeverity.Error,
-        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalIssues} issues found in ${metadata.modsChecked} mods checked`,
+        `Nexus mod requirements check incomplete: ${metadata.errors.length} fetch error(s), ${totalMissingMods} issues found in ${metadata.modsChecked} mods checked`,
         { details, metadata },
       );
     }
 
-    if (totalIssues === 0) {
+    if (totalMissingMods === 0) {
       return createResult(
         startTime,
         "passed",
@@ -480,14 +477,11 @@ export async function checkModRequirements(
       );
     }
 
-    const severity = totalMissingMods > 0 ? HealthCheckSeverity.Warning : HealthCheckSeverity.Info;
-    const status = totalMissingMods > 0 ? "warning" : "passed";
-
     return createResult(
       startTime,
-      status,
-      severity,
-      `Found ${totalIssues} requirement issues (${totalMissingMods} mod, ${totalDlcRequirements} DLC) across ${modsWithIssues.length} mods`,
+      "warning",
+      HealthCheckSeverity.Warning,
+      `Found ${totalMissingMods} requirement issues across ${modsWithMissing.length} mods`,
       { details, metadata },
     );
   } catch (error) {

--- a/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/DetailView.tsx
@@ -140,7 +140,8 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
               api,
               showPremiumAd,
               identity,
-              requestDownload: (candidate) => downloadFileRequirement(api, candidate, identity),
+              requestDownload: (candidate, enabledFile) =>
+                downloadFileRequirement(api, candidate, identity, enabledFile),
               onInstall: (candidate, resolution) =>
                 trackOneClickInstallClicked({
                   mod_id: decodeUID(candidate.modUID)?.id ?? 0,

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   canQuickInstall,
-  downloadCandidates,
+  downloadTargets,
   requirementModName,
   switchTargets,
   uninstalledFiles,
@@ -51,7 +51,8 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
   } = useIssueTracking();
 
   const { identity, issueType, resolutionType } = useIssue();
-  const candidates = downloadCandidates(report.requirements);
+  const targets = downloadTargets(report.requirements);
+  const candidates = targets.map((target) => target.candidate);
   const quickInstall = canQuickInstall(report.category) && !!candidates.length;
   const switches = switchTargets(report.requirements);
   const toInstall = uninstalledFiles(report.requirements);
@@ -106,7 +107,9 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
       return;
     }
 
-    candidates.forEach((candidate) => void downloadFileRequirement(api, candidate, identity));
+    targets.forEach(
+      (target) => void downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
+    );
   };
 
   return (

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -6,7 +6,7 @@ import type { IFileActionContext } from "@/extensions/health_check/utils/fileReq
 import { downloadFileRequirement } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   canQuickInstall,
-  downloadCandidates,
+  downloadTargets,
   type FileRequirementCategory,
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
@@ -86,11 +86,9 @@ export const RequirementBody = ({
   const title = t(groupTitleKey(report.category));
   const { requirements } = report;
 
-  const installAllCandidates = canQuickInstall(report.category)
-    ? downloadCandidates(requirements)
-    : [];
+  const installAllTargets = canQuickInstall(report.category) ? downloadTargets(requirements) : [];
 
-  const hasInstallAll = installAllCandidates.length > 1;
+  const hasInstallAll = installAllTargets.length > 1;
 
   // While "install all" runs, every card's install button also shows loading.
   const rowCtx: IFileActionContext = {
@@ -100,14 +98,19 @@ export const RequirementBody = ({
   };
 
   const installAll = () => {
-    ctx.onInstallAll(installAllCandidates, sharedRequirementState(requirements));
+    ctx.onInstallAll(
+      installAllTargets.map((target) => target.candidate),
+      sharedRequirementState(requirements),
+    );
     if (ctx.showPremiumAd) {
       setPremiumOpen(true);
       return;
     }
     setDownloadingAll(true);
     void Promise.all(
-      installAllCandidates.map((candidate) => downloadFileRequirement(api, candidate, identity)),
+      installAllTargets.map((target) =>
+        downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
+      ),
     ).then((results) => {
       // On full success the requirements clear and this view unmounts; only reset
       // when something failed and the buttons are still around.
@@ -129,7 +132,7 @@ export const RequirementBody = ({
     >
       {downloadingAll
         ? t("detail::item::downloading")
-        : t("actions::install_all", { count: installAllCandidates.length })}
+        : t("actions::install_all", { count: installAllTargets.length })}
     </Button>
   );
 
@@ -158,7 +161,7 @@ export const RequirementBody = ({
       <PremiumModal
         downloadScope="all"
         isOpen={premiumOpen}
-        modCount={installAllCandidates.length}
+        modCount={installAllTargets.length}
         trigger="batch_install"
         onClose={() => setPremiumOpen(false)}
         onDownload={() => setPremiumOpen(false)}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -9,6 +9,7 @@ import {
   type IResolutionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
 import { openModPage } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
+import type { IInstalledFile } from "@/extensions/health_check/utils/fileRequirements/installedFiles";
 import type { IFileRequirementCandidate } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
@@ -20,18 +21,21 @@ import { FileRequirement } from "../FileRequirement";
 export const CandidateCard = ({
   ctx,
   candidate,
+  enabledFile,
   resolution,
   isOr,
 }: {
   ctx: IFileActionContext;
   candidate: IFileRequirementCandidate;
+  /** The wrong version this download replaces, if any; disabled once the download installs. */
+  enabledFile?: IInstalledFile;
   resolution: IResolutionContext;
   isOr?: boolean;
 }) => {
   const { t } = useTranslation(["health_check", "common"]);
 
   const { isLoading, onClick } = useInstallButton(
-    () => ctx.requestDownload(candidate),
+    () => ctx.requestDownload(candidate, enabledFile),
     ctx.showPremiumAd,
   );
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/OrRows.tsx
@@ -23,7 +23,13 @@ const branchCard = (
   switch (branch.kind) {
     case "download":
       return (
-        <CandidateCard candidate={branch.candidate} ctx={ctx} isOr={true} resolution={resolution} />
+        <CandidateCard
+          candidate={branch.candidate}
+          ctx={ctx}
+          enabledFile={branch.enabledFile}
+          isOr={true}
+          resolution={resolution}
+        />
       );
     case "install":
       return (

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -39,6 +39,7 @@ export const ReplaceRows = ({
         <CandidateCard
           candidate={requirement.candidate}
           ctx={ctx}
+          enabledFile={requirement.installedFile}
           resolution={{ requirementState: requirementStateFor(requirement) }}
         />
       </div>

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/cardHelpers.ts
@@ -46,8 +46,14 @@ export interface IFileActionContext {
   showPremiumAd: boolean;
   /** The issue these cards resolve, for the install funnel events. */
   identity: IssueAnalyticsIdentity;
-  /** Download a candidate, opening the premium upsell first for free users. Resolves to whether a download ran. */
-  requestDownload: (candidate: IFileRequirementCandidate) => Promise<boolean>;
+  /**
+   * Download a candidate, opening the premium upsell first for free users. `enabledFile` is
+   * the wrong version it replaces, if any. Resolves to whether a download ran.
+   */
+  requestDownload: (
+    candidate: IFileRequirementCandidate,
+    enabledFile?: IInstalledFile,
+  ) => Promise<boolean>;
   /** Appearance for a card's install button; demoted to "moderate" when an "install all" is shown. */
   installButtonAppearance?: "strong" | "moderate";
   /** True while "install all" is running; puts every card's install button into the loading state. */

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// The action layer is tested against mocked boundaries: the store selectors, the
+// enable/disable action and the download events. What matters here is which mods end up
+// enabled and disabled, so `setModsEnabled` is the assertion surface.
+vi.mock("@/extensions/nexus_integration/selectors", () => ({ shouldShowPremiumAd: vi.fn() }));
+vi.mock("@/extensions/nexus_integration/util", () => ({ nexusGames: vi.fn(() => []) }));
+vi.mock("@/extensions/nexus_integration/util/convertGameId", () => ({
+  convertGameIdReverse: vi.fn(() => "skyrimse"),
+}));
+vi.mock("@/extensions/gamemode_management/selectors", () => ({ knownGames: vi.fn(() => []) }));
+vi.mock("@/extensions/profile_management/selectors", () => ({ activeProfile: vi.fn() }));
+vi.mock("@/extensions/profile_management/actions/profiles", () => ({
+  setModsEnabled: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/logging", () => ({ log: vi.fn() }));
+vi.mock("@/util/api", () => ({
+  opn: vi.fn(() => Promise.resolve()),
+  renderModName: vi.fn(() => "Mod"),
+  sanitizeCSSId: vi.fn((id: string) => id),
+}));
+vi.mock("../shared/installTracking", () => ({
+  trackedInstall: vi.fn((_api, _identity, run: () => Promise<void>) => run()),
+}));
+
+import { knownGames } from "@/extensions/gamemode_management/selectors";
+import { shouldShowPremiumAd } from "@/extensions/nexus_integration/selectors";
+import { nexusGames } from "@/extensions/nexus_integration/util";
+import { setModsEnabled } from "@/extensions/profile_management/actions/profiles";
+import { activeProfile } from "@/extensions/profile_management/selectors";
+import type { IExtensionApi } from "@/types/IExtensionContext";
+import { opn } from "@/util/api";
+
+import { trackedInstall } from "../shared/installTracking";
+import { downloadFileRequirement, installDownloadedFile } from "./fileRequirementActions";
+import type { IDownloadedFile, IInstalledFile } from "./installedFiles";
+import type { IFileRequirementCandidate } from "./mapRequirementsReport";
+
+const mockPremiumAd = vi.mocked(shouldShowPremiumAd);
+const mockActiveProfile = vi.mocked(activeProfile);
+const mockSetModsEnabled = vi.mocked(setModsEnabled);
+const mockTrackedInstall = vi.mocked(trackedInstall);
+
+const NEXUS_GAME_ID = 1704;
+
+/** A composite UID as the Nexus API builds them: (gameId << 32) | id. */
+const uid = (id: number): string => ((BigInt(NEXUS_GAME_ID) << BigInt(32)) | BigInt(id)).toString();
+
+/** The mod id "start-install-download" reports for the freshly installed version. */
+const INSTALLED_MOD_ID = "correct-version";
+
+const CANDIDATE: IFileRequirementCandidate = {
+  fileUID: uid(9001),
+  modUID: uid(42),
+  modName: "Required Mod",
+  fileName: "required.zip",
+  version: "2.0",
+  adultContent: false,
+};
+
+const DOWNLOADED: IDownloadedFile = {
+  downloadId: "dl-1",
+  fileUID: uid(9001),
+  modUID: uid(42),
+  modName: "Required Mod",
+  fileName: "required.zip",
+  version: "2.0",
+  adultContent: false,
+};
+
+function installedFile(modId: string): IInstalledFile {
+  return {
+    modId,
+    fileUID: uid(9000),
+    modUID: uid(42),
+    modName: "Required Mod",
+    fileName: "required-old.zip",
+    version: "1.0",
+    adultContent: false,
+    enabled: true,
+  };
+}
+
+/** An api whose mod store holds the given mod ids, and whose download events succeed. */
+function makeApi(modIds: string[] = ["wrong-version", INSTALLED_MOD_ID]): IExtensionApi {
+  const mods = Object.fromEntries(modIds.map((id) => [id, { id }]));
+  return {
+    getState: () => ({ persistent: { mods: { skyrimse: mods } } }),
+    events: {
+      emit: (event: string, ...args: unknown[]) => {
+        // Both download events take a node-style callback; the id they report is all the
+        // action uses. "start-download" carries extra options before its callback.
+        const callback = args.find((arg) => typeof arg === "function") as (
+          err: Error | null,
+          res: string,
+        ) => void;
+        callback(null, event === "start-download" ? "dl-1" : INSTALLED_MOD_ID);
+      },
+    },
+    showErrorNotification: vi.fn(),
+  } as unknown as IExtensionApi;
+}
+
+/** The (modIds, enabled) pairs setModsEnabled was called with, in order. */
+const enableCalls = (): Array<[string[], boolean]> =>
+  mockSetModsEnabled.mock.calls.map((call) => [call[2], call[3]]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPremiumAd.mockReturnValue(false);
+  mockSetModsEnabled.mockReturnValue(Promise.resolve() as never);
+  mockTrackedInstall.mockImplementation((_api, _identity, run) => run());
+  vi.mocked(nexusGames).mockReturnValue([{ id: NEXUS_GAME_ID, domain_name: "skyrimse" }] as never);
+  vi.mocked(knownGames).mockReturnValue([] as never);
+  mockActiveProfile.mockReturnValue({ id: "profile-1", gameId: "skyrimse" } as never);
+});
+
+describe("downloadFileRequirement", () => {
+  test("disables the version it replaces before enabling the download", async () => {
+    const api = makeApi();
+
+    expect(
+      await downloadFileRequirement(api, CANDIDATE, undefined, installedFile("wrong-version")),
+    ).toBe(true);
+
+    // Disable first: leaving both enabled deploys two versions of the same mod.
+    expect(enableCalls()).toEqual([
+      [["wrong-version"], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the download replaces no installed version", async () => {
+    const api = makeApi();
+
+    expect(await downloadFileRequirement(api, CANDIDATE)).toBe(true);
+
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the install reused the replaced version's mod entry", async () => {
+    const api = makeApi();
+
+    await downloadFileRequirement(api, CANDIDATE, undefined, installedFile(INSTALLED_MOD_ID));
+
+    // Disabling it here would switch off the version just installed.
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("disables nothing when the replaced version has left the mod store", async () => {
+    const api = makeApi([INSTALLED_MOD_ID]);
+
+    await downloadFileRequirement(api, CANDIDATE, undefined, installedFile("wrong-version"));
+
+    expect(enableCalls()).toEqual([
+      [[], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("routes free users to the file page instead of downloading", async () => {
+    mockPremiumAd.mockReturnValue(true);
+
+    expect(await downloadFileRequirement(makeApi(), CANDIDATE)).toBe(false);
+
+    expect(opn).toHaveBeenCalledOnce();
+    expect(mockTrackedInstall).not.toHaveBeenCalled();
+    expect(mockSetModsEnabled).not.toHaveBeenCalled();
+  });
+
+  test("reports a failed install rather than throwing", async () => {
+    const api = makeApi();
+    mockTrackedInstall.mockRejectedValue(new Error("install failed"));
+
+    expect(await downloadFileRequirement(api, CANDIDATE)).toBe(false);
+    expect(api.showErrorNotification).toHaveBeenCalledOnce();
+  });
+});
+
+describe("installDownloadedFile", () => {
+  test("disables the version it replaces before enabling the install", async () => {
+    const api = makeApi();
+
+    expect(
+      await installDownloadedFile(api, DOWNLOADED, undefined, installedFile("wrong-version")),
+    ).toBe(true);
+
+    expect(enableCalls()).toEqual([
+      [["wrong-version"], false],
+      [[INSTALLED_MOD_ID], true],
+    ]);
+  });
+
+  test("installs a downloaded file for free users too", async () => {
+    mockPremiumAd.mockReturnValue(true);
+
+    expect(await installDownloadedFile(makeApi(), DOWNLOADED)).toBe(true);
+  });
+});

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementActions.ts
@@ -39,7 +39,8 @@ function modPageUrl(ref: INexusFileRef): string | undefined {
 }
 
 /**
- * Download and install a missing / wrong-version file, then make it the active version.
+ * Download and install a missing / wrong-version file, then make it the active version,
+ * disabling `enabledFile` when the download replaces a wrong version of the same chain.
  * Free users can't 1-click install, so open the file page instead (website download); the
  * premium upsell is out of MVP scope.
  */
@@ -47,6 +48,7 @@ export async function downloadFileRequirement(
   api: IExtensionApi,
   candidate: IFileRequirementCandidate,
   identity?: IssueAnalyticsIdentity,
+  enabledFile?: IInstalledFile,
 ): Promise<boolean> {
   if (shouldShowPremiumAd(api.getState())) {
     openFilePage(api, candidate);
@@ -100,7 +102,7 @@ export async function downloadFileRequirement(
           ),
         );
 
-        await activateInstalledVersion(api, modId);
+        await activateInstalledVersion(api, modId, enabledFile);
       },
     );
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
@@ -64,13 +64,21 @@ export const categoryOf = (requirement: IFileRequirement): FileRequirementCatego
   }
 };
 
+/** One file to download, with the wrong version it replaces when it is a version change. */
+export interface IFileDownloadTarget {
+  candidate: IFileRequirementCandidate;
+  /** The wrong version currently enabled, disabled once the download installs. */
+  enabledFile?: IInstalledFile;
+}
+
 /** Files to download for a report; OR/toggle/install-uninstalled need a user choice or different action. */
-export const downloadCandidates = (requirements: IFileRequirement[]): IFileRequirementCandidate[] =>
+export const downloadTargets = (requirements: IFileRequirement[]): IFileDownloadTarget[] =>
   requirements.flatMap((requirement) => {
     switch (requirement.kind) {
       case "missing":
+        return [{ candidate: requirement.candidate }];
       case "wrong-version-installed":
-        return [requirement.candidate];
+        return [{ candidate: requirement.candidate, enabledFile: requirement.installedFile }];
       default:
         return [];
     }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -5,6 +5,7 @@ import { nexusGamesProm } from "@/extensions/nexus_integration/util";
 import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import { activeProfile } from "@/extensions/profile_management/selectors";
 import type { IProfile } from "@/extensions/profile_management/types/IProfile";
+import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { getSafe } from "@/util/storeHelper";
 
@@ -285,10 +286,14 @@ export function makeDownloadedFileHydrator(
   const refByUID = new Map(refs.map((ref): [string, IDownloadedFileRef] => [ref.fileUID, ref]));
 
   return (fileUID) => {
+    // A ref miss is a normal negative lookup; callers try installed before downloaded.
     const ref = refByUID.get(fileUID);
     if (!ref) return undefined;
     const download = downloads[ref.downloadId];
-    if (!download) return undefined;
+    if (!download) {
+      log("debug", "unable to hydrate downloaded file", { fileUID, downloadId: ref.downloadId });
+      return undefined;
+    }
     return toDownloadedFile(ref, download, modDetailsByUID.get(ref.modUID));
   };
 }
@@ -352,12 +357,14 @@ export function makeInstalledFileHydrator(
   const refByUID = new Map(refs.map((ref): [string, IInstalledFileRef] => [ref.fileUID, ref]));
 
   return (fileUID) => {
+    // A ref miss is a normal negative lookup; callers try installed before downloaded.
     const ref = refByUID.get(fileUID);
     if (!ref) {
       return undefined;
     }
     const mod = mods[ref.modId];
     if (!mod) {
+      log("debug", "unable to hydrate installed file", { fileUID, modId: ref.modId });
       return undefined;
     }
     const modUID = resolveModUID(mod.attributes ?? {}, gameId);

--- a/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
+++ b/src/renderer/src/extensions/health_check/views/content/FileRequirementsContent.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
   categoryOf,
-  downloadCandidates,
+  downloadTargets,
   type IFileRequirementReport,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementReport";
 import type { IExtensionApi } from "@/types/IExtensionContext";
@@ -76,10 +76,11 @@ export const fileRequirementsContent: IHealthCheckContent = {
           issue_id: fileIssueId(source.sourceFileUID, categoryOf(requirement)),
           check_id: checkId,
         };
-        for (const candidate of downloadCandidates([requirement])) {
+        for (const target of downloadTargets([requirement])) {
           items.push({
-            key: candidate.fileUID,
-            install: () => void downloadFileRequirement(api, candidate, identity),
+            key: target.candidate.fileUID,
+            install: () =>
+              void downloadFileRequirement(api, target.candidate, identity, target.enabledFile),
           });
         }
         if (requirement.kind === "correct-version-uninstalled") {


### PR DESCRIPTION
- A `download-replace` install left both versions enabled. The download now carries the version it replaces through to `activateInstalledVersion`, so the old one is disabled.
- DLC requirements were counted into the result message but no UI renders them, so a DLC-only mod reported issues against an empty page. They no longer count.
- Query-cap truncation and file hydration failures dropped requirements with no trace. Both now log at `debug`.
- First tests for `fileRequirementActions` (8), asserting which mods end up enabled and disabled.