### PR TITLE
Health Check refresh fixes

### DIFF
--- a/src/renderer/src/extensions/health_check/api/triggers.ts
+++ b/src/renderer/src/extensions/health_check/api/triggers.ts
@@ -43,10 +43,10 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
       void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.SettingsChanged);
     });
 
-    // Mods changed triggers - debounced because did-install-mod and
-    // did-enable-mods fire in quick succession for the same install, and
-    // setModsEnabled() in InstallManager is not awaited so state may not
-    // be updated when the first event fires.
+    // Mods changed triggers - debounced because these events can fire in quick
+    // succession (e.g. a batch enable/disable, or did-install-mod alongside
+    // setModsEnabled() in InstallManager, which isn't awaited so state may not
+    // be updated when the first event fires).
     const modsChangedDebouncer = new Debouncer(
       () => triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.ModsChanged),
       500,
@@ -54,6 +54,19 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
 
     api.events.on("did-install-mod", () => {
       log("debug", "Mod installed, scheduling debounced health check");
+      modsChangedDebouncer.schedule();
+    });
+
+    // mod-enabled/mod-disabled are derived from a diff of the active profile's
+    // modState, so they fire for every enable/disable path (single toggle,
+    // bulk selection, profile switch, dependency auto-enable, etc.).
+    api.events.on("mod-enabled", () => {
+      log("debug", "Mod enabled, scheduling debounced health check");
+      modsChangedDebouncer.schedule();
+    });
+
+    api.events.on("mod-disabled", () => {
+      log("debug", "Mod disabled, scheduling debounced health check");
       modsChangedDebouncer.schedule();
     });
 

--- a/src/renderer/src/extensions/health_check/api/triggers.ts
+++ b/src/renderer/src/extensions/health_check/api/triggers.ts
@@ -90,6 +90,41 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
       return Promise.resolve();
     });
 
+    // did-remove-mod/did-remove-mods fire once removal (undeploy + delete)
+    // actually completes, from the single handler every removal path funnels
+    // through (ModList, collections, ModHistory undo).
+    api.events.on("did-remove-mod", () => {
+      log("debug", "Mod removed, scheduling debounced health check");
+      modsChangedDebouncer.schedule();
+    });
+
+    api.events.on("did-remove-mods", () => {
+      log("debug", "Mods removed, scheduling debounced health check");
+      modsChangedDebouncer.schedule();
+    });
+
+    // Downloads are deleted/added from many call sites with no single
+    // completion event (deleting an archive alongside a mod, deleting an
+    // archive-only entry, external cleanup, etc.), so watch the state
+    // directly rather than chasing every emit site. A requirement can be
+    // satisfied by a downloaded-but-not-installed archive, so this affects
+    // what the checks report even though it isn't a mod install/enable.
+    api.onStateChange?.(
+      ["persistent", "downloads", "files"],
+      (previous: Record<string, unknown>, current: Record<string, unknown>) => {
+        const previousKeys = Object.keys(previous ?? {});
+        const currentKeys = Object.keys(current ?? {});
+        const changed =
+          previousKeys.length !== currentKeys.length ||
+          previousKeys.some((id) => !(id in (current ?? {})));
+        if (!changed) {
+          return;
+        }
+        log("debug", "Downloads changed, scheduling debounced health check");
+        modsChangedDebouncer.schedule();
+      },
+    );
+
     // Run health checks after collection post-processing finishes,
     // matching the pattern used by gamebryo-plugin-management for LOOT.
     api.events.on("collection-postprocess-complete", () => {

--- a/src/renderer/src/extensions/health_check/api/triggers.ts
+++ b/src/renderer/src/extensions/health_check/api/triggers.ts
@@ -48,7 +48,7 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
     // setModsEnabled() in InstallManager is not awaited so state may not
     // be updated when the first event fires.
     const modsChangedDebouncer = new Debouncer(
-      () => void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.ModsChanged),
+      () => triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.ModsChanged),
       500,
     );
 

--- a/src/renderer/src/extensions/health_check/api/triggers.ts
+++ b/src/renderer/src/extensions/health_check/api/triggers.ts
@@ -6,6 +6,7 @@ import type { IHealthCheckResult } from "../../../types/IHealthCheck";
 import { HealthCheckTrigger } from "../../../types/IHealthCheck";
 import { hasCollectionActiveSession } from "../../../util/collectionInstallSessionSelectors";
 import Debouncer from "../../../util/Debouncer";
