### PR TITLE
LAZ-684: End-to-end tests for the File Requirements Health Check

### DIFF
--- a/packages/e2e/.gitignore
+++ b/packages/e2e/.gitignore
@@ -2,3 +2,4 @@ playwright-report/
 test-results/
 .env
 reports/
+.auth/

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,6 +10,7 @@
     "e2e": "pnpm exec playwright test",
     "e2e:headed": "pnpm exec cross-env VORTEX_E2E_HEADED=1 pnpm exec playwright test",
     "e2e:ui": "pnpm exec cross-env VORTEX_E2E_HEADED=1 pnpm exec playwright test --ui",
+    "auth:capture": "pnpm exec tsx ./src/authCapture.ts",
     "typecheck": "pnpm exec tsc",
     "lint": "pnpm exec eslint --quiet --concurrency auto .",
     "lint:verbose": "pnpm exec eslint --concurrency auto .",

--- a/packages/e2e/src/authCapture.ts
+++ b/packages/e2e/src/authCapture.ts
@@ -1,0 +1,88 @@
+/**
+ * One-time interactive capture of a Nexus website session, so local E2E runs can
+ * skip the captcha-gated credential login.
+ *
+ *   pnpm -F @vortex/e2e auth:capture            # both free + premium
+ *   pnpm -F @vortex/e2e auth:capture free       # just the free account
+ *   pnpm -F @vortex/e2e auth:capture premium    # just the premium account
+ *
+ * A headed browser opens with the account's credentials pre-filled; you solve the
+ * captcha and finish signing in, then press Enter here to save the session cookies
+ * to packages/e2e/.auth/<username>.json (gitignored). The auth-snapshot fixture
+ * then loads those cookies, so the OAuth flow lands straight on the consent screen
+ * — no credentials, no captcha. Re-run when the cookies expire.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+
+import { chromium } from "@playwright/test";
+
+import { AUTH_DIR, authStatePath } from "./helpers/authState";
+import { freeUser, premiumUser, type NexusUser } from "./helpers/users";
+import { LoginPage } from "./selectors/loginPage";
+
+// Run outside Playwright's runner, so the .env it normally loads isn't present —
+// load it here so the freeUser/premiumUser credential getters resolve.
+const envFile = path.resolve(import.meta.dirname, "..", ".env");
+if (fs.existsSync(envFile)) {
+  process.loadEnvFile(envFile);
+}
+
+const SIGN_IN_URL = "https://users.nexusmods.com/auth/sign_in";
+
+async function captureFor(label: string, user: NexusUser): Promise<void> {
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+  const file = authStatePath(user);
+
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(SIGN_IN_URL, { waitUntil: "domcontentloaded" }).catch(() => undefined);
+
+  // Best-effort pre-fill so you only have to solve the captcha and submit; if the
+  // page differs, just sign in by hand.
+  const login = new LoginPage(page);
+  await login.usernameInput.fill(user.username, { timeout: 5_000 }).catch(() => undefined);
+  await login.passwordInput.fill(user.password, { timeout: 5_000 }).catch(() => undefined);
+
+  console.log(
+    `\n[auth:capture] A browser opened for the ${label} account (${user.username}).\n` +
+      `  1. Solve the captcha and click "Log in" (credentials are pre-filled).\n` +
+      `  2. Wait until you are back on a signed-in Nexus Mods page.\n` +
+      `  3. Return here and press Enter to save the session.\n`,
+  );
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  await rl.question("[auth:capture] Press Enter once signed in… ");
+  rl.close();
+
+  await context.storageState({ path: file });
+  await browser.close();
+  console.log(`[auth:capture] Saved ${label} session → ${path.relative(process.cwd(), file)}\n`);
+}
+
+async function main(): Promise<void> {
+  const arg = (process.argv[2] ?? "").toLowerCase();
+  const all: Array<{ label: string; user: NexusUser }> = [
+    { label: "free", user: freeUser },
+    { label: "premium", user: premiumUser },
+  ];
+  const targets = arg === "" ? all : all.filter((t) => t.label === arg);
+
+  if (targets.length === 0) {
+    console.error(`Unknown account "${arg}". Usage: auth:capture [free|premium]`);
+    process.exit(1);
+  }
+
+  // Sequentially — one browser window at a time so the prompts don't interleave.
+  for (const { label, user } of targets) {
+    await captureFor(label, user);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -28,11 +28,13 @@ export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
 ];
 
 /**
- * SDV mod that declares a single page-level ("mod") requirement. Installed on its
- * own (that required mod absent) it drives one blue Health Check *suggestion*
- * ("Additional mod file may be required for: …") — the mod-to-mod counterpart of
- * SDV_FILE_REQUIREMENT_MOD_URL's file-level warning. It must keep its legacy mod
- * requirements enabled (not be set to file-requirements-only) so the suggestion
- * isn't suppressed for the flag-enrolled E2E users (see LAZ-852).
+ * SDV mod that declares a single page-level ("mod") requirement — Generic Mod
+ * Config Menu (5098), which requires SMAPI. Installed on its own (SMAPI absent) it
+ * drives one blue Health Check *suggestion* ("Additional mod file may be required
+ * for: …") — the mod-to-mod counterpart of SDV_FILE_REQUIREMENT_MOD_URL's
+ * file-level warning. It must offer a Mod-Manager download (not manual-only) so the
+ * install helper can drive it, and keep its legacy mod requirements enabled (not be
+ * set to file-requirements-only) so the suggestion isn't suppressed for the
+ * flag-enrolled E2E users (see LAZ-852).
  */
-export const SDV_MOD_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/46415";
+export const SDV_MOD_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/5098";

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -26,3 +26,13 @@ export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
   "https://www.nexusmods.com/stardewvalley/mods/5382",
   "https://www.nexusmods.com/stardewvalley/mods/49098",
 ];
+
+/**
+ * SDV mod that declares a single page-level ("mod") requirement. Installed on its
+ * own (that required mod absent) it drives one blue Health Check *suggestion*
+ * ("Additional mod file may be required for: …") — the mod-to-mod counterpart of
+ * SDV_FILE_REQUIREMENT_MOD_URL's file-level warning. It must keep its legacy mod
+ * requirements enabled (not be set to file-requirements-only) so the suggestion
+ * isn't suppressed for the flag-enrolled E2E users (see LAZ-852).
+ */
+export const SDV_MOD_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/46415";

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -29,14 +29,13 @@ export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
 
 /**
  * Matches an externally-opened URL that points at one of the required mods' pages
- * (5382 / 49098). Derived from SDV_FILE_REQUIREMENT_TARGET_URLS so the two stay in
- * sync — used to assert the "Install via mod page" link targets a required mod.
+ * (5382 / 49098) — used to assert the "Install via mod page" link targets a
+ * required mod. A static literal with the '.' escaped (deriving it from
+ * SDV_FILE_REQUIREMENT_TARGET_URLS trips CodeQL's "incomplete hostname regex");
+ * keep the ids in sync with that list by hand.
  */
-export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN = new RegExp(
-  `nexusmods\\.com/stardewvalley/mods/(${SDV_FILE_REQUIREMENT_TARGET_URLS.map((url) =>
-    url.split("/").pop(),
-  ).join("|")})$`,
-);
+export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN =
+  /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/;
 
 /**
  * SDV mod that declares a single page-level ("mod") requirement — Generic Mod

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -28,6 +28,17 @@ export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
 ];
 
 /**
+ * Matches an externally-opened URL that points at one of the required mods' pages
+ * (5382 / 49098). Derived from SDV_FILE_REQUIREMENT_TARGET_URLS so the two stay in
+ * sync — used to assert the "Install via mod page" link targets a required mod.
+ */
+export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN = new RegExp(
+  `nexusmods\\.com/stardewvalley/mods/(${SDV_FILE_REQUIREMENT_TARGET_URLS.map((url) =>
+    url.split("/").pop(),
+  ).join("|")})$`,
+);
+
+/**
  * SDV mod that declares a single page-level ("mod") requirement — Generic Mod
  * Config Menu (5098), which requires SMAPI. Installed on its own (SMAPI absent) it
  * drives one blue Health Check *suggestion* ("Additional mod file may be required

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -4,3 +4,10 @@
  */
 
 export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
+
+/**
+ * SDV mod whose installed file declares a file-level requirement on SMAPI
+ * (mods/2400). Installed on its own (SMAPI absent) it drives a file-requirements
+ * Health Check warning — the fixture for the LAZ-684 warning/install flow.
+ */
+export const SDV_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/1915";

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -14,3 +14,15 @@ export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
  * dedicated installer.
  */
 export const SDV_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/49786";
+
+/**
+ * The two mods whose files SDV_FILE_REQUIREMENT_MOD_URL (49786) requires: Item Bags
+ * (5382) and Pokemon Eggventure - Day Care (49098). Downloading both from the website
+ * is the manual flow a free user follows to satisfy the requirements and clear the
+ * warning (a free user can't 1-click install). Fixture-specific — if 49786's declared
+ * requirements change, update this list.
+ */
+export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
+  "https://www.nexusmods.com/stardewvalley/mods/5382",
+  "https://www.nexusmods.com/stardewvalley/mods/49098",
+];

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -6,8 +6,11 @@
 export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
 
 /**
- * SDV mod whose installed file declares a file-level requirement on SMAPI
- * (mods/2400). Installed on its own (SMAPI absent) it drives a file-requirements
- * Health Check warning — the fixture for the LAZ-684 warning/install flow.
+ * SDV mod with a single main file that declares two file-level requirements.
+ * Installed on its own (those required files absent) it drives one file-requirements
+ * Health Check warning covering both — the fixture for the LAZ-684 warning/install
+ * flow. Chosen to have a single main file so the download uses the main mod page
+ * (the proven Mod-Manager flow), and not SMAPI, which Vortex special-cases with a
+ * dedicated installer.
  */
-export const SDV_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/1915";
+export const SDV_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/49786";

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -23,6 +23,7 @@ import { manageGame, type ManagedGame } from "../helpers/games";
 import { stubRemoteImages } from "../helpers/imageStub";
 import { loginToNexus } from "../helpers/login";
 import { launchNexusBrowser } from "../helpers/nexusBrowser";
+import { neutralizeOsProtocolRegistration } from "../helpers/protocolClient";
 import { Timeouts } from "../helpers/timeouts";
 import type { NexusUser } from "../helpers/users";
 import {
@@ -377,6 +378,10 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
       timeout: Timeouts.LIFECYCLE,
       inspect: !!process.env.VORTEX_E2E_INSPECT,
     });
+    // Test-side replacement for the removed production VORTEX_E2E gate: stop this
+    // instance from seizing the OS nxm:// handler. Runs before the renderer's
+    // deferred protocol registration (launchVortexApp returns at app-ready).
+    await neutralizeOsProtocolRegistration(app);
     await use(app);
     await closeElectronApp(app);
   },

--- a/packages/e2e/src/fixtures/vortex-app.ts
+++ b/packages/e2e/src/fixtures/vortex-app.ts
@@ -12,6 +12,7 @@ import {
 } from "@playwright/test";
 
 import { cleanupFakeGame } from "../fixtures/game-setup/fake-game";
