### PR TITLE
(1) extract the nxm protocol handler into its own module

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -1,19 +1,14 @@
+import type { IModRequirements } from "@nexusmods/nexus-api";
 /**
  * Mod Requirements Health Check
  * Validates that all Nexus mod requirements are satisfied
  */
-
-import type { IModRequirements } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 
 import { getModFilesWithCache } from "@/extensions/health_check/utils/modRequirements/modFiles";
-import {
-  chunked,
-  createKeyedCache,
-  resolveCached,
-  type KeyedCache,
-} from "@/extensions/health_check/utils/shared/batchCache";
+import { chunked, resolveCached } from "@/extensions/health_check/utils/shared/batchCache";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
+import { createKeyedCache, type KeyedCache } from "@/util/keyedCache";
 
 import { log } from "../../../logging";
 import type { IExtensionApi } from "../../../types/IExtensionContext";

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/fileDependencyPorts.ts
@@ -6,15 +6,11 @@ import type {
 } from "@nexusmods/file-dependency-resolver";
 import type { components } from "@vortex/nexus-api-v3";
 
-import {
-  chunked,
-  createKeyedCache,
-  resolveCached,
-  type KeyedCache,
-} from "@/extensions/health_check/utils/shared/batchCache";
+import { chunked, resolveCached } from "@/extensions/health_check/utils/shared/batchCache";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
 import { createVortexNexusV3Client } from "@/extensions/nexus_integration/nexusV3Client";
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { createKeyedCache, type KeyedCache } from "@/util/keyedCache";
 
 type V3Client = ReturnType<typeof createVortexNexusV3Client>;
 type V3Candidate = components["schemas"]["ModFileVersionDependencyCandidate"];

--- a/src/renderer/src/extensions/health_check/utils/modRequirements/modFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/modRequirements/modFiles.ts
@@ -1,11 +1,8 @@
 import type { IModDetails, IModFileInfo } from "@/extensions/health_check/types";