+import { isLoggedIn } from "../../nexus_integration/selectors";
 import type { IHealthCheckApi } from "../types";
 
 /**
@@ -41,6 +42,19 @@ export function setupAutomaticTriggers(api: IExtensionApi, healthCheckApi: IHeal
     api.events.on("settings-changed", (path: string[]) => {
       log("debug", "Triggering settings change health checks", { path });
       void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.SettingsChanged);
+    });
+
+    // Login changed trigger - fires only when whether we actually have Nexus
+    // login data flips, not on every credential write.
+    let wasLoggedIn = isLoggedIn(api.getState());
+    api.onStateChange?.(["confidential", "account", "nexus"], () => {
+      const isNowLoggedIn = isLoggedIn(api.getState());
+      if (isNowLoggedIn === wasLoggedIn) {
+        return;
+      }
+      wasLoggedIn = isNowLoggedIn;
+      log("debug", "Login state changed, triggering health checks", { isNowLoggedIn });
+      void triggerHealthChecks(api, healthCheckApi, HealthCheckTrigger.LoginChanged);
     });
 
     // Mods changed triggers - debounced because these events can fire in quick

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
@@ -142,6 +142,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.ProfileChanged,
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
+    HealthCheckTrigger.LoginChanged,
   ],
   check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     // Reading the flag through FlagService reports an evaluation metric to the server.

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -526,6 +526,7 @@ export const modRequirementsHealthCheck: IHealthCheck = {
     HealthCheckTrigger.ProfileChanged,
     HealthCheckTrigger.GameChanged,
     HealthCheckTrigger.SettingsChanged,
+    HealthCheckTrigger.LoginChanged,
   ],
   check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     if (!isModRequirementsEnabled(api.getState())) {

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.runaway.test.ts
@@ -2,11 +2,20 @@ import { afterEach, describe, expect, vi } from "vitest";
 
 import { makeHealthCheckResult } from "../../../test-utils/builders";
 import { test } from "../../../test-utils/healthCheckTest";
+import {
+  HealthCheckCategory,
+  HealthCheckSeverity,
+  HealthCheckTrigger,
+} from "../../../types/IHealthCheck";
 import * as perModRunner from "./perModRunner";
 
 // Budget for a parked body to notice its abort and return. Sized for a loaded CI box, not the
 // ~10ms it normally takes: a stuck body burns the budget once instead of failing at random.
 const SETTLE = { timeout: 10000, interval: 10 };
+
+// Budget for the coalesced rerun to fire: the registry's own 500ms post-collision debounce plus
+// slack for a loaded CI box.
+const RERUN_SETTLE = { timeout: 3000, interval: 20 };
 
 /** What the registry does with a check whose body outlives the run's timeout (GH#23776). */
 describe("HealthCheckRegistry timeout handling", () => {
@@ -74,6 +83,48 @@ describe("HealthCheckRegistry timeout handling", () => {
     await vi.waitFor(() => expect(parked.hasSettled()).toBe(true), SETTLE);
     await harness.run(parked.id);
     expect(parked.starts()).toBe(2);
+  });
+});
+
+/** What the registry does when a request collides with a run already in flight. */
+describe("HealthCheckRegistry busy-collision handling", () => {
+  test("reruns once after the current run settles, coalescing several collisions", async ({
+    makeHealthCheck,
+  }) => {
+    const harness = makeHealthCheck();
+    let starts = 0;
+    const releaseInvocation: Array<() => void> = [];
+    harness.registry.register({
+      id: "manual-check",
+      name: "manual-check",
+      description: "",
+      category: HealthCheckCategory.System,
+      severity: HealthCheckSeverity.Info,
+      triggers: [HealthCheckTrigger.Manual],
+      timeout: 100000,
+      check: async () => {
+        starts += 1;
+        await new Promise<void>((resolve) => releaseInvocation.push(resolve));
+        return makeHealthCheckResult({ checkId: "manual-check" });
+      },
+    });
+
+    const firstRun = harness.run("manual-check");
+    expect(starts).toBe(1);
+
+    // Three collisions while it's busy must coalesce into exactly one rerun, not three.
+    await harness.run("manual-check");
+    await harness.run("manual-check");
+    await harness.run("manual-check");
+    expect(starts).toBe(1);
+
+    releaseInvocation[0]();
+    await firstRun;
+
+    await vi.waitFor(() => expect(starts).toBe(2), RERUN_SETTLE);
+
+    // Wind down the coalesced run's own body so nothing leaks into a later test.
+    releaseInvocation[1]();
   });
 });
 