+import { authStatePath } from "../helpers/authState";
 import {
   type DiagnosticsTeardown,
   instrumentNexusPage,
@@ -292,9 +293,15 @@ export const test = base.extend<VortexTestFixtures & VortexOptions, VortexWorker
             try {
               const window = await setupMainWindow(app, Timeouts.SNAPSHOT);
               windowTeardown = await instrumentVortexWindow(app, window, "snapshot");
+              // Reuse a locally-captured Nexus session (pnpm auth:capture) so the
+              // OAuth flow lands on the consent screen and skips the captcha-gated
+              // credential login. Absent on CI → full OAuth credential flow, unchanged.
+              const capturedState = authStatePath(user);
+              const seededStorageState = fs.existsSync(capturedState) ? capturedState : undefined;
               const loginResult = await loginToNexus(app, window, user, {
                 skipSteps: true,
                 keepBrowser: true,
+                storageStatePath: seededStorageState,
                 nexusDiagnostics: { testInfo, prefix: "snapshot-nexus" },
               });
               if (loginResult !== null) {

--- a/packages/e2e/src/helpers/authState.ts
+++ b/packages/e2e/src/helpers/authState.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+import type { NexusUser } from "./users";
+
+/**
+ * Directory holding captured Nexus website session storage-state files.
+ *
+ * Populated by `pnpm -F @vortex/e2e auth:capture` (a one-time headed login where
+ * you solve the captcha by hand) and consumed by the auth-snapshot fixture to
+ * skip the captcha-gated credential login on local runs. Gitignored — the files
+ * contain live session cookies and must never be committed. Absent on CI, so the
+ * fixture falls back to the full OAuth credential flow there.
+ */
+export const AUTH_DIR = path.resolve(import.meta.dirname, "..", "..", ".auth");
+
+/** Path to the captured storage-state file for a user, keyed by username. */
+export function authStatePath(user: NexusUser): string {
+  const safe = user.username.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(AUTH_DIR, `${safe}.json`);
+}

--- a/packages/e2e/src/helpers/consent.ts
+++ b/packages/e2e/src/helpers/consent.ts
@@ -2,28 +2,28 @@ import type { Page } from "@playwright/test";
 
 import { CookieConsent } from "../selectors/cookieConsent";
 
+// The consent CMP loads asynchronously after navigation, so wait briefly for an
+// accept control to appear rather than checking once (which races the dialog and
+// usually misses it). Best-effort: pages without a CMP just wait out the timeout.
+const CONSENT_WAIT_MS = 8_000;
+
 // Accept rather than dismiss — some download-flow JS is gated on consent state.
 export async function acceptConsent(page: Page): Promise<void> {
   const consent = new CookieConsent(page);
-  const candidates = [
-    consent.quantcastAccept,
-    consent.cookiebotAllowAll,
-    consent.cookiebotAcceptId,
-  ];
-  for (const locator of candidates) {
-    if (
-      await locator
-        .first()
-        .isVisible()
-        .catch(() => false)
-    ) {
-      await locator
-        .first()
-        .click()
-        .catch(() => undefined);
-      return;
-    }
+  const accept = consent.quantcastAccept
+    .or(consent.cookiebotAllowAll)
+    .or(consent.cookiebotAcceptId)
+    .first();
+
+  const appeared = await accept
+    .waitFor({ state: "visible", timeout: CONSENT_WAIT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (appeared) {
+    await accept.click().catch(() => undefined);
+    return;
   }
+
   // Quantcast can render inside an iframe.
   for (const frame of page.frames()) {
     const acceptInFrame = frame.locator("button#accept-btn, button:has-text('Allow all')").first();

--- a/packages/e2e/src/helpers/externalOpen.ts
+++ b/packages/e2e/src/helpers/externalOpen.ts
@@ -1,0 +1,33 @@
+import { type ElectronApplication } from "@playwright/test";
+
+/**
+ * Spy on the main-process `shell.openExternal` so a test can observe — and
+ * suppress — the URLs the app would open in the OS default browser (e.g. the
+ * "Install via mod page" links). Those otherwise launch the user's real browser,
+ * a detached process outside Playwright's control, so the click can't be followed.
+ *
+ * The renderer's opn() routes through the "shell:openUrl" IPC to main's openUrl(),
+ * which calls shell.openExternal — the singleton patched here (see src/main/src/
+ * open.ts). Call installExternalOpenSpy before the action, then readExternalOpens.
+ */
+export async function installExternalOpenSpy(vortexApp: ElectronApplication): Promise<void> {
+  await vortexApp.evaluate(({ shell }) => {
+    const store = globalThis as unknown as { __externalOpens?: string[] };
+    store.__externalOpens = [];
+    // Record and swallow: actually opening the OS browser would escape the test
+    // and isn't observable anyway.
+    (shell as unknown as { openExternal: (url: string) => Promise<void> }).openExternal = (
+      url: string,
+    ) => {
+      store.__externalOpens?.push(url);
+      return Promise.resolve();
+    };
+  });
+}
+
+/** The URLs passed to shell.openExternal since installExternalOpenSpy was called. */
+export async function readExternalOpens(vortexApp: ElectronApplication): Promise<string[]> {
+  return vortexApp.evaluate(
+    () => (globalThis as unknown as { __externalOpens?: string[] }).__externalOpens ?? [],
+  );
+}

--- a/packages/e2e/src/helpers/games.ts
+++ b/packages/e2e/src/helpers/games.ts
@@ -27,12 +27,19 @@ export async function manageGame(
     const navbar = new NavBar(vortexWindow);
     const gamesPage = new GamesPage(vortexWindow);
 
-    await expect(navbar.gamesLink).toBeVisible();
+    // First interaction after a cold app launch — allow the nav to finish
+    // mounting rather than racing the default 5s UI budget.
+    await expect(navbar.gamesLink).toBeVisible({ timeout: Timeouts.NETWORK });
     await navbar.gamesLink.click();
 
     await electronApp.evaluate(({ dialog }, gamePath) => {
       dialog.showOpenDialog = () => Promise.resolve({ canceled: false, filePaths: [gamePath] });
     }, fakeGame.gamePath);
+
+    // The unmanaged games list is paginated/windowed, so the target game's row
+    // isn't in the DOM until the list is filtered down to it. Search by name first.
+    await expect(gamesPage.searchInput).toBeVisible();
+    await gamesPage.searchInput.fill(gameName);
 
     const row = gamesPage.gameRow(gameName);
     await expect(row).toBeVisible({ timeout: Timeouts.NETWORK });

--- a/packages/e2e/src/helpers/healthCheck.ts
+++ b/packages/e2e/src/helpers/healthCheck.ts
@@ -1,8 +1,13 @@
 import { type ElectronApplication, expect, type Page } from "@playwright/test";
 
-import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
+import { SDV_FILE_REQUIREMENT_MOD_URL, SDV_MOD_REQUIREMENT_MOD_URL } from "../constants";
 import { test } from "../fixtures/vortex-app";
-import { HealthCheckDetail, HealthCheckPage, HealthCheckWarnings } from "../selectors/healthCheck";
+import {
+  HealthCheckDetail,
+  HealthCheckPage,
+  HealthCheckSuggestions,
+  HealthCheckWarnings,
+} from "../selectors/healthCheck";
 import { downloadModViaModManager } from "./modDownload";
 import { navigateToHealthCheck } from "./navigation";
 import { dismissAllNotifications } from "./notifications";
@@ -60,4 +65,34 @@ export async function openWarningDetail(
   });
 
   return detail;
+}
+
+/**
+ * Install the mod-requirement fixture mod (46415) with its required mod absent,
+ * open Health Check and refresh — leaving the single page-level requirement
+ * "suggestion" visible on the list. Returns the page + suggestions POMs.
+ *
+ * The suggestion is populated by the mod-requirements check's Nexus round-trip
+ * (slower than the file check), so the wait uses the network budget.
+ */
+export async function openModRequirementSuggestion(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<{ hc: HealthCheckPage; suggestions: HealthCheckSuggestions }> {
+  const hc = new HealthCheckPage(vortexWindow);
+  const suggestions = new HealthCheckSuggestions(vortexWindow);
+
+  await test.step("Install a mod that declares a page-level requirement", async () => {
+    await downloadModViaModManager(nexusPage, vortexApp, SDV_MOD_REQUIREMENT_MOD_URL);
+  });
+
+  await test.step("Open Health Check and refresh", async () => {
+    await navigateToHealthCheck(vortexWindow);
+    await hc.refreshButton.click();
+    await expect(suggestions.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+    await dismissAllNotifications(vortexWindow);
+  });
+
+  return { hc, suggestions };
 }

--- a/packages/e2e/src/helpers/healthCheck.ts
+++ b/packages/e2e/src/helpers/healthCheck.ts
@@ -57,10 +57,7 @@ export async function openWarningDetail(
   const detail = new HealthCheckDetail(vortexWindow);
 
   await test.step("Open the warning detail view", async () => {
-    await warnings
-      .row()
-      .getByText(/Missing required mods? for:/)
-      .click();
+    await warnings.title().click();
     await expect(detail.warningTitle).toBeVisible();
   });
 

--- a/packages/e2e/src/helpers/healthCheck.ts
+++ b/packages/e2e/src/helpers/healthCheck.ts
@@ -1,0 +1,63 @@
+import { type ElectronApplication, expect, type Page } from "@playwright/test";
+
+import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
+import { test } from "../fixtures/vortex-app";
+import { HealthCheckDetail, HealthCheckPage, HealthCheckWarnings } from "../selectors/healthCheck";
+import { downloadModViaModManager } from "./modDownload";
+import { navigateToHealthCheck } from "./navigation";
+import { dismissAllNotifications } from "./notifications";
+import { Timeouts } from "./timeouts";
+
+/**
+ * Install the file-requirement fixture mod (49786) with its required files absent,
+ * open Health Check and refresh — leaving the single file-requirements warning
+ * visible on the list. Returns the page + warnings POMs for the caller to drive.
+ *
+ * Shared by every file-requirement test so the download → open → refresh flow lives
+ * in one place; uses `test.step` internally so each test's trace stays granular.
+ */
+export async function openFileRequirementWarning(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<{ hc: HealthCheckPage; warnings: HealthCheckWarnings }> {
+  const hc = new HealthCheckPage(vortexWindow);
+  const warnings = new HealthCheckWarnings(vortexWindow);
+
+  await test.step("Install the requiring mod with its required files absent", async () => {
+    await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+  });
+
+  await test.step("Open Health Check and refresh", async () => {
+    await navigateToHealthCheck(vortexWindow);
+    await hc.refreshButton.click();
+    await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+    // Persistent notifications auto-open a tray that overlays the top-right and
+    // intercepts clicks on the tabs' buttons and a row's hide/feedback icons;
+    // clear it once the check has settled so it stays shut.
+    await dismissAllNotifications(vortexWindow);
+  });
+
+  return { hc, warnings };
+}
+
+/**
+ * Open the sole warning's detail view from the list and confirm it rendered.
+ * Returns the detail POM.
+ */
+export async function openWarningDetail(
+  vortexWindow: Page,
+  warnings: HealthCheckWarnings,
+): Promise<HealthCheckDetail> {
+  const detail = new HealthCheckDetail(vortexWindow);
+
+  await test.step("Open the warning detail view", async () => {
+    await warnings
+      .row()
+      .getByText(/Missing required mods? for:/)
+      .click();
+    await expect(detail.warningTitle).toBeVisible();
+  });
+
+  return detail;
+}

--- a/packages/e2e/src/helpers/modDownload.ts
+++ b/packages/e2e/src/helpers/modDownload.ts
@@ -35,15 +35,17 @@ export async function downloadModViaModManager(
     await expect(modPage.modManagerDownload).toBeVisible({ timeout: Timeouts.NETWORK });
     await modPage.modManagerDownload.click({ timeout: Timeouts.NETWORK });
 
+    // A mod with file-level requirements opens the "Download mod file" modal
+    // before emitting nxm://; its primary Download action fires it. Mods without
+    // requirements skip the modal (nxm:// fires on the click above), so bound the
+    // wait rather than blocking on the default 30s timeout for that case.
     if (
       await modPage.downloadModal
-        .waitFor({ state: "visible" })
+        .waitFor({ state: "visible", timeout: Timeouts.MODAL })
         .then(() => true)
         .catch(() => false)
     ) {
-      if (await modPage.modalDownloadLink.isVisible().catch(() => false)) {
-        await modPage.modalDownloadLink.click({ timeout: Timeouts.NETWORK });
-      }
+      await modPage.modalDownloadLink.click({ timeout: Timeouts.NETWORK });
     }
 
     await nexusPage.waitForLoadState("load", { timeout: Timeouts.NETWORK }).catch(() => undefined);

--- a/packages/e2e/src/helpers/navigation.ts
+++ b/packages/e2e/src/helpers/navigation.ts
@@ -10,6 +10,17 @@ export async function navigateToSettings(page: Page): Promise<void> {
 }
 
 /**
+ * Navigate to the per-game Health Check page via its sidebar entry. Requires a
+ * managed, active game (the entry only renders inside the per-game workspace).
+ * The sidebar label is "Health check" (lower-case "c"), distinct from the
+ * "Health Check" page heading, so match exactly to avoid selecting the heading.
+ */
+export async function navigateToHealthCheck(page: Page): Promise<void> {
+  await page.getByText("Health check", { exact: true }).first().click();
+  await expect(page.locator("#health-check-page")).toBeVisible();
+}
+
+/**
  * Navigate to the Games page via the home/games link.
  */
 export async function navigateToGames(page: Page): Promise<void> {

--- a/packages/e2e/src/helpers/notifications.ts
+++ b/packages/e2e/src/helpers/notifications.ts
@@ -1,0 +1,38 @@
+import { type Page } from "@playwright/test";
+
+/**
+ * Dismiss all on-screen notifications.
+ *
+ * Vortex's Header renders notifications in a HeadlessUI Popover anchored to the
+ * nav bell (see views/components/Header/Notifications). The tray AUTO-OPENS
+ * whenever a new notification arrives, and its panel is `absolute right-0` — so
+ * it hangs down over the top-right of the content and intercepts pointer events
+ * on right-aligned controls (the Health Check tabs' action buttons and a warning
+ * row's hide/feedback icons). Startup notifications ("SMAPI is not installed",
+ * "Vortex X is available", the privacy prompt, …) don't auto-expire, so the tray
+ * lingers. Clear it before interacting with any such control.
+ *
+ * The bell's accessible name is its unread-count badge, so target it by its
+ * `title` instead. Open the tray if it's collapsed (so the per-item "Dismiss"
+ * buttons are in the DOM), then dismiss every item; once the last one goes the
+ * tray unmounts. Bounded in case a notification re-fires mid-loop.
+ */
+export async function dismissAllNotifications(page: Page): Promise<void> {
+  const bell = page.getByTitle("Notifications", { exact: true }).first();
+  if (
+    (await bell.count()) > 0 &&
+    (await bell.isEnabled()) &&
+    (await bell.getAttribute("aria-expanded")) !== "true"
+  ) {
+    await bell.click().catch(() => undefined);
+  }
+
+  const dismiss = page.getByRole("button", { name: "Dismiss", exact: true });
+  for (let attempt = 0; attempt < 12; attempt++) {
+    if ((await dismiss.count()) === 0) return;
+    await dismiss
+      .first()
+      .click()
+      .catch(() => undefined);
+  }
+}

--- a/packages/e2e/src/helpers/protocolClient.ts
+++ b/packages/e2e/src/helpers/protocolClient.ts
@@ -1,0 +1,32 @@
+import { type ElectronApplication } from "@playwright/test";
+
+/**
+ * Keep the E2E-launched Vortex from taking over the OS `nxm://` protocol
+ * association. On a dev machine with Vortex installed, registering it would
+ * hijack the nxm:// hand-off the download specs must capture inside the test
+ * browser — and clobber the developer's real Vortex registration. In-app nxm
+ * handling (the "external-url" IPC) is unaffected, so forwarded downloads still
+ * install.
+ *
+ * The renderer registers the protocol through the "app:setProtocolClient" IPC,
+ * which calls app.setAsDefaultProtocolClient. We patch that main-process method
+ * to clear the association instead of setting it — the same test-side approach
+ * installExternalOpenSpy uses for shell.openExternal, so no E2E-only branch is
+ * needed in production. Call once per launch, before the renderer's (deferred)
+ * registration runs; the vortexApp fixture does so right after launch.
+ */
+export async function neutralizeOsProtocolRegistration(
+  vortexApp: ElectronApplication,
+): Promise<void> {
+  await vortexApp.evaluate(({ app }) => {
+    const proto = app as unknown as {
+      setAsDefaultProtocolClient: (protocol: string, path?: string, args?: string[]) => boolean;
+      removeAsDefaultProtocolClient: (protocol: string, path?: string, args?: string[]) => boolean;
+    };
+    const remove = proto.removeAsDefaultProtocolClient.bind(app);
+    proto.setAsDefaultProtocolClient = (protocol, path, args) => {
+      remove(protocol, path, args);
+      return false;
+    };
+  });
+}

--- a/packages/e2e/src/helpers/timeouts.ts
+++ b/packages/e2e/src/helpers/timeouts.ts
@@ -17,6 +17,8 @@ export const GlobalTimeouts = {
 export const Timeouts = {
   /** For assertions or actions that depend on a network round-trip. */
   NETWORK: sec(30) * scalingFactor,
+  /** Bounded wait for a client-rendered modal to appear (or confirm it won't). */
+  MODAL: sec(10) * scalingFactor,
   /** Cold-start and worker fixture setup. */
   LIFECYCLE: min(3) * scalingFactor,
   /** Worker-scoped auth snapshot build: cold Electron start + OAuth flow + flush margin. */

--- a/packages/e2e/src/selectors/games.ts
+++ b/packages/e2e/src/selectors/games.ts
@@ -2,9 +2,16 @@ import type { Locator, Page } from "@playwright/test";
 
 export class GamesPage {
   readonly page: Page;
+  /**
+   * Filter box for the games picker (placeholder "Search games..."). The
+   * unmanaged list is paginated/windowed, so narrowing it by name is the only
+   * reliable way to bring a specific game's row into the DOM.
+   */
+  readonly searchInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
+    this.searchInput = page.getByRole("textbox", { name: /search games/i }).first();
   }
 
   gameRow(gameName: string): Locator {

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -91,6 +91,15 @@ export class HealthCheckWarnings {
   }
 
   /**
+   * The warning's title text element ("Missing required mod(s) for: …"). Use for
+   * hover/click targets and title-copy assertions; the regex tolerates the
+   * singular/plural forms. Pass the required mod name only to disambiguate.
+   */
+  title(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByText(/Missing required mods? for:/);
+  }
+
+  /**
    * The "1-click install" button inside a warning row. Label is "1-click install"
    * for a single requirement and "1-click install (N)" for several, so match on
    * the prefix rather than an exact string.
@@ -129,7 +138,6 @@ export class HealthCheckDetail {
   readonly root: Locator;
   readonly warningTitle: Locator;
   readonly backButton: Locator;
-  readonly requiresFileLine: Locator;
   readonly installViaModPageButton: Locator;
   readonly installOneClickButton: Locator;
   readonly installRequiredHeader: Locator;
@@ -144,12 +152,6 @@ export class HealthCheckDetail {
     // Severity title heading ("Warning") + a "BETA" badge sit in the header.
     this.warningTitle = this.root.getByRole("heading", { name: "Warning" });
     this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
-    // Detail subtitle for a missing "download" requirement (shared::requires_files
-    // via useReportCopy). Count-tolerant: "Requires 1 additional mod file …" or
-    // "Requires N additional mod files …".
-    this.requiresFileLine = this.root.getByText(
-      /Requires \d+ additional mod files? to be installed to work correctly/,
-    );
     // With several requirements the detail renders one card per required mod, so
     // these controls can appear multiple times — take the first.
     this.installViaModPageButton = this.root
@@ -171,6 +173,18 @@ export class HealthCheckDetail {
     this.feedbackPrompt = this.root.getByText("Was this warning helpful?");
     this.feedbackThanks = this.root.getByText("Thanks for your feedback");
     this.notHelpfulButton = this.root.getByRole("button", { name: "Not helpful", exact: true });
+  }
+
+  /**
+   * The "download" requirement summary for a given outstanding count
+   * (shared::requires_files via useReportCopy), e.g. requiresFileSummary(2) →
+   * "Requires 2 additional mod files to be installed to work correctly". Encodes
+   * the singular/plural copy so tests assert the count without an inline string.
+   */
+  requiresFileSummary(count: number): Locator {
+    return this.root.getByText(
+      `Requires ${count} additional mod ${count === 1 ? "file" : "files"} to be installed to work correctly`,
+    );
   }
 
   /** The requirement card row for a required mod (e.g. /SMAPI/i). */
@@ -287,6 +301,20 @@ export class HealthCheckSuggestions {
     return (
       requiringModName === undefined ? rows : rows.filter({ hasText: requiringModName })
     ).first();
+  }
+
+  /**
+   * The suggestion's title text element ("Additional mod file(s) may be required
+   * for: …"); use for click/visibility. The regex tolerates the singular/plural
+   * forms. Pass the requiring mod name only to disambiguate.
+   */
+  title(requiringModName?: string | RegExp): Locator {
+    return this.row(requiringModName).getByText(/Additional mod files? may be required for:/);
+  }
+
+  /** The "Missing mod: <name>" line inside a suggestion row. */
+  missingMod(requiringModName?: string | RegExp): Locator {
+    return this.row(requiringModName).getByText(/Missing mod:/);
   }
 
   /** The "1-click install" button inside a suggestion row (always a single required mod). */

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -60,22 +60,31 @@ export class HealthCheckWarnings {
   }
 
   /**
-   * The list row for a missing-requirement warning, identified by the
-   * "Missing required mod for:" title and the required mod's name (e.g. /SMAPI/i).
-   * The row is a `role="button"` container; filtering by the title text excludes
-   * the header/action buttons that also carry that role.
+   * The list row for a missing-requirement warning, identified by its
+   * "Missing required mod(s) for:" title (singular or plural, depending on how
+   * many requirements the source file has). Pass the required mod's name (e.g.
+   * /SMAPI/i) only to disambiguate when several such warnings are present; omit
+   * it to target the sole warning. The row is a `role="button"` container;
+   * filtering by the title text excludes the header/action buttons that also
+   * carry that role, and the mod-requirement ("Additional mod file may be
+   * required for:") rows, so this matches file-requirement warnings only.
    */
-  row(requiredModName: string | RegExp): Locator {
-    return this.root
+  row(requiredModName?: string | RegExp): Locator {
+    const rows = this.root
       .locator('[role="button"]')
-      .filter({ hasText: /Missing required mod for:/ })
-      .filter({ hasText: requiredModName })
-      .first();
+      .filter({ hasText: /Missing required mods? for:/ });
+    return (
+      requiredModName === undefined ? rows : rows.filter({ hasText: requiredModName })
+    ).first();
   }
 
-  /** The single-file "1-click install" button inside a warning row. */
-  installOneClick(requiredModName: string | RegExp): Locator {
-    return this.row(requiredModName).getByRole("button", { name: "1-click install", exact: true });
+  /**
+   * The "1-click install" button inside a warning row. Label is "1-click install"
+   * for a single requirement and "1-click install (N)" for several, so match on
+   * the prefix rather than an exact string.
+   */
+  installOneClick(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: /1-click install/ });
   }
 }
 
@@ -98,17 +107,20 @@ export class HealthCheckDetail {
     // Severity title heading ("Warning") + a "BETA" badge sit in the header.
     this.warningTitle = this.root.getByRole("heading", { name: "Warning" });
     this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
-    // Detail subtitle for a single missing "download" requirement. Sourced from
-    // the shared::requires_files locale key (via useReportCopy) — matched by a
-    // stable substring so the trailing "additional …:" wording can't re-break it.
+    // Detail subtitle for a missing "download" requirement (shared::requires_files
+    // via useReportCopy). Count-tolerant: "Requires 1 additional mod file …" or
+    // "Requires N additional mod files …".
     this.requiresFileLine = this.root.getByText(
-      /Requires 1 additional mod file to be installed to work correctly/,
+      /Requires \d+ additional mod files? to be installed to work correctly/,
     );
-    this.installViaModPageButton = this.root.getByRole("button", { name: "Install via mod page" });
-    this.installOneClickButton = this.root.getByRole("button", {
-      name: "1-click install",
-      exact: true,
-    });
+    // With several requirements the detail renders one card per required mod, so
+    // these controls can appear multiple times — take the first.
+    this.installViaModPageButton = this.root
+      .getByRole("button", { name: "Install via mod page" })
+      .first();
+    this.installOneClickButton = this.root
+      .getByRole("button", { name: /^1-click install$/ })
+      .first();
   }
 
   /** The requirement card row for a required mod (e.g. /SMAPI/i). */

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -277,3 +277,76 @@ export class HealthCheckFeedbackModal {
     this.skipButton = this.root.getByRole("button", { name: "Skip", exact: true });
   }
 }
+
+/**
+ * Mod-requirement "suggestions" as they appear in the Health Check list. A missing
+ * page-level (mod-to-mod) requirement renders a blue Suggestion row titled
+ * "Additional mod file may be required for: <requiring mod>" (severity "suggestion"
+ * → info/blue; see components/mod_requirement/ListingRow.tsx). Distinct from the
+ * yellow file-requirement warnings ("Missing required mods for: …").
+ */
+export class HealthCheckSuggestions {
+  readonly page: Page;
+  readonly root: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator("#health-check-page");
+  }
+
+  /**
+   * The suggestion row, identified by its "Additional mod file may be required
+   * for:" title. Pass the requiring mod's name to disambiguate when several are
+   * present; omit it to target the sole suggestion.
+   */
+  row(requiringModName?: string | RegExp): Locator {
+    const rows = this.root
+      .locator('[role="button"]')
+      .filter({ hasText: /Additional mod files? may be required for:/ });
+    return (
+      requiringModName === undefined ? rows : rows.filter({ hasText: requiringModName })
+    ).first();
+  }
+
+  /** The "1-click install" button inside a suggestion row (always a single required mod). */
+  installOneClick(requiringModName?: string | RegExp): Locator {
+    return this.row(requiringModName).getByRole("button", { name: /1-click install/ });
+  }
+}
+
+/**
+ * The expanded detail for a mod-requirement suggestion (mod_requirement/DetailView,
+ * inside #health-check-detail-page). The severity heading is "Suggestion" (vs the
+ * file requirement's "Warning"), and it carries the distinctive "identified from the
+ * mod page" disclaimer plus a suggestion-worded feedback prompt.
+ */
+export class HealthCheckSuggestionDetail {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly suggestionTitle: Locator;
+  readonly backButton: Locator;
+  readonly mayRequireLine: Locator;
+  readonly modPageSourceNote: Locator;
+  readonly feedbackPrompt: Locator;
+  readonly installViaModPageButton: Locator;
+  readonly installOneClickButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator("#health-check-detail-page");
+    // Severity heading rendered by HealthCheckDetailPage as detail::title::suggestion.
+    this.suggestionTitle = this.root.getByRole("heading", { name: "Suggestion" });
+    this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
+    this.mayRequireLine = this.root.getByText(
+      "May require this additional mod file to be installed to work correctly",
+    );
+    // The "identified from the mod page rather than the file-level requirement
+    // system" disclaimer that marks this as a page-level suggestion, not a warning.
+    this.modPageSourceNote = this.root.getByText(
+      /identified from the mod page rather than the file-level requirement system/,
+    );
+    this.feedbackPrompt = this.root.getByText("Was this suggestion helpful?");
+    this.installViaModPageButton = this.root.getByRole("button", { name: "Install via mod page" });
+    this.installOneClickButton = this.root.getByRole("button", { name: /^1-click install$/ });
+  }
+}

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -1,0 +1,153 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Health Check page — the per-game main page registered by the health_check
+ * extension. Reached from the sidebar entry titled "Health check" (lower-case
+ * "c", distinct from the "Health Check" page heading).
+ */
+export class HealthCheckPage {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly title: Locator;
+  readonly betaBadge: Locator;
+  readonly subtitle: Locator;
+  readonly refreshButton: Locator;
+  readonly settingsButton: Locator;
+  readonly lastUpdated: Locator;
+  readonly emptyStateTitle: Locator;
+  readonly emptyStateMessage: Locator;
+  readonly premiumBanner: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator("#health-check-page");
+    // Page heading (PageHeader renders the title as an <h2>). Capitalised
+    // "Health Check" distinguishes it from both the lower-case "Health check"
+    // sidebar entry and the "Health check passed" empty-state title.
+    this.title = this.root.getByRole("heading", { name: "Health Check" });
+    // "Beta" pill next to the title (BetaBadge → common:::beta).
+    this.betaBadge = this.root.getByText("Beta", { exact: true });
+    this.subtitle = this.root.getByText(
+      "Review your Loadout for any issues and learn how to resolve them if needed.",
+    );
+    // Icon-only header buttons; their accessible name comes from the `title` prop.
+    this.refreshButton = this.root.getByRole("button", { name: "Refresh" });
+    this.settingsButton = this.root.getByRole("button", { name: "Settings" });
+    this.lastUpdated = this.root.getByText(/Last updated:/);
+    this.emptyStateTitle = this.root.getByText("Health check passed");
+    this.emptyStateMessage = this.root.getByText("Ready for gaming");
+    // Free-user upsell banner; the "<premiumLink>Go premium</premiumLink>" is a
+    // separate node, so match on the leading sentence only.
+    this.premiumBanner = this.root.getByText(
+      "Download requirements in 1-click. No page visits or waiting.",
+    );
+  }
+}
+
+/**
+ * File-requirement warnings as they appear in the Health Check *list*. A missing
+ * required mod renders a row titled "Missing required mod for: <source mod>" with
+ * the required mod's name and a "1-click install" action (see
+ * components/file_requirement/ListingRow.tsx + hooks/useReportCopy.ts).
+ */
+export class HealthCheckWarnings {
+  readonly page: Page;
+  readonly root: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator("#health-check-page");
+  }
+
+  /**
+   * The list row for a missing-requirement warning, identified by the
+   * "Missing required mod for:" title and the required mod's name (e.g. /SMAPI/i).
+   * The row is a `role="button"` container; filtering by the title text excludes
+   * the header/action buttons that also carry that role.
+   */
+  row(requiredModName: string | RegExp): Locator {
+    return this.root
+      .locator('[role="button"]')
+      .filter({ hasText: /Missing required mod for:/ })
+      .filter({ hasText: requiredModName })
+      .first();
+  }
+
+  /** The single-file "1-click install" button inside a warning row. */
+  installOneClick(requiredModName: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "1-click install", exact: true });
+  }
+}
+
+/**
+ * The expanded Health Check detail page (HealthCheckDetailPage + the file
+ * requirement DetailView). Shown after opening a warning row; replaces the list.
+ */
+export class HealthCheckDetail {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly warningTitle: Locator;
+  readonly backButton: Locator;
+  readonly requiresFileLine: Locator;
+  readonly installViaModPageButton: Locator;
+  readonly installOneClickButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator("#health-check-detail-page");
+    // Severity title heading ("Warning") + a "BETA" badge sit in the header.
+    this.warningTitle = this.root.getByRole("heading", { name: "Warning" });
+    this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
+    // Detail subtitle for a single missing "download" requirement. Sourced from
+    // the shared::requires_files locale key (via useReportCopy) — matched by a
+    // stable substring so the trailing "additional …:" wording can't re-break it.
+    this.requiresFileLine = this.root.getByText(
+      /Requires 1 additional mod file to be installed to work correctly/,
+    );
+    this.installViaModPageButton = this.root.getByRole("button", { name: "Install via mod page" });
+    this.installOneClickButton = this.root.getByRole("button", {
+      name: "1-click install",
+      exact: true,
+    });
+  }
+
+  /** The requirement card row for a required mod (e.g. /SMAPI/i). */
+  requirementCard(requiredModName: string | RegExp): Locator {
+    return this.root.getByText(requiredModName).first();
+  }
+}
+
+/**
+ * Health Check settings section, rendered on Settings > Vortex tab
+ * (see SettingsHealthCheck.tsx). The file-requirements toggle only renders when
+ * the Unleash flag is present for the current user.
+ */
+export class HealthCheckSettings {
+  readonly page: Page;
+  readonly sectionTitle: Locator;
+  readonly description: Locator;
+  readonly modRequirementsToggle: Locator;
+  readonly fileRequirementsToggle: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.sectionTitle = page.getByText("Health Check (Beta)", { exact: true });
+    this.description = page.getByText(
+      "Detect issues with your mod list and suggest fixes. More checks are coming soon.",
+    );
+    this.modRequirementsToggle = this.toggle("Missing mod requirements suggestions");
+    this.fileRequirementsToggle = this.toggle("Missing file requirements warnings");
+  }
+
+  /**
+   * The clickable `.toggle` element for a labelled Health Check toggle. Mirrors
+   * SettingsPage.automationToggle: the shared Toggle control
+   * (src/renderer/src/controls/Toggle.tsx) exposes no accessible role, name, or
+   * checked state — identity comes from the visible label via `.filter({ hasText })`
+   * and on/off state from the `toggle-on` / `toggle-off` class (assert with
+   * toHaveClass). The app-side fix is to give Toggle `role="switch"` + `aria-checked`.
+   */
+  private toggle(label: string): Locator {
+    return this.page.locator(".toggle-container").filter({ hasText: label }).locator(".toggle");
+  }
+}

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -19,9 +19,6 @@ export class HealthCheckPage {
   readonly premiumBanner: Locator;
   readonly activeTab: Locator;
   readonly hiddenTab: Locator;
-  readonly hideAllButton: Locator;
-  readonly unhideAllButton: Locator;
-  readonly hiddenEmptyState: Locator;
   readonly installAllButton: Locator;
 
   constructor(page: Page) {
@@ -51,10 +48,6 @@ export class HealthCheckPage {
     // "(N)" count suffix, so match the name loosely and read the count via text).
     this.activeTab = this.root.getByRole("tab", { name: /Active/ });
     this.hiddenTab = this.root.getByRole("tab", { name: /Hidden/ });
-    // Bulk hide/unhide controls; the label gains a " (N)" suffix when non-zero.
-    this.hideAllButton = this.root.getByRole("button", { name: /Hide all/ });
-    this.unhideAllButton = this.root.getByRole("button", { name: /Unhide all/ });
-    this.hiddenEmptyState = this.root.getByText("No hidden items");
     // Page-level batch action in the tabs header ("1-click install all (N)");
     // installs the download candidates across all active warnings. Free users get
     // a Premium badge on it. Distinct from the detail group's install-all, which
@@ -107,16 +100,12 @@ export class HealthCheckWarnings {
   }
 
   /**
-   * The per-row EntryActions controls (thumbs + hide eye). In the list they're
+   * The per-row EntryActions controls (thumbs-down + hide eye). In the list they're
    * `invisible` until the row is hovered/focused, so hover the row first
    * (`await warnings.row().hover()`) before asserting/clicking these. Names are
-   * exact so "Hide" doesn't also match the header "Hide all" and "Helpful"
-   * doesn't match "Not helpful".
+   * exact so "Hide" doesn't also match the header "Hide all" and "Not helpful"
+   * matches only the thumbs-down.
    */
-  helpfulButton(requiredModName?: string | RegExp): Locator {
-    return this.row(requiredModName).getByRole("button", { name: "Helpful", exact: true });
-  }
-
   notHelpfulButton(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: "Not helpful", exact: true });
   }
@@ -147,7 +136,6 @@ export class HealthCheckDetail {
   readonly installAllInGroupButton: Locator;
   readonly feedbackPrompt: Locator;
   readonly feedbackThanks: Locator;
-  readonly helpfulButton: Locator;
   readonly notHelpfulButton: Locator;
 
   constructor(page: Page) {
@@ -178,11 +166,10 @@ export class HealthCheckDetail {
       .getByRole("button", { name: /1-click install all/ })
       .first();
     // EntryActions (detail variant): a prompt that flips to a thank-you once
-    // feedback is given, plus the thumbs controls (exact names so "Helpful"
-    // doesn't also match "Not helpful").
+    // feedback is given, plus the thumbs-down control (exact name so it doesn't
+    // match a "Helpful" button).
     this.feedbackPrompt = this.root.getByText("Was this warning helpful?");
     this.feedbackThanks = this.root.getByText("Thanks for your feedback");
-    this.helpfulButton = this.root.getByRole("button", { name: "Helpful", exact: true });
     this.notHelpfulButton = this.root.getByRole("button", { name: "Not helpful", exact: true });
   }
 
@@ -241,8 +228,6 @@ export class HealthCheckPremiumModal {
   readonly singleTitle: Locator;
   readonly benefitsTitle: Locator;
   readonly unlockButton: Locator;
-  readonly fallbackAllButton: Locator;
-  readonly fallbackSingleButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -251,8 +236,6 @@ export class HealthCheckPremiumModal {
     this.singleTitle = page.getByText("Skip the website and install instantly.");
     this.benefitsTitle = this.root.getByText("With Premium you get:");
     this.unlockButton = this.root.getByRole("button", { name: "Unlock 1-click installs" });
-    this.fallbackAllButton = this.root.getByRole("button", { name: "Return and open mod pages" });
-    this.fallbackSingleButton = this.root.getByRole("button", { name: "Go to mod page (free)" });
   }
 }
 
@@ -266,7 +249,6 @@ export class HealthCheckFeedbackModal {
   readonly title: Locator;
   readonly incorrectRequirement: Locator;
   readonly sendButton: Locator;
-  readonly skipButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -274,7 +256,6 @@ export class HealthCheckFeedbackModal {
     this.title = page.getByText("Thanks for letting us know");
     this.incorrectRequirement = this.root.getByText("Incorrect requirement");
     this.sendButton = this.root.getByRole("button", { name: "Send feedback" });
-    this.skipButton = this.root.getByRole("button", { name: "Skip", exact: true });
   }
 }
 
@@ -324,19 +305,15 @@ export class HealthCheckSuggestionDetail {
   readonly page: Page;
   readonly root: Locator;
   readonly suggestionTitle: Locator;
-  readonly backButton: Locator;
   readonly mayRequireLine: Locator;
   readonly modPageSourceNote: Locator;
   readonly feedbackPrompt: Locator;
-  readonly installViaModPageButton: Locator;
-  readonly installOneClickButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.root = page.locator("#health-check-detail-page");
     // Severity heading rendered by HealthCheckDetailPage as detail::title::suggestion.
     this.suggestionTitle = this.root.getByRole("heading", { name: "Suggestion" });
-    this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
     this.mayRequireLine = this.root.getByText(
       "May require this additional mod file to be installed to work correctly",
     );
@@ -346,7 +323,5 @@ export class HealthCheckSuggestionDetail {
       /identified from the mod page rather than the file-level requirement system/,
     );
     this.feedbackPrompt = this.root.getByText("Was this suggestion helpful?");
-    this.installViaModPageButton = this.root.getByRole("button", { name: "Install via mod page" });
-    this.installOneClickButton = this.root.getByRole("button", { name: /^1-click install$/ });
   }
 }

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -22,6 +22,7 @@ export class HealthCheckPage {
   readonly hideAllButton: Locator;
   readonly unhideAllButton: Locator;
   readonly hiddenEmptyState: Locator;
+  readonly installAllButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -54,6 +55,11 @@ export class HealthCheckPage {
     this.hideAllButton = this.root.getByRole("button", { name: /Hide all/ });
     this.unhideAllButton = this.root.getByRole("button", { name: /Unhide all/ });
     this.hiddenEmptyState = this.root.getByText("No hidden items");
+    // Page-level batch action in the tabs header ("1-click install all (N)");
+    // installs the download candidates across all active warnings. Free users get
+    // a Premium badge on it. Distinct from the detail group's install-all, which
+    // lives under #health-check-detail-page.
+    this.installAllButton = this.root.getByRole("button", { name: /1-click install all/ });
   }
 }
 

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -17,6 +17,11 @@ export class HealthCheckPage {
   readonly emptyStateTitle: Locator;
   readonly emptyStateMessage: Locator;
   readonly premiumBanner: Locator;
+  readonly activeTab: Locator;
+  readonly hiddenTab: Locator;
+  readonly hideAllButton: Locator;
+  readonly unhideAllButton: Locator;
+  readonly hiddenEmptyState: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -41,6 +46,14 @@ export class HealthCheckPage {
     this.premiumBanner = this.root.getByText(
       "Download requirements in 1-click. No page visits or waiting.",
     );
+    // Active / Hidden tabs (TabButton renders role="tab"; the label carries a
+    // "(N)" count suffix, so match the name loosely and read the count via text).
+    this.activeTab = this.root.getByRole("tab", { name: /Active/ });
+    this.hiddenTab = this.root.getByRole("tab", { name: /Hidden/ });
+    // Bulk hide/unhide controls; the label gains a " (N)" suffix when non-zero.
+    this.hideAllButton = this.root.getByRole("button", { name: /Hide all/ });
+    this.unhideAllButton = this.root.getByRole("button", { name: /Unhide all/ });
+    this.hiddenEmptyState = this.root.getByText("No hidden items");
   }
 }
 
@@ -86,6 +99,30 @@ export class HealthCheckWarnings {
   installOneClick(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: /1-click install/ });
   }
+
+  /**
+   * The per-row EntryActions controls (thumbs + hide eye). In the list they're
+   * `invisible` until the row is hovered/focused, so hover the row first
+   * (`await warnings.row().hover()`) before asserting/clicking these. Names are
+   * exact so "Hide" doesn't also match the header "Hide all" and "Helpful"
+   * doesn't match "Not helpful".
+   */
+  helpfulButton(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "Helpful", exact: true });
+  }
+
+  notHelpfulButton(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "Not helpful", exact: true });
+  }
+
+  /** The hide (eye-off) control; becomes "Unhide" once the row is hidden. */
+  hideButton(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "Hide", exact: true });
+  }
+
+  unhideButton(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "Unhide", exact: true });
+  }
 }
 
 /**
@@ -100,6 +137,12 @@ export class HealthCheckDetail {
   readonly requiresFileLine: Locator;
   readonly installViaModPageButton: Locator;
   readonly installOneClickButton: Locator;
+  readonly installRequiredHeader: Locator;
+  readonly installAllInGroupButton: Locator;
+  readonly feedbackPrompt: Locator;
+  readonly feedbackThanks: Locator;
+  readonly helpfulButton: Locator;
+  readonly notHelpfulButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -121,6 +164,20 @@ export class HealthCheckDetail {
     this.installOneClickButton = this.root
       .getByRole("button", { name: /^1-click install$/ })
       .first();
+    // "Install required" group header for the download report type (RequirementBody).
+    this.installRequiredHeader = this.root.getByText("Install required", { exact: true });
+    // Section-level batch button, rendered only when the group has >1 candidate
+    // ("1-click install all (N)"); free users additionally get a Premium badge.
+    this.installAllInGroupButton = this.root
+      .getByRole("button", { name: /1-click install all/ })
+      .first();
+    // EntryActions (detail variant): a prompt that flips to a thank-you once
+    // feedback is given, plus the thumbs controls (exact names so "Helpful"
+    // doesn't also match "Not helpful").
+    this.feedbackPrompt = this.root.getByText("Was this warning helpful?");
+    this.feedbackThanks = this.root.getByText("Thanks for your feedback");
+    this.helpfulButton = this.root.getByRole("button", { name: "Helpful", exact: true });
+    this.notHelpfulButton = this.root.getByRole("button", { name: "Not helpful", exact: true });
   }
 
   /** The requirement card row for a required mod (e.g. /SMAPI/i). */
