### PR TITLE
Remove manual RTL cleanup() boilerplate from renderer tests

### DIFF
--- a/src/renderer/src/controls/ContextMenu.test.tsx
+++ b/src/renderer/src/controls/ContextMenu.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as PropTypes from "prop-types";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -64,7 +64,6 @@ describe("ContextMenu", () => {
   });
 
   afterEach(() => {
-    cleanup();
     menuLayer.remove();
   });
 

--- a/src/renderer/src/controls/DraggableList.test.tsx
+++ b/src/renderer/src/controls/DraggableList.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { makeLoadOrderEntry } from "../test-utils/builders";
 import DraggableList from "./DraggableList";
@@ -16,10 +16,6 @@ beforeAll(() => {
     public unobserve(): void {}
     public disconnect(): void {}
   };
-});
-
-afterEach(() => {
-  cleanup();
 });
 
 const Row: React.FC<React.PropsWithChildren<{ item: { id: string } }>> = ({ item }) => (

--- a/src/renderer/src/extensions/category_management/views/CategoryDialog.test.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryDialog.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import CategoryDialog from "./CategoryDialog";
 
@@ -10,8 +10,6 @@ vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }
 vi.mock("./CategoryList", () => ({
   default: () => <div data-testid="cat-list">stub</div>,
 }));
