### PR TITLE
Health Check fixes and polish

### DIFF
--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -84,7 +84,11 @@
       "enable_required": "Enable required version",
       "view_in_mods": "View in Mods",
       "enable_this_version": "Enable this version",
-      "install_uninstalled": "Install (downloaded)"
+      "install_uninstalled": "Install (downloaded)",
+      "adult": "Adult",
+      "installed": "Installed",
+      "enabled": "Enabled",
+      "disabled": "Disabled"
     },
     "feedback_modal": {
       "title": "Thanks for letting us know",

--- a/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/FileRequirement.tsx
@@ -5,6 +5,7 @@ import {
   mdiMonitorArrowDownVariant,
 } from "@mdi/js";
 import React, { type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 import { Bullet } from "@/ui/components/bullet/Bullet";
 import { Icon } from "@/ui/components/icon/Icon";
@@ -38,6 +39,8 @@ export function FileRequirement({
   onOpenMod,
   onOpenFile,
 }: IFileRequirementProps) {
+  const { t } = useTranslation("health_check");
+
   const modImage = (
     <AdultAwareImage
       alt={file.modName}
@@ -86,7 +89,7 @@ export function FileRequirement({
                   <Bullet />
 
                   <Typography brand="danger" typographyType="body-sm">
-                    Adult
+                    {t("detail::item::adult")}
                   </Typography>
                 </>
               )}
@@ -138,14 +141,14 @@ export function FileRequirement({
         <div className="flex items-center gap-x-2">
           {file.installed && (
             <>
-              <Pill iconPath={mdiMonitorArrowDownVariant}>Installed</Pill>
+              <Pill iconPath={mdiMonitorArrowDownVariant}>{t("detail::item::installed")}</Pill>
 
               {file.enabled ? (
                 <Pill iconPath={mdiCheckCircleOutline} pillType="success">
-                  Enabled
+                  {t("detail::item::enabled")}
                 </Pill>
               ) : (
-                <Pill iconPath={mdiCloseCircleOutline}>Disabled</Pill>
+                <Pill iconPath={mdiCloseCircleOutline}>{t("detail::item::disabled")}</Pill>
               )}
 
               {!!actions && <div className="w-px self-stretch bg-stroke-weak" />}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/RequirementBody.tsx
@@ -15,8 +15,8 @@ import { sharedRequirementState } from "@/extensions/health_check/utils/shared/t
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
-import { Typography } from "@/ui/components/typography/Typography";
 
+import { Divider } from "../divider/Divider";
 import { PremiumModal } from "../premium_modal/PremiumModal";
 import { RequirementGroup } from "./RequirementGroup";
 import { DownloadRows } from "./rows/DownloadRows";
@@ -56,18 +56,6 @@ const requirementRows = (requirement: IFileRequirement, ctx: IFileActionContext)
       return <OrRows ctx={ctx} requirement={requirement} />;
   }
 };
-
-const AndDivider = () => (
-  <div aria-hidden className="flex h-9.5 items-center gap-x-3">
-    <div className="h-px w-3 bg-surface-mid" />
-
-    <Typography as="div" className="font-semibold">
-      And
-    </Typography>
-
-    <div className="h-px grow bg-surface-mid" />
-  </div>
-);
 
 export const RequirementBody = ({
   report,
@@ -149,7 +137,7 @@ export const RequirementBody = ({
       ) : (
         requirements.map((requirement, index) => (
           <React.Fragment key={requirement.requirementDefId}>
-            {index > 0 && <AndDivider />}
+            {index > 0 && <Divider className="h-9.5" variant="and" />}
 
             <RequirementGroup actions={index === 0 ? installAllAction : undefined} title={title}>
               {requirementRows(requirement, rowCtx)}

--- a/src/renderer/src/extensions/health_check/index.ts
+++ b/src/renderer/src/extensions/health_check/index.ts
@@ -13,6 +13,7 @@ import { createHealthCheckApi } from "./api";
 import { setupAutomaticTriggers } from "./api/triggers";
 import {
   fileRequirementsHealthCheck,
+  FILE_REQUIREMENTS_CHECK_ID,
   FILE_REQUIREMENTS_FLAG,
 } from "./checks/fileRequirementsCheck";
 import { modRequirementsHealthCheck } from "./checks/modRequirementsCheck";
@@ -100,14 +101,15 @@ function init(context: IExtensionContext): boolean {
     });
 
     // Re-run the file-level check when the Unleash flag flips. subscribeToFlag
-    // fires once immediately (skipped here) and then only on actual changes.
+    // fires once immediately (skipped here) and then only on actual changes. The flag gates
+    // this check alone, so only it re-runs.
     let initialFlag = true;
     FlagService.instance.subscribeToFlag(FILE_REQUIREMENTS_FLAG, () => {
       if (initialFlag) {
         initialFlag = false;
         return;
       }
-      void healthCheckApi?.runChecksByTrigger?.(HealthCheckTrigger.SettingsChanged);
+      void healthCheckApi?.custom.run(FILE_REQUIREMENTS_CHECK_ID);
     });
   });
 

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileRequirementReport.ts
@@ -21,10 +21,7 @@ export type FileRequirementCategory =
   | "download"
   /** A wrong version is enabled and the correct one isn't owned: download a different version. */
   | "download-replace"
-  /**
-   * Correct version downloaded but not installed: install it. Reserved; not
-   * produced until uninstalled-state support lands (no resolver input yet).
-   */
+  /** Correct version downloaded but not installed: install it. */
   | "install-uninstalled"
   /** Correct version installed but disabled while a wrong one is enabled: switch the active version. */
   | "toggle"

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import type { IState } from "@/types/IState";
 import { Button } from "@/ui/components/button/Button";
 import { Typography } from "@/ui/components/typography/Typography";
 import { Page } from "@/views/components/Page/Page";
@@ -21,7 +22,7 @@ import {
   fileRequirementsCheckResult,
   hiddenFileRequirements,
   hiddenModRequirements,
-  isAnyHealthCheckRunning,
+  isHealthCheckRunning,
   modRequirementsCheckResult,
 } from "../selectors";
 import { selectListedEntries } from "../utils/shared/listedEntries";
@@ -87,7 +88,9 @@ function HealthCheckDetailPage({
   const modResult = useSelector(modRequirementsCheckResult);
   const hiddenFile = useSelector(hiddenFileRequirements);
   const hiddenMod = useSelector(hiddenModRequirements);
-  const isRunning = useSelector(isAnyHealthCheckRunning);
+  // Only the entry's own check can bring its requirements back, so waiting on the other one
+  // would hold a resolved page open for the rest of that run.
+  const isRunning = useSelector((state: IState) => isHealthCheckRunning(state, entry.checkId));
 
   const liveEntry = useMemo(
     () => content.selectEntries(api.getState()).find((candidate) => candidate.id === entry.id),

--- a/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/graphQueries.ts
@@ -5,8 +5,6 @@ import type {
   IModFileQuery,
 } from "@nexusmods/nexus-api";
 
-import { FlagService } from "@/FlagService";
-
 const revisionInfo: IRevisionQuery = {
   id: true,
   revisionNumber: true,
@@ -233,15 +231,13 @@ export const MOD_FILE_INFO: Partial<IModFileQuery> = {
 };
 
 /**
- * Get the mod requirements query object. The $filter property is only included
- * when the file-level requirements feature flag is enabled, to prevent pulling in
- * mod-to-mod requirements when they are disabled by file-to-file requirements.
+ * Get the mod requirements query object. Mod-to-mod requirements that a file-to-file
+ * requirement has superseded are always skipped, so the mod-level check can never report a
+ * requirement the file-level one owns.
  */
 export function getModRequirementsInfo(): IModRequirementsQuery {
-  const flagEnabled =
-    FlagService.instance?.getFlag("vortex-file-requirements-health-check") !== undefined;
-
-  const baseQuery: IModRequirementsQuery = {
+  return {
+    $filter: { skipDisabledRequirements: true },
     dlcRequirements: {
       gameExpansion: { id: true, name: true },
       notes: true,
@@ -262,12 +258,6 @@ export function getModRequirementsInfo(): IModRequirementsQuery {
       totalCount: true,
     },
   };
-
-  if (flagEnabled) {
-    baseQuery.$filter = { skipDisabledRequirements: true };
-  }
-
-  return baseQuery;
 }
 
 export const MY_COLLECTIONS_SEARCH_QUERY: ICollectionQuery = {


### PR DESCRIPTION
- `skipDisabledRequirements` is now always sent, so the mod-level query no longer varies with the file-requirements Unleash flag. A flag flip re-runs only the file check instead of both.
- A resolved detail page returned only once every check had finished; it now waits on its own.
- "Adult", "Installed", "Enabled", "Disabled" and the "And" divider were hardcoded English; now translated, with the local divider replaced by the shared one.
- Dropped a stale comment claiming the `install-uninstalled` category isn't produced.

Closes LAZ-852