@@ -161,5 +218,56 @@ export class HealthCheckSettings {
    */
   private toggle(label: string): Locator {
     return this.page.locator(".toggle-container").filter({ hasText: label }).locator(".toggle");
+  }
+}
+
+/**
+ * The Premium upsell modal (PremiumModal) a free user gets when clicking a
+ * 1-click install action. Copy differs by scope: a single requirement shows the
+ * "…install instantly." variant; several show the "…install all requirements
+ * instantly." variant (see premium::modal in locales/en/health_check.json).
+ * Rendered as a role="dialog" only while open.
+ */
+export class HealthCheckPremiumModal {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly allTitle: Locator;
+  readonly singleTitle: Locator;
+  readonly benefitsTitle: Locator;
+  readonly unlockButton: Locator;
+  readonly fallbackAllButton: Locator;
+  readonly fallbackSingleButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.getByRole("dialog").filter({ hasText: /Skip the website and install/ });
+    this.allTitle = page.getByText("Skip the website and install all requirements instantly.");
+    this.singleTitle = page.getByText("Skip the website and install instantly.");
+    this.benefitsTitle = this.root.getByText("With Premium you get:");
+    this.unlockButton = this.root.getByRole("button", { name: "Unlock 1-click installs" });
+    this.fallbackAllButton = this.root.getByRole("button", { name: "Return and open mod pages" });
+    this.fallbackSingleButton = this.root.getByRole("button", { name: "Go to mod page (free)" });
+  }
+}
+
+/**
+ * The "Not helpful" feedback modal (FeedbackModal), opened from the thumbs-down
+ * control. Rendered as a role="dialog" only while open.
+ */
+export class HealthCheckFeedbackModal {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly title: Locator;
+  readonly incorrectRequirement: Locator;
+  readonly sendButton: Locator;
+  readonly skipButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.getByRole("dialog").filter({ hasText: "Thanks for letting us know" });
+    this.title = page.getByText("Thanks for letting us know");
+    this.incorrectRequirement = this.root.getByText("Incorrect requirement");
+    this.sendButton = this.root.getByRole("button", { name: "Send feedback" });
+    this.skipButton = this.root.getByRole("button", { name: "Skip", exact: true });
   }
 }