-
-afterEach(() => cleanup());
 
 describe("CategoryDialog", () => {
   it("does not render when not visible", () => {

--- a/src/renderer/src/extensions/category_management/views/CategoryList.test.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryList.test.tsx
@@ -1,7 +1,7 @@
-import { screen, cleanup, render } from "@testing-library/react";
+import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import CategoryList from "./CategoryList";
 
@@ -84,10 +84,6 @@ const baseHookProps: UseCategoryTreeResult = {
   setIsFetching: vi.fn(),
   setIsFetchError: vi.fn(),
 };
-
-afterEach(() => {
-  cleanup();
-});
 
 describe("CategoryList", () => {
   it("calls setSearchString when searching", async () => {

--- a/src/renderer/src/extensions/category_management/views/CategoryListItem.nested.test.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListItem.nested.test.tsx
@@ -1,20 +1,16 @@
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TFunction } from "i18next";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { makeCategory } from "@/test-utils/builders";
 
 import type { ICategoriesTreeEntry } from "../types/ICategoriesTreeEntry";
 import buildCategoryTree from "../util/buildCategoryTree";
 import CategoryListItem from "./CategoryListItem";
-
-afterEach(() => {
-  cleanup();
-});
 
 const t = ((k: string) => k) as TFunction;
 

--- a/src/renderer/src/extensions/category_management/views/CategoryListItem.test.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListItem.test.tsx
@@ -1,7 +1,7 @@
-import { screen, cleanup, render } from "@testing-library/react";
+import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import CategoryListItem from "./CategoryListItem";
 
@@ -14,10 +14,6 @@ vi.mock("react-dnd", () => ({
   // eslint-disable-next-line @eslint-react/component-hook-factories
   useDrop: () => [{ isOver: false, canDrop: false }, vi.fn()],
 }));
-
-afterEach(() => {
-  cleanup();
-});
 
 const mockCategory = {
   categoryId: "1",

--- a/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
+++ b/src/renderer/src/extensions/download_management/views/DownloadGraph.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -60,7 +60,6 @@ const Graph = DownloadGraph as unknown as React.ComponentType<
 const t = (key: string) => key;
 
 afterEach(() => {
-  cleanup();
   resizeObserverInstances.length = 0;
   delete (globalThis as any).ResizeObserver;
 });

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.test.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.test.tsx
@@ -6,9 +6,9 @@
  */
 import { EventEmitter } from "events";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
@@ -28,11 +28,6 @@ function fakeUseTranslation() {
 }
 
 vi.mock("react-i18next", () => ({ useTranslation: fakeUseTranslation }));
-
-// RTL only auto-cleans when vitest runs with globals; this project doesn't, so without
-// this every render leaks into document.body and screen queries hit the previous test's
-// component — which silently sends its events to the previous test's emitter.
-afterEach(cleanup);
 
 const entry: IHealthCheckEntry = {
   id: "uid-42:toggle",

--- a/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.test.tsx
+++ b/src/renderer/src/extensions/health_check/hooks/HealthCheckTracking.context.test.tsx
@@ -6,9 +6,9 @@
  */
 import { EventEmitter } from "events";
 
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
@@ -46,10 +46,6 @@ const modEntry: IHealthCheckEntry = {
   resolutionType: "install",
   data: {},
 };
-
-// vitest runs without globals here, so RTL never auto-cleans; without this each
-// render leaks into document.body.
-afterEach(cleanup);
 
 /** Emits back_clicked with only its own properties — the identity should be supplied. */
 const BackClicker = () => {

--- a/src/renderer/src/ui/components/bullet/Bullet.test.tsx
+++ b/src/renderer/src/ui/components/bullet/Bullet.test.tsx
@@ -1,14 +1,10 @@
-import { render, cleanup } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Bullet } from "./Bullet";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const getBullet = () => document.querySelector(".nxm-bullet");
 

--- a/src/renderer/src/ui/components/button/Button.test.tsx
+++ b/src/renderer/src/ui/components/button/Button.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Button } from "./Button";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const getButton = () => screen.getByRole("button", { name: /click/i });
 

--- a/src/renderer/src/ui/components/collection_tile/CollectionTile.test.tsx
+++ b/src/renderer/src/ui/components/collection_tile/CollectionTile.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
@@ -19,10 +19,6 @@ vi.mock("@/util/util", () => ({ delayed: () => Promise.resolve() }));
 vi.mock("@/util/selectors", () => ({ isCollectionModPresent: () => false }));
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 // A minimal, fully-typed stand-in for the fields of ICollection the tile reads,
 // so tests can assert against the fixture rather than hardcoded strings.

--- a/src/renderer/src/ui/components/dropdown/Dropdown.test.tsx
+++ b/src/renderer/src/ui/components/dropdown/Dropdown.test.tsx
@@ -1,8 +1,8 @@
 import { Menu } from "@headlessui/react";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Dropdown } from "./Dropdown";
 import { DropdownDivider } from "./DropdownDivider";
@@ -10,10 +10,6 @@ import { DropdownItem } from "./DropdownItem";
 import { DropdownItems } from "./DropdownItems";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = () => {
   const onEdit = vi.fn();

--- a/src/renderer/src/ui/components/form/checkbox/Checkbox.test.tsx
+++ b/src/renderer/src/ui/components/form/checkbox/Checkbox.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Checkbox } from "./Checkbox";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Checkbox>> = {}) => {
   const onChange = vi.fn();

--- a/src/renderer/src/ui/components/form/formfield/FormField.test.tsx
+++ b/src/renderer/src/ui/components/form/formfield/FormField.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { FormField } from "./FormField";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 // the FormField root always carries the min-w-0 utility
 const getRoot = () => document.querySelector(".min-w-0");

--- a/src/renderer/src/ui/components/form/input/Input.test.tsx
+++ b/src/renderer/src/ui/components/form/input/Input.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Input } from "./Input";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Input>> = {}) => {
   const onChange = vi.fn();

--- a/src/renderer/src/ui/components/form/select/Select.test.tsx
+++ b/src/renderer/src/ui/components/form/select/Select.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Select } from "./Select";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const options = (
   <>

--- a/src/renderer/src/ui/components/form/switch/Switch.test.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.test.tsx
@@ -1,13 +1,9 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Switch } from "./Switch";
-
-afterEach(() => {
-  cleanup();
-});
 
 const getSwitch = () => screen.getByRole("checkbox");
 

--- a/src/renderer/src/ui/components/icon/Icon.test.tsx
+++ b/src/renderer/src/ui/components/icon/Icon.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Icon } from "./Icon";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Icon>> = {}) => {
   const path = "M0 0h24v24H0z";

--- a/src/renderer/src/ui/components/image/AdultAwareImage.test.tsx
+++ b/src/renderer/src/ui/components/image/AdultAwareImage.test.tsx
@@ -1,7 +1,7 @@
-import { render, cleanup } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
 import { useSelector } from "react-redux";
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { AdultAwareImage } from "./AdultAwareImage";
 
@@ -24,10 +24,6 @@ const getImg = () => document.querySelector("img");
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-afterEach(() => {
-  cleanup();
 });
 
 // --- Tests ---

--- a/src/renderer/src/ui/components/image/Image.test.tsx
+++ b/src/renderer/src/ui/components/image/Image.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Image } from "./Image";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Image>> = {}) => {
   const onError = vi.fn();

--- a/src/renderer/src/ui/components/listbox/Listbox.test.tsx
+++ b/src/renderer/src/ui/components/listbox/Listbox.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Listbox } from "./Listbox";
 import { ListboxButton } from "./ListboxButton";
@@ -9,10 +9,6 @@ import { ListboxOption } from "./ListboxOption";
 import { ListboxOptions } from "./ListboxOptions";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const ControlledListbox = ({
   onChange,

--- a/src/renderer/src/ui/components/listing/Listing.test.tsx
+++ b/src/renderer/src/ui/components/listing/Listing.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Listing } from "./Listing";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const SkeletonTile = () => <div data-testid="skeleton" />;
 

--- a/src/renderer/src/ui/components/listing_loader/ListingLoader.test.tsx
+++ b/src/renderer/src/ui/components/listing_loader/ListingLoader.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { ListingLoader } from "./ListingLoader";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const SkeletonTile = () => <div data-testid="skeleton" />;
 

--- a/src/renderer/src/ui/components/modal/Modal.test.tsx
+++ b/src/renderer/src/ui/components/modal/Modal.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Modal } from "./Modal";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Modal>> = {}) => {
   const onClose = vi.fn();

--- a/src/renderer/src/ui/components/no_results/NoResults.test.tsx
+++ b/src/renderer/src/ui/components/no_results/NoResults.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
@@ -8,7 +8,6 @@ import { NoResults } from "./NoResults";
 // --- Helpers ---
 
 afterEach(() => {
-  cleanup();
   vi.restoreAllMocks();
 });
 

--- a/src/renderer/src/ui/components/pagination/Pagination.test.tsx
+++ b/src/renderer/src/ui/components/pagination/Pagination.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Pagination } from "./Pagination";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Pagination>> = {}) => {
   const onPaginationUpdate = vi.fn();

--- a/src/renderer/src/ui/components/picker/Picker.test.tsx
+++ b/src/renderer/src/ui/components/picker/Picker.test.tsx
@@ -1,17 +1,13 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { type IListboxOption } from "@/ui/components/listbox/ListboxOption";
 
 import { Picker } from "./Picker";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const defaultOptions: IListboxOption<string>[] = [
   { label: "Red", value: "red" },

--- a/src/renderer/src/ui/components/pictogram/Pictogram.test.tsx
+++ b/src/renderer/src/ui/components/pictogram/Pictogram.test.tsx
@@ -1,14 +1,10 @@
-import { render, cleanup } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Pictogram } from "./Pictogram";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof Pictogram>> = {}) => {
   const name = props.name ?? "tools";

--- a/src/renderer/src/ui/components/pill/Pill.test.tsx
+++ b/src/renderer/src/ui/components/pill/Pill.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Pill } from "./Pill";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 type PillProps = React.ComponentProps<typeof Pill>;
 