--- a/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
+++ b/src/renderer/src/extensions/health_check/core/HealthCheckRegistry.ts
@@ -19,11 +19,18 @@ import type { HealthCheckId } from "../types";
 import { runPerModCheck } from "./perModRunner";
 
 export class HealthCheckRegistry {
+  /** How long to wait, once a busy check settles, before running a rerun requested while it was busy. */
+  private static readonly RERUN_DEBOUNCE_MS = 500;
+
   private mHealthChecks: Map<HealthCheckId, IHealthCheckEntry> = new Map();
   private mTriggerMap: Map<HealthCheckTrigger, Set<HealthCheckId>> = new Map();
   private mExecutionQueue: Set<HealthCheckId> = new Set();
   private mApi: IExtensionApi;
   private mResults: Map<HealthCheckId, IHealthCheckResult> = new Map();
+  /** Set when a request collides with a run already in flight; consumed once that run settles. */
+  private mRerunRequested: Set<HealthCheckId> = new Set();
+  /** The pending post-collision rerun timer, so it can be cancelled on disposal/teardown. */
+  private mRerunTimers: Map<HealthCheckId, ReturnType<typeof setTimeout>> = new Map();
 
   constructor(api: IExtensionApi) {
     this.mApi = api;
@@ -164,9 +171,14 @@ export class HealthCheckRegistry {
       return entry.lastResult;
     }
 
-    // Prevent concurrent execution of the same check
+    // Already running: don't start a second one. Let it finish undisturbed, and make sure
+    // exactly one fresh run happens once it settles - no matter how many requests land in the
+    // meantime, they all coalesce into that one rerun.
     if (this.mExecutionQueue.has(checkId)) {
-      log("debug", "Health check already executing, skipping", { id: checkId });
+      log("debug", "Health check already executing, scheduling a rerun once it settles", {
+        id: checkId,
+      });
+      this.mRerunRequested.add(checkId);
       return entry.lastResult;
     }
 
@@ -174,6 +186,16 @@ export class HealthCheckRegistry {
     const startTime = Date.now();
     let timedOut = false;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let released = false;
+    // Both the fire-and-forget path (which outlives a timeout) and the normal-completion path
+    // release the slot for the same run, so this must tolerate being called twice.
+    const release = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.finishRun(checkId, api);
+    };
 
     try {
       const timeout = entry.healthCheck.timeout || 30000;
@@ -205,7 +227,7 @@ export class HealthCheckRegistry {
               afterMs: Date.now() - startTime,
             });
           }
-          this.mExecutionQueue.delete(checkId);
+          release();
         });
 
       const result = await Promise.race([checkPromise, timeoutPromise]);
@@ -266,9 +288,40 @@ export class HealthCheckRegistry {
       // On timeout the body runs on and releases the slot from its settle handler; any other
       // exit means it is done.
       if (!timedOut) {
-        this.mExecutionQueue.delete(checkId);
+        release();
       }
     }
+  }
+
+  /**
+   * Frees a run's execution slot once its body has actually settled, and fires a coalesced rerun
+   * if any request collided with it while it ran.
+   */
+  private finishRun(checkId: HealthCheckId, api: IExtensionApi): void {
+    if (!this.mRerunRequested.has(checkId)) {
+      this.mExecutionQueue.delete(checkId);
+      return;
+    }
+
+    this.mRerunRequested.delete(checkId);
+    // mExecutionQueue stays marked busy through this wait, so further collisions coalesce into
+    // this same pending rerun instead of starting their own.
+    const timer = setTimeout(() => {
+      this.mRerunTimers.delete(checkId);
+      this.mExecutionQueue.delete(checkId);
+      void this.runHealthCheck(checkId, api);
+    }, HealthCheckRegistry.RERUN_DEBOUNCE_MS);
+    this.mRerunTimers.set(checkId, timer);
+  }
+
+  /**
+   * Cancels any rerun scheduled after a busy collision, without waiting for it to fire. Intended
+   * for disposal/teardown, so a pending timer doesn't fire into unrelated later work.
+   */
+  public cancelPendingReruns(): void {
+    this.mRerunTimers.forEach((timer) => clearTimeout(timer));
+    this.mRerunTimers.clear();
+    this.mRerunRequested.clear();
   }
 
   /**

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -874,6 +874,10 @@ export function makeHealthCheckHarness(
     releaseParked: async () => {
       releases.forEach((release) => release());
       await Promise.all(bodies);
+      // Let the fire-and-forget completion handling that follows a settled body run - and, with
+      // it, any rerun that handling schedules after a collision - before cancelling it below.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      registry.cancelPendingReruns();
     },
   };
 }

--- a/src/renderer/src/types/IHealthCheck.ts
+++ b/src/renderer/src/types/IHealthCheck.ts
@@ -23,6 +23,7 @@ export enum HealthCheckTrigger {
   GameChanged = "game-changed",
   ProfileChanged = "profile-changed",
   ModsChanged = "mods-changed",
+  LoginChanged = "login-changed",
   SettingsChanged = "settings-changed",
   PluginsChanged = "plugins-changed",
   LootUpdated = "loot-updated",


### PR DESCRIPTION
- Health check should now correctly refresh on login state change
- Health check should now correctly refresh on enabled state change
- Health check should now correctly debounce multiple triggers, instead of running multiple checks at the same time.
- Health check should now correctly refresh on mods being removed
- Health check should now correctly refresh on downloads being removed or added