-import {
-  createKeyedCache,
-  type KeyedCache,
-} from "@/extensions/health_check/utils/shared/batchCache";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
 import { makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { createKeyedCache, type KeyedCache } from "@/util/keyedCache";
 
 /**
  * Fetch available MAIN files for a mod from Nexus

--- a/src/renderer/src/extensions/health_check/utils/shared/batchCache.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/batchCache.ts
@@ -1,3 +1,5 @@
+import type { KeyedCache } from "@/util/keyedCache";
+
 /**
  * Helpers for chunked, cached batch fetching: split id lists into request-sized
  * chunks, and memoize fetched rows by key so re-runs (e.g. on ModsChanged) only
@@ -9,34 +11,6 @@ export function* chunked<T>(items: T[], size: number): Generator<T[]> {
   for (let i = 0; i < items.length; i += size) {
     yield items.slice(i, i + size);
   }
-}
-
-/** Minimal in-memory cache keyed by string with a per-entry TTL. */
-export interface KeyedCache<V> {
-  get(key: string): V | undefined;
-  set(key: string, value: V): void;
-}
-
-/** Create a keyed cache whose entries expire `ttlMs` after they are set. */
-export function createKeyedCache<V>(ttlMs: number): KeyedCache<V> {
-  const entries = new Map<string, { value: V; expires: number }>();
-
-  return {
-    get(key) {
-      const entry = entries.get(key);
-      if (entry === undefined) {
-        return undefined;
-      }
-      if (entry.expires <= Date.now()) {
-        entries.delete(key);
-        return undefined;
-      }
-      return entry.value;
-    },
-    set(key, value) {
-      entries.set(key, { value, expires: Date.now() + ttlMs });
-    },
-  };
 }
 
 /**

--- a/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/modDetails.ts
@@ -3,8 +3,9 @@ import type { components } from "@vortex/nexus-api-v3";
 import type { IModDetails } from "@/extensions/health_check/types";
 import { createVortexNexusV3Client } from "@/extensions/nexus_integration/nexusV3Client";
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { createKeyedCache, type KeyedCache } from "@/util/keyedCache";
 
-import { chunked, createKeyedCache, resolveCached, type KeyedCache } from "./batchCache";
+import { chunked, resolveCached } from "./batchCache";
 
 type V3Client = ReturnType<typeof createVortexNexusV3Client>;
 type V3ModDetail = components["schemas"]["ModDetail"];

--- a/src/renderer/src/extensions/nexus_integration/NXMUrl.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/NXMUrl.test.ts
@@ -1,15 +1,183 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import NXMUrl from "./NXMUrl";
+import { makeDownload, makeGameStored } from "@/test-utils/builders";
+
+import NXMUrl, {
+  buildNXMCollectionUrl,
+  buildNXMModUrl,
+  NXMType,
+  nxmModUrl,
+  nxmUrlFromDownload,
+} from "./NXMUrl";
 
 describe("NXMUrl", () => {
-  it("parses correctly", () => {
-    const url = new NXMUrl("nxm://Fallout4/mods/123/files/456");
-    expect(url.gameId).toBe("Fallout4");
-    expect(url.modId).toBe(123);
-    expect(url.fileId).toBe(456);
+  describe("mod file links", () => {
+    it("parses the game, mod and file", () => {
+      const url = new NXMUrl("nxm://Fallout4/mods/123/files/456");
+      expect(url.type).toBe("mod");
+      expect(url.gameId).toBe("Fallout4");
+      expect(url.modId).toBe(123);
+      expect(url.fileId).toBe(456);
+    });
+
+    it("exposes mod identifiers for the download pipeline", () => {
+      expect(new NXMUrl("nxm://Fallout4/mods/123/files/456").identifiers).toEqual({
+        type: NXMType.Mod,
+        gameId: "Fallout4",
+        modId: 123,
+        fileId: 456,
+      });
+    });
+
+    it("parses the authorisation a site-generated link carries", () => {
+      const url = new NXMUrl("nxm://Fallout4/mods/1/files/2?key=abc&expires=1700000000&user_id=42");
+      expect(url.key).toBe("abc");
+      expect(url.expires).toBe(1700000000);
+      expect(url.userId).toBe(42);
+    });
+
+    it("leaves the authorisation undefined on a link Vortex built itself", () => {
+      const url = new NXMUrl("nxm://Fallout4/mods/1/files/2");
+      expect(url.key).toBeUndefined();
+      expect(url.expires).toBeUndefined();
+      expect(url.userId).toBeUndefined();
+    });
+
+    it("reads the view flag in either of its spellings", () => {
+      expect(new NXMUrl("nxm://Fallout4/mods/1/files/2?view=true").view).toBe(true);
+      expect(new NXMUrl("nxm://Fallout4/mods/1/files/2?view=1").view).toBe(true);
+      expect(new NXMUrl("nxm://Fallout4/mods/1/files/2").view).toBe(false);
+    });
+
+    it("keeps any other query parameter reachable", () => {
+      const url = new NXMUrl("nxm://Fallout4/mods/1/files/2?campaign=health_check");
+      expect(url.getParam("campaign")).toBe("health_check");
+      expect(url.getParam("absent")).toBeUndefined();
+    });
   });
-  it("throws on invalid url", () => {
-    expect(() => new NXMUrl("gugu")).toThrow("invalid nxm url");
+
+  describe("collection links", () => {
+    it("parses a slug and revision number", () => {
+      const url = new NXMUrl("nxm://skyrimspecialedition/collections/abcdef/revisions/3");
+      expect(url.type).toBe("collection");
+      expect(url.collectionSlug).toBe("abcdef");
+      expect(url.revisionNumber).toBe(3);
+      expect(url.collectionId).toBeUndefined();
+    });
+
+    it("marks a latest-revision link with -1", () => {
+      const url = new NXMUrl("nxm://skyrimspecialedition/collections/abcdef/revisions/latest");
+      expect(url.revisionNumber).toBe(-1);
+    });
+
+    it("still parses the legacy numeric collection form", () => {
+      const url = new NXMUrl("nxm://skyrimspecialedition/collections/12345/revisions/678");
+      expect(url.collectionId).toBe(12345);
+      expect(url.revisionId).toBe(678);
+      expect(url.collectionSlug).toBeUndefined();
+    });
+
+    it("exposes collection identifiers for the download pipeline", () => {
+      const url = new NXMUrl("nxm://skyrimspecialedition/collections/abcdef/revisions/3");
+      expect(url.identifiers).toEqual({
+        type: NXMType.Collection,
+        gameId: "skyrimspecialedition",
+        collectionId: undefined,
+        revisionId: undefined,
+        collectionSlug: "abcdef",
+        revisionNumber: 3,
+      });
+    });
+  });
+
+  describe("non-download links", () => {
+    it("parses an oauth callback", () => {
+      const url = new NXMUrl("nxm://oauth/callback?code=the-code&state=the-state");
+      expect(url.type).toBe("oauth");
+      expect(url.oauthCode).toBe("the-code");
+      expect(url.oauthState).toBe("the-state");
+      expect(url.identifiers).toBeNull();
+    });
+
+    it("parses the membership-changed link", () => {
+      expect(new NXMUrl("nxm://premium").type).toBe("premium");
+    });
+  });
+
+  describe("rejected input", () => {
+    it.each([
+      ["not a url at all", "gugu"],
+      ["another protocol", "https://www.nexusmods.com/skyrimspecialedition/mods/1"],
+      ["an nxm url with no recognised path", "nxm://Fallout4/something/else"],
+    ])("throws on %s", (_label, input) => {
+      expect(() => new NXMUrl(input)).toThrow("invalid nxm url");
+    });
+  });
+
+  describe("building links", () => {
+    it("builds a mod file link from a resolved domain", () => {
+      expect(buildNXMModUrl("skyrimspecialedition", 100, 500)).toBe(
+        "nxm://skyrimspecialedition/mods/100/files/500",
+      );
+    });
+
+    it("builds a collection link from a resolved domain", () => {
+      expect(buildNXMCollectionUrl("skyrimspecialedition", "abcdef", 3)).toBe(
+        "nxm://skyrimspecialedition/collections/abcdef/revisions/3",
+      );
+    });
+
+    it("resolves the game's nxm link id when building from a game", () => {
+      const game = makeGameStored({ id: "skyrimse", details: { nxmLinkId: "SkyrimSE" } });
+      expect(nxmModUrl(game, "skyrimse", 100, 500)).toBe("nxm://SkyrimSE/mods/100/files/500");
+    });
+  });
+
+  describe("rebuilding the link for a stored download", () => {
+    it("rebuilds a mod download from its nexus ids", () => {
+      const download = makeDownload({
+        modInfo: { nexus: { ids: { gameId: "skyrimspecialedition", modId: 100, fileId: 500 } } },
+      });
+      expect(nxmUrlFromDownload(download)).toBe("nxm://skyrimspecialedition/mods/100/files/500");
+    });
+
+    it("rebuilds a collection download from its slug and revision", () => {
+      const download = makeDownload({
+        modInfo: {
+          nexus: {
+            ids: { gameId: "skyrimspecialedition", collectionSlug: "abcdef", revisionNumber: 3 },
+          },
+        },
+      });
+      expect(nxmUrlFromDownload(download)).toBe(
+        "nxm://skyrimspecialedition/collections/abcdef/revisions/3",
+      );
+    });
+
+    it("falls back to the meta domain when the nexus game id is missing", () => {
+      const download = makeDownload({
+        modInfo: {
+          nexus: { ids: { modId: 100, fileId: 500 } },
+          meta: { gameId: "1704", domainName: "skyrimspecialedition" },
+        },
+      });
+      expect(nxmUrlFromDownload(download)).toBe("nxm://skyrimspecialedition/mods/100/files/500");
+    });
+
+    it.each([
+      ["there is no nexus identity at all", makeDownload()],
+      [
+        "a mod download is missing its file id",
+        makeDownload({ modInfo: { nexus: { ids: { gameId: "skyrimspecialedition", modId: 1 } } } }),
+      ],
+      [
+        "a collection download is missing its revision",
+        makeDownload({
+          modInfo: { nexus: { ids: { gameId: "skyrimspecialedition", collectionSlug: "abc" } } },
+        }),
+      ],
+    ])("returns nothing when %s", (_label, download) => {
+      expect(nxmUrlFromDownload(download)).toBeUndefined();
+    });
   });
 });

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -3,21 +3,18 @@ import * as path from "path";
 import type {
   IDownloadURL,
   IFileInfo,
-  IFileUpdate,
   IModFile,
   IModFileQuery,
   IModInfo,
   ICollection,
   IRevision,
-  IRevisionQuery,
   IValidateKeyResponse,
   IRating,
   RatingOptions,
 } from "@nexusmods/nexus-api";
 import type NexusT from "@nexusmods/nexus-api";
-import { NexusError, RateLimitError, TimeoutError } from "@nexusmods/nexus-api";
+import { TimeoutError } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
-import { DownloadIsHTML } from "@vortex/shared/errors";
 import PromiseBB from "bluebird";
 import * as fuzz from "fuzzball";
 import type { TFunction } from "i18next";
@@ -38,22 +35,14 @@ import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionCon
 import type { IModLookupResult } from "../../types/IModLookupResult";
 import type { IState } from "../../types/IState";
 import { getApplication } from "../../util/application";
-import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
-import { markCollectionMemberSkipped } from "../../util/collectionSkip";
-import {
-  DataInvalid,
-  HTTPError,
-  ProcessCanceled,
-  ServiceTemporarilyUnavailable,
-  UserCanceled,
-} from "../../util/CustomErrors";
+import { ProcessCanceled } from "../../util/CustomErrors";
 import Debouncer from "../../util/Debouncer";
 import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
 import type { LogLevel } from "../../util/log";
 import { showError } from "../../util/message";
 import opn from "../../util/opn";
-import { activeGameId, downloadPathForGame, gameById, knownGames } from "../../util/selectors";
+import { activeGameId, downloadPathForGame, gameById } from "../../util/selectors";
 import { currentGame, getSafe } from "../../util/storeHelper";
 import {
   batchDispatch,
@@ -67,14 +56,12 @@ import {
 import { MainContext } from "../../views/MainWindow";
 import type { ICategoryDictionary } from "../category_management/types/ICategoryDictionary";
 import type { IDownload } from "../download_management/types/IDownload";
-import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
 import { SITE_ID } from "../gamemode_management/constants";
 import type { IGameStored } from "../gamemode_management/types/IGameStored";
 import { getGame } from "../gamemode_management/util/getGame";
 import type { IMod, IModRepoId } from "../mod_management/types/IMod";
 import { isDownloadIdValid, isIdValid } from "../mod_management/util/modUpdateState";
 import { setNewestVersion } from "./actions/persistent";
-import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
 import { setAssociatedWithNXMURLs } from "./actions/settings";
 import {
   genCollectionIdAttribute,
@@ -90,7 +77,16 @@ import {
   REVALIDATION_FREQUENCY,
 } from "./constants";
 import * as eh from "./eventHandlers";
-import NXMUrl, { buildNXMModUrl } from "./NXMUrl";
+import {
+  makeNXMLinkCallback,
+  makeNXMProtocol,
+  onCancelImpl,
+  onDownloadImpl,
+  onRetryImpl,
+  onSkip,
+  onUpdated,
+} from "./nxmProtocol";
+import { buildNXMModUrl } from "./NXMUrl";
 import { accountReducer } from "./reducers/account";
 import { persistentReducer } from "./reducers/persistent";
 import { sessionReducer } from "./reducers/session";
@@ -99,12 +95,10 @@ import * as sel from "./selectors";
 import type { INexusAPIExtension } from "./types/INexusAPIExtension";
 import type { IRemoteInfo } from "./util";
 import {
-  bringToFront,
   endorseThing,
   ensureLoggedIn,
   getCollectionInfo,
   getInfo,
-  getInfoGraphQL,
   nexusGames,
   nexusGamesProm,
   oauthCallback,
@@ -112,11 +106,10 @@ import {
   processErrorMessage,
   requestLogin,
   retrieveNexusGames,
-  startDownload,
   updateToken,
 } from "./util";
 import { checkModVersion } from "./util/checkModsVersion";
-import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
+import { nexusGameId } from "./util/convertGameId";
 import { fillNexusIdByMD5, guessFromFileName, queryResetSource } from "./util/guessModID";
 import { isStoragePathName } from "./util/healStoragePathNames";
 import retrieveCategoryList from "./util/retrieveCategories";
@@ -711,161 +704,7 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
   });
 }
 
-function doDownload(api: IExtensionApi, url: string): PromiseBB<string> {
-  return (
-    startDownload(api, nexus, url)
-      .catch(DownloadIsHTML, () => undefined)
-      // DataInvalid is used here to indicate invalid user input or invalid
-      // data from remote, so it's presumably not a bug in Vortex
-      .catch(DataInvalid, () => {
-        api.showErrorNotification("Failed to start download", url, {
-          allowReport: false,
-        });
-        return PromiseBB.resolve(undefined);
-      })
-      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
-      .catch((err) => {
-        api.showErrorNotification("Failed to start download", err);
-        return PromiseBB.resolve(undefined);
-      })
-  );
-}
-
 // Main process initialization moved to src/main/extensions/nexusIntegration.ts
-
-interface IAwaitedLink {
-  gameId: string;
-  modId: number;
-  fileId: number;
-  resolve: (url: string) => void;
-}
-
-const awaitedLinks: IAwaitedLink[] = [];
-
-function makeNXMLinkCallback(api: IExtensionApi) {
-  return (url: string, install: boolean) => {
-    let nxmUrl: NXMUrl;
-    try {
-      nxmUrl = new NXMUrl(url);
-
-      const state = api.getState();
-      const isExtAvailable =
-        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
-        undefined;
-
-      if (nxmUrl.type === "oauth") {
-        try {
-          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.type === "premium") {
-        try {
-          log("info", "makeNXMLinkCallback() premium");
-          userInfoDebouncer.schedule();
-          return false;
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
-        if (install) {
-          return api.emitAndAwait("install-extension", {
-            name: "Pending",
-            modId: nxmUrl.modId,
-            fileId: nxmUrl.fileId,
-          });
-        } else {
-          api.events.emit("show-extension-page", nxmUrl.modId);
-          bringToFront();
-          return PromiseBB.resolve();
-        }
-      } else {
-        const { foregroundDL } = state.settings.interface;
-        if (foregroundDL) {
-          bringToFront();
-        }
-      }
-    } catch (err) {
-      api.showErrorNotification("Invalid URL", err, { allowReport: false });
-      return;
-    }
-
-    const awaitedIdx = awaitedLinks.findIndex(
-      (link) =>
-        link.gameId === nxmUrl.gameId &&
-        link.modId === nxmUrl.modId &&
-        link.fileId === nxmUrl.fileId,
-    );
-    if (awaitedIdx !== -1) {
-      const awaited = awaitedLinks.splice(awaitedIdx, 1);
-      awaited[0].resolve(url);
-      return;
-    }
-
-    ensureLoggedIn(api)
-      .then(() => doDownload(api, url))
-      .then((dlId) => {
-        if (dlId === undefined || dlId === null) {
-          return PromiseBB.resolve(undefined);
-        }
-
-        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
-        if (nxmUrl.collectionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
-        }
-        if (nxmUrl.revisionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
-        }
-        if (nxmUrl.collectionSlug !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
-        }
-        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
-          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
-        }
-        batchDispatch(api.store, actions);
-
-        return new PromiseBB((resolve, reject) => {
-          const currentState: IState = api.store.getState();
-          const download = currentState.persistent.downloads.files[dlId];
-          if (download === undefined) {
-            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
-          }
-          // collections always get installed automatically.
-          if (install && nxmUrl.type !== "collection") {
-            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
-              if (err !== null) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
-          } else {
-            resolve();
-          }
-        });
-      })
-      // doDownload handles all download errors so the catches below are
-      //  only for log in errors
-      .catch(UserCanceled, () => null)
-      .catch(ProcessCanceled, (err) => {
-        api.showErrorNotification("Log-in failed", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch(ServiceTemporarilyUnavailable, (err) => {
-        api.showErrorNotification("Service temporarily unavailable", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch((err) => {
-        api.showErrorNotification("Failed to get access key", err, {
-          id: "failed-get-nexus-key",
-        });
-      });
-  };
-}
 
 function makeRepositoryLookup(api: IExtensionApi, nexusConn: NexusT) {
   const query: Partial<IModFileQuery> = {
@@ -1110,7 +949,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
     const didRegister: boolean = await api.registerProtocol(
       "nxm",
       def !== false,
-      makeNXMLinkCallback(api),
+      makeNXMLinkCallback(api, nexus, () => userInfoDebouncer.schedule()),
     );
     if (didRegister) {
       api.sendNotification({
@@ -1456,426 +1295,8 @@ function fixIds(api: IExtensionApi, instanceIds: string[]) {
   ).then(() => null);
 }
 
-type AwaitLinkCB = (gameId: string, modId: number, fileId: number) => PromiseBB<string>;
-
-interface IDLQueueItem {
-  input: string;
-  url: NXMUrl;
-  canceled: boolean;
-  res: (res: IResolvedURL) => void;
-  rej: (err: Error) => void;
-  queryRelevantUpdates: () => PromiseBB<IFileUpdate[]>;
-}
-
-const freeDLQueue: IDLQueueItem[] = [];
-
-const DL_QUERY: IRevisionQuery = {
-  id: true,
-  revisionNumber: true,
-  downloadLink: true,
-  collection: {
-    id: true,
-  },
-};
-
-function makeNXMProtocol(api: IExtensionApi, onAwaitLink: AwaitLinkCB) {
-  // for free users a dialog needs to be displayed sending them to the site for the download.
-  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
-  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
-  // out of the larger process without the user having to click cancel multiple times.
-  // Thus we have to keep track of all queued downloads.
-
-  function freeUserDownload(input: string, url: NXMUrl) {
-    // non-premium user trying to download a file with no id, have to send the user to the
-    // corresponding site to generate a proper link
-    return new PromiseBB<IResolvedURL>((resolve, reject, onCancel) => {
-      const res = (result: IResolvedURL) => {
-        if (resolve !== undefined) {
-          // just to make sure we remove the correct item, idx should always be 0
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          resolve(result);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const rej = (err) => {
-        if (reject !== undefined) {
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          reject(err);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const queryRelevantUpdates = () => {
-        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
-          // Build a bidirectional map for O(1) lookups, we're doing this
-          //  in the hope that the mod authors have kept a clear update chain
-          //  which we can use to find relevant fileIds.
-          // It's not cool that we're consuming an API slot for this, but without this
-          //  we can't reliably compare the dependency reference to what we're attempting
-          //  to skip (we only have the NXM url which isn't enough).
-          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
-          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
-
-          files.file_updates.forEach((update) => {
-            forwardMap.set(update.old_file_id, update);
-            backwardMap.set(update.new_file_id, update);
-          });
-
-          // Traverse backwards to find the oldest file in the chain
-          let currentId = url.fileId;
-          const backwardChain: IFileUpdate[] = [];
-
-          while (backwardMap.has(currentId)) {
-            const update = backwardMap.get(currentId);
-            backwardChain.unshift(update); // Add to beginning
-            currentId = update.old_file_id;
-          }
-
-          // Now traverse forwards from the oldest file to build complete chain
-          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
-          currentId = oldestId;
-          const completeChain: IFileUpdate[] = [];
-
-          while (forwardMap.has(currentId)) {
-            const update = forwardMap.get(currentId);
-            completeChain.push(update);
-            currentId = update.new_file_id;
-          }
-
-          return completeChain;
-        });
-      };
-      const queueItems = {
-        input,
-        url,
-        res,
-        rej,
-        queryRelevantUpdates,
-        canceled: false,
-      };
-      onCancel(() => {
-        queueItems.canceled = true;
-        const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-        freeDLQueue.splice(idx, 1);
-      });
-      freeDLQueue.push(queueItems as any);
-      api.store.dispatch(addFreeUserDLItem(input));
-    });
-  }
-
-  // Cache download URLs to avoid repeated API calls for the same file
-  const downloadURLCache: {
-    [key: string]: { urls: string[]; expires: number; meta: any };
-  } = {};
-  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
-  function premiumUserDownload(
-    input: string,
-    url: NXMUrl,
-    directDownloadEnabled: boolean = false,
-  ): PromiseBB<IResolvedURL> {
-    const state = api.getState();
-    const games = knownGames(state);
-    const gameId = convertNXMIdReverse(games, url.gameId);
-    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-    let revisionInfo: Partial<IRevision>;
-
-    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
-
-    if (!["mod", "collection"].includes(url.type)) {
-      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
-    }
-
-    // Create cache key
-    const cacheKey =
-      url.type === "mod"
-        ? `mod_${url.modId}_${url.fileId}_${pageId}`
-        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
-
-    // Check cache first
-    const cached = downloadURLCache[cacheKey];
-    if (cached && Date.now() < cached.expires) {
-      return PromiseBB.resolve({
-        urls: cached.urls,
-        updatedUrl: input,
-        meta: cached.meta,
-      });
-    }
-
-    const downloadKey = directDownloadEnabled ? undefined : url.key;
-    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
-
-    return PromiseBB.resolve()
-      .then(() =>
-        url.type === "mod"
-          ? nexus
-              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
-              .then((res: IDownloadURL[]) => {
-                const result = {
-                  urls: res.map((u) => u.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        modId: url.modId,
-                        fileId: url.fileId,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              })
-          : nexus
-              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
-              .catch((err) => {
-                err["collectionSlug"] = url.collectionSlug;
-                err["revisionNumber"] = url.revisionNumber;
-                return PromiseBB.reject(err);
-              })
-              .then((revision: Partial<IRevision>) => {
-                revisionInfo = revision;
-                return nexus.getCollectionDownloadLink(revision.downloadLink);
-              })
-              .then((downloadUrls) => {
-                const result = {
-                  urls: downloadUrls.map((iter) => iter.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        collectionId: revisionInfo.collection.id,
-                        revisionId: revisionInfo.id,
-                        collectionSlug: url.collectionSlug,
-                        revisionNumber: revisionInfo.revisionNumber ?? url.revisionNumber,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              }),
-      )
-      .catch(NexusError, (err) => {
-        const newError = new HTTPError(err.statusCode, err.message, err.request);
-        newError.stack = err.stack;
-        return PromiseBB.reject(newError);
-      })
-      .catch(HTTPError, (err) => {
-        // A 401 here means the Nexus client could not authenticate the
-        // request and could not (or did not) refresh its token. Reachable
-        // when persisted state says we have OAuth credentials but the live
-        // Nexus instance does not (e.g. updateToken never ran on startup,
-        // forced-logout migration path), when the refresh token has been
-        // revoked server-side, or on a resume after logout. Surface as a
-        // ProcessCanceled so reportDownloadError shows a friendly,
-        // non-reportable notification instead of letting the raw 401 fall
-        // through to the generic else branch with the Report button.
-        if (err.statusCode === 401) {
-          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
-        }
-        return PromiseBB.reject(err);
-      })
-      .catch(RateLimitError, (err) => {
-        api.showErrorNotification("Rate limit exceeded", err, {
-          allowReport: false,
-        });
-        return PromiseBB.reject(err);
-      });
-  }
-
-  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
-    const state = api.store.getState();
-
-    let url: NXMUrl;
-    try {
-      url = new NXMUrl(input);
-    } catch (err) {
-      return PromiseBB.reject(err);
-    }
-
-    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
-    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
-      const userName: string = getSafe(
-        state,
-        ["persistent", "nexus", "userInfo", "name"],
-        undefined,
-      );
-      api.showErrorNotification(
-        "Invalid download links",
-        "The link was not created for this account ({{userName}}). " +
-          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
-        { allowReport: false, replace: { userName } },
-      );
-      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
-    }
-
-    if (
-      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
-      url.type === "mod" &&
-      url.gameId !== SITE_ID &&
-      url.key === undefined
-    ) {
-      const games = knownGames(state);
-      const gameId = convertNXMIdReverse(games, url.gameId);
-      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-
-      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
-        .then(({ modInfo, fileInfo }) => {
-          if (modInfo["direct_download_enabled"]) {
-            return premiumUserDownload(input, url, true);
-          } else {
-            return freeUserDownload(input, url);
-          }
-        })
-        .catch((err) => {
-          const message = getErrorMessageOrDefault(err);
-          // Cancellation must propagate; otherwise sibling deps whose in-flight
-          // mod-info queries get aborted re-enter freeUserDownload, repopulate
-          // the queue, and the dialog re-opens behind the one the user just
-          // dismissed.
-          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
-            return PromiseBB.reject(err);
-          }
-          // If we can't query mod info, fall back to free user flow
-          log("warn", "failed to query mod info for direct download check", {
-            error: message,
-          });
-          return freeUserDownload(input, url);
-        });
-    } else {
-      return premiumUserDownload(input, url);
-    }
-  };
-
-  return resolveFunc;
-}
-
-function onUpdated() {
-  bringToFront();
-}
-
-type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
-
-function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-  const { url } = queueItem;
-
-  awaitedLinks.push({
-    gameId: url.gameId,
-    modId: url.modId,
-    fileId: url.fileId,
-    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
-  });
-
-  opn(
-    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
-  ).catch(() => null);
-}
-
-function onSkip(api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem !== undefined) {
-    queueItem
-      .queryRelevantUpdates()
-      .then((updates) => {
-        const fileIdSet = new Set<string>();
-        const fileNames = new Set<string>();
-        fileIdSet.add(queueItem.url.fileId.toString());
-        updates.forEach((update) => {
-          if (update.old_file_id != null) {
-            fileIdSet.add(update.old_file_id.toString());
-            fileNames.add(update.old_file_name);
-          }
-          if (update.new_file_id != null) {
-            fileIdSet.add(update.new_file_id.toString());
-            fileNames.add(update.new_file_name);
-          }
-        });
-        const parsed = new NXMUrl(queueItem.input);
-        const itemIdentifiers = {
-          ...parsed.identifiers,
-          fileNames: Array.from(fileNames),
-          fileIds: Array.from(fileIdSet),
-        };
-        // collections is now core, so the skip site dispatches the ignore directly against the
-        // active install session rather than emitting an event for the InstallDriver to handle
-        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
-        queueItem.rej(new UserCanceled(true));
-      })
-      .catch((err) => {
-        log("warn", "failed to query relevant updates on skip", {
-          error: err.message,
-        });
-        queueItem.rej(new UserCanceled(true));
-      });
-  }
-}
-
-function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-
-  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
-}
-
 function onCheckStatusImpl() {
   userInfoDebouncer.schedule();
-}
-
-function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
-  const copy = freeDLQueue.slice(0);
-  if (copy.length !== 0) {
-    copy.forEach((item) => {
-      item.rej(new UserCanceled(false));
-    });
-    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
-    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
-    // routes through the collections plugin for the full cleanup: stop queuing,
-    // reset the driver, dismiss the install notification.
-    const session = getCollectionActiveSession(api.getState());
-    if (session?.collectionId && session.gameId) {
-      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
-    }
-    return true;
-  } else {
-    api.store.dispatch(removeFreeUserDLItem(inputUrl));
-    return false;
-  }
 }
 
 function init(context: IExtensionContext): boolean {
@@ -2077,18 +1498,7 @@ function init(context: IExtensionContext): boolean {
     },
   );
 
-  const resolveFunc = makeNXMProtocol(
-    context.api,
-    (gameId: string, modId: number, fileId: number) =>
-      new PromiseBB((resolve) => {
-        console.log("makeNXMProtocol", {
-          gameId: gameId,
-          modId: modId,
-          fileId: fileId,
-        });
-        awaitedLinks.push({ gameId, modId, fileId, resolve });
-      }),
-  );
+  const resolveFunc = makeNXMProtocol(context.api, nexus);
 
   // this makes it so the download manager can use nxm urls as download urls
   context.registerDownloadProtocol("nxm", resolveFunc);

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -77,15 +77,7 @@ import {
   REVALIDATION_FREQUENCY,
 } from "./constants";
 import * as eh from "./eventHandlers";
-import {
-  makeNXMLinkCallback,
-  makeNXMProtocol,
-  onCancelImpl,
-  onDownloadImpl,
-  onRetryImpl,
-  onSkip,
-  onUpdated,
-} from "./nxmProtocol";
+import { NxmProtocol } from "./nxmProtocol";
 import { buildNXMModUrl } from "./NXMUrl";
 import { accountReducer } from "./reducers/account";
 import { persistentReducer } from "./reducers/persistent";
@@ -123,6 +115,9 @@ import {} from "./views/Settings";
 
 let nexus: NexusT;
 let userInfoDebouncer: Debouncer;
+// built in init() so the protocol handlers can be registered there, and shared with the once()
+// callback that registers the OS-level nxm:// handler - both sides need the same queue
+let nxmProtocol: NxmProtocol;
 
 export class APIDisabled extends Error {
   constructor(instruction: string) {
@@ -949,7 +944,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
     const didRegister: boolean = await api.registerProtocol(
       "nxm",
       def !== false,
-      makeNXMLinkCallback(api, nexus, () => userInfoDebouncer.schedule()),
+      nxmProtocol.handleLink,
     );
     if (didRegister) {
       api.sendNotification({
@@ -1295,10 +1290,6 @@ function fixIds(api: IExtensionApi, instanceIds: string[]) {
   ).then(() => null);
 }
 
-function onCheckStatusImpl() {
-  userInfoDebouncer.schedule();
-}
-
 function init(context: IExtensionContext): boolean {
   context.registerReducer(["confidential", "account", "nexus"], accountReducer);
   context.registerReducer(["settings", "nexus"], settingsReducer);
@@ -1498,10 +1489,13 @@ function init(context: IExtensionContext): boolean {
     },
   );
 
-  const resolveFunc = makeNXMProtocol(context.api, nexus);
+  // the connection is built later, in the once() callback, so it's read lazily
+  nxmProtocol = new NxmProtocol(context.api, () => nexus, {
+    onRefreshMembership: () => userInfoDebouncer.schedule(),
+  });
 
   // this makes it so the download manager can use nxm urls as download urls
-  context.registerDownloadProtocol("nxm", resolveFunc);
+  context.registerDownloadProtocol("nxm", nxmProtocol.resolve);
 
   context.registerSettings(
     "Download",
@@ -1515,23 +1509,11 @@ function init(context: IExtensionContext): boolean {
     onReceiveCode: (code: string, state: string) => oauthCallback(context.api, code, state),
   }));
 
-  const onDownload = (inputUrl: string) => onDownloadImpl(resolveFunc, inputUrl);
-
-  const onCancel = (inputUrl: string) => onCancelImpl(context.api, inputUrl);
-
-  const onCheckStatus = () => onCheckStatusImpl();
-
-  const onRetry = (inputUrl: string) => onRetryImpl(resolveFunc, context.api, inputUrl);
-
   context.registerDialog("free-user-download", FreeUserDLDialog, () => ({
     t: context.api.translate,
     nexus,
-    onUpdated,
-    onDownload,
-    onSkip: (inputUrl: string) => onSkip(context.api, inputUrl),
-    onCancel,
-    onRetry,
-    onCheckStatus,
+    ...nxmProtocol.dialogHandlers,
+    onCheckStatus: () => userInfoDebouncer.schedule(),
   }));
 
   context.registerBanner(

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -3,21 +3,18 @@ import * as path from "path";
 import type {
   IDownloadURL,
   IFileInfo,
-  IFileUpdate,
   IModFile,
   IModFileQuery,
   IModInfo,
   ICollection,
   IRevision,
-  IRevisionQuery,
   IValidateKeyResponse,
   IRating,
   RatingOptions,
 } from "@nexusmods/nexus-api";
 import type NexusT from "@nexusmods/nexus-api";
-import { NexusError, RateLimitError, TimeoutError } from "@nexusmods/nexus-api";
+import { TimeoutError } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
-import { DownloadIsHTML } from "@vortex/shared/errors";
 import PromiseBB from "bluebird";
 import * as fuzz from "fuzzball";
 import type { TFunction } from "i18next";
@@ -38,22 +35,14 @@ import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionCon
 import type { IModLookupResult } from "../../types/IModLookupResult";
 import type { IState } from "../../types/IState";
 import { getApplication } from "../../util/application";
-import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
-import { markCollectionMemberSkipped } from "../../util/collectionSkip";
-import {
-  DataInvalid,
-  HTTPError,
-  ProcessCanceled,
-  ServiceTemporarilyUnavailable,
-  UserCanceled,
-} from "../../util/CustomErrors";
+import { ProcessCanceled } from "../../util/CustomErrors";
 import Debouncer from "../../util/Debouncer";
 import * as fs from "../../util/fs";
 import getVortexPath from "../../util/getVortexPath";
 import type { LogLevel } from "../../util/log";
 import { showError } from "../../util/message";
 import opn from "../../util/opn";
-import { activeGameId, downloadPathForGame, gameById, knownGames } from "../../util/selectors";
+import { activeGameId, downloadPathForGame, gameById } from "../../util/selectors";
 import { currentGame, getSafe } from "../../util/storeHelper";
 import {
   batchDispatch,
@@ -67,14 +56,12 @@ import {
 import { MainContext } from "../../views/MainWindow";
 import type { ICategoryDictionary } from "../category_management/types/ICategoryDictionary";
 import type { IDownload } from "../download_management/types/IDownload";
-import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
 import { SITE_ID } from "../gamemode_management/constants";
 import type { IGameStored } from "../gamemode_management/types/IGameStored";
 import { getGame } from "../gamemode_management/util/getGame";
 import type { IMod, IModRepoId } from "../mod_management/types/IMod";
 import { isDownloadIdValid, isIdValid } from "../mod_management/util/modUpdateState";
 import { setNewestVersion } from "./actions/persistent";
-import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
 import { setAssociatedWithNXMURLs } from "./actions/settings";
 import {
   genCollectionIdAttribute,
@@ -90,7 +77,16 @@ import {
   REVALIDATION_FREQUENCY,
 } from "./constants";
 import * as eh from "./eventHandlers";
-import NXMUrl, { buildNXMModUrl } from "./NXMUrl";
+import {
+  makeNXMLinkCallback,
+  makeNXMProtocol,
+  onCancelImpl,
+  onDownloadImpl,
+  onRetryImpl,
+  onSkip,
+  onUpdated,
+} from "./nxmProtocol";
+import { buildNXMModUrl } from "./NXMUrl";
 import { accountReducer } from "./reducers/account";
 import { persistentReducer } from "./reducers/persistent";
 import { sessionReducer } from "./reducers/session";
@@ -99,12 +95,10 @@ import * as sel from "./selectors";
 import type { INexusAPIExtension } from "./types/INexusAPIExtension";
 import type { IRemoteInfo } from "./util";
 import {
-  bringToFront,
   endorseThing,
   ensureLoggedIn,
   getCollectionInfo,
   getInfo,
-  getInfoGraphQL,
   nexusGames,
   nexusGamesProm,
   oauthCallback,
@@ -112,11 +106,10 @@ import {
   processErrorMessage,
   requestLogin,
   retrieveNexusGames,
-  startDownload,
   updateToken,
 } from "./util";
 import { checkModVersion } from "./util/checkModsVersion";
-import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
+import { nexusGameId } from "./util/convertGameId";
 import { fillNexusIdByMD5, guessFromFileName, queryResetSource } from "./util/guessModID";
 import { isStoragePathName } from "./util/healStoragePathNames";
 import retrieveCategoryList from "./util/retrieveCategories";
@@ -711,161 +704,7 @@ function processAttributes(state: IState, input: any, quick: boolean): PromiseBB
   });
 }
 
-function doDownload(api: IExtensionApi, url: string): PromiseBB<string> {
-  return (
-    startDownload(api, nexus, url)
-      .catch(DownloadIsHTML, () => undefined)
-      // DataInvalid is used here to indicate invalid user input or invalid
-      // data from remote, so it's presumably not a bug in Vortex
-      .catch(DataInvalid, () => {
-        api.showErrorNotification("Failed to start download", url, {
-          allowReport: false,
-        });
-        return PromiseBB.resolve(undefined);
-      })
-      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
-      .catch((err) => {
-        api.showErrorNotification("Failed to start download", err);
-        return PromiseBB.resolve(undefined);
-      })
-  );
-}
-
 // Main process initialization moved to src/main/extensions/nexusIntegration.ts
-
-interface IAwaitedLink {
-  gameId: string;
-  modId: number;
-  fileId: number;
-  resolve: (url: string) => void;
-}
-
-const awaitedLinks: IAwaitedLink[] = [];
-
-function makeNXMLinkCallback(api: IExtensionApi) {
-  return (url: string, install: boolean) => {
-    let nxmUrl: NXMUrl;
-    try {
-      nxmUrl = new NXMUrl(url);
-
-      const state = api.getState();
-      const isExtAvailable =
-        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
-        undefined;
-
-      if (nxmUrl.type === "oauth") {
-        try {
-          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.type === "premium") {
-        try {
-          log("info", "makeNXMLinkCallback() premium");
-          userInfoDebouncer.schedule();
-          return false;
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
-        if (install) {
-          return api.emitAndAwait("install-extension", {
-            name: "Pending",
-            modId: nxmUrl.modId,
-            fileId: nxmUrl.fileId,
-          });
-        } else {
-          api.events.emit("show-extension-page", nxmUrl.modId);
-          bringToFront();
-          return PromiseBB.resolve();
-        }
-      } else {
-        const { foregroundDL } = state.settings.interface;
-        if (foregroundDL) {
-          bringToFront();
-        }
-      }
-    } catch (err) {
-      api.showErrorNotification("Invalid URL", err, { allowReport: false });
-      return;
-    }
-
-    const awaitedIdx = awaitedLinks.findIndex(
-      (link) =>
-        link.gameId === nxmUrl.gameId &&
-        link.modId === nxmUrl.modId &&
-        link.fileId === nxmUrl.fileId,
-    );
-    if (awaitedIdx !== -1) {
-      const awaited = awaitedLinks.splice(awaitedIdx, 1);
-      awaited[0].resolve(url);
-      return;
-    }
-
-    ensureLoggedIn(api)
-      .then(() => doDownload(api, url))
-      .then((dlId) => {
-        if (dlId === undefined || dlId === null) {
-          return PromiseBB.resolve(undefined);
-        }
-
-        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
-        if (nxmUrl.collectionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
-        }
-        if (nxmUrl.revisionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
-        }
-        if (nxmUrl.collectionSlug !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
-        }
-        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
-          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
-        }
-        batchDispatch(api.store, actions);
-
-        return new PromiseBB((resolve, reject) => {
-          const currentState: IState = api.store.getState();
-          const download = currentState.persistent.downloads.files[dlId];
-          if (download === undefined) {
-            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
-          }
-          // collections always get installed automatically.
-          if (install && nxmUrl.type !== "collection") {
-            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
-              if (err !== null) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
-          } else {
-            resolve();
-          }
-        });
-      })
-      // doDownload handles all download errors so the catches below are
-      //  only for log in errors
-      .catch(UserCanceled, () => null)
-      .catch(ProcessCanceled, (err) => {
-        api.showErrorNotification("Log-in failed", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch(ServiceTemporarilyUnavailable, (err) => {
-        api.showErrorNotification("Service temporarily unavailable", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch((err) => {
-        api.showErrorNotification("Failed to get access key", err, {
-          id: "failed-get-nexus-key",
-        });
-      });
-  };
-}
 
 function makeRepositoryLookup(api: IExtensionApi, nexusConn: NexusT) {
   const query: Partial<IModFileQuery> = {
@@ -1110,7 +949,7 @@ function once(api: IExtensionApi, callbacks: Array<(nexus: NexusT) => void>) {
     const didRegister: boolean = await api.registerProtocol(
       "nxm",
       def !== false,
-      makeNXMLinkCallback(api),
+      makeNXMLinkCallback(api, nexus, () => userInfoDebouncer.schedule()),
     );
     if (didRegister) {
       api.sendNotification({
@@ -1456,425 +1295,8 @@ function fixIds(api: IExtensionApi, instanceIds: string[]) {
   ).then(() => null);
 }
 
-type AwaitLinkCB = (gameId: string, modId: number, fileId: number) => PromiseBB<string>;
-
-interface IDLQueueItem {
-  input: string;
-  url: NXMUrl;
-  canceled: boolean;
-  res: (res: IResolvedURL) => void;
-  rej: (err: Error) => void;
-  queryRelevantUpdates: () => PromiseBB<IFileUpdate[]>;
-}
-
-const freeDLQueue: IDLQueueItem[] = [];
-
-const DL_QUERY: IRevisionQuery = {
-  id: true,
-  downloadLink: true,
-  collection: {
-    id: true,
-  },
-};
-
-function makeNXMProtocol(api: IExtensionApi, onAwaitLink: AwaitLinkCB) {
-  // for free users a dialog needs to be displayed sending them to the site for the download.
-  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
-  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
-  // out of the larger process without the user having to click cancel multiple times.
-  // Thus we have to keep track of all queued downloads.
-
-  function freeUserDownload(input: string, url: NXMUrl) {
-    // non-premium user trying to download a file with no id, have to send the user to the
-    // corresponding site to generate a proper link
-    return new PromiseBB<IResolvedURL>((resolve, reject, onCancel) => {
-      const res = (result: IResolvedURL) => {
-        if (resolve !== undefined) {
-          // just to make sure we remove the correct item, idx should always be 0
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          resolve(result);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const rej = (err) => {
-        if (reject !== undefined) {
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          reject(err);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const queryRelevantUpdates = () => {
-        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
-          // Build a bidirectional map for O(1) lookups, we're doing this
-          //  in the hope that the mod authors have kept a clear update chain
-          //  which we can use to find relevant fileIds.
-          // It's not cool that we're consuming an API slot for this, but without this
-          //  we can't reliably compare the dependency reference to what we're attempting
-          //  to skip (we only have the NXM url which isn't enough).
-          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
-          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
-
-          files.file_updates.forEach((update) => {
-            forwardMap.set(update.old_file_id, update);
-            backwardMap.set(update.new_file_id, update);
-          });
-
-          // Traverse backwards to find the oldest file in the chain
-          let currentId = url.fileId;
-          const backwardChain: IFileUpdate[] = [];
-
-          while (backwardMap.has(currentId)) {
-            const update = backwardMap.get(currentId);
-            backwardChain.unshift(update); // Add to beginning
-            currentId = update.old_file_id;
-          }
-
-          // Now traverse forwards from the oldest file to build complete chain
-          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
-          currentId = oldestId;
-          const completeChain: IFileUpdate[] = [];
-
-          while (forwardMap.has(currentId)) {
-            const update = forwardMap.get(currentId);
-            completeChain.push(update);
-            currentId = update.new_file_id;
-          }
-
-          return completeChain;
-        });
-      };
-      const queueItems = {
-        input,
-        url,
-        res,
-        rej,
-        queryRelevantUpdates,
-        canceled: false,
-      };
-      onCancel(() => {
-        queueItems.canceled = true;
-        const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-        freeDLQueue.splice(idx, 1);
-      });
-      freeDLQueue.push(queueItems as any);
-      api.store.dispatch(addFreeUserDLItem(input));
-    });
-  }
-
-  // Cache download URLs to avoid repeated API calls for the same file
-  const downloadURLCache: {
-    [key: string]: { urls: string[]; expires: number; meta: any };
-  } = {};
-  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
-  function premiumUserDownload(
-    input: string,
-    url: NXMUrl,
-    directDownloadEnabled: boolean = false,
-  ): PromiseBB<IResolvedURL> {
-    const state = api.getState();
-    const games = knownGames(state);
-    const gameId = convertNXMIdReverse(games, url.gameId);
-    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-    let revisionInfo: Partial<IRevision>;
-
-    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
-
-    if (!["mod", "collection"].includes(url.type)) {
-      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
-    }
-
-    // Create cache key
-    const cacheKey =
-      url.type === "mod"
-        ? `mod_${url.modId}_${url.fileId}_${pageId}`
-        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
-
-    // Check cache first
-    const cached = downloadURLCache[cacheKey];
-    if (cached && Date.now() < cached.expires) {
-      return PromiseBB.resolve({
-        urls: cached.urls,
-        updatedUrl: input,
-        meta: cached.meta,
-      });
-    }
-
-    const downloadKey = directDownloadEnabled ? undefined : url.key;
-    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
-
-    return PromiseBB.resolve()
-      .then(() =>
-        url.type === "mod"
-          ? nexus
-              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
-              .then((res: IDownloadURL[]) => {
-                const result = {
-                  urls: res.map((u) => u.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        modId: url.modId,
-                        fileId: url.fileId,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              })
-          : nexus
-              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
-              .catch((err) => {
-                err["collectionSlug"] = url.collectionSlug;
-                err["revisionNumber"] = url.revisionNumber;
-                return PromiseBB.reject(err);
-              })
-              .then((revision: Partial<IRevision>) => {
-                revisionInfo = revision;
-                return nexus.getCollectionDownloadLink(revision.downloadLink);
-              })
-              .then((downloadUrls) => {
-                const result = {
-                  urls: downloadUrls.map((iter) => iter.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        collectionId: revisionInfo.collection.id,
-                        revisionId: revisionInfo.id,
-                        collectionSlug: url.collectionSlug,
-                        revisionNumber: url.revisionNumber,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              }),
-      )
-      .catch(NexusError, (err) => {
-        const newError = new HTTPError(err.statusCode, err.message, err.request);
-        newError.stack = err.stack;
-        return PromiseBB.reject(newError);
-      })
-      .catch(HTTPError, (err) => {
-        // A 401 here means the Nexus client could not authenticate the
-        // request and could not (or did not) refresh its token. Reachable
-        // when persisted state says we have OAuth credentials but the live
-        // Nexus instance does not (e.g. updateToken never ran on startup,
-        // forced-logout migration path), when the refresh token has been
-        // revoked server-side, or on a resume after logout. Surface as a
-        // ProcessCanceled so reportDownloadError shows a friendly,
-        // non-reportable notification instead of letting the raw 401 fall
-        // through to the generic else branch with the Report button.
-        if (err.statusCode === 401) {
-          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
-        }
-        return PromiseBB.reject(err);
-      })
-      .catch(RateLimitError, (err) => {
-        api.showErrorNotification("Rate limit exceeded", err, {
-          allowReport: false,
-        });
-        return PromiseBB.reject(err);
-      });
-  }
-
-  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
-    const state = api.store.getState();
-
-    let url: NXMUrl;
-    try {
-      url = new NXMUrl(input);
-    } catch (err) {
-      return PromiseBB.reject(err);
-    }
-
-    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
-    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
-      const userName: string = getSafe(
-        state,
-        ["persistent", "nexus", "userInfo", "name"],
-        undefined,
-      );
-      api.showErrorNotification(
-        "Invalid download links",
-        "The link was not created for this account ({{userName}}). " +
-          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
-        { allowReport: false, replace: { userName } },
-      );
-      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
-    }
-
-    if (
-      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
-      url.type === "mod" &&
-      url.gameId !== SITE_ID &&
-      url.key === undefined
-    ) {
-      const games = knownGames(state);
-      const gameId = convertNXMIdReverse(games, url.gameId);
-      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-
-      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
-        .then(({ modInfo, fileInfo }) => {
-          if (modInfo["direct_download_enabled"]) {
-            return premiumUserDownload(input, url, true);
-          } else {
-            return freeUserDownload(input, url);
-          }
-        })
-        .catch((err) => {
-          const message = getErrorMessageOrDefault(err);
-          // Cancellation must propagate; otherwise sibling deps whose in-flight
-          // mod-info queries get aborted re-enter freeUserDownload, repopulate
-          // the queue, and the dialog re-opens behind the one the user just
-          // dismissed.
-          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
-            return PromiseBB.reject(err);
-          }
-          // If we can't query mod info, fall back to free user flow
-          log("warn", "failed to query mod info for direct download check", {
-            error: message,
-          });
-          return freeUserDownload(input, url);
-        });
-    } else {
-      return premiumUserDownload(input, url);
-    }
-  };
-
-  return resolveFunc;
-}
-
-function onUpdated() {
-  bringToFront();
-}
-
-type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
-
-function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-  const { url } = queueItem;
-
-  awaitedLinks.push({
-    gameId: url.gameId,
-    modId: url.modId,
-    fileId: url.fileId,
-    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
-  });
-
-  opn(
-    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
-  ).catch(() => null);
-}
-
-function onSkip(api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem !== undefined) {
-    queueItem
-      .queryRelevantUpdates()
-      .then((updates) => {
-        const fileIdSet = new Set<string>();
-        const fileNames = new Set<string>();
-        fileIdSet.add(queueItem.url.fileId.toString());
-        updates.forEach((update) => {
-          if (update.old_file_id != null) {
-            fileIdSet.add(update.old_file_id.toString());
-            fileNames.add(update.old_file_name);
-          }
-          if (update.new_file_id != null) {
-            fileIdSet.add(update.new_file_id.toString());
-            fileNames.add(update.new_file_name);
-          }
-        });
-        const parsed = new NXMUrl(queueItem.input);
-        const itemIdentifiers = {
-          ...parsed.identifiers,
-          fileNames: Array.from(fileNames),
-          fileIds: Array.from(fileIdSet),
-        };
-        // collections is now core, so the skip site dispatches the ignore directly against the
-        // active install session rather than emitting an event for the InstallDriver to handle
-        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
-        queueItem.rej(new UserCanceled(true));
-      })
-      .catch((err) => {
-        log("warn", "failed to query relevant updates on skip", {
-          error: err.message,
-        });
-        queueItem.rej(new UserCanceled(true));
-      });
-  }
-}
-
-function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-
-  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
-}
-
 function onCheckStatusImpl() {
   userInfoDebouncer.schedule();
-}
-
-function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
-  const copy = freeDLQueue.slice(0);
-  if (copy.length !== 0) {
-    copy.forEach((item) => {
-      item.rej(new UserCanceled(false));
-    });
-    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
-    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
-    // routes through the collections plugin for the full cleanup: stop queuing,
-    // reset the driver, dismiss the install notification.
-    const session = getCollectionActiveSession(api.getState());
-    if (session?.collectionId && session.gameId) {
-      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
-    }
-    return true;
-  } else {
-    api.store.dispatch(removeFreeUserDLItem(inputUrl));
-    return false;
-  }
 }
 
 function init(context: IExtensionContext): boolean {
@@ -2076,18 +1498,7 @@ function init(context: IExtensionContext): boolean {
     },
   );
 
-  const resolveFunc = makeNXMProtocol(
-    context.api,
-    (gameId: string, modId: number, fileId: number) =>
-      new PromiseBB((resolve) => {
-        console.log("makeNXMProtocol", {
-          gameId: gameId,
-          modId: modId,
-          fileId: fileId,
-        });
-        awaitedLinks.push({ gameId, modId, fileId, resolve });
-      }),
-  );
+  const resolveFunc = makeNXMProtocol(context.api, nexus);
 
   // this makes it so the download manager can use nxm urls as download urls
   context.registerDownloadProtocol("nxm", resolveFunc);

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
@@ -1,16 +1,18 @@
 import PromiseBB from "bluebird";
 import { beforeEach, describe, expect, vi } from "vitest";
 
-import { makeDownload, makeGameStored, makeNxmHarness } from "@/test-utils/builders";
-import { test } from "@/test-utils/harnessTest";
-import type { INxmHarness, INxmHarnessOpts } from "@/test-utils/harnessTypes";
+import { makeDownload, makeGameStored } from "@/test-utils/builders";
+import type { INxmHarness } from "@/test-utils/harnessTypes";
+import type { INxmFixtures, INxmSetup } from "@/test-utils/nxmTest";
+import { COLLECTION_URL, FREE, MOD_URL, test } from "@/test-utils/nxmTest";
 import { ProcessCanceled, UserCanceled } from "@/util/CustomErrors";
 
 import { SITE_ID } from "../gamemode_management/constants";
-import { makeNXMLinkCallback, makeNXMProtocol, onCancelImpl, onDownloadImpl } from "./nxmProtocol";
+import type * as nexusUtil from "./util";
 import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
 
-vi.mock("./util", () => ({
+vi.mock("./util", async (importOriginal) => ({
+  ...(await importOriginal<typeof nexusUtil>()),
   bringToFront: vi.fn(),
   ensureLoggedIn: vi.fn(() => PromiseBB.resolve()),
   getInfoGraphQL: vi.fn(),
@@ -22,12 +24,6 @@ vi.mock("../../util/opn", () => ({ default: vi.fn(() => PromiseBB.resolve()) }))
 
 vi.mock("../../util/collectionSkip", () => ({ markCollectionMemberSkipped: vi.fn() }));
 
-const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
-const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
-
-const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
-const FREE = { userId: 7, name: "free-user", isPremium: false };
-
 const beginDownload = vi.mocked(startDownload);
 const logIn = vi.mocked(ensureLoggedIn);
 const modInfoQuery = vi.mocked(getInfoGraphQL);
@@ -35,27 +31,18 @@ const focusWindow = vi.mocked(bringToFront);
 const finishOAuth = vi.mocked(oauthCallback);
 
 describe("nxm link callback", () => {
-  const openQueues: INxmHarness[] = [];
-
   beforeEach(() => {
     beginDownload.mockReturnValue(PromiseBB.resolve("dl-1") as never);
     logIn.mockReturnValue(PromiseBB.resolve() as never);
     modInfoQuery.mockReset();
   });
 
-  const arrange = (opts: INxmHarnessOpts = {}) => {
-    const harness = makeNxmHarness({ userInfo: PREMIUM, ...opts });
-    openQueues.push(harness);
-    // the callback only dispatches modInfo once the download record exists
-    harness.setState((draft) => {
+  /** The link callback only dispatches modInfo once the download record exists. */
+  const arrangeLink = (setup: INxmSetup) => {
+    setup.harness.setState((draft) => {
       draft.persistent.downloads.files["dl-1"] = makeDownload({ id: "dl-1" });
     });
-    const onPremiumLink = vi.fn();
-    return {
-      harness,
-      onPremiumLink,
-      handleLink: makeNXMLinkCallback(harness.api, harness.nexus, onPremiumLink),
-    };
+    return { ...setup, handleLink: setup.nxm.handleLink };
   };
 
   const dispatchedModInfo = (harness: INxmHarness) =>
@@ -63,8 +50,8 @@ describe("nxm link callback", () => {
       .filter((action) => action.type === "SET_DOWNLOAD_MODINFO")
       .map((action) => action.payload as { key: string; value: unknown });
 
-  test("hands an oauth callback url to the login flow", () => {
-    const { harness, handleLink } = arrange();
+  test("hands an oauth callback url to the login flow", ({ makeNxm }) => {
+    const { harness, handleLink } = arrangeLink(makeNxm());
 
     handleLink("nxm://oauth/callback?code=the-code&state=the-state", false);
 
@@ -72,17 +59,17 @@ describe("nxm link callback", () => {
     expect(beginDownload).not.toHaveBeenCalled();
   });
 
-  test("treats a premium url as a prompt to re-read the membership", () => {
-    const { onPremiumLink, handleLink } = arrange();
+  test("treats a premium url as a prompt to re-read the membership", ({ makeNxm }) => {
+    const { onRefreshMembership, handleLink } = arrangeLink(makeNxm());
 
     expect(handleLink("nxm://premium", false)).toBe(false);
 
-    expect(onPremiumLink).toHaveBeenCalled();
+    expect(onRefreshMembership).toHaveBeenCalled();
     expect(beginDownload).not.toHaveBeenCalled();
   });
 
-  test("reports an unparseable url without offering a report", () => {
-    const { harness, handleLink } = arrange();
+  test("reports an unparseable url without offering a report", ({ makeNxm }) => {
+    const { harness, handleLink } = arrangeLink(makeNxm());
 
     handleLink("nxm://not-a-download", false);
 
@@ -93,14 +80,16 @@ describe("nxm link callback", () => {
   });
 
   describe("extension downloads from the site domain", () => {
-    const arrangeSite = () =>
-      arrange({
-        knownGames: [makeGameStored({ id: SITE_ID, details: undefined })],
-        availableExtensions: [{ modId: 100 }],
-      });
+    const arrangeSite = (makeNxm: INxmFixtures["makeNxm"]) =>
+      arrangeLink(
+        makeNxm({
+          knownGames: [makeGameStored({ id: SITE_ID, details: undefined })],
+          availableExtensions: [{ modId: 100 }],
+        }),
+      );
 
-    test("installs the extension when the link asks to install", () => {
-      const { harness, handleLink } = arrangeSite();
+    test("installs the extension when the link asks to install", ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeSite(makeNxm);
       const emitAndAwait = vi.spyOn(harness.api, "emitAndAwait");
 
       handleLink(`nxm://${SITE_ID}/mods/100/files/500`, true);
@@ -112,8 +101,8 @@ describe("nxm link callback", () => {
       });
     });
 
-    test("opens the extension page when the link is only a view", () => {
-      const { harness, handleLink } = arrangeSite();
+    test("opens the extension page when the link is only a view", ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeSite(makeNxm);
       const shown = vi.fn();
       harness.api.events.on("show-extension-page", shown);
 
@@ -125,8 +114,8 @@ describe("nxm link callback", () => {
   });
 
   describe("mod downloads", () => {
-    test("logs in, starts the download and tags it as a nexus download", async () => {
-      const { harness, handleLink } = arrange();
+    test("logs in, starts the download and tags it as a nexus download", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
 
       handleLink(MOD_URL, false);
 
@@ -138,8 +127,8 @@ describe("nxm link callback", () => {
       ]);
     });
 
-    test("installs the download when the link asks to install", async () => {
-      const { harness, handleLink } = arrange();
+    test("installs the download when the link asks to install", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
       const install = vi.fn((_id: string, cb: (err: Error | null, id: string) => void) =>
         cb(null, "mod-1"),
       );
@@ -151,8 +140,8 @@ describe("nxm link callback", () => {
       expect(install.mock.calls[0][0]).toBe("dl-1");
     });
 
-    test("brings the window forward when foreground downloads are enabled", () => {
-      const { harness, handleLink } = arrange();
+    test("brings the window forward when foreground downloads are enabled", ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
       harness.setState((draft) => {
         draft.settings.interface.foregroundDL = true;
       });
@@ -162,9 +151,9 @@ describe("nxm link callback", () => {
       expect(focusWindow).toHaveBeenCalled();
     });
 
-    test("does nothing further when the download never started", async () => {
-      const { harness, handleLink } = arrange();
-      // doDownload swallows its own failures and resolves to undefined
+    test("does nothing further when the download never started", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
+      // the handler reports download failures itself and resolves to undefined
       beginDownload.mockReturnValue(PromiseBB.resolve(undefined) as never);
 
       handleLink(MOD_URL, false);
@@ -173,8 +162,8 @@ describe("nxm link callback", () => {
       expect(dispatchedModInfo(harness)).toEqual([]);
     });
 
-    test("reports a log-in failure without offering a report", async () => {
-      const { harness, handleLink } = arrange();
+    test("reports a log-in failure without offering a report", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
       logIn.mockReturnValue(PromiseBB.reject(new ProcessCanceled("no key")) as never);
 
       handleLink(MOD_URL, false);
@@ -186,8 +175,8 @@ describe("nxm link callback", () => {
       );
     });
 
-    test("stays quiet when the user cancels the log in", async () => {
-      const { harness, handleLink } = arrange();
+    test("stays quiet when the user cancels the log in", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
       logIn.mockReturnValue(PromiseBB.reject(new UserCanceled()) as never);
 
       handleLink(MOD_URL, false);
@@ -198,8 +187,8 @@ describe("nxm link callback", () => {
   });
 
   describe("collection downloads", () => {
-    test("tags the download with the revision it came from", async () => {
-      const { harness, handleLink } = arrange();
+    test("tags the download with the revision it came from", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
 
       handleLink(COLLECTION_URL, true);
 
@@ -211,8 +200,8 @@ describe("nxm link callback", () => {
       ]);
     });
 
-    test("leaves installing to the collection driver", async () => {
-      const { harness, handleLink } = arrange();
+    test("leaves installing to the collection driver", async ({ makeNxm }) => {
+      const { harness, handleLink } = arrangeLink(makeNxm());
       const install = vi.fn();
       harness.api.events.on("start-install-download", install);
 
@@ -223,18 +212,18 @@ describe("nxm link callback", () => {
     });
   });
 
-  test("routes a site-generated link back to the download that is waiting for it", async () => {
-    const { harness, handleLink } = arrange({ userInfo: FREE });
+  test("routes a site-generated link back to the download that is waiting for it", async ({
+    makeNxm,
+  }) => {
+    const { harness, nxm, handleLink } = arrangeLink(makeNxm({ userInfo: FREE }));
     modInfoQuery.mockResolvedValue({
       modInfo: { direct_download_enabled: false },
       fileInfo: {},
     } as never);
-    const resolve = makeNXMProtocol(harness.api, harness.nexus);
-
-    const pending = resolve(MOD_URL);
+    const pending = nxm.resolve(MOD_URL);
     await vi.waitFor(() => expect(harness.freeUserQueue()).toHaveLength(1));
     // sending the user to the website registers the link the callback should route back
-    onDownloadImpl(resolve, MOD_URL);
+    nxm.dialogHandlers.onDownload(MOD_URL);
 
     harness.getDownloadURLs.mockResolvedValue([{ URI: "https://cdn/file.7z" }]);
     handleLink(`${MOD_URL}?key=abc&expires=1700000000`, false);
@@ -245,12 +234,15 @@ describe("nxm link callback", () => {
     expect(harness.freeUserQueue()).toEqual([]);
   });
 
-  test("starts a fresh download when no queued download is waiting for the link", async () => {
-    const { harness, handleLink } = arrange();
+  test("starts a fresh download when no queued download is waiting for the link", async ({
+    makeNxm,
+  }) => {
+    const { nxm, handleLink } = arrangeLink(makeNxm());
 
     handleLink(`${MOD_URL}?key=abc&expires=1700000000`, false);
 
     await vi.waitFor(() => expect(beginDownload).toHaveBeenCalled());
-    expect(onCancelImpl(harness.api, MOD_URL)).toBe(false);
+    // nothing was queued, so there is no parked download for the link to have satisfied
+    expect(nxm.dialogHandlers.onCancel(MOD_URL)).toBe(false);
   });
 });

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
@@ -1,0 +1,256 @@
+import PromiseBB from "bluebird";
+import { beforeEach, describe, expect, vi } from "vitest";
+
+import { makeDownload, makeGameStored, makeNxmHarness } from "@/test-utils/builders";
+import { test } from "@/test-utils/harnessTest";
+import type { INxmHarness, INxmHarnessOpts } from "@/test-utils/harnessTypes";
+import { ProcessCanceled, UserCanceled } from "@/util/CustomErrors";
+
+import { SITE_ID } from "../gamemode_management/constants";
+import { makeNXMLinkCallback, makeNXMProtocol, onCancelImpl, onDownloadImpl } from "./nxmProtocol";
+import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
+
+vi.mock("./util", () => ({
+  bringToFront: vi.fn(),
+  ensureLoggedIn: vi.fn(() => PromiseBB.resolve()),
+  getInfoGraphQL: vi.fn(),
+  oauthCallback: vi.fn(),
+  startDownload: vi.fn(() => PromiseBB.resolve("dl-1")),
+}));
+
+vi.mock("../../util/opn", () => ({ default: vi.fn(() => PromiseBB.resolve()) }));
+
+vi.mock("../../util/collectionSkip", () => ({ markCollectionMemberSkipped: vi.fn() }));
+
+const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
+const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
+
+const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
+const FREE = { userId: 7, name: "free-user", isPremium: false };
+
+const beginDownload = vi.mocked(startDownload);
+const logIn = vi.mocked(ensureLoggedIn);
+const modInfoQuery = vi.mocked(getInfoGraphQL);
+const focusWindow = vi.mocked(bringToFront);
+const finishOAuth = vi.mocked(oauthCallback);
+
+describe("nxm link callback", () => {
+  const openQueues: INxmHarness[] = [];
+
+  beforeEach(() => {
+    beginDownload.mockReturnValue(PromiseBB.resolve("dl-1") as never);
+    logIn.mockReturnValue(PromiseBB.resolve() as never);
+    modInfoQuery.mockReset();
+  });
+
+  const arrange = (opts: INxmHarnessOpts = {}) => {
+    const harness = makeNxmHarness({ userInfo: PREMIUM, ...opts });
+    openQueues.push(harness);
+    // the callback only dispatches modInfo once the download record exists
+    harness.setState((draft) => {
+      draft.persistent.downloads.files["dl-1"] = makeDownload({ id: "dl-1" });
+    });
+    const onPremiumLink = vi.fn();
+    return {
+      harness,
+      onPremiumLink,
+      handleLink: makeNXMLinkCallback(harness.api, harness.nexus, onPremiumLink),
+    };
+  };
+
+  const dispatchedModInfo = (harness: INxmHarness) =>
+    harness.dispatched
+      .filter((action) => action.type === "SET_DOWNLOAD_MODINFO")
+      .map((action) => action.payload as { key: string; value: unknown });
+
+  test("hands an oauth callback url to the login flow", () => {
+    const { harness, handleLink } = arrange();
+
+    handleLink("nxm://oauth/callback?code=the-code&state=the-state", false);
+
+    expect(finishOAuth).toHaveBeenCalledWith(harness.api, "the-code", "the-state");
+    expect(beginDownload).not.toHaveBeenCalled();
+  });
+
+  test("treats a premium url as a prompt to re-read the membership", () => {
+    const { onPremiumLink, handleLink } = arrange();
+
+    expect(handleLink("nxm://premium", false)).toBe(false);
+
+    expect(onPremiumLink).toHaveBeenCalled();
+    expect(beginDownload).not.toHaveBeenCalled();
+  });
+
+  test("reports an unparseable url without offering a report", () => {
+    const { harness, handleLink } = arrange();
+
+    handleLink("nxm://not-a-download", false);
+
+    expect(harness.errorNotifications).toEqual([
+      expect.objectContaining({ title: "Invalid URL", allowReport: false }),
+    ]);
+    expect(beginDownload).not.toHaveBeenCalled();
+  });
+
+  describe("extension downloads from the site domain", () => {
+    const arrangeSite = () =>
+      arrange({
+        knownGames: [makeGameStored({ id: SITE_ID, details: undefined })],
+        availableExtensions: [{ modId: 100 }],
+      });
+
+    test("installs the extension when the link asks to install", () => {
+      const { harness, handleLink } = arrangeSite();
+      const emitAndAwait = vi.spyOn(harness.api, "emitAndAwait");
+
+      handleLink(`nxm://${SITE_ID}/mods/100/files/500`, true);
+
+      expect(emitAndAwait).toHaveBeenCalledWith("install-extension", {
+        name: "Pending",
+        modId: 100,
+        fileId: 500,
+      });
+    });
+
+    test("opens the extension page when the link is only a view", () => {
+      const { harness, handleLink } = arrangeSite();
+      const shown = vi.fn();
+      harness.api.events.on("show-extension-page", shown);
+
+      handleLink(`nxm://${SITE_ID}/mods/100/files/500`, false);
+
+      expect(shown).toHaveBeenCalledWith(100);
+      expect(focusWindow).toHaveBeenCalled();
+    });
+  });
+
+  describe("mod downloads", () => {
+    test("logs in, starts the download and tags it as a nexus download", async () => {
+      const { harness, handleLink } = arrange();
+
+      handleLink(MOD_URL, false);
+
+      await vi.waitFor(() => expect(dispatchedModInfo(harness)).not.toHaveLength(0));
+      expect(logIn).toHaveBeenCalledWith(harness.api);
+      expect(beginDownload).toHaveBeenCalledWith(harness.api, harness.nexus, MOD_URL);
+      expect(dispatchedModInfo(harness)).toEqual([
+        expect.objectContaining({ key: "source", value: "nexus" }),
+      ]);
+    });
+
+    test("installs the download when the link asks to install", async () => {
+      const { harness, handleLink } = arrange();
+      const install = vi.fn((_id: string, cb: (err: Error | null, id: string) => void) =>
+        cb(null, "mod-1"),
+      );
+      harness.api.events.on("start-install-download", install);
+
+      handleLink(MOD_URL, true);
+
+      await vi.waitFor(() => expect(install).toHaveBeenCalled());
+      expect(install.mock.calls[0][0]).toBe("dl-1");
+    });
+
+    test("brings the window forward when foreground downloads are enabled", () => {
+      const { harness, handleLink } = arrange();
+      harness.setState((draft) => {
+        draft.settings.interface.foregroundDL = true;
+      });
+
+      handleLink(MOD_URL, false);
+
+      expect(focusWindow).toHaveBeenCalled();
+    });
+
+    test("does nothing further when the download never started", async () => {
+      const { harness, handleLink } = arrange();
+      // doDownload swallows its own failures and resolves to undefined
+      beginDownload.mockReturnValue(PromiseBB.resolve(undefined) as never);
+
+      handleLink(MOD_URL, false);
+
+      await vi.waitFor(() => expect(beginDownload).toHaveBeenCalled());
+      expect(dispatchedModInfo(harness)).toEqual([]);
+    });
+
+    test("reports a log-in failure without offering a report", async () => {
+      const { harness, handleLink } = arrange();
+      logIn.mockReturnValue(PromiseBB.reject(new ProcessCanceled("no key")) as never);
+
+      handleLink(MOD_URL, false);
+
+      await vi.waitFor(() =>
+        expect(harness.errorNotifications).toEqual([
+          expect.objectContaining({ title: "Log-in failed", allowReport: false }),
+        ]),
+      );
+    });
+
+    test("stays quiet when the user cancels the log in", async () => {
+      const { harness, handleLink } = arrange();
+      logIn.mockReturnValue(PromiseBB.reject(new UserCanceled()) as never);
+
+      handleLink(MOD_URL, false);
+
+      await vi.waitFor(() => expect(logIn).toHaveBeenCalled());
+      expect(harness.errorNotifications).toEqual([]);
+    });
+  });
+
+  describe("collection downloads", () => {
+    test("tags the download with the revision it came from", async () => {
+      const { harness, handleLink } = arrange();
+
+      handleLink(COLLECTION_URL, true);
+
+      await vi.waitFor(() => expect(dispatchedModInfo(harness)).toHaveLength(3));
+      expect(dispatchedModInfo(harness)).toEqual([
+        expect.objectContaining({ key: "source", value: "nexus" }),
+        expect.objectContaining({ key: "collectionSlug", value: "abcdef" }),
+        expect.objectContaining({ key: "revisionNumber", value: 3 }),
+      ]);
+    });
+
+    test("leaves installing to the collection driver", async () => {
+      const { harness, handleLink } = arrange();
+      const install = vi.fn();
+      harness.api.events.on("start-install-download", install);
+
+      handleLink(COLLECTION_URL, true);
+
+      await vi.waitFor(() => expect(dispatchedModInfo(harness)).not.toHaveLength(0));
+      expect(install).not.toHaveBeenCalled();
+    });
+  });
+
+  test("routes a site-generated link back to the download that is waiting for it", async () => {
+    const { harness, handleLink } = arrange({ userInfo: FREE });
+    modInfoQuery.mockResolvedValue({
+      modInfo: { direct_download_enabled: false },
+      fileInfo: {},
+    } as never);
+    const resolve = makeNXMProtocol(harness.api, harness.nexus);
+
+    const pending = resolve(MOD_URL);
+    await vi.waitFor(() => expect(harness.freeUserQueue()).toHaveLength(1));
+    // sending the user to the website registers the link the callback should route back
+    onDownloadImpl(resolve, MOD_URL);
+
+    harness.getDownloadURLs.mockResolvedValue([{ URI: "https://cdn/file.7z" }]);
+    handleLink(`${MOD_URL}?key=abc&expires=1700000000`, false);
+
+    await expect(pending).resolves.toMatchObject({ urls: ["https://cdn/file.7z"] });
+    // the awaited link is consumed by the queued download, not started as a new one
+    expect(beginDownload).not.toHaveBeenCalled();
+    expect(harness.freeUserQueue()).toEqual([]);
+  });
+
+  test("starts a fresh download when no queued download is waiting for the link", async () => {
+    const { harness, handleLink } = arrange();
+
+    handleLink(`${MOD_URL}?key=abc&expires=1700000000`, false);
+
+    await vi.waitFor(() => expect(beginDownload).toHaveBeenCalled());
+    expect(onCancelImpl(harness.api, MOD_URL)).toBe(false);
+  });
+});

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
@@ -234,6 +234,30 @@ describe("nxm link callback", () => {
     expect(harness.freeUserQueue()).toEqual([]);
   });
 
+  // the website opens on every click, so a user who gives up may have asked for a link more than
+  // once; a cancelled download must stop waiting for all of them or the link is swallowed
+  test("stops waiting for a link once its download is cancelled, however often it was asked for", async ({
+    makeNxm,
+  }) => {
+    const { harness, nxm, handleLink } = arrangeLink(makeNxm({ userInfo: FREE }));
+    modInfoQuery.mockResolvedValue({
+      modInfo: { direct_download_enabled: false },
+      fileInfo: {},
+    } as never);
+    const pending = nxm.resolve(MOD_URL);
+    await vi.waitFor(() => expect(harness.freeUserQueue()).toHaveLength(1));
+
+    nxm.dialogHandlers.onDownload(MOD_URL);
+    nxm.dialogHandlers.onDownload(MOD_URL);
+    nxm.dialogHandlers.onCancel(MOD_URL);
+    await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+
+    // the link now belongs to nothing, so it starts a download of its own
+    handleLink(`${MOD_URL}?key=abc&expires=1700000000`, false);
+
+    await vi.waitFor(() => expect(beginDownload).toHaveBeenCalled());
+  });
+
   test("starts a fresh download when no queued download is waiting for the link", async ({
     makeNxm,
   }) => {

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
@@ -1,0 +1,438 @@
+import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import PromiseBB from "bluebird";
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
+
+import { makeGameStored, makeNxmHarness, makeSession } from "@/test-utils/builders";
+import { test } from "@/test-utils/harnessTest";
+import type { INxmHarness, INxmHarnessOpts } from "@/test-utils/harnessTypes";
+import { DataInvalid, HTTPError, ProcessCanceled, UserCanceled } from "@/util/CustomErrors";
+
+import { markCollectionMemberSkipped } from "../../util/collectionSkip";
+import opn from "../../util/opn";
+import { SITE_ID } from "../gamemode_management/constants";
+import { makeNXMProtocol, onCancelImpl, onDownloadImpl, onRetryImpl, onSkip } from "./nxmProtocol";
+import { getInfoGraphQL } from "./util";
+
+vi.mock("./util", () => ({
+  bringToFront: vi.fn(),
+  ensureLoggedIn: vi.fn(() => PromiseBB.resolve()),
+  getInfoGraphQL: vi.fn(),
+  oauthCallback: vi.fn(),
+  startDownload: vi.fn(() => PromiseBB.resolve("dl-1")),
+}));
+
+vi.mock("../../util/opn", () => ({ default: vi.fn(() => PromiseBB.resolve()) }));
+
+vi.mock("../../util/collectionSkip", () => ({ markCollectionMemberSkipped: vi.fn() }));
+
+const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
+const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
+
+const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
+const FREE = { userId: 7, name: "free-user", isPremium: false };
+
+const modInfoQuery = vi.mocked(getInfoGraphQL);
+const openPage = vi.mocked(opn);
+const markSkipped = vi.mocked(markCollectionMemberSkipped);
+
+/** A resolved download link, in the shape the v1 API returns. */
+const downloadLink = (uri: string) => [{ URI: uri, short_name: "cdn", name: "CDN" }];
+
+/** An API refusal, as nexus-api raises it before the handler maps it to an HTTPError. */
+const apiError = (statusCode: number, message: string) =>
+  new NexusError(message, statusCode, "https://api/download_link", message);
+
+describe("nxm protocol resolver", () => {
+  // the handler holds its free-download queue in module scope, so anything a test leaves queued
+  // has to be rejected before the next one runs
+  const openQueues: INxmHarness[] = [];
+
+  beforeEach(() => {
+    modInfoQuery.mockReset();
+  });
+
+  afterEach(() => {
+    openQueues.forEach((harness) =>
+      harness.freeUserQueue().forEach((url) => onCancelImpl(harness.api, url)),
+    );
+    openQueues.length = 0;
+  });
+
+  const arrange = (opts: INxmHarnessOpts = {}) => {
+    const harness = makeNxmHarness({ userInfo: PREMIUM, ...opts });
+    openQueues.push(harness);
+    return { harness, resolve: makeNXMProtocol(harness.api, harness.nexus) };
+  };
+
+  test("rejects a url that isn't an nxm link", async () => {
+    const { resolve } = arrange();
+    await expect(resolve("not-a-url")).rejects.toBeInstanceOf(DataInvalid);
+  });
+
+  test("rejects a link generated for a different account, without offering a report", async () => {
+    const { harness, resolve } = arrange();
+
+    await expect(resolve(`${MOD_URL}?user_id=99`)).rejects.toBeInstanceOf(ProcessCanceled);
+    expect(harness.errorNotifications).toEqual([
+      expect.objectContaining({ title: "Invalid download links", allowReport: false }),
+    ]);
+  });
+
+  test("rejects an nxm url that isn't a download link", async () => {
+    const { resolve } = arrange();
+    await expect(resolve("nxm://premium")).rejects.toThrow("Not a download url");
+  });
+
+  describe("premium account", () => {
+    test("resolves a mod file to its download urls and nexus ids", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
+
+      await expect(resolve(MOD_URL)).resolves.toEqual({
+        urls: ["https://cdn/file.7z"],
+        updatedUrl: MOD_URL,
+        meta: expect.objectContaining({
+          source: "nexus",
+          nexus: { ids: { modId: 100, fileId: 500 } },
+        }),
+      });
+      // the nxm domain is mapped to the game's nexus page id before the request
+      expect(harness.getDownloadURLs).toHaveBeenCalledWith(
+        100,
+        500,
+        undefined,
+        undefined,
+        "skyrimspecialedition",
+      );
+    });
+
+    test("forwards the key and expiry of a site-generated link", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
+
+      await resolve(`${MOD_URL}?key=abc&expires=1700000000`);
+
+      expect(harness.getDownloadURLs).toHaveBeenCalledWith(
+        100,
+        500,
+        "abc",
+        1700000000,
+        "skyrimspecialedition",
+      );
+    });
+
+    test("serves a repeated request for the same file from the cache", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
+
+      await resolve(MOD_URL);
+      await resolve(MOD_URL);
+
+      expect(harness.getDownloadURLs).toHaveBeenCalledTimes(1);
+    });
+
+    test("resolves a collection revision through its download link", async () => {
+      const { harness, resolve } = arrange();
+      harness.getCollectionRevisionGraph.mockResolvedValue({
+        id: 42,
+        downloadLink: "https://api/revisions/42/download",
+        collection: { id: 11 },
+      });
+      harness.getCollectionDownloadLink.mockResolvedValue(downloadLink("https://cdn/coll.7z"));
+
+      await expect(resolve(COLLECTION_URL)).resolves.toEqual({
+        urls: ["https://cdn/coll.7z"],
+        updatedUrl: COLLECTION_URL,
+        meta: expect.objectContaining({
+          source: "nexus",
+          nexus: {
+            ids: {
+              collectionId: 11,
+              revisionId: 42,
+              collectionSlug: "abcdef",
+              revisionNumber: 3,
+            },
+          },
+        }),
+      });
+      expect(harness.getCollectionRevisionGraph).toHaveBeenCalledWith(
+        expect.anything(),
+        "abcdef",
+        3,
+      );
+    });
+
+    test("asks for the latest revision when the url says latest", async () => {
+      const { harness, resolve } = arrange();
+      harness.getCollectionRevisionGraph.mockRejectedValue(new Error("boom"));
+
+      await expect(
+        resolve("nxm://skyrimspecialedition/collections/abcdef/revisions/latest"),
+      ).rejects.toThrow("boom");
+      expect(harness.getCollectionRevisionGraph).toHaveBeenCalledWith(
+        expect.anything(),
+        "abcdef",
+        undefined,
+      );
+    });
+
+    test("annotates a failed collection lookup with the revision it was for", async () => {
+      const { harness, resolve } = arrange();
+      harness.getCollectionRevisionGraph.mockRejectedValue(new Error("boom"));
+
+      await expect(resolve(COLLECTION_URL)).rejects.toMatchObject({
+        collectionSlug: "abcdef",
+        revisionNumber: 3,
+      });
+    });
+
+    test("still uses the premium path for a site (extension) download", async () => {
+      const { harness, resolve } = arrange({
+        userInfo: FREE,
+        knownGames: [makeGameStored({ id: SITE_ID, details: undefined })],
+      });
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/ext.7z"));
+
+      await resolve(`nxm://${SITE_ID}/mods/100/files/500`);
+
+      expect(harness.getDownloadURLs).toHaveBeenCalled();
+      expect(harness.freeUserQueue()).toEqual([]);
+    });
+  });
+
+  describe("api errors", () => {
+    test("turns a nexus api error into an HTTPError carrying the status code", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockRejectedValue(apiError(500, "server exploded"));
+
+      const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
+
+      expect(err).toBeInstanceOf(HTTPError);
+      expect((err as HTTPError).statusCode).toBe(500);
+    });
+
+    test("reports a 401 as a log-in problem rather than a raw http error", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockRejectedValue(apiError(401, "unauthorized"));
+
+      await expect(resolve(MOD_URL)).rejects.toThrow("You are not logged in to Nexus Mods!");
+    });
+
+    test("shows a non-reportable notification when the api rate limit is hit", async () => {
+      const { harness, resolve } = arrange();
+      harness.getDownloadURLs.mockRejectedValue(new RateLimitError());
+
+      await expect(resolve(MOD_URL)).rejects.toBeInstanceOf(RateLimitError);
+      expect(harness.errorNotifications).toEqual([
+        expect.objectContaining({ title: "Rate limit exceeded", allowReport: false }),
+      ]);
+    });
+  });
+
+  describe("free account", () => {
+    const websiteRoundTrip = () =>
+      modInfoQuery.mockResolvedValue({
+        modInfo: { direct_download_enabled: false },
+        fileInfo: {},
+      } as never);
+
+    const queued = (harness: INxmHarness) =>
+      vi.waitFor(() => expect(harness.freeUserQueue()).toHaveLength(1));
+
+    test("queues the download for the site round trip", async () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+      websiteRoundTrip();
+
+      const pending = resolve(MOD_URL);
+      await queued(harness);
+
+      expect(harness.freeUserQueue()).toEqual([MOD_URL]);
+      expect(harness.getDownloadURLs).not.toHaveBeenCalled();
+
+      onCancelImpl(harness.api, MOD_URL);
+      await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+    });
+
+    test("downloads a direct-download mod in app instead of queueing it", async () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+      modInfoQuery.mockResolvedValue({
+        modInfo: { direct_download_enabled: true },
+        fileInfo: {},
+      } as never);
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/free.7z"));
+
+      await expect(resolve(MOD_URL)).resolves.toMatchObject({
+        urls: ["https://cdn/free.7z"],
+      });
+      expect(harness.freeUserQueue()).toEqual([]);
+    });
+
+    test("skips the free-user path entirely for a keyed link", async () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+      harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/keyed.7z"));
+
+      await expect(resolve(`${MOD_URL}?key=abc&expires=1700000000`)).resolves.toMatchObject({
+        urls: ["https://cdn/keyed.7z"],
+      });
+      // the site already authorised this link, so no mod-info lookup and no queueing
+      expect(modInfoQuery).not.toHaveBeenCalled();
+      expect(harness.freeUserQueue()).toEqual([]);
+    });
+
+    test("queues the download when the mod info lookup fails", async () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+      modInfoQuery.mockRejectedValue(new Error("network down"));
+
+      const pending = resolve(MOD_URL);
+      await queued(harness);
+
+      onCancelImpl(harness.api, MOD_URL);
+      await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+    });
+
+    test("propagates a cancellation instead of re-queueing the download", async () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+      modInfoQuery.mockRejectedValue(new UserCanceled());
+
+      await expect(resolve(MOD_URL)).rejects.toBeInstanceOf(UserCanceled);
+      expect(harness.freeUserQueue()).toEqual([]);
+    });
+
+    test("takes the free path for a premium account when downloads are forced free", async () => {
+      vi.stubEnv("FORCE_FREE_DOWNLOADS", "yes");
+      const { harness, resolve } = arrange();
+      websiteRoundTrip();
+
+      const pending = resolve(MOD_URL);
+      await queued(harness);
+
+      onCancelImpl(harness.api, MOD_URL);
+      await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+      vi.unstubAllEnvs();
+    });
+
+    describe("the queued download", () => {
+      const arrangeQueued = async () => {
+        const { harness, resolve } = arrange({ userInfo: FREE });
+        websiteRoundTrip();
+        const pending = resolve(MOD_URL);
+        await queued(harness);
+        return { harness, resolve, pending };
+      };
+
+      // what FreeUserDLDialog does when the user upgrades while the dialog is open
+      test("retrying after an upgrade resolves it down the premium path", async () => {
+        const { harness, resolve, pending } = await arrangeQueued();
+        harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
+        harness.setUserInfo(PREMIUM);
+
+        onRetryImpl(resolve, harness.api, MOD_URL);
+
+        await expect(pending).resolves.toMatchObject({ urls: ["https://cdn/file.7z"] });
+        expect(harness.freeUserQueue()).toEqual([]);
+      });
+
+      test("opens the file's page on the website when the user picks download there", async () => {
+        const { harness, pending } = await arrangeQueued();
+
+        onDownloadImpl(makeNXMProtocol(harness.api, harness.nexus), MOD_URL);
+
+        expect(openPage).toHaveBeenCalledWith(
+          "https://www.nexusmods.com/skyrimspecialedition/mods/100?tab=files&file_id=500&nmm=1",
+        );
+
+        onCancelImpl(harness.api, MOD_URL);
+        await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+      });
+
+      test("skipping marks the mod skipped in the active collection install", async () => {
+        const { harness, pending } = await arrangeQueued();
+        harness.getModFiles.mockResolvedValue({
+          file_updates: [
+            {
+              old_file_id: 400,
+              new_file_id: 500,
+              old_file_name: "old.7z",
+              new_file_name: "new.7z",
+            },
+          ],
+        });
+
+        onSkip(harness.api, MOD_URL);
+
+        await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+        expect(markSkipped).toHaveBeenCalledWith(
+          harness.api,
+          expect.objectContaining({
+            identifiers: expect.objectContaining({
+              fileIds: expect.arrayContaining(["400", "500"]),
+              fileNames: expect.arrayContaining(["old.7z", "new.7z"]),
+            }),
+          }),
+        );
+      });
+
+      test("skipping still cancels when the update chain can't be queried", async () => {
+        const { harness, pending } = await arrangeQueued();
+        harness.getModFiles.mockRejectedValue(new Error("network down"));
+
+        onSkip(harness.api, MOD_URL);
+
+        await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+      });
+
+      test("cancelling pauses the collection install that queued it", async () => {
+        const { harness, pending } = await arrangeQueued();
+        harness.setState((draft) => {
+          draft.session["collections"].activeSession = makeSession({
+            gameId: "skyrimse",
+            collectionId: "coll-1",
+          });
+        });
+        const paused = vi.fn();
+        harness.api.events.on("pause-collection", paused);
+
+        expect(onCancelImpl(harness.api, MOD_URL)).toBe(true);
+
+        await expect(pending).rejects.toBeInstanceOf(UserCanceled);
+        expect(paused).toHaveBeenCalledWith("skyrimse", "coll-1", "free-user-cancel");
+      });
+    });
+
+    test("cancelling an empty queue just drops the url from the dialog", () => {
+      const { harness } = arrange({ userInfo: FREE });
+
+      expect(onCancelImpl(harness.api, MOD_URL)).toBe(false);
+      expect(harness.dispatched.map((action) => action.type)).toContain("REMOVE_FREEUSER_DLITEM");
+    });
+
+    test("retrying a url that isn't queued does nothing", () => {
+      const { harness, resolve } = arrange({ userInfo: FREE });
+
+      expect(() => onRetryImpl(resolve, harness.api, MOD_URL)).not.toThrow();
+      expect(harness.getDownloadURLs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("membership that ended on the website (LAZ-836)", () => {
+    /**
+     * Cancelling a membership on the website pushes nothing to Vortex, so the cached userInfo
+     * still says premium and the resolver takes the premium path. The API then refuses the
+     * keyless download link, and today that refusal reaches the caller as a raw HTTP error
+     * instead of the free-user flow the account is now entitled to.
+     */
+    test("surfaces the refused download link as a raw http error", async () => {
+      const { harness, resolve } = arrange({ userInfo: PREMIUM });
+      harness.getDownloadURLs.mockRejectedValue(apiError(403, "forbidden"));
+
+      const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
+
+      expect(err).toBeInstanceOf(HTTPError);
+      expect((err as HTTPError).statusCode).toBe(403);
+      // the download never reaches the free-user dialog the account now qualifies for
+      expect(harness.freeUserQueue()).toEqual([]);
+      // and the stale membership stays in place, so the next attempt fails the same way
+      expect(harness.getState().persistent["nexus"].userInfo).toMatchObject({ isPremium: true });
+    });
+  });
+});

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
@@ -2,15 +2,15 @@ import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
 import PromiseBB from "bluebird";
 import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 
-import { makeGameStored, makeNxmHarness, makeSession } from "@/test-utils/builders";
-import { test } from "@/test-utils/harnessTest";
-import type { INxmHarness, INxmHarnessOpts } from "@/test-utils/harnessTypes";
+import { makeGameStored, makeSession } from "@/test-utils/builders";
+import type { INxmHarness } from "@/test-utils/harnessTypes";
+import type { INxmFixtures } from "@/test-utils/nxmTest";
+import { COLLECTION_URL, FREE, MOD_URL, PREMIUM, test } from "@/test-utils/nxmTest";
 import { DataInvalid, HTTPError, ProcessCanceled, UserCanceled } from "@/util/CustomErrors";
 
 import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import opn from "../../util/opn";
 import { SITE_ID } from "../gamemode_management/constants";
-import { makeNXMProtocol, onCancelImpl, onDownloadImpl, onRetryImpl, onSkip } from "./nxmProtocol";
 import { getInfoGraphQL } from "./util";
 
 vi.mock("./util", () => ({
@@ -25,12 +25,6 @@ vi.mock("../../util/opn", () => ({ default: vi.fn(() => PromiseBB.resolve()) }))
 
 vi.mock("../../util/collectionSkip", () => ({ markCollectionMemberSkipped: vi.fn() }));
 
-const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
-const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
-
-const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
-const FREE = { userId: 7, name: "free-user", isPremium: false };
-
 const modInfoQuery = vi.mocked(getInfoGraphQL);
 const openPage = vi.mocked(opn);
 const markSkipped = vi.mocked(markCollectionMemberSkipped);
@@ -43,34 +37,19 @@ const apiError = (statusCode: number, message: string) =>
   new NexusError(message, statusCode, "https://api/download_link", message);
 
 describe("nxm protocol resolver", () => {
-  // the handler holds its free-download queue in module scope, so anything a test leaves queued
-  // has to be rejected before the next one runs
-  const openQueues: INxmHarness[] = [];
-
   beforeEach(() => {
     modInfoQuery.mockReset();
   });
 
-  afterEach(() => {
-    openQueues.forEach((harness) =>
-      harness.freeUserQueue().forEach((url) => onCancelImpl(harness.api, url)),
-    );
-    openQueues.length = 0;
-  });
-
-  const arrange = (opts: INxmHarnessOpts = {}) => {
-    const harness = makeNxmHarness({ userInfo: PREMIUM, ...opts });
-    openQueues.push(harness);
-    return { harness, resolve: makeNXMProtocol(harness.api, harness.nexus) };
-  };
-
-  test("rejects a url that isn't an nxm link", async () => {
-    const { resolve } = arrange();
+  test("rejects a url that isn't an nxm link", async ({ makeNxm }) => {
+    const { resolve } = makeNxm();
     await expect(resolve("not-a-url")).rejects.toBeInstanceOf(DataInvalid);
   });
 
-  test("rejects a link generated for a different account, without offering a report", async () => {
-    const { harness, resolve } = arrange();
+  test("rejects a link generated for a different account, without offering a report", async ({
+    makeNxm,
+  }) => {
+    const { harness, resolve } = makeNxm();
 
     await expect(resolve(`${MOD_URL}?user_id=99`)).rejects.toBeInstanceOf(ProcessCanceled);
     expect(harness.errorNotifications).toEqual([
@@ -78,14 +57,14 @@ describe("nxm protocol resolver", () => {
     ]);
   });
 
-  test("rejects an nxm url that isn't a download link", async () => {
-    const { resolve } = arrange();
+  test("rejects an nxm url that isn't a download link", async ({ makeNxm }) => {
+    const { resolve } = makeNxm();
     await expect(resolve("nxm://premium")).rejects.toThrow("Not a download url");
   });
 
   describe("premium account", () => {
-    test("resolves a mod file to its download urls and nexus ids", async () => {
-      const { harness, resolve } = arrange();
+    test("resolves a mod file to its download urls and nexus ids", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
 
       await expect(resolve(MOD_URL)).resolves.toEqual({
@@ -106,8 +85,8 @@ describe("nxm protocol resolver", () => {
       );
     });
 
-    test("forwards the key and expiry of a site-generated link", async () => {
-      const { harness, resolve } = arrange();
+    test("forwards the key and expiry of a site-generated link", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
 
       await resolve(`${MOD_URL}?key=abc&expires=1700000000`);
@@ -121,8 +100,8 @@ describe("nxm protocol resolver", () => {
       );
     });
 
-    test("serves a repeated request for the same file from the cache", async () => {
-      const { harness, resolve } = arrange();
+    test("serves a repeated request for the same file from the cache", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
 
       await resolve(MOD_URL);
@@ -131,8 +110,8 @@ describe("nxm protocol resolver", () => {
       expect(harness.getDownloadURLs).toHaveBeenCalledTimes(1);
     });
 
-    test("resolves a collection revision through its download link", async () => {
-      const { harness, resolve } = arrange();
+    test("resolves a collection revision through its download link", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getCollectionRevisionGraph.mockResolvedValue({
         id: 42,
         downloadLink: "https://api/revisions/42/download",
@@ -162,8 +141,8 @@ describe("nxm protocol resolver", () => {
       );
     });
 
-    test("asks for the latest revision when the url says latest", async () => {
-      const { harness, resolve } = arrange();
+    test("asks for the latest revision when the url says latest", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getCollectionRevisionGraph.mockRejectedValue(new Error("boom"));
 
       await expect(
@@ -176,8 +155,10 @@ describe("nxm protocol resolver", () => {
       );
     });
 
-    test("annotates a failed collection lookup with the revision it was for", async () => {
-      const { harness, resolve } = arrange();
+    test("annotates a failed collection lookup with the revision it was for", async ({
+      makeNxm,
+    }) => {
+      const { harness, resolve } = makeNxm();
       harness.getCollectionRevisionGraph.mockRejectedValue(new Error("boom"));
 
       await expect(resolve(COLLECTION_URL)).rejects.toMatchObject({
@@ -186,8 +167,8 @@ describe("nxm protocol resolver", () => {
       });
     });
 
-    test("still uses the premium path for a site (extension) download", async () => {
-      const { harness, resolve } = arrange({
+    test("still uses the premium path for a site (extension) download", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm({
         userInfo: FREE,
         knownGames: [makeGameStored({ id: SITE_ID, details: undefined })],
       });
@@ -201,8 +182,10 @@ describe("nxm protocol resolver", () => {
   });
 
   describe("api errors", () => {
-    test("turns a nexus api error into an HTTPError carrying the status code", async () => {
-      const { harness, resolve } = arrange();
+    test("turns a nexus api error into an HTTPError carrying the status code", async ({
+      makeNxm,
+    }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockRejectedValue(apiError(500, "server exploded"));
 
       const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
@@ -211,15 +194,17 @@ describe("nxm protocol resolver", () => {
       expect((err as HTTPError).statusCode).toBe(500);
     });
 
-    test("reports a 401 as a log-in problem rather than a raw http error", async () => {
-      const { harness, resolve } = arrange();
+    test("reports a 401 as a log-in problem rather than a raw http error", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockRejectedValue(apiError(401, "unauthorized"));
 
       await expect(resolve(MOD_URL)).rejects.toThrow("You are not logged in to Nexus Mods!");
     });
 
-    test("shows a non-reportable notification when the api rate limit is hit", async () => {
-      const { harness, resolve } = arrange();
+    test("shows a non-reportable notification when the api rate limit is hit", async ({
+      makeNxm,
+    }) => {
+      const { harness, resolve } = makeNxm();
       harness.getDownloadURLs.mockRejectedValue(new RateLimitError());
 
       await expect(resolve(MOD_URL)).rejects.toBeInstanceOf(RateLimitError);
@@ -239,8 +224,8 @@ describe("nxm protocol resolver", () => {
     const queued = (harness: INxmHarness) =>
       vi.waitFor(() => expect(harness.freeUserQueue()).toHaveLength(1));
 
-    test("queues the download for the site round trip", async () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("queues the download for the site round trip", async ({ makeNxm }) => {
+      const { harness, nxm, resolve } = makeNxm({ userInfo: FREE });
       websiteRoundTrip();
 
       const pending = resolve(MOD_URL);
@@ -249,12 +234,12 @@ describe("nxm protocol resolver", () => {
       expect(harness.freeUserQueue()).toEqual([MOD_URL]);
       expect(harness.getDownloadURLs).not.toHaveBeenCalled();
 
-      onCancelImpl(harness.api, MOD_URL);
+      nxm.dialogHandlers.onCancel(MOD_URL);
       await expect(pending).rejects.toBeInstanceOf(UserCanceled);
     });
 
-    test("downloads a direct-download mod in app instead of queueing it", async () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("downloads a direct-download mod in app instead of queueing it", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm({ userInfo: FREE });
       modInfoQuery.mockResolvedValue({
         modInfo: { direct_download_enabled: true },
         fileInfo: {},
@@ -267,8 +252,8 @@ describe("nxm protocol resolver", () => {
       expect(harness.freeUserQueue()).toEqual([]);
     });
 
-    test("skips the free-user path entirely for a keyed link", async () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("skips the free-user path entirely for a keyed link", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm({ userInfo: FREE });
       harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/keyed.7z"));
 
       await expect(resolve(`${MOD_URL}?key=abc&expires=1700000000`)).resolves.toMatchObject({
@@ -279,74 +264,80 @@ describe("nxm protocol resolver", () => {
       expect(harness.freeUserQueue()).toEqual([]);
     });
 
-    test("queues the download when the mod info lookup fails", async () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("queues the download when the mod info lookup fails", async ({ makeNxm }) => {
+      const { harness, nxm, resolve } = makeNxm({ userInfo: FREE });
       modInfoQuery.mockRejectedValue(new Error("network down"));
 
       const pending = resolve(MOD_URL);
       await queued(harness);
 
-      onCancelImpl(harness.api, MOD_URL);
+      nxm.dialogHandlers.onCancel(MOD_URL);
       await expect(pending).rejects.toBeInstanceOf(UserCanceled);
     });
 
-    test("propagates a cancellation instead of re-queueing the download", async () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("propagates a cancellation instead of re-queueing the download", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm({ userInfo: FREE });
       modInfoQuery.mockRejectedValue(new UserCanceled());
 
       await expect(resolve(MOD_URL)).rejects.toBeInstanceOf(UserCanceled);
       expect(harness.freeUserQueue()).toEqual([]);
     });
 
-    test("takes the free path for a premium account when downloads are forced free", async () => {
+    test("takes the free path for a premium account when downloads are forced free", async ({
+      makeNxm,
+    }) => {
       vi.stubEnv("FORCE_FREE_DOWNLOADS", "yes");
-      const { harness, resolve } = arrange();
+      const { harness, nxm, resolve } = makeNxm();
       websiteRoundTrip();
 
       const pending = resolve(MOD_URL);
       await queued(harness);
 
-      onCancelImpl(harness.api, MOD_URL);
+      nxm.dialogHandlers.onCancel(MOD_URL);
       await expect(pending).rejects.toBeInstanceOf(UserCanceled);
       vi.unstubAllEnvs();
     });
 
     describe("the queued download", () => {
-      const arrangeQueued = async () => {
-        const { harness, resolve } = arrange({ userInfo: FREE });
+      const arrangeQueued = async (makeNxm: INxmFixtures["makeNxm"]) => {
+        const { harness, nxm, resolve } = makeNxm({ userInfo: FREE });
         websiteRoundTrip();
         const pending = resolve(MOD_URL);
         await queued(harness);
-        return { harness, resolve, pending };
+        return { harness, nxm, pending };
       };
 
       // what FreeUserDLDialog does when the user upgrades while the dialog is open
-      test("retrying after an upgrade resolves it down the premium path", async () => {
-        const { harness, resolve, pending } = await arrangeQueued();
+      test("retrying after an upgrade resolves it down the premium path", async ({ makeNxm }) => {
+        const { harness, nxm, pending } = await arrangeQueued(makeNxm);
         harness.getDownloadURLs.mockResolvedValue(downloadLink("https://cdn/file.7z"));
         harness.setUserInfo(PREMIUM);
 
-        onRetryImpl(resolve, harness.api, MOD_URL);
+        nxm.dialogHandlers.onRetry(MOD_URL);
 
         await expect(pending).resolves.toMatchObject({ urls: ["https://cdn/file.7z"] });
         expect(harness.freeUserQueue()).toEqual([]);
       });
 
-      test("opens the file's page on the website when the user picks download there", async () => {
-        const { harness, pending } = await arrangeQueued();
+      test("opens the file's page on the website when the user picks download there", async ({
+        makeNxm,
+      }) => {
+        const { harness, nxm, pending } = await arrangeQueued(makeNxm);
 
-        onDownloadImpl(makeNXMProtocol(harness.api, harness.nexus), MOD_URL);
+        nxm.dialogHandlers.onDownload(MOD_URL);
 
         expect(openPage).toHaveBeenCalledWith(
           "https://www.nexusmods.com/skyrimspecialedition/mods/100?tab=files&file_id=500&nmm=1",
         );
 
-        onCancelImpl(harness.api, MOD_URL);
+        nxm.dialogHandlers.onCancel(MOD_URL);
         await expect(pending).rejects.toBeInstanceOf(UserCanceled);
       });
 
-      test("skipping marks the mod skipped in the active collection install", async () => {
-        const { harness, pending } = await arrangeQueued();
+      test("skipping marks the mod skipped in the active collection install", async ({
+        makeNxm,
+      }) => {
+        const { harness, nxm, pending } = await arrangeQueued(makeNxm);
         harness.getModFiles.mockResolvedValue({
           file_updates: [
             {
@@ -358,7 +349,7 @@ describe("nxm protocol resolver", () => {
           ],
         });
 
-        onSkip(harness.api, MOD_URL);
+        nxm.dialogHandlers.onSkip(MOD_URL);
 
         await expect(pending).rejects.toBeInstanceOf(UserCanceled);
         expect(markSkipped).toHaveBeenCalledWith(
@@ -372,17 +363,17 @@ describe("nxm protocol resolver", () => {
         );
       });
 
-      test("skipping still cancels when the update chain can't be queried", async () => {
-        const { harness, pending } = await arrangeQueued();
+      test("skipping still cancels when the update chain can't be queried", async ({ makeNxm }) => {
+        const { harness, nxm, pending } = await arrangeQueued(makeNxm);
         harness.getModFiles.mockRejectedValue(new Error("network down"));
 
-        onSkip(harness.api, MOD_URL);
+        nxm.dialogHandlers.onSkip(MOD_URL);
 
         await expect(pending).rejects.toBeInstanceOf(UserCanceled);
       });
 
-      test("cancelling pauses the collection install that queued it", async () => {
-        const { harness, pending } = await arrangeQueued();
+      test("cancelling pauses the collection install that queued it", async ({ makeNxm }) => {
+        const { harness, nxm, pending } = await arrangeQueued(makeNxm);
         harness.setState((draft) => {
           draft.session["collections"].activeSession = makeSession({
             gameId: "skyrimse",
@@ -392,24 +383,24 @@ describe("nxm protocol resolver", () => {
         const paused = vi.fn();
         harness.api.events.on("pause-collection", paused);
 
-        expect(onCancelImpl(harness.api, MOD_URL)).toBe(true);
+        expect(nxm.dialogHandlers.onCancel(MOD_URL)).toBe(true);
 
         await expect(pending).rejects.toBeInstanceOf(UserCanceled);
         expect(paused).toHaveBeenCalledWith("skyrimse", "coll-1", "free-user-cancel");
       });
     });
 
-    test("cancelling an empty queue just drops the url from the dialog", () => {
-      const { harness } = arrange({ userInfo: FREE });
+    test("cancelling an empty queue just drops the url from the dialog", ({ makeNxm }) => {
+      const { harness, nxm } = makeNxm({ userInfo: FREE });
 
-      expect(onCancelImpl(harness.api, MOD_URL)).toBe(false);
+      expect(nxm.dialogHandlers.onCancel(MOD_URL)).toBe(false);
       expect(harness.dispatched.map((action) => action.type)).toContain("REMOVE_FREEUSER_DLITEM");
     });
 
-    test("retrying a url that isn't queued does nothing", () => {
-      const { harness, resolve } = arrange({ userInfo: FREE });
+    test("retrying a url that isn't queued does nothing", ({ makeNxm }) => {
+      const { harness, nxm, resolve } = makeNxm({ userInfo: FREE });
 
-      expect(() => onRetryImpl(resolve, harness.api, MOD_URL)).not.toThrow();
+      expect(() => nxm.dialogHandlers.onRetry(MOD_URL)).not.toThrow();
       expect(harness.getDownloadURLs).not.toHaveBeenCalled();
     });
   });
@@ -421,8 +412,8 @@ describe("nxm protocol resolver", () => {
      * keyless download link, and today that refusal reaches the caller as a raw HTTP error
      * instead of the free-user flow the account is now entitled to.
      */
-    test("surfaces the refused download link as a raw http error", async () => {
-      const { harness, resolve } = arrange({ userInfo: PREMIUM });
+    test("surfaces the refused download link as a raw http error", async ({ makeNxm }) => {
+      const { harness, resolve } = makeNxm({ userInfo: PREMIUM });
       harness.getDownloadURLs.mockRejectedValue(apiError(403, "forbidden"));
 
       const err = await resolve(MOD_URL).catch((caught: unknown) => caught);

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -1,0 +1,592 @@
+import type { IDownloadURL, IFileUpdate, IRevision, IRevisionQuery } from "@nexusmods/nexus-api";
+import type NexusT from "@nexusmods/nexus-api";
+import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import { getErrorMessageOrDefault } from "@vortex/shared";
+import { DownloadIsHTML } from "@vortex/shared/errors";
+import PromiseBB from "bluebird";
+import type { Action } from "redux";
+
+import { setDownloadModInfo } from "../../actions";
+import { log } from "../../logging";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import type { IState } from "../../types/IState";
+import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
+import { markCollectionMemberSkipped } from "../../util/collectionSkip";
+import {
+  DataInvalid,
+  HTTPError,
+  ProcessCanceled,
+  ServiceTemporarilyUnavailable,
+  UserCanceled,
+} from "../../util/CustomErrors";
+import opn from "../../util/opn";
+import { gameById, knownGames } from "../../util/selectors";
+import { getSafe } from "../../util/storeHelper";
+import { batchDispatch } from "../../util/util";
+import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
+import { SITE_ID } from "../gamemode_management/constants";
+import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
+import { NEXUS_BASE_URL } from "./constants";
+import NXMUrl from "./NXMUrl";
+import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
+import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
+
+export type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
+
+interface IDLQueueItem {
+  input: string;
+  url: NXMUrl;
+  res: (res: IResolvedURL) => void;
+  rej: (err: Error) => void;
+  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
+}
+
+const freeDLQueue: IDLQueueItem[] = [];
+
+const DL_QUERY: IRevisionQuery = {
+  id: true,
+  revisionNumber: true,
+  downloadLink: true,
+  collection: {
+    id: true,
+  },
+};
+
+interface IAwaitedLink {
+  gameId: string;
+  modId: number;
+  fileId: number;
+  resolve: (url: string) => void;
+}
+
+const awaitedLinks: IAwaitedLink[] = [];
+
+function doDownload(api: IExtensionApi, nexus: NexusT, url: string): PromiseBB<string> {
+  return (
+    startDownload(api, nexus, url)
+      .catch(DownloadIsHTML, () => undefined)
+      // DataInvalid is used here to indicate invalid user input or invalid
+      // data from remote, so it's presumably not a bug in Vortex
+      .catch(DataInvalid, () => {
+        api.showErrorNotification("Failed to start download", url, {
+          allowReport: false,
+        });
+        return PromiseBB.resolve(undefined);
+      })
+      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
+      .catch((err) => {
+        api.showErrorNotification("Failed to start download", err);
+        return PromiseBB.resolve(undefined);
+      })
+  );
+}
+
+/**
+ * Handle an incoming nxm:// link. `onPremiumLink` runs for the nxm://premium form, which the
+ * site opens after a membership change so the client re-reads the user info.
+ */
+export function makeNXMLinkCallback(api: IExtensionApi, nexus: NexusT, onPremiumLink: () => void) {
+  return (url: string, install: boolean) => {
+    let nxmUrl: NXMUrl;
+    try {
+      nxmUrl = new NXMUrl(url);
+
+      const state = api.getState();
+      const isExtAvailable =
+        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
+        undefined;
+
+      if (nxmUrl.type === "oauth") {
+        try {
+          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
+        } catch (err) {
+          // ignore unexpected code
+        }
+      } else if (nxmUrl.type === "premium") {
+        try {
+          log("info", "makeNXMLinkCallback() premium");
+          onPremiumLink();
+          return false;
+        } catch (err) {
+          // ignore unexpected code
+        }
+      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
+        if (install) {
+          return api.emitAndAwait("install-extension", {
+            name: "Pending",
+            modId: nxmUrl.modId,
+            fileId: nxmUrl.fileId,
+          });
+        } else {
+          api.events.emit("show-extension-page", nxmUrl.modId);
+          bringToFront();
+          return PromiseBB.resolve();
+        }
+      } else {
+        const { foregroundDL } = state.settings.interface;
+        if (foregroundDL) {
+          bringToFront();
+        }
+      }
+    } catch (err) {
+      api.showErrorNotification("Invalid URL", err, { allowReport: false });
+      return;
+    }
+
+    const awaitedIdx = awaitedLinks.findIndex(
+      (link) =>
+        link.gameId === nxmUrl.gameId &&
+        link.modId === nxmUrl.modId &&
+        link.fileId === nxmUrl.fileId,
+    );
+    if (awaitedIdx !== -1) {
+      const awaited = awaitedLinks.splice(awaitedIdx, 1);
+      awaited[0].resolve(url);
+      return;
+    }
+
+    ensureLoggedIn(api)
+      .then(() => doDownload(api, nexus, url))
+      .then((dlId) => {
+        if (dlId === undefined || dlId === null) {
+          return PromiseBB.resolve(undefined);
+        }
+
+        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
+        if (nxmUrl.collectionId !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
+        }
+        if (nxmUrl.revisionId !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
+        }
+        if (nxmUrl.collectionSlug !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
+        }
+        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
+          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
+        }
+        batchDispatch(api.store, actions);
+
+        return new PromiseBB((resolve, reject) => {
+          const currentState: IState = api.store.getState();
+          const download = currentState.persistent.downloads.files[dlId];
+          if (download === undefined) {
+            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
+          }
+          // collections always get installed automatically.
+          if (install && nxmUrl.type !== "collection") {
+            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
+              if (err !== null) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          } else {
+            resolve();
+          }
+        });
+      })
+      // doDownload handles all download errors so the catches below are
+      //  only for log in errors
+      .catch(UserCanceled, () => null)
+      .catch(ProcessCanceled, (err) => {
+        api.showErrorNotification("Log-in failed", err, {
+          id: "failed-get-nexus-key",
+          allowReport: false,
+        });
+      })
+      .catch(ServiceTemporarilyUnavailable, (err) => {
+        api.showErrorNotification("Service temporarily unavailable", err, {
+          id: "failed-get-nexus-key",
+          allowReport: false,
+        });
+      })
+      .catch((err) => {
+        api.showErrorNotification("Failed to get access key", err, {
+          id: "failed-get-nexus-key",
+        });
+      });
+  };
+}
+
+export function makeNXMProtocol(api: IExtensionApi, nexus: NexusT): ResolveFunc {
+  // for free users a dialog needs to be displayed sending them to the site for the download.
+  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
+  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
+  // out of the larger process without the user having to click cancel multiple times.
+  // Thus we have to keep track of all queued downloads.
+
+  function freeUserDownload(input: string, url: NXMUrl) {
+    // non-premium user trying to download a file with no id, have to send the user to the
+    // corresponding site to generate a proper link
+    return new PromiseBB<IResolvedURL>((resolve, reject) => {
+      const res = (result: IResolvedURL) => {
+        if (resolve !== undefined) {
+          // just to make sure we remove the correct item, idx should always be 0
+          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
+          api.store.dispatch(removeFreeUserDLItem(input));
+          freeDLQueue.splice(idx, 1);
+          resolve(result);
+          reject = undefined;
+          resolve = undefined;
+        }
+      };
+      const rej = (err) => {
+        if (reject !== undefined) {
+          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
+          api.store.dispatch(removeFreeUserDLItem(input));
+          freeDLQueue.splice(idx, 1);
+          reject(err);
+          reject = undefined;
+          resolve = undefined;
+        }
+      };
+      const queryRelevantUpdates = () => {
+        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
+          // Build a bidirectional map for O(1) lookups, we're doing this
+          //  in the hope that the mod authors have kept a clear update chain
+          //  which we can use to find relevant fileIds.
+          // It's not cool that we're consuming an API slot for this, but without this
+          //  we can't reliably compare the dependency reference to what we're attempting
+          //  to skip (we only have the NXM url which isn't enough).
+          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
+          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
+
+          files.file_updates.forEach((update) => {
+            forwardMap.set(update.old_file_id, update);
+            backwardMap.set(update.new_file_id, update);
+          });
+
+          // Traverse backwards to find the oldest file in the chain
+          let currentId = url.fileId;
+          const backwardChain: IFileUpdate[] = [];
+
+          while (backwardMap.has(currentId)) {
+            const update = backwardMap.get(currentId);
+            backwardChain.unshift(update); // Add to beginning
+            currentId = update.old_file_id;
+          }
+
+          // Now traverse forwards from the oldest file to build complete chain
+          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
+          currentId = oldestId;
+          const completeChain: IFileUpdate[] = [];
+
+          while (forwardMap.has(currentId)) {
+            const update = forwardMap.get(currentId);
+            completeChain.push(update);
+            currentId = update.new_file_id;
+          }
+
+          return completeChain;
+        });
+      };
+      freeDLQueue.push({ input, url, res, rej, queryRelevantUpdates });
+      api.store.dispatch(addFreeUserDLItem(input));
+    });
+  }
+
+  // Cache download URLs to avoid repeated API calls for the same file
+  const downloadURLCache: {
+    [key: string]: { urls: string[]; expires: number; meta: any };
+  } = {};
+  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+  function premiumUserDownload(
+    input: string,
+    url: NXMUrl,
+    directDownloadEnabled: boolean = false,
+  ): PromiseBB<IResolvedURL> {
+    const state = api.getState();
+    const games = knownGames(state);
+    const gameId = convertNXMIdReverse(games, url.gameId);
+    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+    let revisionInfo: Partial<IRevision>;
+
+    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
+
+    if (!["mod", "collection"].includes(url.type)) {
+      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
+    }
+
+    // Create cache key
+    const cacheKey =
+      url.type === "mod"
+        ? `mod_${url.modId}_${url.fileId}_${pageId}`
+        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
+
+    // Check cache first
+    const cached = downloadURLCache[cacheKey];
+    if (cached && Date.now() < cached.expires) {
+      return PromiseBB.resolve({
+        urls: cached.urls,
+        updatedUrl: input,
+        meta: cached.meta,
+      });
+    }
+
+    const downloadKey = directDownloadEnabled ? undefined : url.key;
+    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
+
+    return PromiseBB.resolve()
+      .then(() =>
+        url.type === "mod"
+          ? nexus
+              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
+              .then((res: IDownloadURL[]) => {
+                const result = {
+                  urls: res.map((u) => u.URI),
+                  updatedUrl: input,
+                  meta: {
+                    source: "nexus",
+                    nexus: {
+                      ids: {
+                        modId: url.modId,
+                        fileId: url.fileId,
+                      },
+                    },
+                  } as any,
+                };
+
+                // Cache the result
+                downloadURLCache[cacheKey] = {
+                  urls: result.urls,
+                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
+                  meta: result.meta,
+                };
+
+                return result;
+              })
+          : nexus
+              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
+              .catch((err) => {
+                err["collectionSlug"] = url.collectionSlug;
+                err["revisionNumber"] = url.revisionNumber;
+                return PromiseBB.reject(err);
+              })
+              .then((revision: Partial<IRevision>) => {
+                revisionInfo = revision;
+                return nexus.getCollectionDownloadLink(revision.downloadLink);
+              })
+              .then((downloadUrls) => {
+                const result = {
+                  urls: downloadUrls.map((iter) => iter.URI),
+                  updatedUrl: input,
+                  meta: {
+                    source: "nexus",
+                    nexus: {
+                      ids: {
+                        collectionId: revisionInfo.collection.id,
+                        revisionId: revisionInfo.id,
+                        collectionSlug: url.collectionSlug,
+                        revisionNumber: revisionInfo.revisionNumber ?? url.revisionNumber,
+                      },
+                    },
+                  } as any,
+                };
+
+                // Cache the result
+                downloadURLCache[cacheKey] = {
+                  urls: result.urls,
+                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
+                  meta: result.meta,
+                };
+
+                return result;
+              }),
+      )
+      .catch(NexusError, (err) => {
+        const newError = new HTTPError(err.statusCode, err.message, err.request);
+        newError.stack = err.stack;
+        return PromiseBB.reject(newError);
+      })
+      .catch(HTTPError, (err) => {
+        // A 401 here means the Nexus client could not authenticate the
+        // request and could not (or did not) refresh its token. Reachable
+        // when persisted state says we have OAuth credentials but the live
+        // Nexus instance does not (e.g. updateToken never ran on startup,
+        // forced-logout migration path), when the refresh token has been
+        // revoked server-side, or on a resume after logout. Surface as a
+        // ProcessCanceled so reportDownloadError shows a friendly,
+        // non-reportable notification instead of letting the raw 401 fall
+        // through to the generic else branch with the Report button.
+        if (err.statusCode === 401) {
+          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
+        }
+        return PromiseBB.reject(err);
+      })
+      .catch(RateLimitError, (err) => {
+        api.showErrorNotification("Rate limit exceeded", err, {
+          allowReport: false,
+        });
+        return PromiseBB.reject(err);
+      });
+  }
+
+  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
+    const state = api.store.getState();
+
+    let url: NXMUrl;
+    try {
+      url = new NXMUrl(input);
+    } catch (err) {
+      return PromiseBB.reject(err);
+    }
+
+    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
+    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
+      const userName: string = getSafe(
+        state,
+        ["persistent", "nexus", "userInfo", "name"],
+        undefined,
+      );
+      api.showErrorNotification(
+        "Invalid download links",
+        "The link was not created for this account ({{userName}}). " +
+          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
+        { allowReport: false, replace: { userName } },
+      );
+      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
+    }
+
+    if (
+      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
+      url.type === "mod" &&
+      url.gameId !== SITE_ID &&
+      url.key === undefined
+    ) {
+      const games = knownGames(state);
+      const gameId = convertNXMIdReverse(games, url.gameId);
+      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+
+      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
+        .then(({ modInfo, fileInfo }) => {
+          if (modInfo["direct_download_enabled"]) {
+            return premiumUserDownload(input, url, true);
+          } else {
+            return freeUserDownload(input, url);
+          }
+        })
+        .catch((err) => {
+          const message = getErrorMessageOrDefault(err);
+          // Cancellation must propagate; otherwise sibling deps whose in-flight
+          // mod-info queries get aborted re-enter freeUserDownload, repopulate
+          // the queue, and the dialog re-opens behind the one the user just
+          // dismissed.
+          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
+            return PromiseBB.reject(err);
+          }
+          // If we can't query mod info, fall back to free user flow
+          log("warn", "failed to query mod info for direct download check", {
+            error: message,
+          });
+          return freeUserDownload(input, url);
+        });
+    } else {
+      return premiumUserDownload(input, url);
+    }
+  };
+
+  return resolveFunc;
+}
+
+export function onUpdated() {
+  bringToFront();
+}
+
+export function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem === undefined) {
+    log("error", "failed to find queue item", {
+      inputUrl,
+      queue: JSON.stringify(freeDLQueue),
+    });
+    return;
+  }
+  const { url } = queueItem;
+
+  awaitedLinks.push({
+    gameId: url.gameId,
+    modId: url.modId,
+    fileId: url.fileId,
+    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
+  });
+
+  opn(
+    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
+  ).catch(() => null);
+}
+
+export function onSkip(api: IExtensionApi, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem !== undefined) {
+    queueItem
+      .queryRelevantUpdates()
+      .then((updates) => {
+        const fileIdSet = new Set<string>();
+        const fileNames = new Set<string>();
+        fileIdSet.add(queueItem.url.fileId.toString());
+        updates.forEach((update) => {
+          if (update.old_file_id != null) {
+            fileIdSet.add(update.old_file_id.toString());
+            fileNames.add(update.old_file_name);
+          }
+          if (update.new_file_id != null) {
+            fileIdSet.add(update.new_file_id.toString());
+            fileNames.add(update.new_file_name);
+          }
+        });
+        const parsed = new NXMUrl(queueItem.input);
+        const itemIdentifiers = {
+          ...parsed.identifiers,
+          fileNames: Array.from(fileNames),
+          fileIds: Array.from(fileIdSet),
+        };
+        // collections is now core, so the skip site dispatches the ignore directly against the
+        // active install session rather than emitting an event for the InstallDriver to handle
+        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
+        queueItem.rej(new UserCanceled(true));
+      })
+      .catch((err) => {
+        log("warn", "failed to query relevant updates on skip", {
+          error: getErrorMessageOrDefault(err),
+        });
+        queueItem.rej(new UserCanceled(true));
+      });
+  }
+}
+
+export function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem === undefined) {
+    log("error", "failed to find queue item", {
+      inputUrl,
+      queue: JSON.stringify(freeDLQueue),
+    });
+    return;
+  }
+
+  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
+}
+
+export function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
+  const copy = freeDLQueue.slice(0);
+  if (copy.length !== 0) {
+    copy.forEach((item) => {
+      item.rej(new UserCanceled(false));
+    });
+    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
+    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
+    // routes through the collections plugin for the full cleanup: stop queuing,
+    // reset the driver, dismiss the install notification.
+    const session = getCollectionActiveSession(api.getState());
+    if (session?.collectionId && session.gameId) {
+      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
+    }
+    return true;
+  } else {
+    api.store.dispatch(removeFreeUserDLItem(inputUrl));
+    return false;
+  }
+}

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -1,0 +1,591 @@
+import type { IDownloadURL, IFileUpdate, IRevision, IRevisionQuery } from "@nexusmods/nexus-api";
+import type NexusT from "@nexusmods/nexus-api";
+import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import { getErrorMessageOrDefault } from "@vortex/shared";
+import { DownloadIsHTML } from "@vortex/shared/errors";
+import PromiseBB from "bluebird";
+import type { Action } from "redux";
+
+import { setDownloadModInfo } from "../../actions";
+import { log } from "../../logging";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import type { IState } from "../../types/IState";
+import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
+import { markCollectionMemberSkipped } from "../../util/collectionSkip";
+import {
+  DataInvalid,
+  HTTPError,
+  ProcessCanceled,
+  ServiceTemporarilyUnavailable,
+  UserCanceled,
+} from "../../util/CustomErrors";
+import opn from "../../util/opn";
+import { gameById, knownGames } from "../../util/selectors";
+import { getSafe } from "../../util/storeHelper";
+import { batchDispatch } from "../../util/util";
+import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
+import { SITE_ID } from "../gamemode_management/constants";
+import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
+import { NEXUS_BASE_URL } from "./constants";
+import NXMUrl from "./NXMUrl";
+import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
+import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
+
+export type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
+
+interface IDLQueueItem {
+  input: string;
+  url: NXMUrl;
+  res: (res: IResolvedURL) => void;
+  rej: (err: Error) => void;
+  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
+}
+
+const freeDLQueue: IDLQueueItem[] = [];
+
+const DL_QUERY: IRevisionQuery = {
+  id: true,
+  downloadLink: true,
+  collection: {
+    id: true,
+  },
+};
+
+interface IAwaitedLink {
+  gameId: string;
+  modId: number;
+  fileId: number;
+  resolve: (url: string) => void;
+}
+
+const awaitedLinks: IAwaitedLink[] = [];
+
+function doDownload(api: IExtensionApi, nexus: NexusT, url: string): PromiseBB<string> {
+  return (
+    startDownload(api, nexus, url)
+      .catch(DownloadIsHTML, () => undefined)
+      // DataInvalid is used here to indicate invalid user input or invalid
+      // data from remote, so it's presumably not a bug in Vortex
+      .catch(DataInvalid, () => {
+        api.showErrorNotification("Failed to start download", url, {
+          allowReport: false,
+        });
+        return PromiseBB.resolve(undefined);
+      })
+      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
+      .catch((err) => {
+        api.showErrorNotification("Failed to start download", err);
+        return PromiseBB.resolve(undefined);
+      })
+  );
+}
+
+/**
+ * Handle an incoming nxm:// link. `onPremiumLink` runs for the nxm://premium form, which the
+ * site opens after a membership change so the client re-reads the user info.
+ */
+export function makeNXMLinkCallback(api: IExtensionApi, nexus: NexusT, onPremiumLink: () => void) {
+  return (url: string, install: boolean) => {
+    let nxmUrl: NXMUrl;
+    try {
+      nxmUrl = new NXMUrl(url);
+
+      const state = api.getState();
+      const isExtAvailable =
+        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
+        undefined;
+
+      if (nxmUrl.type === "oauth") {
+        try {
+          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
+        } catch (err) {
+          // ignore unexpected code
+        }
+      } else if (nxmUrl.type === "premium") {
+        try {
+          log("info", "makeNXMLinkCallback() premium");
+          onPremiumLink();
+          return false;
+        } catch (err) {
+          // ignore unexpected code
+        }
+      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
+        if (install) {
+          return api.emitAndAwait("install-extension", {
+            name: "Pending",
+            modId: nxmUrl.modId,
+            fileId: nxmUrl.fileId,
+          });
+        } else {
+          api.events.emit("show-extension-page", nxmUrl.modId);
+          bringToFront();
+          return PromiseBB.resolve();
+        }
+      } else {
+        const { foregroundDL } = state.settings.interface;
+        if (foregroundDL) {
+          bringToFront();
+        }
+      }
+    } catch (err) {
+      api.showErrorNotification("Invalid URL", err, { allowReport: false });
+      return;
+    }
+
+    const awaitedIdx = awaitedLinks.findIndex(
+      (link) =>
+        link.gameId === nxmUrl.gameId &&
+        link.modId === nxmUrl.modId &&
+        link.fileId === nxmUrl.fileId,
+    );
+    if (awaitedIdx !== -1) {
+      const awaited = awaitedLinks.splice(awaitedIdx, 1);
+      awaited[0].resolve(url);
+      return;
+    }
+
+    ensureLoggedIn(api)
+      .then(() => doDownload(api, nexus, url))
+      .then((dlId) => {
+        if (dlId === undefined || dlId === null) {
+          return PromiseBB.resolve(undefined);
+        }
+
+        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
+        if (nxmUrl.collectionId !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
+        }
+        if (nxmUrl.revisionId !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
+        }
+        if (nxmUrl.collectionSlug !== undefined) {
+          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
+        }
+        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
+          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
+        }
+        batchDispatch(api.store, actions);
+
+        return new PromiseBB((resolve, reject) => {
+          const currentState: IState = api.store.getState();
+          const download = currentState.persistent.downloads.files[dlId];
+          if (download === undefined) {
+            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
+          }
+          // collections always get installed automatically.
+          if (install && nxmUrl.type !== "collection") {
+            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
+              if (err !== null) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          } else {
+            resolve();
+          }
+        });
+      })
+      // doDownload handles all download errors so the catches below are
+      //  only for log in errors
+      .catch(UserCanceled, () => null)
+      .catch(ProcessCanceled, (err) => {
+        api.showErrorNotification("Log-in failed", err, {
+          id: "failed-get-nexus-key",
+          allowReport: false,
+        });
+      })
+      .catch(ServiceTemporarilyUnavailable, (err) => {
+        api.showErrorNotification("Service temporarily unavailable", err, {
+          id: "failed-get-nexus-key",
+          allowReport: false,
+        });
+      })
+      .catch((err) => {
+        api.showErrorNotification("Failed to get access key", err, {
+          id: "failed-get-nexus-key",
+        });
+      });
+  };
+}
+
+export function makeNXMProtocol(api: IExtensionApi, nexus: NexusT): ResolveFunc {
+  // for free users a dialog needs to be displayed sending them to the site for the download.
+  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
+  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
+  // out of the larger process without the user having to click cancel multiple times.
+  // Thus we have to keep track of all queued downloads.
+
+  function freeUserDownload(input: string, url: NXMUrl) {
+    // non-premium user trying to download a file with no id, have to send the user to the
+    // corresponding site to generate a proper link
+    return new PromiseBB<IResolvedURL>((resolve, reject) => {
+      const res = (result: IResolvedURL) => {
+        if (resolve !== undefined) {
+          // just to make sure we remove the correct item, idx should always be 0
+          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
+          api.store.dispatch(removeFreeUserDLItem(input));
+          freeDLQueue.splice(idx, 1);
+          resolve(result);
+          reject = undefined;
+          resolve = undefined;
+        }
+      };
+      const rej = (err) => {
+        if (reject !== undefined) {
+          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
+          api.store.dispatch(removeFreeUserDLItem(input));
+          freeDLQueue.splice(idx, 1);
+          reject(err);
+          reject = undefined;
+          resolve = undefined;
+        }
+      };
+      const queryRelevantUpdates = () => {
+        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
+          // Build a bidirectional map for O(1) lookups, we're doing this
+          //  in the hope that the mod authors have kept a clear update chain
+          //  which we can use to find relevant fileIds.
+          // It's not cool that we're consuming an API slot for this, but without this
+          //  we can't reliably compare the dependency reference to what we're attempting
+          //  to skip (we only have the NXM url which isn't enough).
+          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
+          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
+
+          files.file_updates.forEach((update) => {
+            forwardMap.set(update.old_file_id, update);
+            backwardMap.set(update.new_file_id, update);
+          });
+
+          // Traverse backwards to find the oldest file in the chain
+          let currentId = url.fileId;
+          const backwardChain: IFileUpdate[] = [];
+
+          while (backwardMap.has(currentId)) {
+            const update = backwardMap.get(currentId);
+            backwardChain.unshift(update); // Add to beginning
+            currentId = update.old_file_id;
+          }
+
+          // Now traverse forwards from the oldest file to build complete chain
+          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
+          currentId = oldestId;
+          const completeChain: IFileUpdate[] = [];
+
+          while (forwardMap.has(currentId)) {
+            const update = forwardMap.get(currentId);
+            completeChain.push(update);
+            currentId = update.new_file_id;
+          }
+
+          return completeChain;
+        });
+      };
+      freeDLQueue.push({ input, url, res, rej, queryRelevantUpdates });
+      api.store.dispatch(addFreeUserDLItem(input));
+    });
+  }
+
+  // Cache download URLs to avoid repeated API calls for the same file
+  const downloadURLCache: {
+    [key: string]: { urls: string[]; expires: number; meta: any };
+  } = {};
+  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+  function premiumUserDownload(
+    input: string,
+    url: NXMUrl,
+    directDownloadEnabled: boolean = false,
+  ): PromiseBB<IResolvedURL> {
+    const state = api.getState();
+    const games = knownGames(state);
+    const gameId = convertNXMIdReverse(games, url.gameId);
+    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+    let revisionInfo: Partial<IRevision>;
+
+    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
+
+    if (!["mod", "collection"].includes(url.type)) {
+      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
+    }
+
+    // Create cache key
+    const cacheKey =
+      url.type === "mod"
+        ? `mod_${url.modId}_${url.fileId}_${pageId}`
+        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
+
+    // Check cache first
+    const cached = downloadURLCache[cacheKey];
+    if (cached && Date.now() < cached.expires) {
+      return PromiseBB.resolve({
+        urls: cached.urls,
+        updatedUrl: input,
+        meta: cached.meta,
+      });
+    }
+
+    const downloadKey = directDownloadEnabled ? undefined : url.key;
+    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
+
+    return PromiseBB.resolve()
+      .then(() =>
+        url.type === "mod"
+          ? nexus
+              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
+              .then((res: IDownloadURL[]) => {
+                const result = {
+                  urls: res.map((u) => u.URI),
+                  updatedUrl: input,
+                  meta: {
+                    source: "nexus",
+                    nexus: {
+                      ids: {
+                        modId: url.modId,
+                        fileId: url.fileId,
+                      },
+                    },
+                  } as any,
+                };
+
+                // Cache the result
+                downloadURLCache[cacheKey] = {
+                  urls: result.urls,
+                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
+                  meta: result.meta,
+                };
+
+                return result;
+              })
+          : nexus
+              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
+              .catch((err) => {
+                err["collectionSlug"] = url.collectionSlug;
+                err["revisionNumber"] = url.revisionNumber;
+                return PromiseBB.reject(err);
+              })
+              .then((revision: Partial<IRevision>) => {
+                revisionInfo = revision;
+                return nexus.getCollectionDownloadLink(revision.downloadLink);
+              })
+              .then((downloadUrls) => {
+                const result = {
+                  urls: downloadUrls.map((iter) => iter.URI),
+                  updatedUrl: input,
+                  meta: {
+                    source: "nexus",
+                    nexus: {
+                      ids: {
+                        collectionId: revisionInfo.collection.id,
+                        revisionId: revisionInfo.id,
+                        collectionSlug: url.collectionSlug,
+                        revisionNumber: url.revisionNumber,
+                      },
+                    },
+                  } as any,
+                };
+
+                // Cache the result
+                downloadURLCache[cacheKey] = {
+                  urls: result.urls,
+                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
+                  meta: result.meta,
+                };
+
+                return result;
+              }),
+      )
+      .catch(NexusError, (err) => {
+        const newError = new HTTPError(err.statusCode, err.message, err.request);
+        newError.stack = err.stack;
+        return PromiseBB.reject(newError);
+      })
+      .catch(HTTPError, (err) => {
+        // A 401 here means the Nexus client could not authenticate the
+        // request and could not (or did not) refresh its token. Reachable
+        // when persisted state says we have OAuth credentials but the live
+        // Nexus instance does not (e.g. updateToken never ran on startup,
+        // forced-logout migration path), when the refresh token has been
+        // revoked server-side, or on a resume after logout. Surface as a
+        // ProcessCanceled so reportDownloadError shows a friendly,
+        // non-reportable notification instead of letting the raw 401 fall
+        // through to the generic else branch with the Report button.
+        if (err.statusCode === 401) {
+          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
+        }
+        return PromiseBB.reject(err);
+      })
+      .catch(RateLimitError, (err) => {
+        api.showErrorNotification("Rate limit exceeded", err, {
+          allowReport: false,
+        });
+        return PromiseBB.reject(err);
+      });
+  }
+
+  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
+    const state = api.store.getState();
+
+    let url: NXMUrl;
+    try {
+      url = new NXMUrl(input);
+    } catch (err) {
+      return PromiseBB.reject(err);
+    }
+
+    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
+    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
+      const userName: string = getSafe(
+        state,
+        ["persistent", "nexus", "userInfo", "name"],
+        undefined,
+      );
+      api.showErrorNotification(
+        "Invalid download links",
+        "The link was not created for this account ({{userName}}). " +
+          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
+        { allowReport: false, replace: { userName } },
+      );
+      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
+    }
+
+    if (
+      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
+      url.type === "mod" &&
+      url.gameId !== SITE_ID &&
+      url.key === undefined
+    ) {
+      const games = knownGames(state);
+      const gameId = convertNXMIdReverse(games, url.gameId);
+      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+
+      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
+        .then(({ modInfo, fileInfo }) => {
+          if (modInfo["direct_download_enabled"]) {
+            return premiumUserDownload(input, url, true);
+          } else {
+            return freeUserDownload(input, url);
+          }
+        })
+        .catch((err) => {
+          const message = getErrorMessageOrDefault(err);
+          // Cancellation must propagate; otherwise sibling deps whose in-flight
+          // mod-info queries get aborted re-enter freeUserDownload, repopulate
+          // the queue, and the dialog re-opens behind the one the user just
+          // dismissed.
+          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
+            return PromiseBB.reject(err);
+          }
+          // If we can't query mod info, fall back to free user flow
+          log("warn", "failed to query mod info for direct download check", {
+            error: message,
+          });
+          return freeUserDownload(input, url);
+        });
+    } else {
+      return premiumUserDownload(input, url);
+    }
+  };
+
+  return resolveFunc;
+}
+
+export function onUpdated() {
+  bringToFront();
+}
+
+export function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem === undefined) {
+    log("error", "failed to find queue item", {
+      inputUrl,
+      queue: JSON.stringify(freeDLQueue),
+    });
+    return;
+  }
+  const { url } = queueItem;
+
+  awaitedLinks.push({
+    gameId: url.gameId,
+    modId: url.modId,
+    fileId: url.fileId,
+    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
+  });
+
+  opn(
+    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
+  ).catch(() => null);
+}
+
+export function onSkip(api: IExtensionApi, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem !== undefined) {
+    queueItem
+      .queryRelevantUpdates()
+      .then((updates) => {
+        const fileIdSet = new Set<string>();
+        const fileNames = new Set<string>();
+        fileIdSet.add(queueItem.url.fileId.toString());
+        updates.forEach((update) => {
+          if (update.old_file_id != null) {
+            fileIdSet.add(update.old_file_id.toString());
+            fileNames.add(update.old_file_name);
+          }
+          if (update.new_file_id != null) {
+            fileIdSet.add(update.new_file_id.toString());
+            fileNames.add(update.new_file_name);
+          }
+        });
+        const parsed = new NXMUrl(queueItem.input);
+        const itemIdentifiers = {
+          ...parsed.identifiers,
+          fileNames: Array.from(fileNames),
+          fileIds: Array.from(fileIdSet),
+        };
+        // collections is now core, so the skip site dispatches the ignore directly against the
+        // active install session rather than emitting an event for the InstallDriver to handle
+        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
+        queueItem.rej(new UserCanceled(true));
+      })
+      .catch((err) => {
+        log("warn", "failed to query relevant updates on skip", {
+          error: getErrorMessageOrDefault(err),
+        });
+        queueItem.rej(new UserCanceled(true));
+      });
+  }
+}
+
+export function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
+  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
+  if (queueItem === undefined) {
+    log("error", "failed to find queue item", {
+      inputUrl,
+      queue: JSON.stringify(freeDLQueue),
+    });
+    return;
+  }
+
+  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
+}
+
+export function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
+  const copy = freeDLQueue.slice(0);
+  if (copy.length !== 0) {
+    copy.forEach((item) => {
+      item.rej(new UserCanceled(false));
+    });
+    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
+    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
+    // routes through the collections plugin for the full cleanup: stop queuing,
+    // reset the driver, dismiss the install notification.
+    const session = getCollectionActiveSession(api.getState());
+    if (session?.collectionId && session.gameId) {
+      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
+    }
+    return true;
+  } else {
+    api.store.dispatch(removeFreeUserDLItem(inputUrl));
+    return false;
+  }
+}

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -294,11 +294,15 @@ export class NxmProtocol {
    * the settled download alive and re-resolving it if a matching link ever does arrive.
    */
   #dequeue(input: string): void {
-    this.#api.store.dispatch(removeFreeUserDLItem(input));
     // the entry may already be gone
     const queuedIdx = this.#freeQueue.findIndex((iter) => iter.input === input);
     if (queuedIdx !== -1) {
       this.#freeQueue.splice(queuedIdx, 1);
+    }
+    // the queue is keyed by url, so one row can stand for two downloads of the same file; it goes
+    // when the last of them settles, or the survivor is left parked with nothing to release it
+    if (!this.#freeQueue.some((iter) => iter.input === input)) {
+      this.#api.store.dispatch(removeFreeUserDLItem(input));
     }
   }
 

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -3,13 +3,11 @@ import type NexusT from "@nexusmods/nexus-api";
 import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 import { DownloadIsHTML } from "@vortex/shared/errors";
-import PromiseBB from "bluebird";
 import type { Action } from "redux";
 
 import { setDownloadModInfo } from "../../actions";
 import { log } from "../../logging";
 import type { IExtensionApi } from "../../types/IExtensionContext";
-import type { IState } from "../../types/IState";
 import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
 import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import {
@@ -19,29 +17,18 @@ import {
   ServiceTemporarilyUnavailable,
   UserCanceled,
 } from "../../util/CustomErrors";
+import { createKeyedCache } from "../../util/keyedCache";
 import opn from "../../util/opn";
-import { gameById, knownGames } from "../../util/selectors";
-import { getSafe } from "../../util/storeHelper";
 import { batchDispatch } from "../../util/util";
 import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
 import { SITE_ID } from "../gamemode_management/constants";
 import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
 import { NEXUS_BASE_URL } from "./constants";
 import NXMUrl from "./NXMUrl";
+import { isPremium, userInfo } from "./selectors";
 import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
-import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
-
-export type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
-
-interface IDLQueueItem {
-  input: string;
-  url: NXMUrl;
-  res: (res: IResolvedURL) => void;
-  rej: (err: Error) => void;
-  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
-}
-
-const freeDLQueue: IDLQueueItem[] = [];
+import { findLatestUpdate } from "./util/checkModsVersion";
+import { nxmPageId } from "./util/convertGameId";
 
 const DL_QUERY: IRevisionQuery = {
   id: true,
@@ -51,541 +38,545 @@ const DL_QUERY: IRevisionQuery = {
   },
 };
 
-interface IAwaitedLink {
-  gameId: string;
-  modId: number;
-  fileId: number;
-  resolve: (url: string) => void;
+const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000;
+
+/** A download parked until the user fetches an authorised link from the website. */
+interface IQueuedDownload {
+  input: string;
+  url: NXMUrl;
+  resolve: (res: IResolvedURL) => void;
+  reject: (err: Error) => void;
+  /** The file's update chain, used to describe what a skip is skipping. */
+  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
 }
 
-const awaitedLinks: IAwaitedLink[] = [];
+/** What one download-url lookup found: the cdn urls plus the nexus ids identifying them. */
+interface IFoundDownload {
+  urls: IDownloadURL[];
+  ids: Record<string, unknown>;
+}
 
-function doDownload(api: IExtensionApi, nexus: NexusT, url: string): PromiseBB<string> {
-  return (
-    startDownload(api, nexus, url)
-      .catch(DownloadIsHTML, () => undefined)
-      // DataInvalid is used here to indicate invalid user input or invalid
-      // data from remote, so it's presumably not a bug in Vortex
-      .catch(DataInvalid, () => {
-        api.showErrorNotification("Failed to start download", url, {
-          allowReport: false,
-        });
-        return PromiseBB.resolve(undefined);
-      })
-      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
-      .catch((err) => {
-        api.showErrorNotification("Failed to start download", err);
-        return PromiseBB.resolve(undefined);
-      })
-  );
+export interface INxmProtocolDeps {
+  /** Re-read the account's membership. The site opens nxm://premium after a membership change. */
+  onRefreshMembership: () => void;
+}
+
+/** The handlers FreeUserDLDialog is wired to. */
+export interface IFreeUserDialogHandlers {
+  onUpdated: () => void;
+  onDownload: (inputUrl: string) => void;
+  onSkip: (inputUrl: string) => void;
+  onCancel: (inputUrl: string) => boolean;
+  onRetry: (inputUrl: string) => void;
 }
 
 /**
- * Handle an incoming nxm:// link. `onPremiumLink` runs for the nxm://premium form, which the
- * site opens after a membership change so the client re-reads the user info.
+ * A free user can't ask the api for a download link, so only a keyless link to a mod file on a
+ * real game can ever need the website round trip. Collections, extensions from the site domain,
+ * and links the website already authorised go straight to the api.
  */
-export function makeNXMLinkCallback(api: IExtensionApi, nexus: NexusT, onPremiumLink: () => void) {
-  return (url: string, install: boolean) => {
+function needsAuthorisedLink(url: NXMUrl): boolean {
+  return url.type === "mod" && url.gameId !== SITE_ID && url.key === undefined;
+}
+
+/**
+ * Resolves nxm:// urls to something the downloader can fetch, and owns the queue of downloads
+ * parked while a free user fetches an authorised link from the website.
+ *
+ * One instance owns the whole queue, because a cancel rejects every download in it: the queued
+ * downloads are shown one dialog at a time, so cancelling has to mean "get me out of this
+ * install", not "dismiss this one dialog".
+ */
+export class NxmProtocol {
+  readonly #api: IExtensionApi;
+  readonly #getNexus: () => NexusT;
+  readonly #deps: INxmProtocolDeps;
+
+  readonly #freeQueue: IQueuedDownload[] = [];
+  // queued downloads whose user was sent to the website to generate an authorised link
+  readonly #awaitedLinks: IQueuedDownload[] = [];
+  readonly #urlCache = createKeyedCache<{ urls: string[]; meta: unknown }>(
+    DOWNLOAD_URL_CACHE_DURATION,
+  );
+
+  /**
+   * `getNexus` is read on each use: the extension registers its protocol handlers during init,
+   * and only builds the Nexus connection later, in its `once` callback.
+   */
+  constructor(api: IExtensionApi, getNexus: () => NexusT, deps: INxmProtocolDeps) {
+    this.#api = api;
+    this.#getNexus = getNexus;
+    this.#deps = deps;
+  }
+
+  get #nexus(): NexusT {
+    return this.#getNexus();
+  }
+
+  /** Registered as the download protocol handler for the nxm scheme. */
+  readonly resolve = async (input: string): Promise<IResolvedURL> => {
+    const url = new NXMUrl(input);
+
+    const cached = userInfo(this.#api.getState());
+    if (url.userId !== undefined && url.userId !== cached?.userId) {
+      this.#api.showErrorNotification(
+        "Invalid download links",
+        "The link was not created for this account ({{userName}}). " +
+          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
+        { allowReport: false, replace: { userName: cached?.name } },
+      );
+      throw new ProcessCanceled("Wrong user id");
+    }
+
+    // resolved once and threaded through: it costs two scans of the known-games list
+    const pageId = nxmPageId(this.#api.getState(), url.gameId);
+
+    if (this.#canDownloadInApp(url) || (await this.#isDirectDownload(url, pageId))) {
+      return this.#apiDownload(input, url, pageId);
+    }
+
+    return this.#websiteDownload(input, url);
+  };
+
+  /**
+   * Whether the author opted this mod into direct downloads, which makes it free for everyone.
+   * Only the website knows, so a lookup we can't complete counts as "no".
+   */
+  async #isDirectDownload(url: NXMUrl, pageId: string): Promise<boolean> {
+    try {
+      const { modInfo } = await getInfoGraphQL(this.#nexus, pageId, url.modId, url.fileId);
+      return modInfo["direct_download_enabled"] === true;
+    } catch (err) {
+      // Cancellation must propagate; otherwise sibling deps whose in-flight mod-info queries get
+      // aborted re-enter the queue, and the dialog re-opens behind the one the user just dismissed.
+      if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
+        throw err;
+      }
+      log("warn", "failed to query mod info for direct download check", {
+        error: getErrorMessageOrDefault(err),
+      });
+      return false;
+    }
+  }
+
+  /** Registered as the OS handler for nxm:// links. */
+  readonly handleLink = (url: string, install: boolean) => {
     let nxmUrl: NXMUrl;
     try {
       nxmUrl = new NXMUrl(url);
 
-      const state = api.getState();
-      const isExtAvailable =
-        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
-        undefined;
+      const state = this.#api.getState();
 
       if (nxmUrl.type === "oauth") {
-        try {
-          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
-        } catch (err) {
-          // ignore unexpected code
-        }
+        return oauthCallback(this.#api, nxmUrl.oauthCode, nxmUrl.oauthState);
       } else if (nxmUrl.type === "premium") {
-        try {
-          log("info", "makeNXMLinkCallback() premium");
-          onPremiumLink();
-          return false;
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
+        log("info", "nxm premium link, re-reading the membership");
+        this.#deps.onRefreshMembership();
+        return false;
+      } else if (nxmUrl.gameId === SITE_ID && this.#isExtensionAvailable(nxmUrl.modId)) {
         if (install) {
-          return api.emitAndAwait("install-extension", {
+          return this.#api.emitAndAwait("install-extension", {
             name: "Pending",
             modId: nxmUrl.modId,
             fileId: nxmUrl.fileId,
           });
-        } else {
-          api.events.emit("show-extension-page", nxmUrl.modId);
-          bringToFront();
-          return PromiseBB.resolve();
         }
-      } else {
-        const { foregroundDL } = state.settings.interface;
-        if (foregroundDL) {
-          bringToFront();
-        }
+        this.#api.events.emit("show-extension-page", nxmUrl.modId);
+        bringToFront();
+        return Promise.resolve();
+      } else if (state.settings.interface.foregroundDL) {
+        bringToFront();
       }
     } catch (err) {
-      api.showErrorNotification("Invalid URL", err, { allowReport: false });
+      this.#api.showErrorNotification("Invalid URL", err, { allowReport: false });
       return;
     }
 
-    const awaitedIdx = awaitedLinks.findIndex(
-      (link) =>
-        link.gameId === nxmUrl.gameId &&
-        link.modId === nxmUrl.modId &&
-        link.fileId === nxmUrl.fileId,
-    );
-    if (awaitedIdx !== -1) {
-      const awaited = awaitedLinks.splice(awaitedIdx, 1);
-      awaited[0].resolve(url);
+    if (this.#deliverAwaitedLink(nxmUrl, url)) {
       return;
     }
 
-    ensureLoggedIn(api)
-      .then(() => doDownload(api, nexus, url))
-      .then((dlId) => {
-        if (dlId === undefined || dlId === null) {
-          return PromiseBB.resolve(undefined);
-        }
-
-        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
-        if (nxmUrl.collectionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
-        }
-        if (nxmUrl.revisionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
-        }
-        if (nxmUrl.collectionSlug !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
-        }
-        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
-          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
-        }
-        batchDispatch(api.store, actions);
-
-        return new PromiseBB((resolve, reject) => {
-          const currentState: IState = api.store.getState();
-          const download = currentState.persistent.downloads.files[dlId];
-          if (download === undefined) {
-            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
-          }
-          // collections always get installed automatically.
-          if (install && nxmUrl.type !== "collection") {
-            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
-              if (err !== null) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
-          } else {
-            resolve();
-          }
-        });
-      })
-      // doDownload handles all download errors so the catches below are
-      //  only for log in errors
-      .catch(UserCanceled, () => null)
-      .catch(ProcessCanceled, (err) => {
-        api.showErrorNotification("Log-in failed", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch(ServiceTemporarilyUnavailable, (err) => {
-        api.showErrorNotification("Service temporarily unavailable", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch((err) => {
-        api.showErrorNotification("Failed to get access key", err, {
-          id: "failed-get-nexus-key",
-        });
-      });
+    void this.#startLinkDownload(nxmUrl, url, install);
   };
-}
 
-export function makeNXMProtocol(api: IExtensionApi, nexus: NexusT): ResolveFunc {
-  // for free users a dialog needs to be displayed sending them to the site for the download.
-  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
-  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
-  // out of the larger process without the user having to click cancel multiple times.
-  // Thus we have to keep track of all queued downloads.
+  readonly dialogHandlers: IFreeUserDialogHandlers = {
+    onUpdated: bringToFront,
 
-  function freeUserDownload(input: string, url: NXMUrl) {
-    // non-premium user trying to download a file with no id, have to send the user to the
-    // corresponding site to generate a proper link
-    return new PromiseBB<IResolvedURL>((resolve, reject) => {
-      const res = (result: IResolvedURL) => {
-        if (resolve !== undefined) {
-          // just to make sure we remove the correct item, idx should always be 0
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          resolve(result);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const rej = (err) => {
-        if (reject !== undefined) {
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
+    /** Send the user to the file's page to generate an authorised link. */
+    onDownload: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      const { url } = queued;
+
+      this.#awaitedLinks.push(queued);
+
+      opn(
+        `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
+      ).catch(() => null);
+    },
+
+    onSkip: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      void this.#skipQueued(queued);
+    },
+
+    /** Cancels every queued download, not just this one. Returns whether there was any. */
+    onCancel: (inputUrl: string): boolean => {
+      if (this.#freeQueue.length === 0) {
+        this.#api.store.dispatch(removeFreeUserDLItem(inputUrl));
+        return false;
+      }
+
+      this.#freeQueue.slice().forEach((queued) => queued.reject(new UserCanceled(false)));
+
+      // Rejecting the queued downloads dismisses the dialog but doesn't stop the install pipeline
+      // (their UserCanceled doesn't survive IPC). pause-collection routes through the collections
+      // plugin for the full cleanup: stop queuing, reset the driver, dismiss the notification.
+      const session = getCollectionActiveSession(this.#api.getState());
+      if (session?.collectionId && session.gameId) {
+        this.#api.events.emit(
+          "pause-collection",
+          session.gameId,
+          session.collectionId,
+          "free-user-cancel",
+        );
+      }
+      return true;
+    },
+
+    /** Re-resolve a queued download, e.g. after the user upgraded to premium. */
+    onRetry: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      this.resolve(queued.input).then(queued.resolve, queued.reject);
+    },
+  };
+
+  /** Whether this download can go through the api, or has to go via the website. */
+  #canDownloadInApp(url: NXMUrl): boolean {
+    if (!needsAuthorisedLink(url)) {
+      return true;
+    }
+    if (process.env["FORCE_FREE_DOWNLOADS"] === "yes") {
+      return false;
+    }
+    return isPremium(this.#api.getState());
+  }
+
+  /** Whether the site offers an extension with this mod id. */
+  #isExtensionAvailable(modId: number): boolean {
+    const available = this.#api.getState().session.extensions.available;
+    return available.find((iter) => iter.modId === modId) !== undefined;
+  }
+
+  #queuedFor(inputUrl: string): IQueuedDownload | undefined {
+    const queued = this.#freeQueue.find((iter) => iter.input === inputUrl);
+    if (queued === undefined) {
+      log("error", "failed to find queued download", {
+        inputUrl,
+        queued: this.#freeQueue.map((iter) => iter.input),
+      });
+    }
+    return queued;
+  }
+
+  /**
+   * Forget a queued download, including any link the user was sent to the website to fetch for
+   * it - otherwise an abandoned trip to the website leaves an entry that never expires, holding
+   * the settled download alive and re-resolving it if a matching link ever does arrive.
+   */
+  #dequeue(input: string): void {
+    this.#api.store.dispatch(removeFreeUserDLItem(input));
+    // the entry may already be gone
+    const queuedIdx = this.#freeQueue.findIndex((iter) => iter.input === input);
+    if (queuedIdx !== -1) {
+      this.#freeQueue.splice(queuedIdx, 1);
+    }
+    const awaitedIdx = this.#awaitedLinks.findIndex((iter) => iter.input === input);
+    if (awaitedIdx !== -1) {
+      this.#awaitedLinks.splice(awaitedIdx, 1);
+    }
+  }
+
+  /**
+   * Park the download until the user brings back an authorised link from the website (or cancels
+   * or skips it). FreeUserDLDialog renders off the redux queue this dispatches into.
+   */
+  #websiteDownload(input: string, url: NXMUrl): Promise<IResolvedURL> {
+    // a promise settles once and #dequeue tolerates a repeat, so cancelling after a skip is safe
+    return new Promise<IResolvedURL>((resolve, reject) => {
+      this.#freeQueue.push({
+        input,
+        url,
+        resolve: (res) => {
+          this.#dequeue(input);
+          resolve(res);
+        },
+        reject: (err) => {
+          this.#dequeue(input);
           reject(err);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const queryRelevantUpdates = () => {
-        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
-          // Build a bidirectional map for O(1) lookups, we're doing this
-          //  in the hope that the mod authors have kept a clear update chain
-          //  which we can use to find relevant fileIds.
-          // It's not cool that we're consuming an API slot for this, but without this
-          //  we can't reliably compare the dependency reference to what we're attempting
-          //  to skip (we only have the NXM url which isn't enough).
-          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
-          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
-
-          files.file_updates.forEach((update) => {
-            forwardMap.set(update.old_file_id, update);
-            backwardMap.set(update.new_file_id, update);
-          });
-
-          // Traverse backwards to find the oldest file in the chain
-          let currentId = url.fileId;
-          const backwardChain: IFileUpdate[] = [];
-
-          while (backwardMap.has(currentId)) {
-            const update = backwardMap.get(currentId);
-            backwardChain.unshift(update); // Add to beginning
-            currentId = update.old_file_id;
-          }
-
-          // Now traverse forwards from the oldest file to build complete chain
-          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
-          currentId = oldestId;
-          const completeChain: IFileUpdate[] = [];
-
-          while (forwardMap.has(currentId)) {
-            const update = forwardMap.get(currentId);
-            completeChain.push(update);
-            currentId = update.new_file_id;
-          }
-
-          return completeChain;
-        });
-      };
-      freeDLQueue.push({ input, url, res, rej, queryRelevantUpdates });
-      api.store.dispatch(addFreeUserDLItem(input));
+        },
+        queryRelevantUpdates: () => this.#relevantUpdates(url),
+      });
+      this.#api.store.dispatch(addFreeUserDLItem(input));
     });
   }
 
-  // Cache download URLs to avoid repeated API calls for the same file
-  const downloadURLCache: {
-    [key: string]: { urls: string[]; expires: number; meta: any };
-  } = {};
-  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+  /**
+   * The file's full update chain. Skipping has to name every file id the chain covers, because a
+   * dependency may reference an older or newer file than the one being skipped and the nxm url
+   * alone can't tell us which.
+   */
+  async #relevantUpdates(url: NXMUrl): Promise<IFileUpdate[]> {
+    const files = await this.#nexus.getModFiles(url.modId, url.gameId);
 
-  function premiumUserDownload(
-    input: string,
-    url: NXMUrl,
-    directDownloadEnabled: boolean = false,
-  ): PromiseBB<IResolvedURL> {
-    const state = api.getState();
-    const games = knownGames(state);
-    const gameId = convertNXMIdReverse(games, url.gameId);
-    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-    let revisionInfo: Partial<IRevision>;
+    const previous = new Map<number, IFileUpdate>(); // new_file_id -> update
+    files.file_updates.forEach((update) => previous.set(update.new_file_id, update));
 
-    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
+    // walk back to the oldest file in the chain, then forward over the whole of it
+    let oldestId = url.fileId;
+    while (previous.has(oldestId)) {
+      oldestId = previous.get(oldestId).old_file_id;
+    }
+    return findLatestUpdate(files.file_updates, [], oldestId);
+  }
 
+  async #skipQueued(queued: IQueuedDownload): Promise<void> {
+    const fileIds = new Set<string>([queued.url.fileId.toString()]);
+    const fileNames = new Set<string>();
+    try {
+      const updates = await queued.queryRelevantUpdates();
+      updates.forEach((update) => {
+        if (update.old_file_id != null) {
+          fileIds.add(update.old_file_id.toString());
+          fileNames.add(update.old_file_name);
+        }
+        if (update.new_file_id != null) {
+          fileIds.add(update.new_file_id.toString());
+          fileNames.add(update.new_file_name);
+        }
+      });
+
+      // the skip dispatches the ignore directly against the active install session
+      markCollectionMemberSkipped(this.#api, {
+        identifiers: {
+          ...queued.url.identifiers,
+          fileNames: Array.from(fileNames),
+          fileIds: Array.from(fileIds),
+        },
+      });
+    } catch (err) {
+      log("warn", "failed to query relevant updates on skip", {
+        error: getErrorMessageOrDefault(err),
+      });
+    }
+    queued.reject(new UserCanceled(true));
+  }
+
+  /** Ask the api for the download urls, serving a recent answer for the same file from cache. */
+  async #apiDownload(input: string, url: NXMUrl, pageId: string): Promise<IResolvedURL> {
     if (!["mod", "collection"].includes(url.type)) {
-      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
+      throw new ProcessCanceled("Not a download url");
     }
 
-    // Create cache key
+    const revisionNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
     const cacheKey =
       url.type === "mod"
         ? `mod_${url.modId}_${url.fileId}_${pageId}`
-        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
+        : `collection_${url.collectionSlug}_${revisionNumber ?? "latest"}`;
 
-    // Check cache first
-    const cached = downloadURLCache[cacheKey];
-    if (cached && Date.now() < cached.expires) {
-      return PromiseBB.resolve({
-        urls: cached.urls,
-        updatedUrl: input,
-        meta: cached.meta,
-      });
+    const cached = this.#urlCache.get(cacheKey);
+    if (cached !== undefined) {
+      return { urls: cached.urls, updatedUrl: input, meta: cached.meta };
     }
 
-    const downloadKey = directDownloadEnabled ? undefined : url.key;
-    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
-
-    return PromiseBB.resolve()
-      .then(() =>
-        url.type === "mod"
-          ? nexus
-              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
-              .then((res: IDownloadURL[]) => {
-                const result = {
-                  urls: res.map((u) => u.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        modId: url.modId,
-                        fileId: url.fileId,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              })
-          : nexus
-              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
-              .catch((err) => {
-                err["collectionSlug"] = url.collectionSlug;
-                err["revisionNumber"] = url.revisionNumber;
-                return PromiseBB.reject(err);
-              })
-              .then((revision: Partial<IRevision>) => {
-                revisionInfo = revision;
-                return nexus.getCollectionDownloadLink(revision.downloadLink);
-              })
-              .then((downloadUrls) => {
-                const result = {
-                  urls: downloadUrls.map((iter) => iter.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        collectionId: revisionInfo.collection.id,
-                        revisionId: revisionInfo.id,
-                        collectionSlug: url.collectionSlug,
-                        revisionNumber: url.revisionNumber,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              }),
-      )
-      .catch(NexusError, (err) => {
-        const newError = new HTTPError(err.statusCode, err.message, err.request);
-        newError.stack = err.stack;
-        return PromiseBB.reject(newError);
-      })
-      .catch(HTTPError, (err) => {
-        // A 401 here means the Nexus client could not authenticate the
-        // request and could not (or did not) refresh its token. Reachable
-        // when persisted state says we have OAuth credentials but the live
-        // Nexus instance does not (e.g. updateToken never ran on startup,
-        // forced-logout migration path), when the refresh token has been
-        // revoked server-side, or on a resume after logout. Surface as a
-        // ProcessCanceled so reportDownloadError shows a friendly,
-        // non-reportable notification instead of letting the raw 401 fall
-        // through to the generic else branch with the Report button.
-        if (err.statusCode === 401) {
-          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
-        }
-        return PromiseBB.reject(err);
-      })
-      .catch(RateLimitError, (err) => {
-        api.showErrorNotification("Rate limit exceeded", err, {
-          allowReport: false,
-        });
-        return PromiseBB.reject(err);
-      });
-  }
-
-  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
-    const state = api.store.getState();
-
-    let url: NXMUrl;
+    let found: IFoundDownload;
     try {
-      url = new NXMUrl(input);
+      found =
+        url.type === "mod"
+          ? await this.#modDownload(url, pageId)
+          : await this.#collectionDownload(url, revisionNumber);
     } catch (err) {
-      return PromiseBB.reject(err);
+      this.#throwDownloadError(err);
     }
 
-    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
-    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
-      const userName: string = getSafe(
-        state,
-        ["persistent", "nexus", "userInfo", "name"],
-        undefined,
+    const resolved: IResolvedURL = {
+      urls: found.urls.map((iter) => iter.URI),
+      updatedUrl: input,
+      meta: { source: "nexus", nexus: { ids: found.ids } } as IResolvedURL["meta"],
+    };
+
+    this.#urlCache.set(cacheKey, { urls: resolved.urls, meta: resolved.meta });
+    return resolved;
+  }
+
+  async #modDownload(url: NXMUrl, pageId: string): Promise<IFoundDownload> {
+    return {
+      urls: await this.#nexus.getDownloadURLs(url.modId, url.fileId, url.key, url.expires, pageId),
+      ids: { modId: url.modId, fileId: url.fileId },
+    };
+  }
+
+  async #collectionDownload(
+    url: NXMUrl,
+    revisionNumber: number | undefined,
+  ): Promise<IFoundDownload> {
+    let revision: Partial<IRevision>;
+    try {
+      revision = await this.#nexus.getCollectionRevisionGraph(
+        DL_QUERY,
+        url.collectionSlug,
+        revisionNumber,
       );
-      api.showErrorNotification(
-        "Invalid download links",
-        "The link was not created for this account ({{userName}}). " +
-          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
-        { allowReport: false, replace: { userName } },
-      );
-      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
+    } catch (err) {
+      err["collectionSlug"] = url.collectionSlug;
+      err["revisionNumber"] = url.revisionNumber;
+      throw err;
     }
 
-    if (
-      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
-      url.type === "mod" &&
-      url.gameId !== SITE_ID &&
-      url.key === undefined
-    ) {
-      const games = knownGames(state);
-      const gameId = convertNXMIdReverse(games, url.gameId);
-      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+    return {
+      urls: await this.#nexus.getCollectionDownloadLink(revision.downloadLink),
+      ids: {
+        collectionId: revision.collection.id,
+        revisionId: revision.id,
+        collectionSlug: url.collectionSlug,
+        revisionNumber: url.revisionNumber,
+      },
+    };
+  }
 
-      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
-        .then(({ modInfo, fileInfo }) => {
-          if (modInfo["direct_download_enabled"]) {
-            return premiumUserDownload(input, url, true);
-          } else {
-            return freeUserDownload(input, url);
-          }
-        })
-        .catch((err) => {
-          const message = getErrorMessageOrDefault(err);
-          // Cancellation must propagate; otherwise sibling deps whose in-flight
-          // mod-info queries get aborted re-enter freeUserDownload, repopulate
-          // the queue, and the dialog re-opens behind the one the user just
-          // dismissed.
-          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
-            return PromiseBB.reject(err);
-          }
-          // If we can't query mod info, fall back to free user flow
-          log("warn", "failed to query mod info for direct download check", {
-            error: message,
-          });
-          return freeUserDownload(input, url);
-        });
-    } else {
-      return premiumUserDownload(input, url);
+  /** Rethrow an api failure as the error the download pipeline knows how to report. */
+  #throwDownloadError(err: unknown): never {
+    if (err instanceof RateLimitError) {
+      this.#api.showErrorNotification("Rate limit exceeded", err, { allowReport: false });
+      throw err;
     }
-  };
 
-  return resolveFunc;
-}
-
-export function onUpdated() {
-  bringToFront();
-}
-
-export function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-  const { url } = queueItem;
-
-  awaitedLinks.push({
-    gameId: url.gameId,
-    modId: url.modId,
-    fileId: url.fileId,
-    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
-  });
-
-  opn(
-    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
-  ).catch(() => null);
-}
-
-export function onSkip(api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem !== undefined) {
-    queueItem
-      .queryRelevantUpdates()
-      .then((updates) => {
-        const fileIdSet = new Set<string>();
-        const fileNames = new Set<string>();
-        fileIdSet.add(queueItem.url.fileId.toString());
-        updates.forEach((update) => {
-          if (update.old_file_id != null) {
-            fileIdSet.add(update.old_file_id.toString());
-            fileNames.add(update.old_file_name);
-          }
-          if (update.new_file_id != null) {
-            fileIdSet.add(update.new_file_id.toString());
-            fileNames.add(update.new_file_name);
-          }
-        });
-        const parsed = new NXMUrl(queueItem.input);
-        const itemIdentifiers = {
-          ...parsed.identifiers,
-          fileNames: Array.from(fileNames),
-          fileIds: Array.from(fileIdSet),
-        };
-        // collections is now core, so the skip site dispatches the ignore directly against the
-        // active install session rather than emitting an event for the InstallDriver to handle
-        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
-        queueItem.rej(new UserCanceled(true));
-      })
-      .catch((err) => {
-        log("warn", "failed to query relevant updates on skip", {
-          error: getErrorMessageOrDefault(err),
-        });
-        queueItem.rej(new UserCanceled(true));
-      });
-  }
-}
-
-export function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-
-  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
-}
-
-export function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
-  const copy = freeDLQueue.slice(0);
-  if (copy.length !== 0) {
-    copy.forEach((item) => {
-      item.rej(new UserCanceled(false));
-    });
-    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
-    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
-    // routes through the collections plugin for the full cleanup: stop queuing,
-    // reset the driver, dismiss the install notification.
-    const session = getCollectionActiveSession(api.getState());
-    if (session?.collectionId && session.gameId) {
-      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
+    let error = err;
+    if (error instanceof NexusError) {
+      const http = new HTTPError(error.statusCode, error.message, error.request);
+      http.stack = error.stack;
+      error = http;
     }
+
+    // A 401 means the Nexus client could not authenticate the request and could not (or did not)
+    // refresh its token. Reachable when persisted state says we have OAuth credentials but the
+    // live Nexus instance does not (e.g. updateToken never ran on startup, forced-logout migration
+    // path), when the refresh token has been revoked server-side, or on a resume after logout.
+    // Surface as a ProcessCanceled so reportDownloadError shows a friendly, non-reportable
+    // notification instead of a raw 401 behind a Report button.
+    if (error instanceof HTTPError && error.statusCode === 401) {
+      throw new ProcessCanceled("You are not logged in to Nexus Mods!");
+    }
+    throw error;
+  }
+
+  /** Hand an incoming link to the queued download that sent the user to fetch it. */
+  #deliverAwaitedLink(nxmUrl: NXMUrl, url: string): boolean {
+    const idx = this.#awaitedLinks.findIndex(
+      (awaited) =>
+        awaited.url.gameId === nxmUrl.gameId &&
+        awaited.url.modId === nxmUrl.modId &&
+        awaited.url.fileId === nxmUrl.fileId,
+    );
+    if (idx === -1) {
+      return false;
+    }
+    const [queued] = this.#awaitedLinks.splice(idx, 1);
+    this.resolve(url).then(queued.resolve, queued.reject);
     return true;
-  } else {
-    api.store.dispatch(removeFreeUserDLItem(inputUrl));
-    return false;
+  }
+
+  async #startLinkDownload(nxmUrl: NXMUrl, url: string, install: boolean): Promise<void> {
+    try {
+      await ensureLoggedIn(this.#api);
+    } catch (err) {
+      this.#reportLinkError(err);
+      return;
+    }
+
+    // #download reports its own failures, resolving to undefined when nothing was started
+    const dlId = await this.#download(url);
+    if (dlId == null) {
+      return;
+    }
+
+    const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
+    if (nxmUrl.collectionId !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
+    }
+    if (nxmUrl.revisionId !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
+    }
+    if (nxmUrl.collectionSlug !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
+    }
+    if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
+      actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
+    }
+    batchDispatch(this.#api.store, actions);
+
+    if (this.#api.getState().persistent.downloads.files[dlId] === undefined) {
+      this.#reportLinkError(new ProcessCanceled(`Download not found "${dlId}"`));
+      return;
+    }
+
+    // collections always get installed automatically
+    if (install && nxmUrl.type !== "collection") {
+      this.#api.events.emit("start-install-download", dlId, (err: Error) => {
+        if (err !== null) {
+          this.#reportLinkError(err);
+        }
+      });
+    }
+  }
+
+  /** Start a download, reporting any failure here. Resolves to undefined when none started. */
+  async #download(url: string): Promise<string | undefined> {
+    try {
+      return await startDownload(this.#api, this.#nexus, url);
+    } catch (err) {
+      if (err instanceof DownloadIsHTML || err instanceof UserCanceled) {
+        return undefined;
+      }
+      // DataInvalid indicates invalid user input or invalid data from remote, so it's
+      // presumably not a bug in Vortex
+      if (err instanceof DataInvalid) {
+        this.#api.showErrorNotification("Failed to start download", url, { allowReport: false });
+        return undefined;
+      }
+      this.#api.showErrorNotification("Failed to start download", err);
+      return undefined;
+    }
+  }
+
+  #reportLinkError(err: unknown): void {
+    if (err instanceof UserCanceled) {
+      return;
+    }
+    if (err instanceof ProcessCanceled) {
+      this.#api.showErrorNotification("Log-in failed", err, {
+        id: "failed-get-nexus-key",
+        allowReport: false,
+      });
+      return;
+    }
+    if (err instanceof ServiceTemporarilyUnavailable) {
+      this.#api.showErrorNotification("Service temporarily unavailable", err, {
+        id: "failed-get-nexus-key",
+        allowReport: false,
+      });
+      return;
+    }
+    this.#api.showErrorNotification("Failed to get access key", err, {
+      id: "failed-get-nexus-key",
+    });
   }
 }

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -49,6 +49,8 @@ interface IQueuedDownload {
   reject: (err: Error) => void;
   /** The file's update chain, used to describe what a skip is skipping. */
   queryRelevantUpdates: () => Promise<IFileUpdate[]>;
+  /** Whether the user has been sent to the website to fetch an authorised link for this one. */
+  awaitingLink: boolean;
 }
 
 /** What one download-url lookup found: the cdn urls plus the nexus ids identifying them. */
@@ -93,9 +95,8 @@ export class NxmProtocol {
   readonly #getNexus: () => NexusT;
   readonly #deps: INxmProtocolDeps;
 
+  // every parked download, each carrying whether its user has gone to fetch a link for it
   readonly #freeQueue: IQueuedDownload[] = [];
-  // queued downloads whose user was sent to the website to generate an authorised link
-  readonly #awaitedLinks: IQueuedDownload[] = [];
   readonly #urlCache = createKeyedCache<{ urls: string[]; meta: unknown }>(
     DOWNLOAD_URL_CACHE_DURATION,
   );
@@ -211,7 +212,7 @@ export class NxmProtocol {
       }
       const { url } = queued;
 
-      this.#awaitedLinks.push(queued);
+      queued.awaitingLink = true;
 
       opn(
         `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
@@ -300,10 +301,6 @@ export class NxmProtocol {
     if (queuedIdx !== -1) {
       this.#freeQueue.splice(queuedIdx, 1);
     }
-    const awaitedIdx = this.#awaitedLinks.findIndex((iter) => iter.input === input);
-    if (awaitedIdx !== -1) {
-      this.#awaitedLinks.splice(awaitedIdx, 1);
-    }
   }
 
   /**
@@ -325,6 +322,7 @@ export class NxmProtocol {
           reject(err);
         },
         queryRelevantUpdates: () => this.#relevantUpdates(url),
+        awaitingLink: false,
       });
       this.#api.store.dispatch(addFreeUserDLItem(input));
     });
@@ -483,16 +481,18 @@ export class NxmProtocol {
 
   /** Hand an incoming link to the queued download that sent the user to fetch it. */
   #deliverAwaitedLink(nxmUrl: NXMUrl, url: string): boolean {
-    const idx = this.#awaitedLinks.findIndex(
+    const queued = this.#freeQueue.find(
       (awaited) =>
+        awaited.awaitingLink &&
         awaited.url.gameId === nxmUrl.gameId &&
         awaited.url.modId === nxmUrl.modId &&
         awaited.url.fileId === nxmUrl.fileId,
     );
-    if (idx === -1) {
+    if (queued === undefined) {
       return false;
     }
-    const [queued] = this.#awaitedLinks.splice(idx, 1);
+    // the link has arrived, so stop treating it as outstanding; resolving dequeues the download
+    queued.awaitingLink = false;
     this.resolve(url).then(queued.resolve, queued.reject);
     return true;
   }

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -295,11 +295,15 @@ export class NxmProtocol {
    * the settled download alive and re-resolving it if a matching link ever does arrive.
    */
   #dequeue(input: string): void {
-    this.#api.store.dispatch(removeFreeUserDLItem(input));
     // the entry may already be gone
     const queuedIdx = this.#freeQueue.findIndex((iter) => iter.input === input);
     if (queuedIdx !== -1) {
       this.#freeQueue.splice(queuedIdx, 1);
+    }
+    // the queue is keyed by url, so one row can stand for two downloads of the same file; it goes
+    // when the last of them settles, or the survivor is left parked with nothing to release it
+    if (!this.#freeQueue.some((iter) => iter.input === input)) {
+      this.#api.store.dispatch(removeFreeUserDLItem(input));
     }
   }
 

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -48,6 +48,8 @@ interface IQueuedDownload {
   reject: (err: Error) => void;
   /** The file's update chain, used to describe what a skip is skipping. */
   queryRelevantUpdates: () => Promise<IFileUpdate[]>;
+  /** Whether the user has been sent to the website to fetch an authorised link for this one. */
+  awaitingLink: boolean;
 }
 
 /** What one download-url lookup found: the cdn urls plus the nexus ids identifying them. */
@@ -92,9 +94,8 @@ export class NxmProtocol {
   readonly #getNexus: () => NexusT;
   readonly #deps: INxmProtocolDeps;
 
+  // every parked download, each carrying whether its user has gone to fetch a link for it
   readonly #freeQueue: IQueuedDownload[] = [];
-  // queued downloads whose user was sent to the website to generate an authorised link
-  readonly #awaitedLinks: IQueuedDownload[] = [];
   readonly #urlCache = createKeyedCache<{ urls: string[]; meta: unknown }>(
     DOWNLOAD_URL_CACHE_DURATION,
   );
@@ -210,7 +211,7 @@ export class NxmProtocol {
       }
       const { url } = queued;
 
-      this.#awaitedLinks.push(queued);
+      queued.awaitingLink = true;
 
       opn(
         `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
@@ -299,10 +300,6 @@ export class NxmProtocol {
     if (queuedIdx !== -1) {
       this.#freeQueue.splice(queuedIdx, 1);
     }
-    const awaitedIdx = this.#awaitedLinks.findIndex((iter) => iter.input === input);
-    if (awaitedIdx !== -1) {
-      this.#awaitedLinks.splice(awaitedIdx, 1);
-    }
   }
 
   /**
@@ -324,6 +321,7 @@ export class NxmProtocol {
           reject(err);
         },
         queryRelevantUpdates: () => this.#relevantUpdates(url),
+        awaitingLink: false,
       });
       this.#api.store.dispatch(addFreeUserDLItem(input));
     });
@@ -480,16 +478,18 @@ export class NxmProtocol {
 
   /** Hand an incoming link to the queued download that sent the user to fetch it. */
   #deliverAwaitedLink(nxmUrl: NXMUrl, url: string): boolean {
-    const idx = this.#awaitedLinks.findIndex(
+    const queued = this.#freeQueue.find(
       (awaited) =>
+        awaited.awaitingLink &&
         awaited.url.gameId === nxmUrl.gameId &&
         awaited.url.modId === nxmUrl.modId &&
         awaited.url.fileId === nxmUrl.fileId,
     );
-    if (idx === -1) {
+    if (queued === undefined) {
       return false;
     }
-    const [queued] = this.#awaitedLinks.splice(idx, 1);
+    // the link has arrived, so stop treating it as outstanding; resolving dequeues the download
+    queued.awaitingLink = false;
     this.resolve(url).then(queued.resolve, queued.reject);
     return true;
   }

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -3,13 +3,11 @@ import type NexusT from "@nexusmods/nexus-api";
 import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 import { DownloadIsHTML } from "@vortex/shared/errors";
-import PromiseBB from "bluebird";
 import type { Action } from "redux";
 
 import { setDownloadModInfo } from "../../actions";
 import { log } from "../../logging";
 import type { IExtensionApi } from "../../types/IExtensionContext";
-import type { IState } from "../../types/IState";
 import { getCollectionActiveSession } from "../../util/collectionInstallSessionSelectors";
 import { markCollectionMemberSkipped } from "../../util/collectionSkip";
 import {
@@ -19,29 +17,18 @@ import {
   ServiceTemporarilyUnavailable,
   UserCanceled,
 } from "../../util/CustomErrors";
+import { createKeyedCache } from "../../util/keyedCache";
 import opn from "../../util/opn";
-import { gameById, knownGames } from "../../util/selectors";
-import { getSafe } from "../../util/storeHelper";
 import { batchDispatch } from "../../util/util";
 import type { IResolvedURL } from "../download_management/types/ProtocolHandlers";
 import { SITE_ID } from "../gamemode_management/constants";
 import { addFreeUserDLItem, removeFreeUserDLItem } from "./actions/session";
 import { NEXUS_BASE_URL } from "./constants";
 import NXMUrl from "./NXMUrl";
+import { isPremium, userInfo } from "./selectors";
 import { bringToFront, ensureLoggedIn, getInfoGraphQL, oauthCallback, startDownload } from "./util";
-import { convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
-
-export type ResolveFunc = (input: string) => PromiseBB<IResolvedURL>;
-
-interface IDLQueueItem {
-  input: string;
-  url: NXMUrl;
-  res: (res: IResolvedURL) => void;
-  rej: (err: Error) => void;
-  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
-}
-
-const freeDLQueue: IDLQueueItem[] = [];
+import { findLatestUpdate } from "./util/checkModsVersion";
+import { nxmPageId } from "./util/convertGameId";
 
 const DL_QUERY: IRevisionQuery = {
   id: true,
@@ -52,541 +39,547 @@ const DL_QUERY: IRevisionQuery = {
   },
 };
 
-interface IAwaitedLink {
-  gameId: string;
-  modId: number;
-  fileId: number;
-  resolve: (url: string) => void;
+const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000;
+
+/** A download parked until the user fetches an authorised link from the website. */
+interface IQueuedDownload {
+  input: string;
+  url: NXMUrl;
+  resolve: (res: IResolvedURL) => void;
+  reject: (err: Error) => void;
+  /** The file's update chain, used to describe what a skip is skipping. */
+  queryRelevantUpdates: () => Promise<IFileUpdate[]>;
 }
 
-const awaitedLinks: IAwaitedLink[] = [];
+/** What one download-url lookup found: the cdn urls plus the nexus ids identifying them. */
+interface IFoundDownload {
+  urls: IDownloadURL[];
+  ids: Record<string, unknown>;
+}
 
-function doDownload(api: IExtensionApi, nexus: NexusT, url: string): PromiseBB<string> {
-  return (
-    startDownload(api, nexus, url)
-      .catch(DownloadIsHTML, () => undefined)
-      // DataInvalid is used here to indicate invalid user input or invalid
-      // data from remote, so it's presumably not a bug in Vortex
-      .catch(DataInvalid, () => {
-        api.showErrorNotification("Failed to start download", url, {
-          allowReport: false,
-        });
-        return PromiseBB.resolve(undefined);
-      })
-      .catch(UserCanceled, () => PromiseBB.resolve(undefined))
-      .catch((err) => {
-        api.showErrorNotification("Failed to start download", err);
-        return PromiseBB.resolve(undefined);
-      })
-  );
+export interface INxmProtocolDeps {
+  /** Re-read the account's membership. The site opens nxm://premium after a membership change. */
+  onRefreshMembership: () => void;
+}
+
+/** The handlers FreeUserDLDialog is wired to. */
+export interface IFreeUserDialogHandlers {
+  onUpdated: () => void;
+  onDownload: (inputUrl: string) => void;
+  onSkip: (inputUrl: string) => void;
+  onCancel: (inputUrl: string) => boolean;
+  onRetry: (inputUrl: string) => void;
 }
 
 /**
- * Handle an incoming nxm:// link. `onPremiumLink` runs for the nxm://premium form, which the
- * site opens after a membership change so the client re-reads the user info.
+ * A free user can't ask the api for a download link, so only a keyless link to a mod file on a
+ * real game can ever need the website round trip. Collections, extensions from the site domain,
+ * and links the website already authorised go straight to the api.
  */
-export function makeNXMLinkCallback(api: IExtensionApi, nexus: NexusT, onPremiumLink: () => void) {
-  return (url: string, install: boolean) => {
+function needsAuthorisedLink(url: NXMUrl): boolean {
+  return url.type === "mod" && url.gameId !== SITE_ID && url.key === undefined;
+}
+
+/**
+ * Resolves nxm:// urls to something the downloader can fetch, and owns the queue of downloads
+ * parked while a free user fetches an authorised link from the website.
+ *
+ * One instance owns the whole queue, because a cancel rejects every download in it: the queued
+ * downloads are shown one dialog at a time, so cancelling has to mean "get me out of this
+ * install", not "dismiss this one dialog".
+ */
+export class NxmProtocol {
+  readonly #api: IExtensionApi;
+  readonly #getNexus: () => NexusT;
+  readonly #deps: INxmProtocolDeps;
+
+  readonly #freeQueue: IQueuedDownload[] = [];
+  // queued downloads whose user was sent to the website to generate an authorised link
+  readonly #awaitedLinks: IQueuedDownload[] = [];
+  readonly #urlCache = createKeyedCache<{ urls: string[]; meta: unknown }>(
+    DOWNLOAD_URL_CACHE_DURATION,
+  );
+
+  /**
+   * `getNexus` is read on each use: the extension registers its protocol handlers during init,
+   * and only builds the Nexus connection later, in its `once` callback.
+   */
+  constructor(api: IExtensionApi, getNexus: () => NexusT, deps: INxmProtocolDeps) {
+    this.#api = api;
+    this.#getNexus = getNexus;
+    this.#deps = deps;
+  }
+
+  get #nexus(): NexusT {
+    return this.#getNexus();
+  }
+
+  /** Registered as the download protocol handler for the nxm scheme. */
+  readonly resolve = async (input: string): Promise<IResolvedURL> => {
+    const url = new NXMUrl(input);
+
+    const cached = userInfo(this.#api.getState());
+    if (url.userId !== undefined && url.userId !== cached?.userId) {
+      this.#api.showErrorNotification(
+        "Invalid download links",
+        "The link was not created for this account ({{userName}}). " +
+          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
+        { allowReport: false, replace: { userName: cached?.name } },
+      );
+      throw new ProcessCanceled("Wrong user id");
+    }
+
+    // resolved once and threaded through: it costs two scans of the known-games list
+    const pageId = nxmPageId(this.#api.getState(), url.gameId);
+
+    if (this.#canDownloadInApp(url) || (await this.#isDirectDownload(url, pageId))) {
+      return this.#apiDownload(input, url, pageId);
+    }
+
+    return this.#websiteDownload(input, url);
+  };
+
+  /**
+   * Whether the author opted this mod into direct downloads, which makes it free for everyone.
+   * Only the website knows, so a lookup we can't complete counts as "no".
+   */
+  async #isDirectDownload(url: NXMUrl, pageId: string): Promise<boolean> {
+    try {
+      const { modInfo } = await getInfoGraphQL(this.#nexus, pageId, url.modId, url.fileId);
+      return modInfo["direct_download_enabled"] === true;
+    } catch (err) {
+      // Cancellation must propagate; otherwise sibling deps whose in-flight mod-info queries get
+      // aborted re-enter the queue, and the dialog re-opens behind the one the user just dismissed.
+      if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
+        throw err;
+      }
+      log("warn", "failed to query mod info for direct download check", {
+        error: getErrorMessageOrDefault(err),
+      });
+      return false;
+    }
+  }
+
+  /** Registered as the OS handler for nxm:// links. */
+  readonly handleLink = (url: string, install: boolean) => {
     let nxmUrl: NXMUrl;
     try {
       nxmUrl = new NXMUrl(url);
 
-      const state = api.getState();
-      const isExtAvailable =
-        state.session.extensions.available.find((iter) => iter.modId === nxmUrl.modId) !==
-        undefined;
+      const state = this.#api.getState();
 
       if (nxmUrl.type === "oauth") {
-        try {
-          return oauthCallback(api, nxmUrl.oauthCode, nxmUrl.oauthState);
-        } catch (err) {
-          // ignore unexpected code
-        }
+        return oauthCallback(this.#api, nxmUrl.oauthCode, nxmUrl.oauthState);
       } else if (nxmUrl.type === "premium") {
-        try {
-          log("info", "makeNXMLinkCallback() premium");
-          onPremiumLink();
-          return false;
-        } catch (err) {
-          // ignore unexpected code
-        }
-      } else if (nxmUrl.gameId === SITE_ID && isExtAvailable) {
+        log("info", "nxm premium link, re-reading the membership");
+        this.#deps.onRefreshMembership();
+        return false;
+      } else if (nxmUrl.gameId === SITE_ID && this.#isExtensionAvailable(nxmUrl.modId)) {
         if (install) {
-          return api.emitAndAwait("install-extension", {
+          return this.#api.emitAndAwait("install-extension", {
             name: "Pending",
             modId: nxmUrl.modId,
             fileId: nxmUrl.fileId,
           });
-        } else {
-          api.events.emit("show-extension-page", nxmUrl.modId);
-          bringToFront();
-          return PromiseBB.resolve();
         }
-      } else {
-        const { foregroundDL } = state.settings.interface;
-        if (foregroundDL) {
-          bringToFront();
-        }
+        this.#api.events.emit("show-extension-page", nxmUrl.modId);
+        bringToFront();
+        return Promise.resolve();
+      } else if (state.settings.interface.foregroundDL) {
+        bringToFront();
       }
     } catch (err) {
-      api.showErrorNotification("Invalid URL", err, { allowReport: false });
+      this.#api.showErrorNotification("Invalid URL", err, { allowReport: false });
       return;
     }
 
-    const awaitedIdx = awaitedLinks.findIndex(
-      (link) =>
-        link.gameId === nxmUrl.gameId &&
-        link.modId === nxmUrl.modId &&
-        link.fileId === nxmUrl.fileId,
-    );
-    if (awaitedIdx !== -1) {
-      const awaited = awaitedLinks.splice(awaitedIdx, 1);
-      awaited[0].resolve(url);
+    if (this.#deliverAwaitedLink(nxmUrl, url)) {
       return;
     }
 
-    ensureLoggedIn(api)
-      .then(() => doDownload(api, nexus, url))
-      .then((dlId) => {
-        if (dlId === undefined || dlId === null) {
-          return PromiseBB.resolve(undefined);
-        }
-
-        const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
-        if (nxmUrl.collectionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
-        }
-        if (nxmUrl.revisionId !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
-        }
-        if (nxmUrl.collectionSlug !== undefined) {
-          actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
-        }
-        if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
-          actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
-        }
-        batchDispatch(api.store, actions);
-
-        return new PromiseBB((resolve, reject) => {
-          const currentState: IState = api.store.getState();
-          const download = currentState.persistent.downloads.files[dlId];
-          if (download === undefined) {
-            return reject(new ProcessCanceled(`Download not found "${dlId}"`));
-          }
-          // collections always get installed automatically.
-          if (install && nxmUrl.type !== "collection") {
-            api.events.emit("start-install-download", dlId, (err: Error, id: string) => {
-              if (err !== null) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
-          } else {
-            resolve();
-          }
-        });
-      })
-      // doDownload handles all download errors so the catches below are
-      //  only for log in errors
-      .catch(UserCanceled, () => null)
-      .catch(ProcessCanceled, (err) => {
-        api.showErrorNotification("Log-in failed", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch(ServiceTemporarilyUnavailable, (err) => {
-        api.showErrorNotification("Service temporarily unavailable", err, {
-          id: "failed-get-nexus-key",
-          allowReport: false,
-        });
-      })
-      .catch((err) => {
-        api.showErrorNotification("Failed to get access key", err, {
-          id: "failed-get-nexus-key",
-        });
-      });
+    void this.#startLinkDownload(nxmUrl, url, install);
   };
-}
 
-export function makeNXMProtocol(api: IExtensionApi, nexus: NexusT): ResolveFunc {
-  // for free users a dialog needs to be displayed sending them to the site for the download.
-  // if we start multiple downloads in parallel, these are shown one by one but if the user cancels
-  // the dialog, we want to cancel all queued downloads, otherwise the client code can't cancel
-  // out of the larger process without the user having to click cancel multiple times.
-  // Thus we have to keep track of all queued downloads.
+  readonly dialogHandlers: IFreeUserDialogHandlers = {
+    onUpdated: bringToFront,
 
-  function freeUserDownload(input: string, url: NXMUrl) {
-    // non-premium user trying to download a file with no id, have to send the user to the
-    // corresponding site to generate a proper link
-    return new PromiseBB<IResolvedURL>((resolve, reject) => {
-      const res = (result: IResolvedURL) => {
-        if (resolve !== undefined) {
-          // just to make sure we remove the correct item, idx should always be 0
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
-          resolve(result);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const rej = (err) => {
-        if (reject !== undefined) {
-          const idx = freeDLQueue.findIndex((iter) => iter.input === input);
-          api.store.dispatch(removeFreeUserDLItem(input));
-          freeDLQueue.splice(idx, 1);
+    /** Send the user to the file's page to generate an authorised link. */
+    onDownload: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      const { url } = queued;
+
+      this.#awaitedLinks.push(queued);
+
+      opn(
+        `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
+      ).catch(() => null);
+    },
+
+    onSkip: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      void this.#skipQueued(queued);
+    },
+
+    /** Cancels every queued download, not just this one. Returns whether there was any. */
+    onCancel: (inputUrl: string): boolean => {
+      if (this.#freeQueue.length === 0) {
+        this.#api.store.dispatch(removeFreeUserDLItem(inputUrl));
+        return false;
+      }
+
+      this.#freeQueue.slice().forEach((queued) => queued.reject(new UserCanceled(false)));
+
+      // Rejecting the queued downloads dismisses the dialog but doesn't stop the install pipeline
+      // (their UserCanceled doesn't survive IPC). pause-collection routes through the collections
+      // plugin for the full cleanup: stop queuing, reset the driver, dismiss the notification.
+      const session = getCollectionActiveSession(this.#api.getState());
+      if (session?.collectionId && session.gameId) {
+        this.#api.events.emit(
+          "pause-collection",
+          session.gameId,
+          session.collectionId,
+          "free-user-cancel",
+        );
+      }
+      return true;
+    },
+
+    /** Re-resolve a queued download, e.g. after the user upgraded to premium. */
+    onRetry: (inputUrl: string) => {
+      const queued = this.#queuedFor(inputUrl);
+      if (queued === undefined) {
+        return;
+      }
+      this.resolve(queued.input).then(queued.resolve, queued.reject);
+    },
+  };
+
+  /** Whether this download can go through the api, or has to go via the website. */
+  #canDownloadInApp(url: NXMUrl): boolean {
+    if (!needsAuthorisedLink(url)) {
+      return true;
+    }
+    if (process.env["FORCE_FREE_DOWNLOADS"] === "yes") {
+      return false;
+    }
+    return isPremium(this.#api.getState());
+  }
+
+  /** Whether the site offers an extension with this mod id. */
+  #isExtensionAvailable(modId: number): boolean {
+    const available = this.#api.getState().session.extensions.available;
+    return available.find((iter) => iter.modId === modId) !== undefined;
+  }
+
+  #queuedFor(inputUrl: string): IQueuedDownload | undefined {
+    const queued = this.#freeQueue.find((iter) => iter.input === inputUrl);
+    if (queued === undefined) {
+      log("error", "failed to find queued download", {
+        inputUrl,
+        queued: this.#freeQueue.map((iter) => iter.input),
+      });
+    }
+    return queued;
+  }
+
+  /**
+   * Forget a queued download, including any link the user was sent to the website to fetch for
+   * it - otherwise an abandoned trip to the website leaves an entry that never expires, holding
+   * the settled download alive and re-resolving it if a matching link ever does arrive.
+   */
+  #dequeue(input: string): void {
+    this.#api.store.dispatch(removeFreeUserDLItem(input));
+    // the entry may already be gone
+    const queuedIdx = this.#freeQueue.findIndex((iter) => iter.input === input);
+    if (queuedIdx !== -1) {
+      this.#freeQueue.splice(queuedIdx, 1);
+    }
+    const awaitedIdx = this.#awaitedLinks.findIndex((iter) => iter.input === input);
+    if (awaitedIdx !== -1) {
+      this.#awaitedLinks.splice(awaitedIdx, 1);
+    }
+  }
+
+  /**
+   * Park the download until the user brings back an authorised link from the website (or cancels
+   * or skips it). FreeUserDLDialog renders off the redux queue this dispatches into.
+   */
+  #websiteDownload(input: string, url: NXMUrl): Promise<IResolvedURL> {
+    // a promise settles once and #dequeue tolerates a repeat, so cancelling after a skip is safe
+    return new Promise<IResolvedURL>((resolve, reject) => {
+      this.#freeQueue.push({
+        input,
+        url,
+        resolve: (res) => {
+          this.#dequeue(input);
+          resolve(res);
+        },
+        reject: (err) => {
+          this.#dequeue(input);
           reject(err);
-          reject = undefined;
-          resolve = undefined;
-        }
-      };
-      const queryRelevantUpdates = () => {
-        return nexus.getModFiles(url.modId, url.gameId).then((files) => {
-          // Build a bidirectional map for O(1) lookups, we're doing this
-          //  in the hope that the mod authors have kept a clear update chain
-          //  which we can use to find relevant fileIds.
-          // It's not cool that we're consuming an API slot for this, but without this
-          //  we can't reliably compare the dependency reference to what we're attempting
-          //  to skip (we only have the NXM url which isn't enough).
-          const forwardMap = new Map<number, IFileUpdate>(); // old_file_id -> update
-          const backwardMap = new Map<number, IFileUpdate>(); // new_file_id -> update
-
-          files.file_updates.forEach((update) => {
-            forwardMap.set(update.old_file_id, update);
-            backwardMap.set(update.new_file_id, update);
-          });
-
-          // Traverse backwards to find the oldest file in the chain
-          let currentId = url.fileId;
-          const backwardChain: IFileUpdate[] = [];
-
-          while (backwardMap.has(currentId)) {
-            const update = backwardMap.get(currentId);
-            backwardChain.unshift(update); // Add to beginning
-            currentId = update.old_file_id;
-          }
-
-          // Now traverse forwards from the oldest file to build complete chain
-          const oldestId = backwardChain.length > 0 ? backwardChain[0].old_file_id : url.fileId;
-          currentId = oldestId;
-          const completeChain: IFileUpdate[] = [];
-
-          while (forwardMap.has(currentId)) {
-            const update = forwardMap.get(currentId);
-            completeChain.push(update);
-            currentId = update.new_file_id;
-          }
-
-          return completeChain;
-        });
-      };
-      freeDLQueue.push({ input, url, res, rej, queryRelevantUpdates });
-      api.store.dispatch(addFreeUserDLItem(input));
+        },
+        queryRelevantUpdates: () => this.#relevantUpdates(url),
+      });
+      this.#api.store.dispatch(addFreeUserDLItem(input));
     });
   }
 
-  // Cache download URLs to avoid repeated API calls for the same file
-  const downloadURLCache: {
-    [key: string]: { urls: string[]; expires: number; meta: any };
-  } = {};
-  const DOWNLOAD_URL_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+  /**
+   * The file's full update chain. Skipping has to name every file id the chain covers, because a
+   * dependency may reference an older or newer file than the one being skipped and the nxm url
+   * alone can't tell us which.
+   */
+  async #relevantUpdates(url: NXMUrl): Promise<IFileUpdate[]> {
+    const files = await this.#nexus.getModFiles(url.modId, url.gameId);
 
-  function premiumUserDownload(
-    input: string,
-    url: NXMUrl,
-    directDownloadEnabled: boolean = false,
-  ): PromiseBB<IResolvedURL> {
-    const state = api.getState();
-    const games = knownGames(state);
-    const gameId = convertNXMIdReverse(games, url.gameId);
-    const pageId = nexusGameId(gameById(state, gameId), url.gameId);
-    let revisionInfo: Partial<IRevision>;
+    const previous = new Map<number, IFileUpdate>(); // new_file_id -> update
+    files.file_updates.forEach((update) => previous.set(update.new_file_id, update));
 
-    const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
+    // walk back to the oldest file in the chain, then forward over the whole of it
+    let oldestId = url.fileId;
+    while (previous.has(oldestId)) {
+      oldestId = previous.get(oldestId).old_file_id;
+    }
+    return findLatestUpdate(files.file_updates, [], oldestId);
+  }
 
+  async #skipQueued(queued: IQueuedDownload): Promise<void> {
+    const fileIds = new Set<string>([queued.url.fileId.toString()]);
+    const fileNames = new Set<string>();
+    try {
+      const updates = await queued.queryRelevantUpdates();
+      updates.forEach((update) => {
+        if (update.old_file_id != null) {
+          fileIds.add(update.old_file_id.toString());
+          fileNames.add(update.old_file_name);
+        }
+        if (update.new_file_id != null) {
+          fileIds.add(update.new_file_id.toString());
+          fileNames.add(update.new_file_name);
+        }
+      });
+
+      // the skip dispatches the ignore directly against the active install session
+      markCollectionMemberSkipped(this.#api, {
+        identifiers: {
+          ...queued.url.identifiers,
+          fileNames: Array.from(fileNames),
+          fileIds: Array.from(fileIds),
+        },
+      });
+    } catch (err) {
+      log("warn", "failed to query relevant updates on skip", {
+        error: getErrorMessageOrDefault(err),
+      });
+    }
+    queued.reject(new UserCanceled(true));
+  }
+
+  /** Ask the api for the download urls, serving a recent answer for the same file from cache. */
+  async #apiDownload(input: string, url: NXMUrl, pageId: string): Promise<IResolvedURL> {
     if (!["mod", "collection"].includes(url.type)) {
-      return PromiseBB.reject(new ProcessCanceled("Not a download url"));
+      throw new ProcessCanceled("Not a download url");
     }
 
-    // Create cache key
+    const revisionNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
     const cacheKey =
       url.type === "mod"
         ? `mod_${url.modId}_${url.fileId}_${pageId}`
-        : `collection_${url.collectionSlug}_${revNumber || "latest"}`;
+        : `collection_${url.collectionSlug}_${revisionNumber ?? "latest"}`;
 
-    // Check cache first
-    const cached = downloadURLCache[cacheKey];
-    if (cached && Date.now() < cached.expires) {
-      return PromiseBB.resolve({
-        urls: cached.urls,
-        updatedUrl: input,
-        meta: cached.meta,
-      });
+    const cached = this.#urlCache.get(cacheKey);
+    if (cached !== undefined) {
+      return { urls: cached.urls, updatedUrl: input, meta: cached.meta };
     }
 
-    const downloadKey = directDownloadEnabled ? undefined : url.key;
-    const downloadExpires = directDownloadEnabled ? undefined : url.expires;
-
-    return PromiseBB.resolve()
-      .then(() =>
-        url.type === "mod"
-          ? nexus
-              .getDownloadURLs(url.modId, url.fileId, downloadKey, downloadExpires, pageId)
-              .then((res: IDownloadURL[]) => {
-                const result = {
-                  urls: res.map((u) => u.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        modId: url.modId,
-                        fileId: url.fileId,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              })
-          : nexus
-              .getCollectionRevisionGraph(DL_QUERY, url.collectionSlug, revNumber)
-              .catch((err) => {
-                err["collectionSlug"] = url.collectionSlug;
-                err["revisionNumber"] = url.revisionNumber;
-                return PromiseBB.reject(err);
-              })
-              .then((revision: Partial<IRevision>) => {
-                revisionInfo = revision;
-                return nexus.getCollectionDownloadLink(revision.downloadLink);
-              })
-              .then((downloadUrls) => {
-                const result = {
-                  urls: downloadUrls.map((iter) => iter.URI),
-                  updatedUrl: input,
-                  meta: {
-                    source: "nexus",
-                    nexus: {
-                      ids: {
-                        collectionId: revisionInfo.collection.id,
-                        revisionId: revisionInfo.id,
-                        collectionSlug: url.collectionSlug,
-                        revisionNumber: revisionInfo.revisionNumber ?? url.revisionNumber,
-                      },
-                    },
-                  } as any,
-                };
-
-                // Cache the result
-                downloadURLCache[cacheKey] = {
-                  urls: result.urls,
-                  expires: Date.now() + DOWNLOAD_URL_CACHE_DURATION,
-                  meta: result.meta,
-                };
-
-                return result;
-              }),
-      )
-      .catch(NexusError, (err) => {
-        const newError = new HTTPError(err.statusCode, err.message, err.request);
-        newError.stack = err.stack;
-        return PromiseBB.reject(newError);
-      })
-      .catch(HTTPError, (err) => {
-        // A 401 here means the Nexus client could not authenticate the
-        // request and could not (or did not) refresh its token. Reachable
-        // when persisted state says we have OAuth credentials but the live
-        // Nexus instance does not (e.g. updateToken never ran on startup,
-        // forced-logout migration path), when the refresh token has been
-        // revoked server-side, or on a resume after logout. Surface as a
-        // ProcessCanceled so reportDownloadError shows a friendly,
-        // non-reportable notification instead of letting the raw 401 fall
-        // through to the generic else branch with the Report button.
-        if (err.statusCode === 401) {
-          return PromiseBB.reject(new ProcessCanceled("You are not logged in to Nexus Mods!"));
-        }
-        return PromiseBB.reject(err);
-      })
-      .catch(RateLimitError, (err) => {
-        api.showErrorNotification("Rate limit exceeded", err, {
-          allowReport: false,
-        });
-        return PromiseBB.reject(err);
-      });
-  }
-
-  const resolveFunc = (input: string): PromiseBB<IResolvedURL> => {
-    const state = api.store.getState();
-
-    let url: NXMUrl;
+    let found: IFoundDownload;
     try {
-      url = new NXMUrl(input);
+      found =
+        url.type === "mod"
+          ? await this.#modDownload(url, pageId)
+          : await this.#collectionDownload(url, revisionNumber);
     } catch (err) {
-      return PromiseBB.reject(err);
+      this.#throwDownloadError(err);
     }
 
-    const userInfo: any = getSafe(state, ["persistent", "nexus", "userInfo"], undefined);
-    if (url.userId !== undefined && url.userId !== userInfo?.userId) {
-      const userName: string = getSafe(
-        state,
-        ["persistent", "nexus", "userInfo", "name"],
-        undefined,
+    const resolved: IResolvedURL = {
+      urls: found.urls.map((iter) => iter.URI),
+      updatedUrl: input,
+      meta: { source: "nexus", nexus: { ids: found.ids } } as IResolvedURL["meta"],
+    };
+
+    this.#urlCache.set(cacheKey, { urls: resolved.urls, meta: resolved.meta });
+    return resolved;
+  }
+
+  async #modDownload(url: NXMUrl, pageId: string): Promise<IFoundDownload> {
+    return {
+      urls: await this.#nexus.getDownloadURLs(url.modId, url.fileId, url.key, url.expires, pageId),
+      ids: { modId: url.modId, fileId: url.fileId },
+    };
+  }
+
+  async #collectionDownload(
+    url: NXMUrl,
+    revisionNumber: number | undefined,
+  ): Promise<IFoundDownload> {
+    let revision: Partial<IRevision>;
+    try {
+      revision = await this.#nexus.getCollectionRevisionGraph(
+        DL_QUERY,
+        url.collectionSlug,
+        revisionNumber,
       );
-      api.showErrorNotification(
-        "Invalid download links",
-        "The link was not created for this account ({{userName}}). " +
-          "You have to be logged into nexusmods.com with the same account that you use in Vortex.",
-        { allowReport: false, replace: { userName } },
-      );
-      return PromiseBB.reject(new ProcessCanceled("Wrong user id"));
+    } catch (err) {
+      err["collectionSlug"] = url.collectionSlug;
+      err["revisionNumber"] = url.revisionNumber;
+      throw err;
     }
 
-    if (
-      (!userInfo?.isPremium || process.env["FORCE_FREE_DOWNLOADS"] === "yes") &&
-      url.type === "mod" &&
-      url.gameId !== SITE_ID &&
-      url.key === undefined
-    ) {
-      const games = knownGames(state);
-      const gameId = convertNXMIdReverse(games, url.gameId);
-      const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+    return {
+      urls: await this.#nexus.getCollectionDownloadLink(revision.downloadLink),
+      ids: {
+        collectionId: revision.collection.id,
+        revisionId: revision.id,
+        collectionSlug: url.collectionSlug,
+        // The api knows the revision a "latest" link resolved to; the url only carries one
+        // when it named a revision explicitly.
+        revisionNumber: revision.revisionNumber ?? url.revisionNumber,
+      },
+    };
+  }
 
-      return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)
-        .then(({ modInfo, fileInfo }) => {
-          if (modInfo["direct_download_enabled"]) {
-            return premiumUserDownload(input, url, true);
-          } else {
-            return freeUserDownload(input, url);
-          }
-        })
-        .catch((err) => {
-          const message = getErrorMessageOrDefault(err);
-          // Cancellation must propagate; otherwise sibling deps whose in-flight
-          // mod-info queries get aborted re-enter freeUserDownload, repopulate
-          // the queue, and the dialog re-opens behind the one the user just
-          // dismissed.
-          if (err instanceof UserCanceled || err instanceof ProcessCanceled) {
-            return PromiseBB.reject(err);
-          }
-          // If we can't query mod info, fall back to free user flow
-          log("warn", "failed to query mod info for direct download check", {
-            error: message,
-          });
-          return freeUserDownload(input, url);
-        });
-    } else {
-      return premiumUserDownload(input, url);
+  /** Rethrow an api failure as the error the download pipeline knows how to report. */
+  #throwDownloadError(err: unknown): never {
+    if (err instanceof RateLimitError) {
+      this.#api.showErrorNotification("Rate limit exceeded", err, { allowReport: false });
+      throw err;
     }
-  };
 
-  return resolveFunc;
-}
-
-export function onUpdated() {
-  bringToFront();
-}
-
-export function onDownloadImpl(resolveFunc: ResolveFunc, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-  const { url } = queueItem;
-
-  awaitedLinks.push({
-    gameId: url.gameId,
-    modId: url.modId,
-    fileId: url.fileId,
-    resolve: (resUrl: string) => resolveFunc(resUrl).then(queueItem.res).catch(queueItem.rej),
-  });
-
-  opn(
-    `${NEXUS_BASE_URL}/${url.gameId}/mods/${url.modId}?tab=files&file_id=${url.fileId}&nmm=1`,
-  ).catch(() => null);
-}
-
-export function onSkip(api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem !== undefined) {
-    queueItem
-      .queryRelevantUpdates()
-      .then((updates) => {
-        const fileIdSet = new Set<string>();
-        const fileNames = new Set<string>();
-        fileIdSet.add(queueItem.url.fileId.toString());
-        updates.forEach((update) => {
-          if (update.old_file_id != null) {
-            fileIdSet.add(update.old_file_id.toString());
-            fileNames.add(update.old_file_name);
-          }
-          if (update.new_file_id != null) {
-            fileIdSet.add(update.new_file_id.toString());
-            fileNames.add(update.new_file_name);
-          }
-        });
-        const parsed = new NXMUrl(queueItem.input);
-        const itemIdentifiers = {
-          ...parsed.identifiers,
-          fileNames: Array.from(fileNames),
-          fileIds: Array.from(fileIdSet),
-        };
-        // collections is now core, so the skip site dispatches the ignore directly against the
-        // active install session rather than emitting an event for the InstallDriver to handle
-        markCollectionMemberSkipped(api, { identifiers: itemIdentifiers });
-        queueItem.rej(new UserCanceled(true));
-      })
-      .catch((err) => {
-        log("warn", "failed to query relevant updates on skip", {
-          error: getErrorMessageOrDefault(err),
-        });
-        queueItem.rej(new UserCanceled(true));
-      });
-  }
-}
-
-export function onRetryImpl(resolveFunc: ResolveFunc, api: IExtensionApi, inputUrl: string) {
-  const queueItem = freeDLQueue.find((iter) => iter.input === inputUrl);
-  if (queueItem === undefined) {
-    log("error", "failed to find queue item", {
-      inputUrl,
-      queue: JSON.stringify(freeDLQueue),
-    });
-    return;
-  }
-
-  resolveFunc(queueItem.input).then(queueItem.res).catch(queueItem.rej);
-}
-
-export function onCancelImpl(api: IExtensionApi, inputUrl: string): boolean {
-  const copy = freeDLQueue.slice(0);
-  if (copy.length !== 0) {
-    copy.forEach((item) => {
-      item.rej(new UserCanceled(false));
-    });
-    // Rejecting freeDLQueue items dismisses the dialog but doesn't stop the
-    // install pipeline (its UserCanceled doesn't survive IPC). pause-collection
-    // routes through the collections plugin for the full cleanup: stop queuing,
-    // reset the driver, dismiss the install notification.
-    const session = getCollectionActiveSession(api.getState());
-    if (session?.collectionId && session.gameId) {
-      api.events.emit("pause-collection", session.gameId, session.collectionId, "free-user-cancel");
+    let error = err;
+    if (error instanceof NexusError) {
+      const http = new HTTPError(error.statusCode, error.message, error.request);
+      http.stack = error.stack;
+      error = http;
     }
+
+    // A 401 means the Nexus client could not authenticate the request and could not (or did not)
+    // refresh its token. Reachable when persisted state says we have OAuth credentials but the
+    // live Nexus instance does not (e.g. updateToken never ran on startup, forced-logout migration
+    // path), when the refresh token has been revoked server-side, or on a resume after logout.
+    // Surface as a ProcessCanceled so reportDownloadError shows a friendly, non-reportable
+    // notification instead of a raw 401 behind a Report button.
+    if (error instanceof HTTPError && error.statusCode === 401) {
+      throw new ProcessCanceled("You are not logged in to Nexus Mods!");
+    }
+    throw error;
+  }
+
+  /** Hand an incoming link to the queued download that sent the user to fetch it. */
+  #deliverAwaitedLink(nxmUrl: NXMUrl, url: string): boolean {
+    const idx = this.#awaitedLinks.findIndex(
+      (awaited) =>
+        awaited.url.gameId === nxmUrl.gameId &&
+        awaited.url.modId === nxmUrl.modId &&
+        awaited.url.fileId === nxmUrl.fileId,
+    );
+    if (idx === -1) {
+      return false;
+    }
+    const [queued] = this.#awaitedLinks.splice(idx, 1);
+    this.resolve(url).then(queued.resolve, queued.reject);
     return true;
-  } else {
-    api.store.dispatch(removeFreeUserDLItem(inputUrl));
-    return false;
+  }
+
+  async #startLinkDownload(nxmUrl: NXMUrl, url: string, install: boolean): Promise<void> {
+    try {
+      await ensureLoggedIn(this.#api);
+    } catch (err) {
+      this.#reportLinkError(err);
+      return;
+    }
+
+    // #download reports its own failures, resolving to undefined when nothing was started
+    const dlId = await this.#download(url);
+    if (dlId == null) {
+      return;
+    }
+
+    const actions: Action[] = [setDownloadModInfo(dlId, "source", "nexus")];
+    if (nxmUrl.collectionId !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "collectionId", nxmUrl.collectionId));
+    }
+    if (nxmUrl.revisionId !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "revisionId", nxmUrl.revisionId));
+    }
+    if (nxmUrl.collectionSlug !== undefined) {
+      actions.push(setDownloadModInfo(dlId, "collectionSlug", nxmUrl.collectionSlug));
+    }
+    if (nxmUrl.revisionNumber !== undefined && nxmUrl.revisionNumber > 0) {
+      actions.push(setDownloadModInfo(dlId, "revisionNumber", nxmUrl.revisionNumber));
+    }
+    batchDispatch(this.#api.store, actions);
+
+    if (this.#api.getState().persistent.downloads.files[dlId] === undefined) {
+      this.#reportLinkError(new ProcessCanceled(`Download not found "${dlId}"`));
+      return;
+    }
+
+    // collections always get installed automatically
+    if (install && nxmUrl.type !== "collection") {
+      this.#api.events.emit("start-install-download", dlId, (err: Error) => {
+        if (err !== null) {
+          this.#reportLinkError(err);
+        }
+      });
+    }
+  }
+
+  /** Start a download, reporting any failure here. Resolves to undefined when none started. */
+  async #download(url: string): Promise<string | undefined> {
+    try {
+      return await startDownload(this.#api, this.#nexus, url);
+    } catch (err) {
+      if (err instanceof DownloadIsHTML || err instanceof UserCanceled) {
+        return undefined;
+      }
+      // DataInvalid indicates invalid user input or invalid data from remote, so it's
+      // presumably not a bug in Vortex
+      if (err instanceof DataInvalid) {
+        this.#api.showErrorNotification("Failed to start download", url, { allowReport: false });
+        return undefined;
+      }
+      this.#api.showErrorNotification("Failed to start download", err);
+      return undefined;
+    }
+  }
+
+  #reportLinkError(err: unknown): void {
+    if (err instanceof UserCanceled) {
+      return;
+    }
+    if (err instanceof ProcessCanceled) {
+      this.#api.showErrorNotification("Log-in failed", err, {
+        id: "failed-get-nexus-key",
+        allowReport: false,
+      });
+      return;
+    }
+    if (err instanceof ServiceTemporarilyUnavailable) {
+      this.#api.showErrorNotification("Service temporarily unavailable", err, {
+        id: "failed-get-nexus-key",
+        allowReport: false,
+      });
+      return;
+    }
+    this.#api.showErrorNotification("Failed to get access key", err, {
+      id: "failed-get-nexus-key",
+    });
   }
 }

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -76,7 +76,12 @@ import { isLoggedIn, userInfo as userInfoSelector } from "./selectors";
 import { accessTokenSchema } from "./types/IJWTAccessToken";
 import type { IMembership, IValidateKeyDataV2 } from "./types/IValidateKeyData";
 import { checkModVersion, fetchRecentUpdates, ONE_DAY, ONE_MINUTE } from "./util/checkModsVersion";
-import { convertGameIdReverse, convertNXMIdReverse, nexusGameId } from "./util/convertGameId";
+import {
+  convertGameIdReverse,
+  convertNXMIdReverse,
+  nexusGameId,
+  nxmPageId,
+} from "./util/convertGameId";
 import { endorseCollection, endorseMod } from "./util/endorseMod";
 import { FULL_REVISION_INFO, MOD_FILE_INFO } from "./util/graphQueries";
 import type { ITokenReply } from "./util/oauth";
@@ -408,9 +413,8 @@ function startDownloadCollection(
   referenceTag?: string,
 ): BluebirdPromise<string> {
   const state: IState = api.getState();
-  const games = knownGames(state);
-  const gameId = convertNXMIdReverse(games, url.gameId);
-  const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+  const gameId = convertNXMIdReverse(knownGames(state), url.gameId);
+  const pageId = nxmPageId(state, url.gameId);
   let revisionInfo: Partial<IRevision>;
 
   const revNumber = url.revisionNumber >= 0 ? url.revisionNumber : undefined;
@@ -753,9 +757,8 @@ function startDownloadMod(
 ): BluebirdPromise<string> {
   log("info", "start download mod", { urlStr, allowInstall });
   let state = api.getState();
-  const games = knownGames(state);
-  const gameId = convertNXMIdReverse(games, url.gameId);
-  const pageId = nexusGameId(gameById(state, gameId), url.gameId);
+  const gameId = convertNXMIdReverse(knownGames(state), url.gameId);
+  const pageId = nxmPageId(state, url.gameId);
 
   let nexusFileInfo: IFileInfo;
   return getInfoGraphQL(nexus, pageId, url.modId, url.fileId)

--- a/src/renderer/src/extensions/nexus_integration/util/convertGameId.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/convertGameId.ts
@@ -5,9 +5,12 @@ import { getErrorMessageOrDefault } from "@vortex/shared";
 import type { IGame } from "../../../types/IGame";
 import type { IState } from "../../../types/IState";
 import { log } from "../../../util/log";
-import { gameById, knownGames } from "../../../util/selectors";
 import { truthy } from "../../../util/util";
 import { SITE_ID } from "../../gamemode_management/constants";
+// the game selectors directly rather than through util/selectors: that barrel re-exports this
+// extension's own selectors, and importing it from here would close an import cycle onto a leaf
+// module that some forty files depend on
+import { gameById, knownGames } from "../../gamemode_management/selectors";
 import type { IGameStored, IGameStoredExt } from "../../gamemode_management/types/IGameStored";
 
 /**

--- a/src/renderer/src/extensions/nexus_integration/util/convertGameId.ts
+++ b/src/renderer/src/extensions/nexus_integration/util/convertGameId.ts
@@ -3,7 +3,9 @@ import { inspect } from "util";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 
 import type { IGame } from "../../../types/IGame";
+import type { IState } from "../../../types/IState";
 import { log } from "../../../util/log";
+import { gameById, knownGames } from "../../../util/selectors";
 import { truthy } from "../../../util/util";
 import { SITE_ID } from "../../gamemode_management/constants";
 import type { IGameStored, IGameStoredExt } from "../../gamemode_management/types/IGameStored";
@@ -75,6 +77,15 @@ export function convertGameIdReverse(knownGames: IGameStored[], input: string): 
       elderscrollsonline: "teso",
     }[input.toLowerCase()] || input.toLowerCase()
   );
+}
+
+/**
+ * the nexus page id (domain) for the game an nxm url names, mapping the link's game id through
+ * the games Vortex knows about
+ */
+export function nxmPageId(state: IState, nxmGameId: string): string {
+  const gameId = convertNXMIdReverse(knownGames(state), nxmGameId);
+  return nexusGameId(gameById(state, gameId), nxmGameId);
 }
 
 /**

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from "events";
 import * as path from "path";
 
 import type { IFileInfo } from "@nexusmods/nexus-api";
+import type NexusT from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
 import type { Api, DownloaderApi } from "@vortex/shared/preload";
 import { batch } from "redux-act";
@@ -55,6 +56,7 @@ import type {
 } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+import { sessionReducer as nexusSessionReducer } from "../extensions/nexus_integration/reducers/session";
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
@@ -91,6 +93,8 @@ import type {
   IInstallManagerHarness,
   IModCheckOpts,
   IModChangeHarness,
+  INxmHarness,
+  INxmHarnessOpts,
   IParkCheckOpts,
   IParkedCheck,
   IRevisionFixture,
@@ -997,5 +1001,114 @@ export function makeLoadOrderEntry(overrides: Partial<ILoadOrderEntry> = {}): IL
     name: id,
     enabled: true,
     ...overrides,
+  };
+}
+
+/**
+ * A fake api + Nexus connection for the nxm protocol handler (makeNXMProtocol /
+ * makeNXMLinkCallback). Distinct from makeApiHarness because the handler reads slices that one
+ * doesn't model - the cached membership, the known-games list it maps nxm domains through, and
+ * the free-user download queue - and because it needs an observable Nexus connection.
+ *
+ * The nexus methods are vi.fn()s that reject by default: a test states the one call it exercises,
+ * and any unexpected request fails loudly instead of resolving to undefined.
+ */
+export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
+  const knownGames = opts.knownGames ?? [makeGameStored()];
+  const dispatched: ITrackedAction[] = [];
+  const errorNotifications: INxmHarness["errorNotifications"] = [];
+
+  const state = {
+    persistent: {
+      nexus: { userInfo: opts.userInfo },
+      downloads: { files: {} },
+    },
+    session: {
+      nexus: { ...nexusSessionReducer.defaults },
+      gameMode: { known: knownGames },
+      extensions: { available: opts.availableExtensions ?? [] },
+      collections: { activeSession: opts.activeSession },
+    },
+    settings: {
+      interface: { foregroundDL: false },
+    },
+  } as unknown as IState;
+
+  const apply = (action: ITrackedAction | null | undefined): void => {
+    if (action == null) {
+      return;
+    }
+    if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
+      (action.payload as ITrackedAction[]).forEach(apply);
+      return;
+    }
+    dispatched.push(action);
+    const reducer = nexusSessionReducer.reducers[action.type];
+    if (reducer !== undefined) {
+      state.session["nexus"] = reducer(state.session["nexus"], action.payload);
+    }
+  };
+
+  const events = new EventEmitter();
+  events.setMaxListeners(0);
+
+  const rejectUnexpected = (name: string) => () =>
+    Promise.reject(new Error(`unexpected nexus.${name} call`));
+
+  const getDownloadURLs = vi.fn(rejectUnexpected("getDownloadURLs"));
+  const getCollectionRevisionGraph = vi.fn(rejectUnexpected("getCollectionRevisionGraph"));
+  const getCollectionDownloadLink = vi.fn(rejectUnexpected("getCollectionDownloadLink"));
+  const getModFiles = vi.fn(rejectUnexpected("getModFiles"));
+
+  const nexus = {
+    getDownloadURLs,
+    getCollectionRevisionGraph,
+    getCollectionDownloadLink,
+    getModFiles,
+  } as unknown as NexusT;
+
+  const api = {
+    getState: () => state,
+    store: { getState: () => state, dispatch: apply },
+    events,
+    onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
+      events.on(event, cb);
+    },
+    onStateChange: () => undefined,
+    sendNotification: () => undefined,
+    dismissNotification: () => undefined,
+    showErrorNotification: (
+      title: string,
+      message: unknown,
+      options?: { allowReport?: boolean },
+    ) => {
+      errorNotifications.push({ title, message, allowReport: options?.allowReport });
+    },
+    translate: (key: string) => key,
+    emitAndAwait: () => Promise.resolve([]),
+  } as unknown as IExtensionApi;
+
+  return {
+    api,
+    nexus,
+    dispatched,
+    errorNotifications,
+    emit: (event: string, ...args: unknown[]) => {
+      events.emit(event, ...args);
+    },
+    getState: () => state,
+    setState: (mutate: (draft: IState) => void) => {
+      mutate(state);
+    },
+    setNextDialog: () => undefined,
+    dialogCalls: [],
+    freeUserQueue: () => state.session["nexus"].freeUserDLQueue ?? [],
+    setUserInfo: (userInfo) => {
+      state.persistent["nexus"].userInfo = userInfo;
+    },
+    getDownloadURLs,
+    getCollectionRevisionGraph,
+    getCollectionDownloadLink,
+    getModFiles,
   };
 }

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from "events";
 import * as path from "path";
 
 import type { IFileInfo } from "@nexusmods/nexus-api";
+import type NexusT from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
 import type { Api, DownloaderApi } from "@vortex/shared/preload";
 import { batch } from "redux-act";
@@ -55,6 +56,7 @@ import type {
 } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+import { sessionReducer as nexusSessionReducer } from "../extensions/nexus_integration/reducers/session";
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
@@ -91,6 +93,8 @@ import type {
   IInstallManagerHarness,
   IModCheckOpts,
   IModChangeHarness,
+  INxmHarness,
+  INxmHarnessOpts,
   IParkCheckOpts,
   IParkedCheck,
   IRevisionFixture,
@@ -993,5 +997,114 @@ export function makeLoadOrderEntry(overrides: Partial<ILoadOrderEntry> = {}): IL
     name: id,
     enabled: true,
     ...overrides,
+  };
+}
+
+/**
+ * A fake api + Nexus connection for the nxm protocol handler (makeNXMProtocol /
+ * makeNXMLinkCallback). Distinct from makeApiHarness because the handler reads slices that one
+ * doesn't model - the cached membership, the known-games list it maps nxm domains through, and
+ * the free-user download queue - and because it needs an observable Nexus connection.
+ *
+ * The nexus methods are vi.fn()s that reject by default: a test states the one call it exercises,
+ * and any unexpected request fails loudly instead of resolving to undefined.
+ */
+export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
+  const knownGames = opts.knownGames ?? [makeGameStored()];
+  const dispatched: ITrackedAction[] = [];
+  const errorNotifications: INxmHarness["errorNotifications"] = [];
+
+  const state = {
+    persistent: {
+      nexus: { userInfo: opts.userInfo },
+      downloads: { files: {} },
+    },
+    session: {
+      nexus: { ...nexusSessionReducer.defaults },
+      gameMode: { known: knownGames },
+      extensions: { available: opts.availableExtensions ?? [] },
+      collections: { activeSession: opts.activeSession },
+    },
+    settings: {
+      interface: { foregroundDL: false },
+    },
+  } as unknown as IState;
+
+  const apply = (action: ITrackedAction | null | undefined): void => {
+    if (action == null) {
+      return;
+    }
+    if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
+      (action.payload as ITrackedAction[]).forEach(apply);
+      return;
+    }
+    dispatched.push(action);
+    const reducer = nexusSessionReducer.reducers[action.type];
+    if (reducer !== undefined) {
+      state.session["nexus"] = reducer(state.session["nexus"], action.payload);
+    }
+  };
+
+  const events = new EventEmitter();
+  events.setMaxListeners(0);
+
+  const rejectUnexpected = (name: string) => () =>
+    Promise.reject(new Error(`unexpected nexus.${name} call`));
+
+  const getDownloadURLs = vi.fn(rejectUnexpected("getDownloadURLs"));
+  const getCollectionRevisionGraph = vi.fn(rejectUnexpected("getCollectionRevisionGraph"));
+  const getCollectionDownloadLink = vi.fn(rejectUnexpected("getCollectionDownloadLink"));
+  const getModFiles = vi.fn(rejectUnexpected("getModFiles"));
+
+  const nexus = {
+    getDownloadURLs,
+    getCollectionRevisionGraph,
+    getCollectionDownloadLink,
+    getModFiles,
+  } as unknown as NexusT;
+
+  const api = {
+    getState: () => state,
+    store: { getState: () => state, dispatch: apply },
+    events,
+    onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
+      events.on(event, cb);
+    },
+    onStateChange: () => undefined,
+    sendNotification: () => undefined,
+    dismissNotification: () => undefined,
+    showErrorNotification: (
+      title: string,
+      message: unknown,
+      options?: { allowReport?: boolean },
+    ) => {
+      errorNotifications.push({ title, message, allowReport: options?.allowReport });
+    },
+    translate: (key: string) => key,
+    emitAndAwait: () => Promise.resolve([]),
+  } as unknown as IExtensionApi;
+
+  return {
+    api,
+    nexus,
+    dispatched,
+    errorNotifications,
+    emit: (event: string, ...args: unknown[]) => {
+      events.emit(event, ...args);
+    },
+    getState: () => state,
+    setState: (mutate: (draft: IState) => void) => {
+      mutate(state);
+    },
+    setNextDialog: () => undefined,
+    dialogCalls: [],
+    freeUserQueue: () => state.session["nexus"].freeUserDLQueue ?? [],
+    setUserInfo: (userInfo) => {
+      state.persistent["nexus"].userInfo = userInfo;
+    },
+    getDownloadURLs,
+    getCollectionRevisionGraph,
+    getCollectionDownloadLink,
+    getModFiles,
   };
 }

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -56,6 +56,7 @@ import type {
 } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+import { persistentReducer as nexusPersistentReducer } from "../extensions/nexus_integration/reducers/persistent";
 import { sessionReducer as nexusSessionReducer } from "../extensions/nexus_integration/reducers/session";
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
@@ -94,7 +95,6 @@ import type {
   IModCheckOpts,
   IModChangeHarness,
   INxmHarness,
-  INxmHarnessOpts,
   IParkCheckOpts,
   IParkedCheck,
   IRevisionFixture,
@@ -468,6 +468,9 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
     downloads: {},
     profiles: {},
     session: trackingReducer.defaults,
+    knownGames: [],
+    availableExtensions: [],
+    userInfo: undefined,
     ...overrides,
   };
   // a structurally-partial IState holding only the slices the driver reads; the single cast
@@ -478,12 +481,19 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
       downloads: { files: slices.downloads },
       profiles: slices.profiles,
       collections: { collections: {}, revisions: {} },
+      nexus: { ...nexusPersistentReducer.defaults, userInfo: slices.userInfo },
     },
-    session: { collections: slices.session },
+    session: {
+      collections: slices.session,
+      nexus: { ...nexusSessionReducer.defaults },
+      // knownGames() dereferences this, so it has to exist even for suites that register none
+      gameMode: { known: slices.knownGames },
+      extensions: { available: slices.availableExtensions },
+    },
     settings: {
       // download path pattern so downloadPathForGame resolves a concrete per-game folder
       downloads: { collectionsInstallWhileDownloading: false, path: "{USERDATA}\\downloads" },
-      interface: { language: "en" },
+      interface: { language: "en", foregroundDL: false },
       gameMode: { discovered: {} },
       // empty skeletons so tests can assign settings.mods.installPath[gameId] /
       // settings.profiles.activeProfileId through the typed draft without a cast (the single
@@ -584,6 +594,14 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
     if (modsReducerFn !== undefined) {
       state.persistent.mods = modsReducerFn(state.persistent.mods, action.payload);
     }
+    const nexusSession = nexusSessionReducer.reducers[action.type];
+    if (nexusSession !== undefined) {
+      state.session["nexus"] = nexusSession(state.session["nexus"], action.payload);
+    }
+    const nexusPersistent = nexusPersistentReducer.reducers[action.type];
+    if (nexusPersistent !== undefined) {
+      state.persistent["nexus"] = nexusPersistent(state.persistent["nexus"], action.payload);
+    }
   };
 
   const dispatch = (action: ITrackedAction) => {
@@ -596,6 +614,8 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
 
   let nextDialog: IDialogResult = { action: "Continue", input: {} };
   const dialogCalls: Array<{ type: DialogType; title: string }> = [];
+  const errorNotifications: IApiHarness["errorNotifications"] = [];
+  const notifications: IApiHarness["notifications"] = [];
 
   const api = {
     getState: () => state,
@@ -607,9 +627,17 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
       events.on(event, cb);
     },
     onStateChange: () => undefined,
-    sendNotification: () => undefined,
+    sendNotification: (notification: { type: string; message: string }) => {
+      notifications.push(notification);
+    },
     dismissNotification: () => undefined,
-    showErrorNotification: () => undefined,
+    showErrorNotification: (
+      title: string,
+      message: unknown,
+      options?: { allowReport?: boolean },
+    ) => {
+      errorNotifications.push({ title, message, allowReport: options?.allowReport });
+    },
     showDialog: (
       type: DialogType,
       title: string,
@@ -638,6 +666,8 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
       nextDialog = result;
     },
     dialogCalls,
+    errorNotifications,
+    notifications,
   };
 }
 
@@ -1005,52 +1035,14 @@ export function makeLoadOrderEntry(overrides: Partial<ILoadOrderEntry> = {}): IL
 }
 
 /**
- * A fake api + Nexus connection for the nxm protocol handler (makeNXMProtocol /
- * makeNXMLinkCallback). Distinct from makeApiHarness because the handler reads slices that one
- * doesn't model - the cached membership, the known-games list it maps nxm domains through, and
- * the free-user download queue - and because it needs an observable Nexus connection.
+ * The shared api harness plus an observable Nexus connection, for the nxm protocol handler.
+ * Defaults to one known game so an nxm domain resolves without every suite spelling that out.
  *
  * The nexus methods are vi.fn()s that reject by default: a test states the one call it exercises,
  * and any unexpected request fails loudly instead of resolving to undefined.
  */
-export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
-  const knownGames = opts.knownGames ?? [makeGameStored()];
-  const dispatched: ITrackedAction[] = [];
-  const errorNotifications: INxmHarness["errorNotifications"] = [];
-
-  const state = {
-    persistent: {
-      nexus: { userInfo: opts.userInfo },
-      downloads: { files: {} },
-    },
-    session: {
-      nexus: { ...nexusSessionReducer.defaults },
-      gameMode: { known: knownGames },
-      extensions: { available: opts.availableExtensions ?? [] },
-      collections: { activeSession: opts.activeSession },
-    },
-    settings: {
-      interface: { foregroundDL: false },
-    },
-  } as unknown as IState;
-
-  const apply = (action: ITrackedAction | null | undefined): void => {
-    if (action == null) {
-      return;
-    }
-    if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
-      (action.payload as ITrackedAction[]).forEach(apply);
-      return;
-    }
-    dispatched.push(action);
-    const reducer = nexusSessionReducer.reducers[action.type];
-    if (reducer !== undefined) {
-      state.session["nexus"] = reducer(state.session["nexus"], action.payload);
-    }
-  };
-
-  const events = new EventEmitter();
-  events.setMaxListeners(0);
+export function makeNxmHarness(opts: Partial<IDriverHarnessState> = {}): INxmHarness {
+  const base = makeApiHarness({ knownGames: [makeGameStored()], ...opts });
 
   const rejectUnexpected = (name: string) => () =>
     Promise.reject(new Error(`unexpected nexus.${name} call`));
@@ -1067,44 +1059,14 @@ export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
     getModFiles,
   } as unknown as NexusT;
 
-  const api = {
-    getState: () => state,
-    store: { getState: () => state, dispatch: apply },
-    events,
-    onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
-      events.on(event, cb);
-    },
-    onStateChange: () => undefined,
-    sendNotification: () => undefined,
-    dismissNotification: () => undefined,
-    showErrorNotification: (
-      title: string,
-      message: unknown,
-      options?: { allowReport?: boolean },
-    ) => {
-      errorNotifications.push({ title, message, allowReport: options?.allowReport });
-    },
-    translate: (key: string) => key,
-    emitAndAwait: () => Promise.resolve([]),
-  } as unknown as IExtensionApi;
-
   return {
-    api,
+    ...base,
     nexus,
-    dispatched,
-    errorNotifications,
-    emit: (event: string, ...args: unknown[]) => {
-      events.emit(event, ...args);
-    },
-    getState: () => state,
-    setState: (mutate: (draft: IState) => void) => {
-      mutate(state);
-    },
-    setNextDialog: () => undefined,
-    dialogCalls: [],
-    freeUserQueue: () => state.session["nexus"].freeUserDLQueue ?? [],
+    freeUserQueue: () => base.getState().session["nexus"].freeUserDLQueue ?? [],
     setUserInfo: (userInfo) => {
-      state.persistent["nexus"].userInfo = userInfo;
+      base.setState((draft) => {
+        draft.persistent["nexus"].userInfo = userInfo;
+      });
     },
     getDownloadURLs,
     getCollectionRevisionGraph,

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -56,6 +56,7 @@ import type {
 } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
+import { persistentReducer as nexusPersistentReducer } from "../extensions/nexus_integration/reducers/persistent";
 import { sessionReducer as nexusSessionReducer } from "../extensions/nexus_integration/reducers/session";
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
@@ -94,7 +95,6 @@ import type {
   IModCheckOpts,
   IModChangeHarness,
   INxmHarness,
-  INxmHarnessOpts,
   IParkCheckOpts,
   IParkedCheck,
   IRevisionFixture,
@@ -468,6 +468,9 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
     downloads: {},
     profiles: {},
     session: trackingReducer.defaults,
+    knownGames: [],
+    availableExtensions: [],
+    userInfo: undefined,
     ...overrides,
   };
   // a structurally-partial IState holding only the slices the driver reads; the single cast
@@ -478,12 +481,19 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
       downloads: { files: slices.downloads },
       profiles: slices.profiles,
       collections: { collections: {}, revisions: {} },
+      nexus: { ...nexusPersistentReducer.defaults, userInfo: slices.userInfo },
     },
-    session: { collections: slices.session },
+    session: {
+      collections: slices.session,
+      nexus: { ...nexusSessionReducer.defaults },
+      // knownGames() dereferences this, so it has to exist even for suites that register none
+      gameMode: { known: slices.knownGames },
+      extensions: { available: slices.availableExtensions },
+    },
     settings: {
       // download path pattern so downloadPathForGame resolves a concrete per-game folder
       downloads: { collectionsInstallWhileDownloading: false, path: "{USERDATA}\\downloads" },
-      interface: { language: "en" },
+      interface: { language: "en", foregroundDL: false },
       gameMode: { discovered: {} },
       // empty skeletons so tests can assign settings.mods.installPath[gameId] /
       // settings.profiles.activeProfileId through the typed draft without a cast (the single
@@ -584,6 +594,14 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
     if (modsReducerFn !== undefined) {
       state.persistent.mods = modsReducerFn(state.persistent.mods, action.payload);
     }
+    const nexusSession = nexusSessionReducer.reducers[action.type];
+    if (nexusSession !== undefined) {
+      state.session["nexus"] = nexusSession(state.session["nexus"], action.payload);
+    }
+    const nexusPersistent = nexusPersistentReducer.reducers[action.type];
+    if (nexusPersistent !== undefined) {
+      state.persistent["nexus"] = nexusPersistent(state.persistent["nexus"], action.payload);
+    }
   };
 
   const dispatch = (action: ITrackedAction) => {
@@ -596,6 +614,8 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
 
   let nextDialog: IDialogResult = { action: "Continue", input: {} };
   const dialogCalls: Array<{ type: DialogType; title: string }> = [];
+  const errorNotifications: IApiHarness["errorNotifications"] = [];
+  const notifications: IApiHarness["notifications"] = [];
 
   const api = {
     getState: () => state,
@@ -607,9 +627,17 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
       events.on(event, cb);
     },
     onStateChange: () => undefined,
-    sendNotification: () => undefined,
+    sendNotification: (notification: { type: string; message: string }) => {
+      notifications.push(notification);
+    },
     dismissNotification: () => undefined,
-    showErrorNotification: () => undefined,
+    showErrorNotification: (
+      title: string,
+      message: unknown,
+      options?: { allowReport?: boolean },
+    ) => {
+      errorNotifications.push({ title, message, allowReport: options?.allowReport });
+    },
     showDialog: (
       type: DialogType,
       title: string,
@@ -638,6 +666,8 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
       nextDialog = result;
     },
     dialogCalls,
+    errorNotifications,
+    notifications,
   };
 }
 
@@ -1001,52 +1031,14 @@ export function makeLoadOrderEntry(overrides: Partial<ILoadOrderEntry> = {}): IL
 }
 
 /**
- * A fake api + Nexus connection for the nxm protocol handler (makeNXMProtocol /
- * makeNXMLinkCallback). Distinct from makeApiHarness because the handler reads slices that one
- * doesn't model - the cached membership, the known-games list it maps nxm domains through, and
- * the free-user download queue - and because it needs an observable Nexus connection.
+ * The shared api harness plus an observable Nexus connection, for the nxm protocol handler.
+ * Defaults to one known game so an nxm domain resolves without every suite spelling that out.
  *
  * The nexus methods are vi.fn()s that reject by default: a test states the one call it exercises,
  * and any unexpected request fails loudly instead of resolving to undefined.
  */
-export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
-  const knownGames = opts.knownGames ?? [makeGameStored()];
-  const dispatched: ITrackedAction[] = [];
-  const errorNotifications: INxmHarness["errorNotifications"] = [];
-
-  const state = {
-    persistent: {
-      nexus: { userInfo: opts.userInfo },
-      downloads: { files: {} },
-    },
-    session: {
-      nexus: { ...nexusSessionReducer.defaults },
-      gameMode: { known: knownGames },
-      extensions: { available: opts.availableExtensions ?? [] },
-      collections: { activeSession: opts.activeSession },
-    },
-    settings: {
-      interface: { foregroundDL: false },
-    },
-  } as unknown as IState;
-
-  const apply = (action: ITrackedAction | null | undefined): void => {
-    if (action == null) {
-      return;
-    }
-    if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
-      (action.payload as ITrackedAction[]).forEach(apply);
-      return;
-    }
-    dispatched.push(action);
-    const reducer = nexusSessionReducer.reducers[action.type];
-    if (reducer !== undefined) {
-      state.session["nexus"] = reducer(state.session["nexus"], action.payload);
-    }
-  };
-
-  const events = new EventEmitter();
-  events.setMaxListeners(0);
+export function makeNxmHarness(opts: Partial<IDriverHarnessState> = {}): INxmHarness {
+  const base = makeApiHarness({ knownGames: [makeGameStored()], ...opts });
 
   const rejectUnexpected = (name: string) => () =>
     Promise.reject(new Error(`unexpected nexus.${name} call`));
@@ -1063,44 +1055,14 @@ export function makeNxmHarness(opts: INxmHarnessOpts = {}): INxmHarness {
     getModFiles,
   } as unknown as NexusT;
 
-  const api = {
-    getState: () => state,
-    store: { getState: () => state, dispatch: apply },
-    events,
-    onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
-      events.on(event, cb);
-    },
-    onStateChange: () => undefined,
-    sendNotification: () => undefined,
-    dismissNotification: () => undefined,
-    showErrorNotification: (
-      title: string,
-      message: unknown,
-      options?: { allowReport?: boolean },
-    ) => {
-      errorNotifications.push({ title, message, allowReport: options?.allowReport });
-    },
-    translate: (key: string) => key,
-    emitAndAwait: () => Promise.resolve([]),
-  } as unknown as IExtensionApi;
-
   return {
-    api,
+    ...base,
     nexus,
-    dispatched,
-    errorNotifications,
-    emit: (event: string, ...args: unknown[]) => {
-      events.emit(event, ...args);
-    },
-    getState: () => state,
-    setState: (mutate: (draft: IState) => void) => {
-      mutate(state);
-    },
-    setNextDialog: () => undefined,
-    dialogCalls: [],
-    freeUserQueue: () => state.session["nexus"].freeUserDLQueue ?? [],
+    freeUserQueue: () => base.getState().session["nexus"].freeUserDLQueue ?? [],
     setUserInfo: (userInfo) => {
-      state.persistent["nexus"].userInfo = userInfo;
+      base.setState((draft) => {
+        draft.persistent["nexus"].userInfo = userInfo;
+      });
     },
     getDownloadURLs,
     getCollectionRevisionGraph,

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -58,6 +58,7 @@ import type { InstallPhaseTracker } from "../extensions/mod_management/util/Inst
 import type { IModLookupInfo } from "../extensions/mod_management/util/testModReference";
 import { persistentReducer as nexusPersistentReducer } from "../extensions/nexus_integration/reducers/persistent";
 import { sessionReducer as nexusSessionReducer } from "../extensions/nexus_integration/reducers/session";
+import type { IValidateKeyDataV2 } from "../extensions/nexus_integration/types/IValidateKeyData";
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
@@ -192,6 +193,23 @@ export function makeFileInfo(overrides: Partial<IFileInfo> = {}): IFileInfo {
     mod_version: "1.0.0",
     external_virus_scan_url: "",
     is_primary: true,
+    ...overrides,
+  };
+}
+
+/**
+ * The membership as Vortex stores it, i.e. after the api's role strings have been folded into
+ * flags. Defaults to a plain premium account; override the flags for the free/supporter cases.
+ */
+export function makeUserInfo(overrides: Partial<IValidateKeyDataV2> = {}): IValidateKeyDataV2 {
+  return {
+    userId: 7,
+    name: "test-user",
+    email: "test@example.com",
+    profileUrl: "https://example.com/avatar.png",
+    isPremium: true,
+    isSupporter: false,
+    isLifetime: false,
     ...overrides,
   };
 }

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -36,7 +36,7 @@ export interface ITrackedAction {
   payload?: unknown;
 }
 
-/** The redux slices an InstallDriver test arranges, each a builder-style override. */
+/** The redux slices a harness test arranges, each a builder-style override. */
 export interface IDriverHarnessState {
   // installed mods, keyed by gameId then modId (state.persistent.mods)
   mods: Record<string, Record<string, IMod>>;
@@ -46,6 +46,12 @@ export interface IDriverHarnessState {
   profiles: Record<string, IProfile>;
   // the install-tracking slice (state.session.collections)
   session: ICollectionInstallState;
+  // games Vortex knows about (state.session.gameMode.known); nxm domains are mapped through these
+  knownGames: IGameStored[];
+  // extensions offered on the site domain (state.session.extensions.available)
+  availableExtensions: Array<{ modId: number }>;
+  // the cached membership (state.persistent.nexus.userInfo); undefined models "not fetched yet"
+  userInfo: Partial<IValidateKeyDataV2> | undefined;
 }
 
 export interface IApiHarness {
@@ -62,6 +68,11 @@ export interface IApiHarness {
   setNextDialog: (result: IDialogResult) => void;
   // showDialog calls, recorded in order
   dialogCalls: Array<{ type: DialogType; title: string }>;
+  // showErrorNotification calls, recorded in order. allowReport matters: a false here is what
+  // keeps the Report button off a failure the user caused or can act on themselves
+  errorNotifications: Array<{ title: string; message: unknown; allowReport: boolean | undefined }>;
+  // sendNotification calls, recorded in order
+  notifications: Array<{ type: string; message: string }>;
 }
 
 export interface IDriverHarness extends IApiHarness {
@@ -114,26 +125,11 @@ export interface IDownloadAdapterHarness extends IApiHarness {
   getStates: Mock;
 }
 
-// What an nxm-protocol test arranges: the membership the client has cached, the games it knows
-// about, and whether a collection install is in flight (the free-user cancel path reads it).
-export interface INxmHarnessOpts {
-  // state.persistent.nexus.userInfo; undefined models "not logged in / not fetched yet"
-  userInfo?: Partial<IValidateKeyDataV2> | undefined;
-  // state.session.gameMode.known - the resolver maps the nxm domain through these
-  knownGames?: IGameStored[];
-  // state.session.collections.activeSession
-  activeSession?: { gameId: string; collectionId: string };
-  // state.session.extensions.available - the site-domain branch of the link callback reads it
-  availableExtensions?: Array<{ modId: number }>;
-}
-
 export interface INxmHarness extends IApiHarness {
-  // the fake Nexus connection makeNXMProtocol / makeNXMLinkCallback talk to
+  // the fake Nexus connection the handler talks to
   nexus: NexusT;
   // the queued free-user download urls, as the FreeUserDLDialog would see them
   freeUserQueue: () => string[];
-  // showErrorNotification calls, recorded in order
-  errorNotifications: Array<{ title: string; message: unknown; allowReport: boolean | undefined }>;
   // swap the cached membership mid-test, to model a website-side change Vortex hasn't seen
   setUserInfo: (userInfo: Partial<IValidateKeyDataV2> | undefined) => void;
   getDownloadURLs: Mock;

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -3,6 +3,7 @@
  * factory functions) and the *Test.ts fixture modules so both can import the shapes without pulling
  * in each other's runtime code.
  */
+import type NexusT from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint } from "@vortex/shared/ipc";
 import type { Mock } from "vitest";
 
@@ -11,11 +12,13 @@ import type { ICollectionMod } from "../extensions/collections/types/ICollection
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
+import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
 import type { InstallPhaseTracker } from "../extensions/mod_management/util/InstallPhaseTracker";
+import type { IValidateKeyDataV2 } from "../extensions/nexus_integration/types/IValidateKeyData";
 import type { IProfile } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import type {
@@ -109,6 +112,34 @@ export interface IDownloadAdapterHarness extends IApiHarness {
   start: Mock;
   resume: Mock;
   getStates: Mock;
+}
+
+// What an nxm-protocol test arranges: the membership the client has cached, the games it knows
+// about, and whether a collection install is in flight (the free-user cancel path reads it).
+export interface INxmHarnessOpts {
+  // state.persistent.nexus.userInfo; undefined models "not logged in / not fetched yet"
+  userInfo?: Partial<IValidateKeyDataV2> | undefined;
+  // state.session.gameMode.known - the resolver maps the nxm domain through these
+  knownGames?: IGameStored[];
+  // state.session.collections.activeSession
+  activeSession?: { gameId: string; collectionId: string };
+  // state.session.extensions.available - the site-domain branch of the link callback reads it
+  availableExtensions?: Array<{ modId: number }>;
+}
+
+export interface INxmHarness extends IApiHarness {
+  // the fake Nexus connection makeNXMProtocol / makeNXMLinkCallback talk to
+  nexus: NexusT;
+  // the queued free-user download urls, as the FreeUserDLDialog would see them
+  freeUserQueue: () => string[];
+  // showErrorNotification calls, recorded in order
+  errorNotifications: Array<{ title: string; message: unknown; allowReport: boolean | undefined }>;
+  // swap the cached membership mid-test, to model a website-side change Vortex hasn't seen
+  setUserInfo: (userInfo: Partial<IValidateKeyDataV2> | undefined) => void;
+  getDownloadURLs: Mock;
+  getCollectionRevisionGraph: Mock;
+  getCollectionDownloadLink: Mock;
+  getModFiles: Mock;
 }
 
 export interface IInstallContextHarness extends IApiHarness {

--- a/src/renderer/src/test-utils/nxmTest.ts
+++ b/src/renderer/src/test-utils/nxmTest.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 
 import { NxmProtocol } from "../extensions/nexus_integration/nxmProtocol";
-import { makeNxmHarness } from "./builders";
+import { makeNxmHarness, makeUserInfo } from "./builders";
 import { test as harnessTest } from "./harnessTest";
 import type { IDriverHarnessState, INxmHarness } from "./harnessTypes";
 
@@ -9,8 +9,8 @@ import type { IDriverHarnessState, INxmHarness } from "./harnessTypes";
 export const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
 export const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
 
-export const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
-export const FREE = { userId: 7, name: "free-user", isPremium: false };
+export const PREMIUM = makeUserInfo({ name: "premium-user" });
+export const FREE = makeUserInfo({ name: "free-user", isPremium: false });
 
 export interface INxmSetup {
   harness: INxmHarness;

--- a/src/renderer/src/test-utils/nxmTest.ts
+++ b/src/renderer/src/test-utils/nxmTest.ts
@@ -1,0 +1,45 @@
+import { vi } from "vitest";
+
+import { NxmProtocol } from "../extensions/nexus_integration/nxmProtocol";
+import { makeNxmHarness } from "./builders";
+import { test as harnessTest } from "./harnessTest";
+import type { IDriverHarnessState, INxmHarness } from "./harnessTypes";
+
+/** A mod file on a real game, with no authorisation from the website. */
+export const MOD_URL = "nxm://skyrimspecialedition/mods/100/files/500";
+export const COLLECTION_URL = "nxm://skyrimspecialedition/collections/abcdef/revisions/3";
+
+export const PREMIUM = { userId: 7, name: "premium-user", isPremium: true };
+export const FREE = { userId: 7, name: "free-user", isPremium: false };
+
+export interface INxmSetup {
+  harness: INxmHarness;
+  nxm: NxmProtocol;
+  /** `nxm.resolve`, the download protocol handler under test. */
+  resolve: NxmProtocol["resolve"];
+  /** The membership re-read the site asks for with an nxm://premium link. */
+  onRefreshMembership: ReturnType<typeof vi.fn>;
+}
+
+export interface INxmFixtures {
+  // build the real NxmProtocol over a seeded harness; defaults to a premium account
+  makeNxm: (overrides?: Partial<IDriverHarnessState>) => INxmSetup;
+}
+
+/**
+ * Base test for the nxm protocol suites. The handler keeps its download queue and awaited links
+ * on the instance, so each call gets a fresh one and no suite has to drain state between tests.
+ *
+ * Each suite declares its own `vi.mock` for the modules that reach the network (`./util`), because
+ * mock factories are hoisted per file and can't live here.
+ */
+export const test = harnessTest.extend<INxmFixtures>({
+  makeNxm: async ({ task: _task }, use) => {
+    await use((overrides: Partial<IDriverHarnessState> = {}) => {
+      const harness = makeNxmHarness({ userInfo: PREMIUM, ...overrides });
+      const onRefreshMembership = vi.fn();
+      const nxm = new NxmProtocol(harness.api, () => harness.nexus, { onRefreshMembership });
+      return { harness, nxm, resolve: nxm.resolve, onRefreshMembership };
+    });
+  },
+});

--- a/src/renderer/src/util/keyedCache.ts
+++ b/src/renderer/src/util/keyedCache.ts
@@ -1,0 +1,27 @@
+/** Minimal in-memory cache keyed by string with a per-entry TTL. */
+export interface KeyedCache<V> {
+  get(key: string): V | undefined;
+  set(key: string, value: V): void;
+}
+
+/** Create a keyed cache whose entries expire `ttlMs` after they are set. */
+export function createKeyedCache<V>(ttlMs: number): KeyedCache<V> {
+  const entries = new Map<string, { value: V; expires: number }>();
+
+  return {
+    get(key) {
+      const entry = entries.get(key);
+      if (entry === undefined) {
+        return undefined;
+      }
+      if (entry.expires <= Date.now()) {
+        entries.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+    set(key, value) {
+      entries.set(key, { value, expires: Date.now() + ttlMs });
+    },
+  };
+}


### PR DESCRIPTION
Prep for LAZ-836 and LAZ-838, which both change the free-user download queue.

`index.tsx` (-667) becomes `nxmProtocol.ts` (+623): a class owning `resolve`,
`handleLink`, the queue and `dialogHandlers`. `keyedCache.ts` is lifted out of
`batchCache.ts` with its five consumers re-pointed.

The first three commits are behaviour-identical to master. The last two fix queue
bugs found while extracting: an abandoned trip to the website left an awaited-link
entry that never expired, and the redux queue row is keyed by url, so the first of
two downloads of one file to settle stranded the other.

This PR needs to be merged FIRST into the integration branch.

16 files, +1713/-693, mostly the two new test suites. Best read commit by commit.