--- a/src/renderer/src/ui/components/popover/Popover.test.tsx
+++ b/src/renderer/src/ui/components/popover/Popover.test.tsx
@@ -1,17 +1,13 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Popover } from "./Popover";
 import { PopoverButton } from "./PopoverButton";
 import { PopoverPanel } from "./PopoverPanel";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const renderComponent = () => {
   render(

--- a/src/renderer/src/ui/components/premium_badge/PremiumBadge.test.tsx
+++ b/src/renderer/src/ui/components/premium_badge/PremiumBadge.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { PremiumBadge } from "./PremiumBadge";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const getBadge = () => document.querySelector("span");
 

--- a/src/renderer/src/ui/components/table/Table.test.tsx
+++ b/src/renderer/src/ui/components/table/Table.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Table } from "./Table";
 import type { IColumnDef } from "./Table.types";
-
-afterEach(() => {
-  cleanup();
-});
 
 interface IRow {
   id: string;

--- a/src/renderer/src/ui/components/tabs/Tabs.test.tsx
+++ b/src/renderer/src/ui/components/tabs/Tabs.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { TabBar } from "./TabBar";
 import { TabButton } from "./TabButton";
@@ -9,10 +9,6 @@ import { TabPanel } from "./TabPanel";
 import { TabProvider } from "./Tabs.context";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const ControlledTabs = ({
   disabledThird = false,

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -1,16 +1,12 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Toolbar } from "./Toolbar";
 import { ToolbarGroup, type IToolbarAction } from "./ToolbarGroup";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const makeActions = (count: number): IToolbarAction[] =>
   Array.from({ length: count }, (_, i) => ({ label: `Action ${i + 1}`, iconPath: "mdi-test" }));

--- a/src/renderer/src/ui/components/typography/Typography.test.tsx
+++ b/src/renderer/src/ui/components/typography/Typography.test.tsx
@@ -1,14 +1,10 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Typography } from "./Typography";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const get = (text = "text") => screen.getByText(text);
 

--- a/src/renderer/src/ui/components/typography/TypographyLink.test.tsx
+++ b/src/renderer/src/ui/components/typography/TypographyLink.test.tsx
@@ -1,15 +1,11 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { TypographyLink } from "./TypographyLink";
 
 // --- Helpers ---
-
-afterEach(() => {
-  cleanup();
-});
 
 const getLink = (name: string | RegExp = /link/i) => screen.getByRole("button", { name });
 


### PR DESCRIPTION
Follow-up to #23853. With vitest `globals: true` (added there), @testing-library/react registers its own `afterEach(cleanup)` in every test file that imports it, so our manual hooks do nothing.

- 34 files: deleted the `afterEach` hook (cleanup was its only statement) plus the now-unused `cleanup` and `afterEach` imports.
- 3 files kept their hook and lost only the `cleanup()` line: ContextMenu (still removes the menu layer), DownloadGraph (still resets the ResizeObserver stub), NoResults (still restores mocks).
- 2 stale comments saying RTL never auto-cleans without globals went with their hooks.

Net -138 lines. 168 test files / 1645 tests pass, typecheck clean.

Don't merge into react-18-upgrade: this is meant for master after #23853 lands. It targets react-18-upgrade for a clean diff; when that branch merges and is deleted, GitHub retargets this PR to master automatically.