--- a/packages/e2e/src/selectors/nexusModPage.ts
+++ b/packages/e2e/src/selectors/nexusModPage.ts
@@ -7,8 +7,9 @@ export class NexusModPage {
   readonly manualDownloadLink: Locator;
   readonly slowDownloadButton: Locator;
   /**
-   * Mod-manager download trigger. Free users see a "Mod manager download"
-   * link; premium users see a "Vortex" button — match either role.
+   * Mod-manager download trigger. Rendered as a "Mod manager download" control
+   * (a button on the Files tab, a link elsewhere) or, for premium on some pages,
+   * a "Vortex" button — match the name across either role.
    */
   readonly modManagerDownload: Locator;
   /** Confirmation/requirements modal shown by some download flows. */
@@ -21,7 +22,7 @@ export class NexusModPage {
     this.manualDownloadLink = page.getByRole("link", { name: /^manual( download)?$/i }).first();
     this.slowDownloadButton = page.getByRole("button", { name: "Slow download" }).first();
     this.modManagerDownload = page
-      .getByRole("button", { name: /^vortex$/i })
+      .getByRole("button", { name: /mod manager download|^vortex$/i })
       .or(page.getByRole("link", { name: /mod manager download|vortex/i }))
       .first();
     this.downloadModal = page.locator('.popup, .modal, [role="dialog"], #popup-content').first();

--- a/packages/e2e/src/selectors/nexusModPage.ts
+++ b/packages/e2e/src/selectors/nexusModPage.ts
@@ -12,9 +12,13 @@ export class NexusModPage {
    * a "Vortex" button — match the name across either role.
    */
   readonly modManagerDownload: Locator;
-  /** Confirmation/requirements modal shown by some download flows. */
+  /**
+   * The "Download mod file" confirmation modal that appears when a mod declares
+   * file-level requirements. Mods without requirements skip it and fire nxm://
+   * straight away.
+   */
   readonly downloadModal: Locator;
-  /** The "Download" link inside the confirmation modal (when present). */
+  /** The modal's primary main-file "Download" action (an anchor, sometimes a button). */
   readonly modalDownloadLink: Locator;
 
   constructor(page: Page) {
@@ -25,7 +29,20 @@ export class NexusModPage {
       .getByRole("button", { name: /mod manager download|^vortex$/i })
       .or(page.getByRole("link", { name: /mod manager download|vortex/i }))
       .first();
-    this.downloadModal = page.locator('.popup, .modal, [role="dialog"], #popup-content').first();
-    this.modalDownloadLink = this.downloadModal.getByRole("link", { name: /^download$/i }).first();
+    // Anchor on the modal's own copy ("Download mod file" heading / "Mod file
+    // requirements" section) rather than a generic .modal/.popup union, which on
+    // a mod page can latch onto an unrelated hidden element and miss the real one.
+    this.downloadModal = page
+      .getByRole("dialog")
+      .filter({ hasText: /Download mod file|Mod file requirements/i })
+      .first();
+    // The primary action downloads the main file only: its accessible name is
+    // exactly "Download". The per-requirement rows use icon-only controls (no
+    // "Download" name), so they're excluded — leaving the required mods absent
+    // for the Health Check to flag.
+    this.modalDownloadLink = this.downloadModal
+      .getByRole("link", { name: /^download$/i })
+      .or(this.downloadModal.getByRole("button", { name: /^download$/i }))
+      .first();
   }
 }

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -41,6 +41,7 @@
  */
 import { SDV_FILE_REQUIREMENT_TARGET_URLS } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
+import { installExternalOpenSpy, readExternalOpens } from "../helpers/externalOpen";
 import { openFileRequirementWarning, openWarningDetail } from "../helpers/healthCheck";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { dismissAllNotifications } from "../helpers/notifications";
@@ -230,6 +231,50 @@ test.describe("Health Check - file requirement warning", () => {
         // download + install + deploy span uses the cold-start budget.
         await hc.refreshButton.click();
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
+      });
+    });
+
+    test("[TC-07/25] the detail Install-via-mod-page link opens the required mod and its download resolves the requirement", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const { warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
+
+      await test.step("The detail starts with two outstanding requirements", async () => {
+        await expect(
+          detail.root.getByText(
+            "Requires 2 additional mod files to be installed to work correctly",
+          ),
+        ).toBeVisible();
+      });
+
+      let modPageUrl = "";
+
+      await test.step("'Install via mod page' targets the required mod's Nexus page", async () => {
+        // The link opens the OS browser via shell.openExternal, which Playwright
+        // can't follow — spy on the main process to capture (and suppress) the URL.
+        await installExternalOpenSpy(vortexApp);
+        await dismissAllNotifications(vortexWindow);
+        await detail.installViaModPageButton.click();
+        const opened = await readExternalOpens(vortexApp);
+        modPageUrl =
+          opened.find((url) => /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/.test(url)) ??
+          "";
+        expect(modPageUrl, `opened URLs: ${opened.join(", ")}`).toMatch(
+          /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/,
+        );
+      });
+
+      await test.step("Downloading from that page resolves the requirement (count 2 → 1)", async () => {
+        // Complete the journey the link starts: download the required mod from that
+        // same page and forward it to Vortex; the summary then decrements to singular.
+        await downloadModViaModManager(nexusPage, vortexApp, modPageUrl);
+        await expect(
+          detail.root.getByText("Requires 1 additional mod file to be installed to work correctly"),
+        ).toBeVisible({ timeout: Timeouts.LIFECYCLE });
       });
     });
   });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * File Requirements Health Check — warning + install flow (LAZ-684).
+ *
+ * Fixture: SDV mod 1915 declares a file-level requirement on SMAPI (mods/2400).
+ * Installed on its own (SMAPI absent) it raises a single-file "download" warning,
+ * which drives:
+ *   - TC-01  list warning renders (title / count / required-mod name / 1-click action)
+ *   - TC-07  expanded detail view (Warning header, requirement card, buttons)
+ *   - TC-24  free user: list 1-click opens the single-file Premium upsell
+ *   - TC-26  premium user: 1-click install downloads + installs SMAPI, clearing the warning
+ *
+ * These are heavy (real Mod-Manager download + install) and, like every
+ * authenticated / managed-game spec, currently need CI to run — locally the OAuth
+ * login is captcha-blocked and manageGame can't locate the game row. Kept in their
+ * own file so the fast foundation suite (health-check.spec.ts) isn't slowed.
+ *
+ * Assumption: 1915 declares SMAPI as a FILE-level requirement only, not a
+ * page-level "requires" rule. Enabling a mod silently auto-installs its
+ * page-level dependencies (mod_management/index.ts "mod-enabled" handler); if
+ * 1915 carried a page-level SMAPI rule, SMAPI would auto-install and no warning
+ * would surface. If these tests ever fail at the first warnings.row assertion,
+ * re-confirm the fixture is file-level only (or pick another source mod).
+ */
+import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
+import { test, expect } from "../fixtures/vortex-app";
+import { downloadModViaModManager } from "../helpers/modDownload";
+import { SMAPI_NAME } from "../helpers/mods";
+import { navigateToHealthCheck } from "../helpers/navigation";
+import { Timeouts } from "../helpers/timeouts";
+import { freeUser, premiumUser } from "../helpers/users";
+import { HealthCheckDetail, HealthCheckPage, HealthCheckWarnings } from "../selectors/healthCheck";
+
+test.describe("Health Check - file requirement warning", () => {
+  test.describe("free user", () => {
+    test.use({ nexusUser: freeUser });
+
+    test("[TC-01/07/24] warning renders, detail lists the requirement, 1-click upsells", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+
+      await test.step("Install the requiring mod with SMAPI absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+      });
+
+      await test.step("Warning row offers a 1-click install action", async () => {
+        await expect(warnings.installOneClick(SMAPI_NAME)).toBeVisible();
+      });
+
+      await test.step("Open the warning detail view", async () => {
+        await warnings
+          .row(SMAPI_NAME)
+          .getByText(/Missing required mod for:/)
+          .click();
+        await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
+      });
+
+      const detail = new HealthCheckDetail(vortexWindow);
+
+      await test.step("Detail states the single-file requirement", async () => {
+        await expect(detail.requiresFileLine).toBeVisible();
+      });
+
+      await test.step("Detail names the required mod (SMAPI)", async () => {
+        await expect(detail.requirementCard(SMAPI_NAME)).toBeVisible();
+      });
+
+      await test.step("Detail offers the Install via mod page fallback", async () => {
+        await expect(detail.installViaModPageButton).toBeVisible();
+      });
+
+      await test.step("Return to the list", async () => {
+        await detail.backButton.click();
+        await expect(hc.title).toBeVisible();
+      });
+
+      await test.step("List 1-click opens the single-file Premium upsell", async () => {
+        await warnings.installOneClick(SMAPI_NAME).click();
+        await expect(
+          vortexWindow.getByText("Skip the website and install instantly."),
+        ).toBeVisible();
+      });
+    });
+  });
+
+  test.describe("premium user", () => {
+    test.use({ nexusUser: premiumUser });
+
+    test("[TC-01/26] 1-click install resolves the file requirement", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+
+      await test.step("Install the requiring mod with SMAPI absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+      });
+
+      await test.step("Open the warning detail view", async () => {
+        await warnings
+          .row(SMAPI_NAME)
+          .getByText(/Missing required mod for:/)
+          .click();
+        await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
+      });
+
+      const detail = new HealthCheckDetail(vortexWindow);
+
+      await test.step("Detail offers a 1-click install", async () => {
+        await expect(detail.installOneClickButton).toBeVisible();
+      });
+
+      await test.step("1-click install downloads and installs SMAPI, returning to the list", async () => {
+        await detail.installOneClickButton.click();
+        // On success the requirement clears and the detail auto-returns to the
+        // list (HealthCheckDetailPage's live-entry effect). This spans a real
+        // download + install + deploy + a fresh file-requirements re-run, so use
+        // the cold-start budget rather than a single network round-trip.
+        await expect(hc.title).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+      });
+
+      await test.step("The SMAPI warning is gone", async () => {
+        await expect(warnings.row(SMAPI_NAME)).toHaveCount(0);
+      });
+    });
+  });
+});

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -371,5 +371,74 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
+
+    test("[TC-26] the header 1-click install all resolves the requirements", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("The header 1-click install all installs the requirements, clearing the warning", async () => {
+        // The header button sits top-right where the notification tray overlays;
+        // clear it immediately before clicking. For premium it installs directly
+        // (no upsell), spanning downloads + installs + deploy + a fresh re-run.
+        await dismissAllNotifications(vortexWindow);
+        await hc.installAllButton.click();
+        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
+      });
+    });
+
+    test("[TC-26] the detail 1-click install all resolves the requirements", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+      const detail = new HealthCheckDetail(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("Open the warning detail view", async () => {
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .click();
+        await expect(detail.warningTitle).toBeVisible();
+      });
+
+      await test.step("The detail 1-click install all installs the requirements, clearing the warning", async () => {
+        await dismissAllNotifications(vortexWindow);
+        await detail.installAllInGroupButton.click();
+        // Back to the list to assert the warning cleared as the required mods
+        // install + deploy (navigating away doesn't cancel the in-flight installs).
+        await detail.backButton.click();
+        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
+      });
+    });
   });
 });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -40,7 +40,10 @@
  * warnings.row() assertion, re-confirm the fixture is file-level only (or pick
  * another source mod).
  */
-import { SDV_FILE_REQUIREMENT_TARGET_URLS } from "../constants";
+import {
+  SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN,
+  SDV_FILE_REQUIREMENT_TARGET_URLS,
+} from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
 import { installExternalOpenSpy, readExternalOpens } from "../helpers/externalOpen";
 import { openFileRequirementWarning, openWarningDetail } from "../helpers/healthCheck";
@@ -63,23 +66,17 @@ test.describe("Health Check - file requirement warnings", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The warning uses the plural title (two requirements)", async () => {
-        await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
+        await expect(warnings.title()).toHaveText(/Missing required mods for:/);
       });
 
       await test.step("The list 1-click action is counted (2)", async () => {
-        await expect(
-          warnings.row().getByRole("button", { name: /1-click install \(2\)/ }),
-        ).toBeVisible();
+        await expect(warnings.installOneClick()).toHaveAccessibleName(/1-click install \(2\)/);
       });
 
       const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("Detail states the plural file-requirement summary", async () => {
-        await expect(
-          detail.root.getByText(
-            "Requires 2 additional mod files to be installed to work correctly",
-          ),
-        ).toBeVisible();
+        await expect(detail.requiresFileSummary(2)).toBeVisible();
       });
 
       await test.step("Detail groups the requirements under 'Install required'", async () => {
@@ -138,10 +135,7 @@ test.describe("Health Check - file requirement warnings", () => {
 
       await test.step("Hide the warning via its row control", async () => {
         await dismissAllNotifications(vortexWindow);
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .hover();
+        await warnings.title().hover();
         await warnings.hideButton().click();
         await expect(hc.hiddenTab).toContainText("(1)");
       });
@@ -157,10 +151,7 @@ test.describe("Health Check - file requirement warnings", () => {
 
       await test.step("Unhide the warning via its row control", async () => {
         await dismissAllNotifications(vortexWindow);
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .hover();
+        await warnings.title().hover();
         await warnings.unhideButton().click();
         await expect(hc.hiddenTab).toContainText("(0)");
       });
@@ -181,10 +172,7 @@ test.describe("Health Check - file requirement warnings", () => {
       const feedback = new HealthCheckFeedbackModal(vortexWindow);
 
       await test.step("Hovering the warning reveals its feedback controls", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .hover();
+        await warnings.title().hover();
         await expect(warnings.notHelpfulButton()).toBeVisible();
       });
 
@@ -240,11 +228,7 @@ test.describe("Health Check - file requirement warnings", () => {
       const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("The detail starts with two outstanding requirements", async () => {
-        await expect(
-          detail.root.getByText(
-            "Requires 2 additional mod files to be installed to work correctly",
-          ),
-        ).toBeVisible();
+        await expect(detail.requiresFileSummary(2)).toBeVisible();
       });
 
       let modPageUrl = "";
@@ -256,19 +240,15 @@ test.describe("Health Check - file requirement warnings", () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installViaModPageButton.click();
         const opened = await readExternalOpens(vortexApp);
-        modPageUrl =
-          opened.find((url) => /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/.test(url)) ??
-          "";
+        modPageUrl = opened.find((url) => SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN.test(url)) ?? "";
         expect(modPageUrl, `opened URLs: ${opened.join(", ")}`).toMatch(
-          /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/,
+          SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN,
         );
       });
 
       await test.step("Downloading from that page resolves the requirement (count 2 → 1)", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, modPageUrl);
-        await expect(
-          detail.root.getByText("Requires 1 additional mod file to be installed to work correctly"),
-        ).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+        await expect(detail.requiresFileSummary(1)).toBeVisible({ timeout: Timeouts.LIFECYCLE });
       });
     });
   });
@@ -285,17 +265,13 @@ test.describe("Health Check - file requirement warnings", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The warning uses the plural title (two requirements)", async () => {
-        await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
+        await expect(warnings.title()).toHaveText(/Missing required mods for:/);
       });
 
       const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("Detail states the plural file-requirement summary", async () => {
-        await expect(
-          detail.root.getByText(
-            "Requires 2 additional mod files to be installed to work correctly",
-          ),
-        ).toBeVisible();
+        await expect(detail.requiresFileSummary(2)).toBeVisible();
       });
 
       await test.step("Detail offers a section-level install-all for the two requirements", async () => {
@@ -355,19 +331,13 @@ test.describe("Health Check - file requirement warnings", () => {
       const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("The detail starts with two outstanding requirements", async () => {
-        await expect(
-          detail.root.getByText(
-            "Requires 2 additional mod files to be installed to work correctly",
-          ),
-        ).toBeVisible();
+        await expect(detail.requiresFileSummary(2)).toBeVisible();
       });
 
       await test.step("Installing one requirement (per-card) decrements the count to one", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installOneClickButton.click();
-        await expect(
-          detail.root.getByText("Requires 1 additional mod file to be installed to work correctly"),
-        ).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+        await expect(detail.requiresFileSummary(1)).toBeVisible({ timeout: Timeouts.LIFECYCLE });
       });
     });
   });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -1,30 +1,35 @@
 /**
  * File Requirements Health Check — warning + install flow (LAZ-684).
  *
- * Fixture: SDV mod 1915 declares a file-level requirement on SMAPI (mods/2400).
- * Installed on its own (SMAPI absent) it raises a single-file "download" warning,
- * which drives:
- *   - TC-01  list warning renders (title / count / required-mod name / 1-click action)
- *   - TC-07  expanded detail view (Warning header, requirement card, buttons)
- *   - TC-24  free user: list 1-click opens the single-file Premium upsell
- *   - TC-26  premium user: 1-click install downloads + installs SMAPI, clearing the warning
+ * Fixture: SDV mod 49786 has a single main file declaring two file-level
+ * requirements. Installed on its own (those required files absent) it raises one
+ * file-requirements "download" warning covering both required mods, which drives:
+ *   - TC-01  list warning renders (title / count / 1-click action)
+ *   - TC-07  expanded detail view (Warning header, requirement cards, buttons)
+ *   - TC-24  free user: list 1-click opens the Premium upsell
+ *   - TC-26  premium user: 1-click install downloads + installs the required mods,
+ *            clearing the warning
+ *
+ * The warning is targeted by its title rather than the required mod's name, so
+ * the spec doesn't hard-code the fixture's requirement target. SMAPI is
+ * deliberately avoided here — Vortex special-cases it with a dedicated installer,
+ * which interferes with a clean warning/install flow.
  *
  * These are heavy (real Mod-Manager download + install) and, like every
  * authenticated / managed-game spec, currently need CI to run — locally the OAuth
  * login is captcha-blocked and manageGame can't locate the game row. Kept in their
  * own file so the fast foundation suite (health-check.spec.ts) isn't slowed.
  *
- * Assumption: 1915 declares SMAPI as a FILE-level requirement only, not a
- * page-level "requires" rule. Enabling a mod silently auto-installs its
- * page-level dependencies (mod_management/index.ts "mod-enabled" handler); if
- * 1915 carried a page-level SMAPI rule, SMAPI would auto-install and no warning
- * would surface. If these tests ever fail at the first warnings.row assertion,
- * re-confirm the fixture is file-level only (or pick another source mod).
+ * Assumption: 49786's requirements are file-level only, not page-level "requires"
+ * rules. Enabling a mod silently auto-installs its page-level dependencies
+ * (mod_management/index.ts "mod-enabled" handler); a page-level rule would
+ * auto-install and no warning would surface. If these tests fail at the first
+ * warnings.row() assertion, re-confirm the fixture is file-level only (or pick
+ * another source mod).
  */
 import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
-import { SMAPI_NAME } from "../helpers/mods";
 import { navigateToHealthCheck } from "../helpers/navigation";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
@@ -43,36 +48,32 @@ test.describe("Health Check - file requirement warning", () => {
       const hc = new HealthCheckPage(vortexWindow);
       const warnings = new HealthCheckWarnings(vortexWindow);
 
-      await test.step("Install the requiring mod with SMAPI absent", async () => {
+      await test.step("Install the requiring mod with its required file absent", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
       });
 
       await test.step("Open Health Check and refresh", async () => {
         await navigateToHealthCheck(vortexWindow);
         await hc.refreshButton.click();
-        await expect(warnings.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
       });
 
       await test.step("Warning row offers a 1-click install action", async () => {
-        await expect(warnings.installOneClick(SMAPI_NAME)).toBeVisible();
+        await expect(warnings.installOneClick()).toBeVisible();
       });
 
       await test.step("Open the warning detail view", async () => {
         await warnings
-          .row(SMAPI_NAME)
-          .getByText(/Missing required mod for:/)
+          .row()
+          .getByText(/Missing required mods? for:/)
           .click();
         await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
       });
 
       const detail = new HealthCheckDetail(vortexWindow);
 
-      await test.step("Detail states the single-file requirement", async () => {
+      await test.step("Detail states the file requirement(s)", async () => {
         await expect(detail.requiresFileLine).toBeVisible();
-      });
-
-      await test.step("Detail names the required mod (SMAPI)", async () => {
-        await expect(detail.requirementCard(SMAPI_NAME)).toBeVisible();
       });
 
       await test.step("Detail offers the Install via mod page fallback", async () => {
@@ -84,11 +85,9 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(hc.title).toBeVisible();
       });
 
-      await test.step("List 1-click opens the single-file Premium upsell", async () => {
-        await warnings.installOneClick(SMAPI_NAME).click();
-        await expect(
-          vortexWindow.getByText("Skip the website and install instantly."),
-        ).toBeVisible();
+      await test.step("List 1-click opens the Premium upsell", async () => {
+        await warnings.installOneClick().click();
+        await expect(vortexWindow.getByText(/Skip the website and install/)).toBeVisible();
       });
     });
   });
@@ -105,41 +104,41 @@ test.describe("Health Check - file requirement warning", () => {
       const hc = new HealthCheckPage(vortexWindow);
       const warnings = new HealthCheckWarnings(vortexWindow);
 
-      await test.step("Install the requiring mod with SMAPI absent", async () => {
+      await test.step("Install the requiring mod with its required file absent", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
       });
 
       await test.step("Open Health Check and refresh", async () => {
         await navigateToHealthCheck(vortexWindow);
         await hc.refreshButton.click();
-        await expect(warnings.row(SMAPI_NAME)).toBeVisible({ timeout: Timeouts.NETWORK });
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
       });
 
       await test.step("Open the warning detail view", async () => {
         await warnings
-          .row(SMAPI_NAME)
-          .getByText(/Missing required mod for:/)
+          .row()
+          .getByText(/Missing required mods? for:/)
           .click();
         await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
       });
 
       const detail = new HealthCheckDetail(vortexWindow);
 
-      await test.step("Detail offers a 1-click install", async () => {
-        await expect(detail.installOneClickButton).toBeVisible();
+      await test.step("Detail states the file requirement(s)", async () => {
+        await expect(detail.requiresFileLine).toBeVisible();
       });
 
-      await test.step("1-click install downloads and installs SMAPI, returning to the list", async () => {
-        await detail.installOneClickButton.click();
-        // On success the requirement clears and the detail auto-returns to the
-        // list (HealthCheckDetailPage's live-entry effect). This spans a real
-        // download + install + deploy + a fresh file-requirements re-run, so use
-        // the cold-start budget rather than a single network round-trip.
-        await expect(hc.title).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+      await test.step("Return to the list", async () => {
+        await detail.backButton.click();
+        await expect(hc.title).toBeVisible();
       });
 
-      await test.step("The SMAPI warning is gone", async () => {
-        await expect(warnings.row(SMAPI_NAME)).toHaveCount(0);
+      await test.step("1-click install downloads and installs the required mod(s), clearing the warning", async () => {
+        // For a premium user the list-row 1-click installs every candidate in the
+        // report (both required mods here). Spans real downloads + installs +
+        // deploy + a fresh file-requirements re-run, so use the cold-start budget.
+        await warnings.installOneClick().click();
+        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
   });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -33,7 +33,7 @@
  * warnings.row() assertion, re-confirm the fixture is file-level only (or pick
  * another source mod).
  */
-import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
+import { SDV_FILE_REQUIREMENT_MOD_URL, SDV_FILE_REQUIREMENT_TARGET_URLS } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { navigateToHealthCheck } from "../helpers/navigation";
@@ -265,6 +265,43 @@ test.describe("Health Check - file requirement warning", () => {
         await feedback.incorrectRequirement.click();
         await feedback.sendButton.click();
         await expect(detail.feedbackThanks).toBeVisible();
+      });
+    });
+
+    test("[TC-25] a manual website download resolves the warning for a free user", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("Manually download each required mod from the website", async () => {
+        // A free user can't 1-click install (that opens the Premium upsell — TC-24);
+        // instead they download the required files from the mod pages. Drive that same
+        // Mod-Manager website download and forward it to Vortex, which installs it.
+        for (const url of SDV_FILE_REQUIREMENT_TARGET_URLS) {
+          await downloadModViaModManager(nexusPage, vortexApp, url);
+        }
+      });
+
+      await test.step("The ingested downloads clear the warning", async () => {
+        // Installing the required files re-runs the file-requirements check; the
+        // download + install + deploy span uses the cold-start budget.
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
   });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -5,17 +5,18 @@
  * Fixture: SDV mod 49786 has a single main file declaring two file-level
  * requirements. Installed on its own (those required files absent) it raises one
  * file-requirements "download" warning covering both required mods (category
- * `download` / kind `missing`), which drives:
- *   - TC-01  list warning renders (plural title / count / 1-click action)
- *   - TC-07  expanded detail view (Warning header, "Install required" group,
- *            requirement cards + buttons, section-level install-all)
- *   - TC-20  progressive count: resolving one requirement decrements the summary
- *   - TC-24  free user: list 1-click opens the multi-file Premium upsell
- *   - TC-25  free user: a manual website download resolves the warning
- *   - TC-26  premium user: the list / header / detail 1-click installs resolve it
- *   - TC-05  hide/unhide moves the warning between the Active and Hidden tabs
- *   - TC-29  the warning's feedback controls (thumbs + FeedbackModal)
- *   - TC-35  singular/plural copy (two requirements ⇒ the plural strings)
+ * `download` / kind `missing`). The tests here cover:
+ *   - the list warning (plural title / count / 1-click action)
+ *   - the expanded detail view (Warning header, "Install required" group,
+ *     requirement cards + buttons, section-level install-all)
+ *   - progressive count: resolving one requirement decrements the summary
+ *   - free user: list 1-click opens the multi-file Premium upsell
+ *   - free user: a manual website download, and the "Install via mod page" link,
+ *     resolve the warning
+ *   - premium user: the list / header / detail 1-click installs resolve it
+ *   - hide/unhide moves the warning between the Active and Hidden tabs
+ *   - the warning's feedback controls (thumbs + FeedbackModal)
+ *   - singular/plural copy (two requirements ⇒ the plural strings)
  *
  * The warning is targeted by its title rather than the required mod's name, so
  * the spec doesn't hard-code the fixture's requirement target. SMAPI is
@@ -49,11 +50,11 @@ import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
 import { HealthCheckFeedbackModal, HealthCheckPremiumModal } from "../selectors/healthCheck";
 
-test.describe("Health Check - file requirement warning", () => {
+test.describe("Health Check - file requirement warnings", () => {
   test.describe("free user", () => {
     test.use({ nexusUser: freeUser });
 
-    test("[TC-01/07/24/35] warning renders, detail lists the requirements, 1-click upsells", async ({
+    test("Check the warning and detail render, and 1-click shows the Premium upsell", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -114,7 +115,7 @@ test.describe("Health Check - file requirement warning", () => {
       });
     });
 
-    test("[TC-05] hiding a warning moves it between the Active and Hidden tabs", async ({
+    test("Check that health check items can be moved between the Active and Hidden tabs", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -131,9 +132,6 @@ test.describe("Health Check - file requirement warning", () => {
       });
 
       await test.step("Hide the warning via its row control", async () => {
-        // Clear any (re-)surfaced notification tray that would overlay the row's
-        // right-aligned hide icon, then reveal the icon by hovering the title text
-        // (left-aligned) rather than the row centre, which the action bar overlaps.
         await dismissAllNotifications(vortexWindow);
         await warnings
           .row()
@@ -168,7 +166,7 @@ test.describe("Health Check - file requirement warning", () => {
       });
     });
 
-    test("[TC-29] the warning exposes feedback controls and records feedback", async ({
+    test("Check that the feedback controls are present and operational", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -178,8 +176,6 @@ test.describe("Health Check - file requirement warning", () => {
       const feedback = new HealthCheckFeedbackModal(vortexWindow);
 
       await test.step("Hovering the warning reveals its feedback controls", async () => {
-        // The row's EntryActions are invisible until hover; target the title text
-        // (left-aligned) rather than the row centre, which the action bar overlaps.
         await warnings
           .row()
           .getByText(/Missing required mods? for:/)
@@ -209,7 +205,7 @@ test.describe("Health Check - file requirement warning", () => {
       });
     });
 
-    test("[TC-25] a manual website download resolves the warning for a free user", async ({
+    test("Check that a manual website download resolves the warning for a free user", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -218,8 +214,8 @@ test.describe("Health Check - file requirement warning", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("Manually download each required mod from the website", async () => {
-        // A free user can't 1-click install (that opens the Premium upsell — TC-24);
-        // instead they download the required files from the mod pages. Drive that same
+        // A free user can't 1-click install (that opens the Premium upsell) instead;
+        // they download the required files from the mod pages. Drive that same
         // Mod-Manager website download and forward it to Vortex, which installs it.
         for (const url of SDV_FILE_REQUIREMENT_TARGET_URLS) {
           await downloadModViaModManager(nexusPage, vortexApp, url);
@@ -227,14 +223,12 @@ test.describe("Health Check - file requirement warning", () => {
       });
 
       await test.step("The ingested downloads clear the warning", async () => {
-        // Installing the required files re-runs the file-requirements check; the
-        // download + install + deploy span uses the cold-start budget.
         await hc.refreshButton.click();
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
 
-    test("[TC-07/25] the detail Install-via-mod-page link opens the required mod and its download resolves the requirement", async ({
+    test("Check the 'Install via mod page' link opens the required mod and its download resolves the requirement", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -282,7 +276,7 @@ test.describe("Health Check - file requirement warning", () => {
   test.describe("premium user", () => {
     test.use({ nexusUser: premiumUser });
 
-    test("[TC-01/26/35] 1-click install resolves the file requirements", async ({
+    test("Check the warning-row 1-click install button resolves all requirements", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -322,7 +316,7 @@ test.describe("Health Check - file requirement warning", () => {
       });
     });
 
-    test("[TC-26] the header 1-click install all resolves the requirements", async ({
+    test("Check the header 1-click install button resolves all requirements on the health check", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -331,16 +325,13 @@ test.describe("Health Check - file requirement warning", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The header 1-click install all installs the requirements, clearing the warning", async () => {
-        // The header button sits top-right where the notification tray overlays;
-        // clear it immediately before clicking. For premium it installs directly
-        // (no upsell), spanning downloads + installs + deploy + a fresh re-run.
         await dismissAllNotifications(vortexWindow);
         await hc.installAllButton.click();
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
 
-    test("[TC-26] the detail 1-click install all resolves the requirements", async ({
+    test("Check the detail 'install all' button resolves all requirements", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -352,14 +343,12 @@ test.describe("Health Check - file requirement warning", () => {
       await test.step("The detail 1-click install all installs the requirements, clearing the warning", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installAllInGroupButton.click();
-        // Back to the list to assert the warning cleared as the required mods
-        // install + deploy (navigating away doesn't cancel the in-flight installs).
         await detail.backButton.click();
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
 
-    test("[TC-07/20] a detail per-card 1-click install resolves one requirement and decrements the count", async ({
+    test("Check the per-requirement 1-click install resolves one requirement and decrements the count", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -440,5 +440,54 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
     });
+
+    test("[TC-07/20] a detail per-card 1-click install resolves one requirement and decrements the count", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+      const detail = new HealthCheckDetail(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("Open the warning detail view", async () => {
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .click();
+        await expect(detail.warningTitle).toBeVisible();
+      });
+
+      await test.step("The detail starts with two outstanding requirements", async () => {
+        await expect(
+          detail.root.getByText(
+            "Requires 2 additional mod files to be installed to work correctly",
+          ),
+        ).toBeVisible();
+      });
+
+      await test.step("Installing one requirement (per-card) decrements the count to one", async () => {
+        // The per-card "1-click install" resolves a single requirement; as it
+        // installs, that card drops out and the summary decrements to the singular
+        // copy (Figma: "remove the mod requirement item ... update counts").
+        await dismissAllNotifications(vortexWindow);
+        await detail.installOneClickButton.click();
+        await expect(
+          detail.root.getByText("Requires 1 additional mod file to be installed to work correctly"),
+        ).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+      });
+    });
   });
 });

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -123,11 +123,16 @@ test.describe("Health Check - file requirement warnings", () => {
     }) => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
-      await test.step("Active tab shows one warning", async () => {
-        await expect(hc.activeTab).toContainText("(1)");
+      await test.step("The warning starts on the Active tab", async () => {
+        // Track the file-requirement warning by its own row, not the tab's aggregate
+        // "(N)" count: a page-level mod-requirement "suggestion" can also be active
+        // (see LAZ-852), which would inflate that count. warnings.row() is scoped to
+        // the file-warning title, so it stays correct regardless of what else is listed.
+        await expect(warnings.row()).toBeVisible();
       });
 
       await test.step("Hidden tab starts empty", async () => {
+        // Only the file warning is ever hidden here, so the Hidden count is safe.
         await expect(hc.hiddenTab).toContainText("(0)");
       });
 
@@ -141,8 +146,8 @@ test.describe("Health Check - file requirement warnings", () => {
         await expect(hc.hiddenTab).toContainText("(1)");
       });
 
-      await test.step("The Active tab is now empty", async () => {
-        await expect(hc.activeTab).toContainText("(0)");
+      await test.step("The warning has left the Active tab", async () => {
+        await expect(warnings.row()).toHaveCount(0);
       });
 
       await test.step("The Hidden tab lists the warning", async () => {
@@ -214,9 +219,6 @@ test.describe("Health Check - file requirement warnings", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("Manually download each required mod from the website", async () => {
-        // A free user can't 1-click install (that opens the Premium upsell) instead;
-        // they download the required files from the mod pages. Drive that same
-        // Mod-Manager website download and forward it to Vortex, which installs it.
         for (const url of SDV_FILE_REQUIREMENT_TARGET_URLS) {
           await downloadModViaModManager(nexusPage, vortexApp, url);
         }
@@ -263,8 +265,6 @@ test.describe("Health Check - file requirement warnings", () => {
       });
 
       await test.step("Downloading from that page resolves the requirement (count 2 → 1)", async () => {
-        // Complete the journey the link starts: download the required mod from that
-        // same page and forward it to Vortex; the summary then decrements to singular.
         await downloadModViaModManager(nexusPage, vortexApp, modPageUrl);
         await expect(
           detail.root.getByText("Requires 1 additional mod file to be installed to work correctly"),
@@ -308,9 +308,6 @@ test.describe("Health Check - file requirement warnings", () => {
       });
 
       await test.step("1-click install downloads and installs the required mods, clearing the warning", async () => {
-        // For a premium user the list-row 1-click installs every candidate in the
-        // report (both required mods here). Spans real downloads + installs +
-        // deploy + a fresh file-requirements re-run, so use the cold-start budget.
         await warnings.installOneClick().click();
         await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
       });
@@ -366,9 +363,6 @@ test.describe("Health Check - file requirement warnings", () => {
       });
 
       await test.step("Installing one requirement (per-card) decrements the count to one", async () => {
-        // The per-card "1-click install" resolves a single requirement; as it
-        // installs, that card drops out and the summary decrements to the singular
-        // copy (Figma: "remove the mod requirement item ... update counts").
         await dismissAllNotifications(vortexWindow);
         await detail.installOneClickButton.click();
         await expect(

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -1,14 +1,19 @@
 /**
- * File Requirements Health Check — warning + install flow (LAZ-684).
+ * File Requirements Health Check — warning, detail, feedback + list-management
+ * flows (LAZ-684).
  *
  * Fixture: SDV mod 49786 has a single main file declaring two file-level
  * requirements. Installed on its own (those required files absent) it raises one
- * file-requirements "download" warning covering both required mods, which drives:
- *   - TC-01  list warning renders (title / count / 1-click action)
- *   - TC-07  expanded detail view (Warning header, requirement cards, buttons)
- *   - TC-24  free user: list 1-click opens the Premium upsell
- *   - TC-26  premium user: 1-click install downloads + installs the required mods,
- *            clearing the warning
+ * file-requirements "download" warning covering both required mods (category
+ * `download` / kind `missing`), which drives:
+ *   - TC-01  list warning renders (plural title / count / 1-click action)
+ *   - TC-07  expanded detail view (Warning header, "Install required" group,
+ *            requirement cards + buttons, section-level install-all)
+ *   - TC-24  free user: list 1-click opens the multi-file Premium upsell
+ *   - TC-26  premium user: 1-click install downloads + installs the required mods
+ *   - TC-05  hide/unhide moves the warning between the Active and Hidden tabs
+ *   - TC-29  the warning's feedback controls (thumbs + FeedbackModal)
+ *   - TC-35  singular/plural copy (two requirements ⇒ the plural strings)
  *
  * The warning is targeted by its title rather than the required mod's name, so
  * the spec doesn't hard-code the fixture's requirement target. SMAPI is
@@ -17,8 +22,9 @@
  *
  * These are heavy (real Mod-Manager download + install) and, like every
  * authenticated / managed-game spec, currently need CI to run — locally the OAuth
- * login is captcha-blocked and manageGame can't locate the game row. Kept in their
- * own file so the fast foundation suite (health-check.spec.ts) isn't slowed.
+ * login is captcha-blocked (mitigated by a captured auth snapshot; see
+ * helpers/authState.ts). Kept in their own file so the fast foundation suite
+ * (health-check.spec.ts) isn't slowed.
  *
  * Assumption: 49786's requirements are file-level only, not page-level "requires"
  * rules. Enabling a mod silently auto-installs its page-level dependencies
@@ -31,15 +37,22 @@ import { SDV_FILE_REQUIREMENT_MOD_URL } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { navigateToHealthCheck } from "../helpers/navigation";
+import { dismissAllNotifications } from "../helpers/notifications";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
-import { HealthCheckDetail, HealthCheckPage, HealthCheckWarnings } from "../selectors/healthCheck";
+import {
+  HealthCheckDetail,
+  HealthCheckFeedbackModal,
+  HealthCheckPage,
+  HealthCheckPremiumModal,
+  HealthCheckWarnings,
+} from "../selectors/healthCheck";
 
 test.describe("Health Check - file requirement warning", () => {
   test.describe("free user", () => {
     test.use({ nexusUser: freeUser });
 
-    test("[TC-01/07/24] warning renders, detail lists the requirement, 1-click upsells", async ({
+    test("[TC-01/07/24/35] warning renders, detail lists the requirements, 1-click upsells", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -48,7 +61,7 @@ test.describe("Health Check - file requirement warning", () => {
       const hc = new HealthCheckPage(vortexWindow);
       const warnings = new HealthCheckWarnings(vortexWindow);
 
-      await test.step("Install the requiring mod with its required file absent", async () => {
+      await test.step("Install the requiring mod with its required files absent", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
       });
 
@@ -56,10 +69,20 @@ test.describe("Health Check - file requirement warning", () => {
         await navigateToHealthCheck(vortexWindow);
         await hc.refreshButton.click();
         await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        // A refresh can spawn notifications, which auto-open a popover that overlays
+        // the top-right and intercepts clicks on the tabs' buttons and a row's
+        // hide/feedback icons. Clear it once the check has settled so it stays shut.
+        await dismissAllNotifications(vortexWindow);
       });
 
-      await test.step("Warning row offers a 1-click install action", async () => {
-        await expect(warnings.installOneClick()).toBeVisible();
+      await test.step("The warning uses the plural title (two requirements)", async () => {
+        await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
+      });
+
+      await test.step("The list 1-click action is counted (2)", async () => {
+        await expect(
+          warnings.row().getByRole("button", { name: /1-click install \(2\)/ }),
+        ).toBeVisible();
       });
 
       await test.step("Open the warning detail view", async () => {
@@ -72,12 +95,24 @@ test.describe("Health Check - file requirement warning", () => {
 
       const detail = new HealthCheckDetail(vortexWindow);
 
-      await test.step("Detail states the file requirement(s)", async () => {
-        await expect(detail.requiresFileLine).toBeVisible();
+      await test.step("Detail states the plural file-requirement summary", async () => {
+        await expect(
+          detail.root.getByText(
+            "Requires 2 additional mod files to be installed to work correctly",
+          ),
+        ).toBeVisible();
+      });
+
+      await test.step("Detail groups the requirements under 'Install required'", async () => {
+        await expect(detail.installRequiredHeader).toBeVisible();
       });
 
       await test.step("Detail offers the Install via mod page fallback", async () => {
         await expect(detail.installViaModPageButton).toBeVisible();
+      });
+
+      await test.step("Detail offers a section-level install-all for the two requirements", async () => {
+        await expect(detail.installAllInGroupButton).toBeVisible();
       });
 
       await test.step("Return to the list", async () => {
@@ -85,9 +120,151 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(hc.title).toBeVisible();
       });
 
-      await test.step("List 1-click opens the Premium upsell", async () => {
+      const premiumModal = new HealthCheckPremiumModal(vortexWindow);
+
+      await test.step("List 1-click opens the multi-file Premium upsell", async () => {
         await warnings.installOneClick().click();
-        await expect(vortexWindow.getByText(/Skip the website and install/)).toBeVisible();
+        await expect(premiumModal.allTitle).toBeVisible();
+      });
+
+      await test.step("Upsell lists the Premium benefits", async () => {
+        await expect(premiumModal.benefitsTitle).toBeVisible();
+      });
+
+      await test.step("Upsell offers the Unlock action", async () => {
+        await expect(premiumModal.unlockButton).toBeVisible();
+      });
+    });
+
+    test("[TC-05] hiding a warning moves it between the Active and Hidden tabs", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        // A refresh can spawn notifications, which auto-open a popover that overlays
+        // the top-right and intercepts clicks on the tabs' buttons and a row's
+        // hide/feedback icons. Clear it once the check has settled so it stays shut.
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("Active tab shows one warning", async () => {
+        await expect(hc.activeTab).toContainText("(1)");
+      });
+
+      await test.step("Hidden tab starts empty", async () => {
+        await expect(hc.hiddenTab).toContainText("(0)");
+      });
+
+      await test.step("Hide the warning via its row control", async () => {
+        // Clear any (re-)surfaced notification tray that would overlay the row's
+        // right-aligned hide icon, then reveal the icon by hovering the title text
+        // (left-aligned) rather than the row centre, which the action bar overlaps.
+        await dismissAllNotifications(vortexWindow);
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .hover();
+        await warnings.hideButton().click();
+        await expect(hc.hiddenTab).toContainText("(1)");
+      });
+
+      await test.step("The Active tab is now empty", async () => {
+        await expect(hc.activeTab).toContainText("(0)");
+      });
+
+      await test.step("The Hidden tab lists the warning", async () => {
+        await hc.hiddenTab.click();
+        await expect(warnings.row()).toBeVisible();
+      });
+
+      await test.step("Unhide the warning via its row control", async () => {
+        await dismissAllNotifications(vortexWindow);
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .hover();
+        await warnings.unhideButton().click();
+        await expect(hc.hiddenTab).toContainText("(0)");
+      });
+
+      await test.step("The warning is back on the Active tab", async () => {
+        await hc.activeTab.click();
+        await expect(warnings.row()).toBeVisible();
+      });
+    });
+
+    test("[TC-29] the warning exposes feedback controls and records feedback", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+      const warnings = new HealthCheckWarnings(vortexWindow);
+      const detail = new HealthCheckDetail(vortexWindow);
+      const feedback = new HealthCheckFeedbackModal(vortexWindow);
+
+      await test.step("Install the requiring mod with its required files absent", async () => {
+        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+      });
+
+      await test.step("Open Health Check and refresh", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await hc.refreshButton.click();
+        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        // A refresh can spawn notifications, which auto-open a popover that overlays
+        // the top-right and intercepts clicks on the tabs' buttons and a row's
+        // hide/feedback icons. Clear it once the check has settled so it stays shut.
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("Hovering the warning reveals its feedback controls", async () => {
+        // The row's EntryActions are invisible until hover; target the title text
+        // (left-aligned) rather than the row centre, which the action bar overlaps.
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .hover();
+        await expect(warnings.notHelpfulButton()).toBeVisible();
+      });
+
+      await test.step("Open the warning detail view", async () => {
+        await warnings
+          .row()
+          .getByText(/Missing required mods? for:/)
+          .click();
+        await expect(detail.warningTitle).toBeVisible();
+      });
+
+      await test.step("Detail shows the 'Was this warning helpful?' prompt", async () => {
+        await expect(detail.feedbackPrompt).toBeVisible();
+      });
+
+      await test.step("Thumbs-down opens the feedback modal", async () => {
+        await detail.notHelpfulButton.click();
+        await expect(feedback.title).toBeVisible();
+      });
+
+      await test.step("The feedback modal offers a Send action", async () => {
+        await expect(feedback.sendButton).toBeVisible();
+      });
+
+      await test.step("Sending feedback records it", async () => {
+        await feedback.incorrectRequirement.click();
+        await feedback.sendButton.click();
+        await expect(detail.feedbackThanks).toBeVisible();
       });
     });
   });
@@ -95,7 +272,7 @@ test.describe("Health Check - file requirement warning", () => {
   test.describe("premium user", () => {
     test.use({ nexusUser: premiumUser });
 
-    test("[TC-01/26] 1-click install resolves the file requirement", async ({
+    test("[TC-01/26/35] 1-click install resolves the file requirements", async ({
       vortexApp,
       vortexWindow,
       managedGame: _game,
@@ -104,7 +281,7 @@ test.describe("Health Check - file requirement warning", () => {
       const hc = new HealthCheckPage(vortexWindow);
       const warnings = new HealthCheckWarnings(vortexWindow);
 
-      await test.step("Install the requiring mod with its required file absent", async () => {
+      await test.step("Install the requiring mod with its required files absent", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
       });
 
@@ -112,6 +289,14 @@ test.describe("Health Check - file requirement warning", () => {
         await navigateToHealthCheck(vortexWindow);
         await hc.refreshButton.click();
         await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
+        // A refresh can spawn notifications, which auto-open a popover that overlays
+        // the top-right and intercepts clicks on the tabs' buttons and a row's
+        // hide/feedback icons. Clear it once the check has settled so it stays shut.
+        await dismissAllNotifications(vortexWindow);
+      });
+
+      await test.step("The warning uses the plural title (two requirements)", async () => {
+        await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
       });
 
       await test.step("Open the warning detail view", async () => {
@@ -124,8 +309,16 @@ test.describe("Health Check - file requirement warning", () => {
 
       const detail = new HealthCheckDetail(vortexWindow);
 
-      await test.step("Detail states the file requirement(s)", async () => {
-        await expect(detail.requiresFileLine).toBeVisible();
+      await test.step("Detail states the plural file-requirement summary", async () => {
+        await expect(
+          detail.root.getByText(
+            "Requires 2 additional mod files to be installed to work correctly",
+          ),
+        ).toBeVisible();
+      });
+
+      await test.step("Detail offers a section-level install-all for the two requirements", async () => {
+        await expect(detail.installAllInGroupButton).toBeVisible();
       });
 
       await test.step("Return to the list", async () => {
@@ -133,7 +326,7 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(hc.title).toBeVisible();
       });
 
-      await test.step("1-click install downloads and installs the required mod(s), clearing the warning", async () => {
+      await test.step("1-click install downloads and installs the required mods, clearing the warning", async () => {
         // For a premium user the list-row 1-click installs every candidate in the
         // report (both required mods here). Spans real downloads + installs +
         // deploy + a fresh file-requirements re-run, so use the cold-start budget.

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -9,8 +9,10 @@
  *   - TC-01  list warning renders (plural title / count / 1-click action)
  *   - TC-07  expanded detail view (Warning header, "Install required" group,
  *            requirement cards + buttons, section-level install-all)
+ *   - TC-20  progressive count: resolving one requirement decrements the summary
  *   - TC-24  free user: list 1-click opens the multi-file Premium upsell
- *   - TC-26  premium user: 1-click install downloads + installs the required mods
+ *   - TC-25  free user: a manual website download resolves the warning
+ *   - TC-26  premium user: the list / header / detail 1-click installs resolve it
  *   - TC-05  hide/unhide moves the warning between the Active and Hidden tabs
  *   - TC-29  the warning's feedback controls (thumbs + FeedbackModal)
  *   - TC-35  singular/plural copy (two requirements ⇒ the plural strings)
@@ -19,6 +21,10 @@
  * the spec doesn't hard-code the fixture's requirement target. SMAPI is
  * deliberately avoided here — Vortex special-cases it with a dedicated installer,
  * which interferes with a clean warning/install flow.
+ *
+ * The shared "install the fixture mod → open Health Check → surface the warning"
+ * setup lives in helpers/healthCheck.ts (openFileRequirementWarning); each test
+ * starts from there.
  *
  * These are heavy (real Mod-Manager download + install) and, like every
  * authenticated / managed-game spec, currently need CI to run — locally the OAuth
@@ -33,20 +39,14 @@
  * warnings.row() assertion, re-confirm the fixture is file-level only (or pick
  * another source mod).
  */
-import { SDV_FILE_REQUIREMENT_MOD_URL, SDV_FILE_REQUIREMENT_TARGET_URLS } from "../constants";
+import { SDV_FILE_REQUIREMENT_TARGET_URLS } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
+import { openFileRequirementWarning, openWarningDetail } from "../helpers/healthCheck";
 import { downloadModViaModManager } from "../helpers/modDownload";
-import { navigateToHealthCheck } from "../helpers/navigation";
 import { dismissAllNotifications } from "../helpers/notifications";
 import { Timeouts } from "../helpers/timeouts";
 import { freeUser, premiumUser } from "../helpers/users";
-import {
-  HealthCheckDetail,
-  HealthCheckFeedbackModal,
-  HealthCheckPage,
-  HealthCheckPremiumModal,
-  HealthCheckWarnings,
-} from "../selectors/healthCheck";
+import { HealthCheckFeedbackModal, HealthCheckPremiumModal } from "../selectors/healthCheck";
 
 test.describe("Health Check - file requirement warning", () => {
   test.describe("free user", () => {
@@ -58,22 +58,7 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        // A refresh can spawn notifications, which auto-open a popover that overlays
-        // the top-right and intercepts clicks on the tabs' buttons and a row's
-        // hide/feedback icons. Clear it once the check has settled so it stays shut.
-        await dismissAllNotifications(vortexWindow);
-      });
+      const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The warning uses the plural title (two requirements)", async () => {
         await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
@@ -85,15 +70,7 @@ test.describe("Health Check - file requirement warning", () => {
         ).toBeVisible();
       });
 
-      await test.step("Open the warning detail view", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .click();
-        await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
-      });
-
-      const detail = new HealthCheckDetail(vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("Detail states the plural file-requirement summary", async () => {
         await expect(
@@ -142,22 +119,7 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        // A refresh can spawn notifications, which auto-open a popover that overlays
-        // the top-right and intercepts clicks on the tabs' buttons and a row's
-        // hide/feedback icons. Clear it once the check has settled so it stays shut.
-        await dismissAllNotifications(vortexWindow);
-      });
+      const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("Active tab shows one warning", async () => {
         await expect(hc.activeTab).toContainText("(1)");
@@ -211,24 +173,8 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-      const detail = new HealthCheckDetail(vortexWindow);
+      const { warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
       const feedback = new HealthCheckFeedbackModal(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        // A refresh can spawn notifications, which auto-open a popover that overlays
-        // the top-right and intercepts clicks on the tabs' buttons and a row's
-        // hide/feedback icons. Clear it once the check has settled so it stays shut.
-        await dismissAllNotifications(vortexWindow);
-      });
 
       await test.step("Hovering the warning reveals its feedback controls", async () => {
         // The row's EntryActions are invisible until hover; target the title text
@@ -240,13 +186,7 @@ test.describe("Health Check - file requirement warning", () => {
         await expect(warnings.notHelpfulButton()).toBeVisible();
       });
 
-      await test.step("Open the warning detail view", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .click();
-        await expect(detail.warningTitle).toBeVisible();
-      });
+      const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("Detail shows the 'Was this warning helpful?' prompt", async () => {
         await expect(detail.feedbackPrompt).toBeVisible();
@@ -274,19 +214,7 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        await dismissAllNotifications(vortexWindow);
-      });
+      const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("Manually download each required mod from the website", async () => {
         // A free user can't 1-click install (that opens the Premium upsell — TC-24);
@@ -315,36 +243,13 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        // A refresh can spawn notifications, which auto-open a popover that overlays
-        // the top-right and intercepts clicks on the tabs' buttons and a row's
-        // hide/feedback icons. Clear it once the check has settled so it stays shut.
-        await dismissAllNotifications(vortexWindow);
-      });
+      const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The warning uses the plural title (two requirements)", async () => {
         await expect(warnings.row().getByText("Missing required mods for:")).toBeVisible();
       });
 
-      await test.step("Open the warning detail view", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .click();
-        await expect(new HealthCheckDetail(vortexWindow).warningTitle).toBeVisible();
-      });
-
-      const detail = new HealthCheckDetail(vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("Detail states the plural file-requirement summary", async () => {
         await expect(
@@ -378,19 +283,7 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        await dismissAllNotifications(vortexWindow);
-      });
+      const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The header 1-click install all installs the requirements, clearing the warning", async () => {
         // The header button sits top-right where the notification tray overlays;
@@ -408,28 +301,8 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-      const detail = new HealthCheckDetail(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        await dismissAllNotifications(vortexWindow);
-      });
-
-      await test.step("Open the warning detail view", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .click();
-        await expect(detail.warningTitle).toBeVisible();
-      });
+      const { warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("The detail 1-click install all installs the requirements, clearing the warning", async () => {
         await dismissAllNotifications(vortexWindow);
@@ -447,28 +320,8 @@ test.describe("Health Check - file requirement warning", () => {
       managedGame: _game,
       nexusPage,
     }) => {
-      const hc = new HealthCheckPage(vortexWindow);
-      const warnings = new HealthCheckWarnings(vortexWindow);
-      const detail = new HealthCheckDetail(vortexWindow);
-
-      await test.step("Install the requiring mod with its required files absent", async () => {
-        await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
-      });
-
-      await test.step("Open Health Check and refresh", async () => {
-        await navigateToHealthCheck(vortexWindow);
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-        await dismissAllNotifications(vortexWindow);
-      });
-
-      await test.step("Open the warning detail view", async () => {
-        await warnings
-          .row()
-          .getByText(/Missing required mods? for:/)
-          .click();
-        await expect(detail.warningTitle).toBeVisible();
-      });
+      const { warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
 
       await test.step("The detail starts with two outstanding requirements", async () => {
         await expect(

--- a/packages/e2e/src/tests/health-check-mod-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-mod-requirement.spec.ts
@@ -39,14 +39,11 @@ test.describe("Health Check - mod requirement suggestions", () => {
       const detail = new HealthCheckSuggestionDetail(vortexWindow);
 
       await test.step("The suggestion lists the missing mod", async () => {
-        await expect(suggestions.row().getByText(/Missing mod:/)).toBeVisible();
+        await expect(suggestions.missingMod()).toBeVisible();
       });
 
       await test.step("Open the suggestion detail view", async () => {
-        await suggestions
-          .row()
-          .getByText(/Additional mod files? may be required for:/)
-          .click();
+        await suggestions.title().click();
         await expect(detail.suggestionTitle).toBeVisible();
       });
 

--- a/packages/e2e/src/tests/health-check-mod-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-mod-requirement.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Mod Requirements Health Check — page-level requirement "suggestions" (LAZ-684).
+ *
+ * Fixture: SDV mod 46415 declares a single page-level (mod-to-mod) requirement.
+ * Installed on its own (that required mod absent) it raises one blue Suggestion
+ * ("Additional mod file may be required for: …") — the mod-to-mod counterpart of
+ * the file-requirement warnings in health-check-file-requirement.spec.ts.
+ *
+ * LAZ-852 caveat: page-level suggestions are suppressed for mods *set to use file
+ * requirements* while the file-requirements flag is on. 46415 must keep its legacy
+ * mod requirements enabled for this suggestion to surface for the flag-enrolled E2E
+ * users; if these fail at the first suggestions.row() assertion, re-confirm the
+ * fixture still shows a suggestion.
+ *
+ * Heavy (real Mod-Manager download) + authenticated; needs CI (captured auth). The
+ * shared setup lives in helpers/healthCheck.ts (openModRequirementSuggestion).
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { openModRequirementSuggestion } from "../helpers/healthCheck";
+import { dismissAllNotifications } from "../helpers/notifications";
+import { freeUser } from "../helpers/users";
+import { HealthCheckPremiumModal, HealthCheckSuggestionDetail } from "../selectors/healthCheck";
+
+test.describe("Health Check - mod requirement suggestions", () => {
+  test.describe("free user", () => {
+    test.use({ nexusUser: freeUser });
+
+    test("Check a page-level requirement renders as a suggestion with its detail and disclaimer", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const { suggestions } = await openModRequirementSuggestion(
+        nexusPage,
+        vortexApp,
+        vortexWindow,
+      );
+      const detail = new HealthCheckSuggestionDetail(vortexWindow);
+
+      await test.step("The suggestion lists the missing mod", async () => {
+        await expect(suggestions.row().getByText(/Missing mod:/)).toBeVisible();
+      });
+
+      await test.step("Open the suggestion detail view", async () => {
+        await suggestions
+          .row()
+          .getByText(/Additional mod files? may be required for:/)
+          .click();
+        await expect(detail.suggestionTitle).toBeVisible();
+      });
+
+      await test.step("Detail states that the mod file may be required", async () => {
+        await expect(detail.mayRequireLine).toBeVisible();
+      });
+
+      await test.step("Detail carries the 'identified from the mod page' disclaimer", async () => {
+        await expect(detail.modPageSourceNote).toBeVisible();
+      });
+
+      await test.step("Detail feedback prompt uses the suggestion wording", async () => {
+        await expect(detail.feedbackPrompt).toBeVisible();
+      });
+    });
+
+    test("Check a free user's 1-click on a suggestion opens the Premium upsell", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const { suggestions } = await openModRequirementSuggestion(
+        nexusPage,
+        vortexApp,
+        vortexWindow,
+      );
+      const premiumModal = new HealthCheckPremiumModal(vortexWindow);
+
+      await test.step("1-click opens the single-file Premium upsell", async () => {
+        await dismissAllNotifications(vortexWindow);
+        await suggestions.installOneClick().click();
+        await expect(premiumModal.singleTitle).toBeVisible();
+      });
+    });
+  });
+});

--- a/packages/e2e/src/tests/health-check.spec.ts
+++ b/packages/e2e/src/tests/health-check.spec.ts
@@ -1,15 +1,13 @@
 /**
- * File Requirements Health Check — foundation E2E coverage (LAZ-684).
+ * Health Check — general screen behaviour + settings (LAZ-684).
  *
- * These cover the parts of the feature that are deterministic without special
- * requirement test-data: the empty/passed state, header controls, the Settings
- * toggles, and the free-vs-premium chrome. The warning / suggestion / install /
- * version / hide flows (TC-01, TC-05..TC-23, TC-27..TC-36) need an installed mod
- * with unsatisfied file-level requirement metadata and are tracked as follow-up.
+ * Covers the parts of the screen that are deterministic without special
+ * requirement test-data: the empty/passed state, the header and its controls,
+ * refresh, the Settings toggles (and their within-session persistence), and the
+ * free-vs-premium chrome. The requirement warning / detail / install flows live
+ * in the sibling health-check-file-requirement.spec.ts.
  *
- * TC references map to the behaviour spec in the LAZ-684 comment. Assertions use
- * the strings the app actually ships (locales/en/health_check.json), which differ
- * from the Figma copy quoted in the issue — see the note at the bottom of this file.
+ * Assertions use the strings the app actually ships (locales/en/health_check.json).
  */
 import { test, expect } from "../fixtures/vortex-app";
 import { navigateToHealthCheck, navigateToSettings } from "../helpers/navigation";
@@ -19,13 +17,11 @@ import { Header } from "../selectors/header";
 import { HealthCheckPage, HealthCheckSettings } from "../selectors/healthCheck";
 import { SettingsPage } from "../selectors/settings";
 
-test.describe("Health Check", () => {
-  // The page and settings behave identically for both tiers; run the tier-neutral
-  // foundation as the free user and keep the tier-specific chrome in its own block.
+test.describe("Health Check - screen behaviour and settings", () => {
   test.describe("free user", () => {
     test.use({ nexusUser: freeUser });
 
-    test("[TC-03] empty loadout shows the passed state", async ({
+    test("Check the passed state is shown when there are no issues", async ({
       vortexWindow,
       managedGame: _game,
     }) => {
@@ -45,7 +41,7 @@ test.describe("Health Check", () => {
       });
     });
 
-    test("[TC-03] header shows the title, subtitle and controls", async ({
+    test("Check the header shows the title, subtitle, beta badge and controls", async ({
       vortexWindow,
       managedGame: _game,
     }) => {
@@ -73,7 +69,7 @@ test.describe("Health Check", () => {
       });
     });
 
-    test("[TC-04] refresh re-runs the check and shows 'Last updated'", async ({
+    test("Check refresh re-runs the check and shows the last-updated time", async ({
       vortexWindow,
       managedGame: _game,
     }) => {
@@ -90,7 +86,7 @@ test.describe("Health Check", () => {
       });
     });
 
-    test("[TC-04] settings gear opens Settings at the Health Check section", async ({
+    test("Check the settings gear opens Settings at the Health Check section", async ({
       vortexWindow,
       managedGame: _game,
     }) => {
@@ -107,10 +103,7 @@ test.describe("Health Check", () => {
       });
     });
 
-    test("[TC-25] free user sees the premium banner", async ({
-      vortexWindow,
-      managedGame: _game,
-    }) => {
+    test("Check the premium banner is shown", async ({ vortexWindow, managedGame: _game }) => {
       const hc = new HealthCheckPage(vortexWindow);
 
       await test.step("Open the Health Check page", async () => {
@@ -123,7 +116,7 @@ test.describe("Health Check", () => {
       });
     });
 
-    test("[TC-30] settings expose the mod- and file-requirement toggles", async ({
+    test("Check the settings expose the mod- and file-requirement toggles", async ({
       vortexWindow,
     }) => {
       await test.step("Open Settings and switch to the Vortex tab", async () => {
@@ -138,14 +131,12 @@ test.describe("Health Check", () => {
         await expect(settings.modRequirementsToggle).toBeVisible();
       });
 
-      // Visible only when the Unleash flag is present for this user — the E2E
-      // accounts are enrolled, so it must render.
       await test.step("File-requirements toggle is shown", async () => {
         await expect(settings.fileRequirementsToggle).toBeVisible();
       });
     });
 
-    test("[TC-30] file-requirements toggle flips and persists within the session", async ({
+    test("Check the file-requirements toggle flips and persists within the session", async ({
       vortexWindow,
     }) => {
       await test.step("Open Settings and switch to the Vortex tab", async () => {
@@ -182,7 +173,7 @@ test.describe("Health Check", () => {
   test.describe("premium user", () => {
     test.use({ nexusUser: premiumUser });
 
-    test("[TC-26] premium user sees the premium indicator and no banner", async ({
+    test("Check the premium indicator is shown and the banner is hidden", async ({
       vortexWindow,
       managedGame: _game,
     }) => {
@@ -203,18 +194,3 @@ test.describe("Health Check", () => {
     });
   });
 });
-
-/*
- * Copy discrepancies vs the Figma spec in the LAZ-684 comment (TC-35 — reported,
- * tests assert the shipped strings):
- *   - Page title: ships "Health Check" with a separate "Beta" pill (BetaBadge),
- *     not the inline "Health check (BETA)" of the Figma.
- *   - Subtitle: ships "Review your Loadout for any issues and learn how to resolve
- *     them if needed.", not "Find and fix issues in your loadout".
- *   - Settings description: ships "Detect issues with your mod list and suggest
- *     fixes. More checks are coming soon."
- *   - Toggle labels: ship "Missing mod requirements suggestions" / "Missing file
- *     requirements warnings", not the "Show missing mod ..." phrasing in TC-30.
- * Also note: the Active/Hidden tabs render only once at least one hideable item
- * exists, so the empty state has no "Active (0) / Hidden (0)" tabs (TC-03/TC-05).
- */

--- a/packages/e2e/src/tests/health-check.spec.ts
+++ b/packages/e2e/src/tests/health-check.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * File Requirements Health Check — foundation E2E coverage (LAZ-684).
+ *
+ * These cover the parts of the feature that are deterministic without special
+ * requirement test-data: the empty/passed state, header controls, the Settings
+ * toggles, and the free-vs-premium chrome. The warning / suggestion / install /
+ * version / hide flows (TC-01, TC-05..TC-23, TC-27..TC-36) need an installed mod
+ * with unsatisfied file-level requirement metadata and are tracked as follow-up.
+ *
+ * TC references map to the behaviour spec in the LAZ-684 comment. Assertions use
+ * the strings the app actually ships (locales/en/health_check.json), which differ
+ * from the Figma copy quoted in the issue — see the note at the bottom of this file.
+ */
+import { test, expect } from "../fixtures/vortex-app";
+import { navigateToHealthCheck, navigateToSettings } from "../helpers/navigation";
+import { Timeouts } from "../helpers/timeouts";
+import { freeUser, premiumUser } from "../helpers/users";
+import { Header } from "../selectors/header";
+import { HealthCheckPage, HealthCheckSettings } from "../selectors/healthCheck";
+import { SettingsPage } from "../selectors/settings";
+
+test.describe("Health Check", () => {
+  // The page and settings behave identically for both tiers; run the tier-neutral
+  // foundation as the free user and keep the tier-specific chrome in its own block.
+  test.describe("free user", () => {
+    test.use({ nexusUser: freeUser });
+
+    test("[TC-03] empty loadout shows the passed state", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.title).toBeVisible();
+      });
+
+      await test.step("Passed-state title is shown", async () => {
+        await expect(hc.emptyStateTitle).toBeVisible();
+      });
+
+      await test.step("Passed-state message is shown", async () => {
+        await expect(hc.emptyStateMessage).toBeVisible();
+      });
+    });
+
+    test("[TC-03] header shows the title, subtitle and controls", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.title).toBeVisible();
+      });
+
+      await test.step("Subtitle is shown", async () => {
+        await expect(hc.subtitle).toBeVisible();
+      });
+
+      await test.step("Beta badge is shown", async () => {
+        await expect(hc.betaBadge).toBeVisible();
+      });
+
+      await test.step("Refresh control is shown", async () => {
+        await expect(hc.refreshButton).toBeVisible();
+      });
+
+      await test.step("Settings control is shown", async () => {
+        await expect(hc.settingsButton).toBeVisible();
+      });
+    });
+
+    test("[TC-04] refresh re-runs the check and shows 'Last updated'", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.refreshButton).toBeVisible();
+      });
+
+      await test.step("Refresh and confirm the last-updated timestamp appears", async () => {
+        await hc.refreshButton.click();
+        await expect(hc.lastUpdated).toBeVisible({ timeout: Timeouts.NETWORK });
+      });
+    });
+
+    test("[TC-04] settings gear opens Settings at the Health Check section", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.settingsButton).toBeVisible();
+      });
+
+      await test.step("Click the settings gear", async () => {
+        await hc.settingsButton.click();
+        await expect(new HealthCheckSettings(vortexWindow).sectionTitle).toBeVisible();
+      });
+    });
+
+    test("[TC-25] free user sees the premium banner", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.title).toBeVisible();
+      });
+
+      await test.step("Premium banner is shown", async () => {
+        await expect(hc.premiumBanner).toBeVisible();
+      });
+    });
+
+    test("[TC-30] settings expose the mod- and file-requirement toggles", async ({
+      vortexWindow,
+    }) => {
+      await test.step("Open Settings and switch to the Vortex tab", async () => {
+        await navigateToSettings(vortexWindow);
+        await new SettingsPage(vortexWindow).vortexTab.click();
+        await expect(new HealthCheckSettings(vortexWindow).sectionTitle).toBeVisible();
+      });
+
+      const settings = new HealthCheckSettings(vortexWindow);
+
+      await test.step("Mod-requirements toggle is shown", async () => {
+        await expect(settings.modRequirementsToggle).toBeVisible();
+      });
+
+      // Visible only when the Unleash flag is present for this user — the E2E
+      // accounts are enrolled, so it must render.
+      await test.step("File-requirements toggle is shown", async () => {
+        await expect(settings.fileRequirementsToggle).toBeVisible();
+      });
+    });
+
+    test("[TC-30] file-requirements toggle flips and persists within the session", async ({
+      vortexWindow,
+    }) => {
+      await test.step("Open Settings and switch to the Vortex tab", async () => {
+        await navigateToSettings(vortexWindow);
+        await new SettingsPage(vortexWindow).vortexTab.click();
+        await expect(new HealthCheckSettings(vortexWindow).fileRequirementsToggle).toBeVisible();
+      });
+
+      const settings = new HealthCheckSettings(vortexWindow);
+
+      await test.step("Toggle starts enabled", async () => {
+        await expect(settings.fileRequirementsToggle).toHaveClass(/toggle-on/);
+      });
+
+      await test.step("Turn it off", async () => {
+        await settings.fileRequirementsToggle.click();
+        await expect(settings.fileRequirementsToggle).toHaveClass(/toggle-off/);
+      });
+
+      await test.step("Leave to the Interface tab", async () => {
+        await new SettingsPage(vortexWindow).interfaceTab.click();
+        await expect(new HealthCheckSettings(vortexWindow).sectionTitle).toBeHidden();
+      });
+
+      await test.step("Return to the Vortex tab and confirm the toggle is still off", async () => {
+        await new SettingsPage(vortexWindow).vortexTab.click();
+        await expect(new HealthCheckSettings(vortexWindow).fileRequirementsToggle).toHaveClass(
+          /toggle-off/,
+        );
+      });
+    });
+  });
+
+  test.describe("premium user", () => {
+    test.use({ nexusUser: premiumUser });
+
+    test("[TC-26] premium user sees the premium indicator and no banner", async ({
+      vortexWindow,
+      managedGame: _game,
+    }) => {
+      const hc = new HealthCheckPage(vortexWindow);
+
+      await test.step("Open the Health Check page", async () => {
+        await navigateToHealthCheck(vortexWindow);
+        await expect(hc.title).toBeVisible();
+      });
+
+      await test.step("Premium indicator is shown in the top bar", async () => {
+        await expect(new Header(vortexWindow).premiumIndicator).toBeVisible();
+      });
+
+      await test.step("Premium banner is not shown", async () => {
+        await expect(hc.premiumBanner).toHaveCount(0);
+      });
+    });
+  });
+});
+
+/*
+ * Copy discrepancies vs the Figma spec in the LAZ-684 comment (TC-35 — reported,
+ * tests assert the shipped strings):
+ *   - Page title: ships "Health Check" with a separate "Beta" pill (BetaBadge),
+ *     not the inline "Health check (BETA)" of the Figma.
+ *   - Subtitle: ships "Review your Loadout for any issues and learn how to resolve
+ *     them if needed.", not "Find and fix issues in your loadout".
+ *   - Settings description: ships "Detect issues with your mod list and suggest
+ *     fixes. More checks are coming soon."
+ *   - Toggle labels: ship "Missing mod requirements suggestions" / "Missing file
+ *     requirements warnings", not the "Show missing mod ..." phrasing in TC-30.
+ * Also note: the Active/Hidden tabs render only once at least one hideable item
+ * exists, so the empty state has no "Active (0) / Hidden (0)" tabs (TC-03/TC-05).
+ */

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -160,15 +160,6 @@ export function init() {
     "app:setProtocolClient",
     (_event: IpcMainInvokeEvent, protocol: string, udPath: string | undefined) => {
       const [execPath, args] = selfCL(udPath);
-      // Under E2E, never take over the OS protocol handler. On a dev machine
-      // with Vortex installed this would hijack the nxm:// hand-off that the
-      // download tests must capture inside the test browser. Clear this
-      // instance's registration instead. In-app nxm handling (via the
-      // "external-url" IPC) is unaffected, so forwarded downloads still install.
-      if (process.env.VORTEX_E2E === "1") {
-        app.removeAsDefaultProtocolClient(protocol, execPath, args);
-        return;
-      }
       app.setAsDefaultProtocolClient(protocol, execPath, args);
     },
   );

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -160,6 +160,15 @@ export function init() {
     "app:setProtocolClient",
     (_event: IpcMainInvokeEvent, protocol: string, udPath: string | undefined) => {
       const [execPath, args] = selfCL(udPath);
+      // Under E2E, never take over the OS protocol handler. On a dev machine
+      // with Vortex installed this would hijack the nxm:// hand-off that the
+      // download tests must capture inside the test browser. Clear this
+      // instance's registration instead. In-app nxm handling (via the
+      // "external-url" IPC) is unaffected, so forwarded downloads still install.
+      if (process.env.VORTEX_E2E === "1") {
+        app.removeAsDefaultProtocolClient(protocol, execPath, args);
+        return;
+      }
       app.setAsDefaultProtocolClient(protocol, execPath, args);
     },
   );


### PR DESCRIPTION
Adds Playwright E2E coverage for the Health Check feature (LAZ-684), organised into three specs:

- **health-check.spec.ts** — general screen behaviour + settings (empty/passed state, header + controls, refresh, the mod/file-requirement toggles + persistence, free/premium chrome).
- **health-check-file-requirement.spec.ts** — file-requirement **warnings** (yellow): plural copy, detail view, all four 1-click install entry points (list-row / header / detail-section / per-card + progressive count), free manual-download resolution, the "Install via mod page" link, Active/Hidden hide/unhide, and the feedback controls.
- **health-check-mod-requirement.spec.ts** — mod-requirement **suggestions** (blue): the suggestion + detail + "identified from the mod page" disclaimer, and the free Premium upsell.

Supporting infra: Health Check POMs; helpers for the Mod-Manager download (incl. stepping past the file-requirements download modal), notification-tray dismissal, external-open capture, `auth:capture`, and the `manageGame` search fix; plus a small `VORTEX_E2E` gate so an E2E-launched Vortex doesn't seize the OS `nxm://` registration.

All tests pass locally (`CI=1`).

### Notes for reviewers
- The requirement specs are heavy (real Mod-Manager downloads) and need a logged-in, download-capable account enrolled in the `vortex-file-requirements-health-check` flag.
- Fixtures: SDV mods `49786` (file requirements) and `5098` / GMCM (mod requirement → SMAPI).
- Related observation raised on LAZ-852 (whether a file-requirement mod should also surface a page-level suggestion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
