### PR TITLE
Move the Extensions page onto the new Page layout

### DIFF
--- a/assets/pictograms/premium-pictogram.svg
+++ b/assets/pictograms/premium-pictogram.svg
@@ -1,3 +1,6 @@
+<!-- Not a Pictogram: this is loaded as a plain <Image src="assets/pictograms/premium-pictogram.svg">
+     by the premium banners/dashlet/modal, so it keeps its own colours and 37x36 box rather than
+     the 200x200 currentColor shape the Pictogram component expects. -->
 <svg width="37" height="36" viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M6.50894 19.1579C6.52945 19.1356 6.55359 19.1151 6.58155 19.0969L13.654 14.4937C13.7123 14.4558 13.7804 14.4355 13.85 14.4355H17.8787C17.9462 14.4355 18.0067 14.4528 18.0579 14.4822L19.3409 14.4822C19.3922 14.4528 19.4527 14.4355 19.5202 14.4355H23.5601C23.6297 14.4355 23.6978 14.4558 23.7561 14.4937L30.8286 19.0969C30.8565 19.115 30.8806 19.1355 30.901 19.1578L31.3924 19.4754C31.6074 19.6143 31.6123 19.927 31.4019 20.0726L29.3659 21.4823C25.8187 23.9519 22.2581 26.4035 18.7051 28.8634C15.1418 26.3963 11.5708 23.9376 8.01335 21.4608L6.00831 20.0726C5.79791 19.9269 5.80288 19.6143 6.01781 19.4754L6.50894 19.1579Z" fill="#A78BFA"/>
 <mask id="mask0_272_170" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="5" y="14" width="27" height="15">

--- a/assets/pictograms/puzzle-piece.svg
+++ b/assets/pictograms/puzzle-piece.svg
@@ -1,0 +1,23 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <path d="M141.721 104.15H132.547V79.6852C132.547 72.9573 127.042 67.4527 120.315 67.4527H95.8497V58.2784C95.8497 49.8381 88.9996 42.9879 80.5592 42.9879C72.1188 42.9879 65.2687 49.8381 65.2687 58.2784V67.4527H40.8038C34.076 67.4527 28.6326 72.9573 28.6326 79.6852V102.927H37.7457C46.8589 102.927 54.2595 110.327 54.2595 119.441C54.2595 128.554 46.8589 135.954 37.7457 135.954H28.5714V159.196C28.5714 165.924 34.076 171.428 40.8038 171.428H64.0454V162.254C64.0454 153.141 71.446 145.74 80.5592 145.74C89.6723 145.74 97.0729 153.141 97.0729 162.254V171.428H120.315C127.042 171.428 132.547 165.924 132.547 159.196V134.731H141.721C150.162 134.731 157.012 127.881 157.012 119.441C157.012 111 150.162 104.15 141.721 104.15Z" style="fill: currentColor"/>
+    <g filter="url(#filter0_d_5404_1489)">
+        <path d="M156.138 89.7335H146.964V65.2687C146.964 58.5408 141.459 53.0362 134.731 53.0362H110.267V43.8619C110.267 35.4216 103.416 28.5714 94.9761 28.5714C86.5357 28.5714 79.6856 35.4216 79.6856 43.8619V53.0362H55.2208C48.4929 53.0362 43.0495 58.5408 43.0495 65.2687V88.5103H52.1627C61.2758 88.5103 68.6764 95.9109 68.6764 105.024C68.6764 114.137 61.2758 121.538 52.1627 121.538H42.9883V144.779C42.9883 151.507 48.4929 157.012 55.2208 157.012H78.4624V147.837C78.4624 138.724 85.863 131.324 94.9761 131.324C104.089 131.324 111.49 138.724 111.49 147.837V157.012H134.731C141.459 157.012 146.964 151.507 146.964 144.779V120.315H156.138C164.579 120.315 171.429 113.464 171.429 105.024C171.429 96.5837 164.579 89.7335 156.138 89.7335Z" fill="url(#paint0_radial_5404_1489)"/>
+    </g>
+    <defs>
+        <filter id="filter0_d_5404_1489" x="17.9883" y="10.7143" width="171.298" height="171.298" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+            <feOffset dx="-3.57143" dy="3.57143"/>
+            <feGaussianBlur stdDeviation="10.7143"/>
+            <feComposite in2="hardAlpha" operator="out"/>
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.95 0"/>
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5404_1489"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_5404_1489" result="shape"/>
+        </filter>
+        <radialGradient id="paint0_radial_5404_1489" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(67.3269 59.8505) rotate(17.7249) scale(161.531)">
+            <stop offset="0.365346" stop-color="white"/>
+            <stop offset="0.64903" stop-color="#7D88ED"/>
+            <stop offset="0.748224" stop-color="white"/>
+        </radialGradient>
+    </defs>
+</svg>

--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -61,6 +61,15 @@ export interface IBaseProps {
   defaultSort?: string;
   showHeader?: boolean;
   showDetails?: boolean;
+  // For a table that scrolls with the page rather than in its own pane: drops the
+  // header copy this table would otherwise pin to the top of that pane, and sticks
+  // the header in the body to the top of the page scroll instead, shadowed while
+  // it is stuck.
+  stickyHeader?: boolean;
+  // Lets rows and their hover run to the page edges, with the outer cells carrying
+  // the page's own horizontal padding so their content still lines up. The page
+  // drops its horizontal padding around the table in exchange.
+  edgeToEdge?: boolean;
   hasActions?: boolean;
   onChangeSelection?: (ids: string[]) => void;
   children?: React.ReactNode;
@@ -323,7 +332,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   }
 
   public render(): JSX.Element {
-    const { showHeader, showDetails, tableId } = this.props;
+    const { edgeToEdge, showHeader, showDetails, stickyHeader, tableId } = this.props;
     const { detailsOpen } = this.state;
 
     const openClass = detailsOpen ? "open" : "closed";
@@ -331,6 +340,12 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     const containerClasses = ["table-container"];
     if (showDetails) {
       containerClasses.push("has-details");
+    }
+    if (stickyHeader) {
+      containerClasses.push("sticky-header");
+    }
+    if (edgeToEdge) {
+      containerClasses.push("edge-to-edge");
     }
 
     return (
@@ -354,7 +369,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
           {this.renderFooter()}
         </div>
 
-        {showHeader === false ? null : (
+        {showHeader === false || stickyHeader ? null : (
           <div className="table-header-pane" ref={this.mainHeaderRef}>
             <Table hover={true}>{this.renderHeader(false)}</Table>
           </div>

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -273,9 +273,13 @@ export const ExtensionManager = ({
         </div>
       </PageHeader>
 
-      <PageScroll isFullWidth className="flex flex-col gap-y-4 px-6 pt-6">
+      <PageScroll isFullWidth className="flex flex-col gap-y-4">
         {restartNeeded && (
-          <Alert bsStyle="warning" style={{ display: "flex", alignItems: "center" }}>
+          <Alert
+            bsStyle="warning"
+            className="mx-6"
+            style={{ display: "flex", alignItems: "center" }}
+          >
             <div style={{ flexGrow: 1 }}>{t("You need to restart Vortex to apply changes.")}</div>
 
             <BSButton onClick={() => relaunch()}>{t("Restart")}</BSButton>
@@ -283,6 +287,8 @@ export const ExtensionManager = ({
         )}
 
         <Table
+          edgeToEdge
+          stickyHeader
           actions={actions}
           data={extensionsWithState}
           multiSelect={false}

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -3,22 +3,25 @@ import * as path from "path";
 import { mdiPlus, mdiRefresh } from "@mdi/js";
 import type { EndorsedStatus } from "@nexusmods/nexus-api";
 import * as _ from "lodash";
-import * as React from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Alert, Button as BSButton } from "react-bootstrap";
-import type * as Redux from "redux";
-import type { ThunkDispatch } from "redux-thunk";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
 
-import { setDialogVisible } from "@/actions";
-import { removeExtension, setExtensionEnabled, setExtensionEndorsed } from "@/actions";
-import { ComponentEx, connect, translate } from "@/controls/ComponentEx";
+import {
+  removeExtension,
+  setDialogVisible,
+  setExtensionEnabled,
+  setExtensionEndorsed,
+} from "@/actions";
+import { useMainContext } from "@/contexts";
 import type { DropType } from "@/controls/Dropzone";
 import Dropzone from "@/controls/Dropzone";
 import type { ITableRowAction } from "@/controls/Table";
 import Table from "@/controls/Table";
 import { log } from "@/logging";
 import type { IExtensionWithState } from "@/types/extensions";
-import type { IExtensionLoadFailure, IExtensionState, IState } from "@/types/IState";
-import type { ITableAttribute } from "@/types/ITableAttribute";
+import type { IExtensionState, IState } from "@/types/IState";
 import { Button } from "@/ui/components/button/Button";
 import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
@@ -29,7 +32,6 @@ import { PageContent } from "@/views/components/Page/PageContent";
 import { PageHeader } from "@/views/components/Page/PageHeader";
 import { PageScroll } from "@/views/components/Page/PageScroll";
 
-import type { IDownload } from "../download_management/types/IDownload";
 import { SITE_ID } from "../gamemode_management/constants";
 import { DisplayOptions } from "./components/DisplayOptions";
 import installExtension from "./installExtension";
@@ -45,335 +47,259 @@ export interface IExtensionManagerProps {
   pageId?: string;
 }
 
-interface IConnectedProps {
-  extensions: { [extId: string]: IExtensionState };
-  downloads: { [dlId: string]: IDownload };
-  downloadPath: string;
-  loadFailures: { [extId: string]: IExtensionLoadFailure[] };
-}
+type IExtensionStates = { [extId: string]: IExtensionState };
 
-interface IActionProps {
-  onSetExtensionEnabled: (extId: string, enabled: boolean) => void;
-  onRemoveExtension: (extId: string) => void;
-  onBrowseExtension: () => void;
-}
+const EMPTY_EXTENSIONS: IExtensionStates = {};
 
-type IProps = IExtensionManagerProps & IConnectedProps & IActionProps;
+// Normalise extension config so two sets differ only if the effective
+// configuration does, leaving out the endorsement state.
+const configId = (conf: IExtensionStates) =>
+  Object.values(conf).map((ext) => ({
+    enabled: ext.enabled ?? true,
+    version: ext.version ?? "",
+    remove: ext.remove ?? false,
+  }));
 
-interface IComponentState {
-  oldExtensions: { [extId: string]: IExtensionState };
-  showBundled: boolean;
-}
+export const ExtensionManager = ({
+  active,
+  localState,
+  pageId,
+  updateExtensions,
+  onRefresh,
+}: IExtensionManagerProps) => {
+  const { t } = useTranslation(["common"]);
+  const { api } = useMainContext();
+  const dispatch = useDispatch();
 
-class ExtensionManager extends ComponentEx<IProps, IComponentState> {
-  private staticColumns: ITableAttribute[];
-  private actions: ITableRowAction[];
+  const extensions = useSelector((state: IState) => state.app.extensions) ?? EMPTY_EXTENSIONS;
+  const loadFailures = useSelector((state: IState) => state.session.base.extLoadFailures);
+  const downloads = useSelector((state: IState) => state.persistent.downloads.files);
+  const downloadPath = useSelector(selectors.downloadPath);
 
-  constructor(props: IProps) {
-    super(props);
+  const [showBundled, setShowBundled] = useState(false);
+  // The config as the page found it; a change from here means Vortex needs a restart.
+  const [oldExtensions] = useState(extensions);
 
-    this.initState({
-      oldExtensions: props.extensions,
-      showBundled: false,
-    });
+  // Held in a ref so the columns and row actions stay stable across renders while
+  // their callbacks still see the current extensions.
+  const extensionsRef = useRef(extensions);
+  extensionsRef.current = extensions;
 
-    this.actions = [
+  const setEnabled = useCallback(
+    (extName: string, enabled: boolean) => {
+      const current = extensionsRef.current;
+      const extId = Object.keys(current).find((iter) => current[iter].name === extName);
+      log("info", "user toggling extension manually", { extId, enabled });
+      dispatch(setExtensionEnabled(extId, enabled));
+    },
+    [dispatch],
+  );
+
+  const staticColumns = useMemo(
+    () =>
+      getTableAttributes({
+        onSetExtensionEnabled: setEnabled,
+        onToggleExtensionEnabled: (extName: string) => {
+          const current = extensionsRef.current;
+          const extId = Object.keys(current).find((iter) => current[iter].name === extName);
+          setEnabled(extName, !(current[extId]?.enabled ?? true));
+        },
+        onEndorseMod: (_gameId: string, modIdStr: string, endorseState: EndorsedStatus) => {
+          const current = extensionsRef.current;
+          const modId = parseInt(modIdStr, 10);
+          const extId = Object.keys(current).find((iter) => current[iter].modId === modId);
+
+          if (extId === undefined) {
+            return;
+          }
+
+          api
+            .emitAndAwait("endorse-nexus-mod", SITE_ID, modId, current[extId].version, endorseState)
+            .then((endorsed: EndorsedStatus[]) => {
+              dispatch(setExtensionEndorsed(extId, endorsed[0]));
+            })
+            .catch(() => {
+              dispatch(setExtensionEndorsed(extId, "Undecided"));
+            });
+        },
+      }),
+    [api, dispatch, setEnabled],
+  );
+
+  const actions = useMemo<ITableRowAction[]>(
+    () => [
       {
         icon: "delete",
         title: "Remove",
-        action: this.removeExtension,
-        condition: (instanceId: string) => !this.props.extensions[instanceId]?.bundled,
+        action: (extIds: string[]) => {
+          extIds.forEach((extId) => dispatch(removeExtension(extId)));
+        },
+        condition: (instanceId: string) => !extensionsRef.current[instanceId]?.bundled,
         singleRowAction: true,
       },
-    ];
+    ],
+    [dispatch],
+  );
 
-    this.staticColumns = getTableAttributes({
-      onSetExtensionEnabled: (extName: string, enabled: boolean) => {
-        const { extensions, onSetExtensionEnabled } = this.props;
-        const extId = Object.keys(extensions).find((iter) => extensions[iter].name === extName);
-        log("info", "user toggling extension manually", { extId, enabled });
-        onSetExtensionEnabled(extId, enabled);
-      },
-      onToggleExtensionEnabled: (extName: string) => {
-        const { extensions, onSetExtensionEnabled } = this.props;
-        const extId = Object.keys(extensions).find((iter) => extensions[iter].name === extName);
-        const enabled = !(extensions[extId]?.enabled ?? true);
-        log("info", "user toggling extension manually", { extId, enabled });
-        onSetExtensionEnabled(extId, enabled);
-      },
-      onEndorseMod: (gameId: string, modIdStr: string, endorseState: EndorsedStatus) => {
-        const { extensions } = this.props;
-        const { api } = this.context;
-        const modId: number = parseInt(modIdStr, 10);
-        const extId = Object.keys(extensions).find((iter) => extensions[iter].modId === modId);
+  const bundled = useMemo(
+    () =>
+      (api?.getLoadedExtensions?.() ?? [])
+        .filter((ext) => ext.dynamic && ext.info?.bundled)
+        .reduce<IExtensionStates>((prev, ext) => {
+          prev[ext.name] = {
+            enabled: true,
+            version: ext.info?.version ?? "",
+            remove: false,
+            endorsed: "Undecided",
+            name: ext.info?.name ?? ext.name,
+            author: ext.info?.author ?? "Unknown",
+            description: ext.info?.description ?? "",
+            path: ext.path,
+            bundled: true,
+          };
+          return prev;
+        }, {}),
+    [api],
+  );
 
-        if (extId === undefined) {
-          return;
-        }
-
-        api
-          .emitAndAwait(
-            "endorse-nexus-mod",
-            SITE_ID,
-            modId,
-            extensions[extId].version,
-            endorseState,
-          )
-          .then((endorsed: EndorsedStatus[]) => {
-            api.store.dispatch(setExtensionEndorsed(extId, endorsed[0]));
-          })
-          .catch(() => {
-            api.store.dispatch(setExtensionEndorsed(extId, "Undecided"));
-          });
-      },
-    });
-  }
-
-  public render(): JSX.Element {
-    const { t, active, extensions, localState, pageId } = this.props;
-    const { oldExtensions, showBundled } = this.state;
-
-    const bundled = (this.context?.api?.getLoadedExtensions?.() ?? [])
-      .filter((ext) => ext.dynamic && ext.info?.bundled)
-      .reduce<{ [extId: string]: IExtensionState }>((prev, ext) => {
-        prev[ext.name] = {
-          enabled: true,
-          version: ext.info?.version ?? "",
-          remove: false,
-          endorsed: "Undecided",
-          name: ext.info?.name ?? ext.name,
-          author: ext.info?.author ?? "Unknown",
-          description: ext.info?.description ?? "",
-          path: ext.path,
-          bundled: true,
-        };
-        return prev;
-      }, {});
-
+  const extensionsWithState = useMemo(() => {
     const allExtensions = showBundled ? { ...extensions, ...bundled } : extensions;
 
-    const extensionsWithState = this.mergeExt(allExtensions, showBundled);
+    return Object.keys(allExtensions).reduce<{ [id: string]: IExtensionWithState }>((prev, id) => {
+      const state = allExtensions[id];
 
-    // normalize extension config so they differ only if the effective configuration actually
-    // differs, leaving out the endorsement state
-    const configId = (conf: { [id: string]: IExtensionState }) =>
-      Object.values(conf).map((ext) => ({
-        enabled: ext.enabled ?? true,
-        version: ext.version ?? "",
-        remove: ext.remove ?? false,
-      }));
-
-    return (
-      <Page active={active} pageId={pageId} scrollable={false}>
-        <PageHeader
-          isFullWidth
-          pictogramName="puzzle-piece"
-          subtitle={t("Manage extensions that add features and game support to Vortex.")}
-          title={t("Extensions")}
-        >
-          <div className="flex shrink-0 items-center gap-x-2">
-            <TooltipDelayGroup>
-              <Tooltip content={t("Update extensions")} placement="bottom">
-                <Button
-                  appearance="subdued"
-                  aria-label={t("Update extensions")}
-                  brand="neutral"
-                  leftIconPath={mdiRefresh}
-                  size="sm"
-                  onClick={this.onRefresh}
-                />
-              </Tooltip>
-
-              <Tooltip content={t("Browse extensions")} placement="bottom">
-                <Button
-                  appearance="subdued"
-                  aria-label={t("Browse extensions")}
-                  brand="neutral"
-                  leftIconPath={mdiPlus}
-                  size="sm"
-                  onClick={this.onBrowse}
-                />
-              </Tooltip>
-
-              <DisplayOptions
-                showBundled={showBundled}
-                t={t}
-                onReset={this.resetDisplayOptions}
-                onToggleBundled={this.toggleBundled}
-              />
-            </TooltipDelayGroup>
-          </div>
-        </PageHeader>
-
-        <PageScroll isFullWidth className="flex flex-col gap-y-4 px-6 pt-6">
-          {localState.reloadNecessary || !_.isEqual(configId(extensions), configId(oldExtensions))
-            ? this.renderReload()
-            : null}
-
-          <Table
-            actions={this.actions}
-            data={extensionsWithState}
-            multiSelect={false}
-            staticElements={this.staticColumns}
-            tableId="extensions"
-          />
-        </PageScroll>
-
-        <PageContent isFullWidth className="p-6">
-          <Dropzone
-            accept={["files"]}
-            dialogHint={t("Select extension file")}
-            drop={this.dropExtension}
-            icon="folder-download"
-            // The stand-alone dropzone insets itself by 10px; the page padding does that.
-            style={{ margin: 0, width: "100%" }}
-          />
-        </PageContent>
-      </Page>
-    );
-  }
-
-  private onBrowse = () => {
-    this.props.onBrowseExtension();
-  };
-
-  private onRefresh = () => {
-    this.props.onRefresh();
-  };
-
-  private toggleBundled = () => {
-    this.nextState.showBundled = !this.state.showBundled;
-  };
-
-  private resetDisplayOptions = () => {
-    this.nextState.showBundled = false;
-  };
-
-  private dropExtension = (type: DropType, extPaths: string[]): void => {
-    const { downloads } = this.props;
-    log("info", "installing extension(s) via drag and drop", { extPaths });
-
-    let promises: Promise<boolean>[];
-
-    if (type === "files") {
-      promises = extPaths.map((extPath) =>
-        installExtension(this.context.api, extPath)
-          .then(() => true)
-          .catch((err) => {
-            this.context.api.showErrorNotification("Failed to install extension", err, {
-              allowReport: false,
-            });
-
-            return false;
-          }),
-      );
-    } else {
-      promises = extPaths.map(async (url) => {
-        const downloadId = await new Promise<string>((resolve, reject) => {
-          this.context.api.events.emit<"start-download">(
-            "start-download",
-            [url],
-            { game: SITE_ID },
-            undefined,
-            (err, downloadId) => {
-              if (err) {
-                reject(err);
-                return;
-              }
-
-              resolve(downloadId);
-            },
-          );
-        });
-
-        const downloadPath = path.join(this.props.downloadPath, downloads[downloadId].localPath);
-        return await installExtension(this.context.api, downloadPath)
-          .then(() => true)
-          .catch((err) => {
-            this.context.api.showErrorNotification("Failed to install extension", err, {
-              allowReport: false,
-            });
-
-            return false;
-          });
-      });
-    }
-
-    void (async () => {
-      const results = await Promise.all(promises);
-      if (results.some((success) => success)) {
-        await this.props.updateExtensions();
-      }
-    })();
-  };
-
-  private renderReload(): JSX.Element {
-    const { t } = this.props;
-    return (
-      <Alert bsStyle="warning" style={{ display: "flex", alignItems: "center" }}>
-        <div style={{ flexGrow: 1 }}>{t("You need to restart Vortex to apply changes.")}</div>
-
-        <BSButton onClick={this.restart}>{t("Restart")}</BSButton>
-      </Alert>
-    );
-  }
-
-  private restart = () => {
-    relaunch();
-  };
-
-  private mergeExt(
-    extensions: { [id: string]: IExtensionState },
-    includeBundled: boolean,
-  ): { [id: string]: IExtensionWithState } {
-    const { loadFailures } = this.props;
-    return Object.keys(extensions).reduce((prev, id) => {
-      const state = extensions[id];
-
-      if (!includeBundled && state.bundled) {
+      if ((!showBundled && state.bundled) || state.remove) {
         return prev;
       }
-
-      if (state.remove) {
-        return prev;
-      }
-
-      const enabled = loadFailures[id] === undefined ? (state.enabled ?? true) : "failed";
 
       prev[id] = {
         ...state,
-        enabled,
+        enabled: loadFailures[id] === undefined ? (state.enabled ?? true) : "failed",
         loadFailures: loadFailures[id] || [],
       };
       return prev;
     }, {});
-  }
+  }, [bundled, extensions, loadFailures, showBundled]);
 
-  private removeExtension = (extIds: string[]) => {
-    extIds.forEach((extId) => {
-      this.props.onRemoveExtension(extId);
-    });
-  };
-}
+  const dropExtension = useCallback(
+    (type: DropType, extPaths: string[]) => {
+      log("info", "installing extension(s) via drag and drop", { extPaths });
 
-function mapStateToProps(state: IState): IConnectedProps {
-  return {
-    extensions: state.app.extensions ?? {},
-    loadFailures: state.session.base.extLoadFailures,
-    downloads: state.persistent.downloads.files,
-    downloadPath: selectors.downloadPath(state),
-  };
-}
+      const install = (extPath: string) =>
+        installExtension(api, extPath)
+          .then(() => true)
+          .catch((err) => {
+            api.showErrorNotification("Failed to install extension", err, { allowReport: false });
 
-function mapDispatchToProps(dispatch: ThunkDispatch<any, null, Redux.Action>): IActionProps {
-  return {
-    onSetExtensionEnabled: (extId: string, enabled: boolean) =>
-      dispatch(setExtensionEnabled(extId, enabled)),
-    onRemoveExtension: (extId: string) => dispatch(removeExtension(extId)),
-    onBrowseExtension: () => dispatch(setDialogVisible("browse-extensions")),
-  };
-}
+            return false;
+          });
 
-export default translate(["common"])(
-  connect(mapStateToProps, mapDispatchToProps)(ExtensionManager),
-);
+      const promises =
+        type === "files"
+          ? extPaths.map(install)
+          : extPaths.map(async (url) => {
+              const downloadId = await new Promise<string>((resolve, reject) => {
+                api.events.emit<"start-download">(
+                  "start-download",
+                  [url],
+                  { game: SITE_ID },
+                  undefined,
+                  (err, id) => {
+                    if (err) {
+                      reject(err);
+                      return;
+                    }
+
+                    resolve(id);
+                  },
+                );
+              });
+
+              return await install(path.join(downloadPath, downloads[downloadId].localPath));
+            });
+
+      void (async () => {
+        const results = await Promise.all(promises);
+        if (results.some((success) => success)) {
+          await updateExtensions();
+        }
+      })();
+    },
+    [api, downloadPath, downloads, updateExtensions],
+  );
+
+  const restartNeeded =
+    localState.reloadNecessary || !_.isEqual(configId(extensions), configId(oldExtensions));
+
+  return (
+    <Page active={active} pageId={pageId} scrollable={false}>
+      <PageHeader
+        isFullWidth
+        pictogramName="puzzle-piece"
+        subtitle={t("Manage extensions that add features and game support to Vortex.")}
+        title={t("Extensions")}
+      >
+        <div className="flex shrink-0 items-center gap-x-2">
+          <TooltipDelayGroup>
+            <Tooltip content={t("Update extensions")} placement="bottom">
+              <Button
+                appearance="subdued"
+                aria-label={t("Update extensions")}
+                brand="neutral"
+                leftIconPath={mdiRefresh}
+                size="sm"
+                onClick={onRefresh}
+              />
+            </Tooltip>
+
+            <Tooltip content={t("Browse extensions")} placement="bottom">
+              <Button
+                appearance="subdued"
+                aria-label={t("Browse extensions")}
+                brand="neutral"
+                leftIconPath={mdiPlus}
+                size="sm"
+                onClick={() => dispatch(setDialogVisible("browse-extensions"))}
+              />
+            </Tooltip>
+
+            <DisplayOptions
+              showBundled={showBundled}
+              t={t}
+              onReset={() => setShowBundled(false)}
+              onToggleBundled={() => setShowBundled((prev) => !prev)}
+            />
+          </TooltipDelayGroup>
+        </div>
+      </PageHeader>
+
+      <PageScroll isFullWidth className="flex flex-col gap-y-4 px-6 pt-6">
+        {restartNeeded && (
+          <Alert bsStyle="warning" style={{ display: "flex", alignItems: "center" }}>
+            <div style={{ flexGrow: 1 }}>{t("You need to restart Vortex to apply changes.")}</div>
+
+            <BSButton onClick={() => relaunch()}>{t("Restart")}</BSButton>
+          </Alert>
+        )}
+
+        <Table
+          actions={actions}
+          data={extensionsWithState}
+          multiSelect={false}
+          staticElements={staticColumns}
+          tableId="extensions"
+        />
+      </PageScroll>
+
+      <PageContent isFullWidth className="p-6">
+        <Dropzone
+          accept={["files"]}
+          dialogHint={t("Select extension file")}
+          drop={dropExtension}
+          icon="folder-download"
+          style={{ margin: 0, width: "100%" }}
+        />
+      </PageContent>
+    </Page>
+  );
+};

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -1,33 +1,37 @@
 import * as path from "path";
 
+import { mdiPlus, mdiRefresh } from "@mdi/js";
 import type { EndorsedStatus } from "@nexusmods/nexus-api";
 import * as _ from "lodash";
 import * as React from "react";
-import { Alert, Button, Panel } from "react-bootstrap";
+import { Alert, Button as BSButton } from "react-bootstrap";
 import type * as Redux from "redux";
 import type { ThunkDispatch } from "redux-thunk";
 
+import { setDialogVisible } from "@/actions";
+import { removeExtension, setExtensionEnabled, setExtensionEndorsed } from "@/actions";
+import { ComponentEx, connect, translate } from "@/controls/ComponentEx";
+import type { DropType } from "@/controls/Dropzone";
+import Dropzone from "@/controls/Dropzone";
+import type { ITableRowAction } from "@/controls/Table";
+import Table from "@/controls/Table";
 import { log } from "@/logging";
+import type { IExtensionWithState } from "@/types/extensions";
+import type { IExtensionLoadFailure, IExtensionState, IState } from "@/types/IState";
+import type { ITableAttribute } from "@/types/ITableAttribute";
+import { Button } from "@/ui/components/button/Button";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
+import { relaunch } from "@/util/commandLine";
+import * as selectors from "@/util/selectors";
+import { Page } from "@/views/components/Page/Page";
+import { PageContent } from "@/views/components/Page/PageContent";
+import { PageHeader } from "@/views/components/Page/PageHeader";
+import { PageScroll } from "@/views/components/Page/PageScroll";
 
-import { setDialogVisible } from "../../actions";
-import { removeExtension, setExtensionEnabled, setExtensionEndorsed } from "../../actions/app";
-import { ComponentEx, connect, translate } from "../../controls/ComponentEx";
-import type { DropType } from "../../controls/Dropzone";
-import Dropzone from "../../controls/Dropzone";
-import FlexLayout from "../../controls/FlexLayout";
-import IconBar from "../../controls/IconBar";
-import type { ITableRowAction } from "../../controls/Table";
-import Table from "../../controls/Table";
-import ToolbarIcon from "../../controls/ToolbarIcon";
-import type { IExtensionWithState } from "../../types/extensions";
-import type { IExtensionLoadFailure, IExtensionState, IState } from "../../types/IState";
-import type { ITableAttribute } from "../../types/ITableAttribute";
-import { relaunch } from "../../util/commandLine";
-import * as selectors from "../../util/selectors";
-import { getSafe } from "../../util/storeHelper";
-import MainPage from "../../views/MainPage";
 import type { IDownload } from "../download_management/types/IDownload";
 import { SITE_ID } from "../gamemode_management/constants";
+import { DisplayOptions } from "./components/DisplayOptions";
 import installExtension from "./installExtension";
 import getTableAttributes from "./tableAttributes";
 
@@ -36,6 +40,9 @@ export interface IExtensionManagerProps {
     reloadNecessary: boolean;
   };
   updateExtensions: () => Promise<void>;
+  onRefresh: () => void;
+  active?: boolean;
+  pageId?: string;
 }
 
 interface IConnectedProps {
@@ -123,7 +130,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
   }
 
   public render(): JSX.Element {
-    const { t, extensions, localState } = this.props;
+    const { t, active, extensions, localState, pageId } = this.props;
     const { oldExtensions, showBundled } = this.state;
 
     const bundled = (this.context?.api?.getLoadedExtensions?.() ?? [])
@@ -157,67 +164,72 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
       }));
 
     return (
-      <MainPage>
-        <MainPage.Header>
-          <IconBar
-            id="extensions-layout-list"
-            group="extensions-layout-icons"
-            staticElements={[]}
-            className="menubar"
-            t={t}
-          >
-            <ToolbarIcon
-              id="show-bundled-extensions"
-              text={showBundled ? t("Hide Bundled") : t("Show Bundled")}
-              onClick={this.toggleBundled}
-              icon={showBundled ? "hide" : "show"}
-              tooltip={showBundled ? t("Hide Bundled Extensions") : t("Show Bundled Extensions")}
-            />
-          </IconBar>
-        </MainPage.Header>
-        <MainPage.Body>
-          <Panel>
-            <Panel.Body>
-              <FlexLayout type="column">
-                <FlexLayout.Fixed>
-                  {localState.reloadNecessary ||
-                  !_.isEqual(configId(extensions), configId(oldExtensions))
-                    ? this.renderReload()
-                    : null}
-                </FlexLayout.Fixed>
-                <FlexLayout.Flex>
-                  <Table
-                    tableId="extensions"
-                    data={extensionsWithState}
-                    actions={this.actions}
-                    staticElements={this.staticColumns}
-                    multiSelect={false}
-                  />
-                </FlexLayout.Flex>
-                <FlexLayout.Fixed>
-                  <FlexLayout type="row">
-                    <FlexLayout.Flex className="extensions-find-button-container">
-                      <div className="flex-center-both">
-                        <Button id="btn-more-extensions" onClick={this.onBrowse} bsStyle="ghost">
-                          {t("Find more")}
-                        </Button>
-                      </div>
-                    </FlexLayout.Flex>
-                    <FlexLayout.Flex>
-                      <Dropzone
-                        accept={["files"]}
-                        drop={this.dropExtension}
-                        dialogHint={t("Select extension file")}
-                        icon="folder-download"
-                      />
-                    </FlexLayout.Flex>
-                  </FlexLayout>
-                </FlexLayout.Fixed>
-              </FlexLayout>
-            </Panel.Body>
-          </Panel>
-        </MainPage.Body>
-      </MainPage>
+      <Page active={active} pageId={pageId} scrollable={false}>
+        <PageHeader
+          isFullWidth
+          pictogramName="puzzle-piece"
+          subtitle={t("Manage extensions that add features and game support to Vortex.")}
+          title={t("Extensions")}
+        >
+          <div className="flex shrink-0 items-center gap-x-2">
+            <TooltipDelayGroup>
+              <Tooltip content={t("Update extensions")} placement="bottom">
+                <Button
+                  appearance="subdued"
+                  aria-label={t("Update extensions")}
+                  brand="neutral"
+                  leftIconPath={mdiRefresh}
+                  size="sm"
+                  onClick={this.onRefresh}
+                />
+              </Tooltip>
+
+              <Tooltip content={t("Browse extensions")} placement="bottom">
+                <Button
+                  appearance="subdued"
+                  aria-label={t("Browse extensions")}
+                  brand="neutral"
+                  leftIconPath={mdiPlus}
+                  size="sm"
+                  onClick={this.onBrowse}
+                />
+              </Tooltip>
+
+              <DisplayOptions
+                showBundled={showBundled}
+                t={t}
+                onReset={this.resetDisplayOptions}
+                onToggleBundled={this.toggleBundled}
+              />
+            </TooltipDelayGroup>
+          </div>
+        </PageHeader>
+
+        <PageScroll isFullWidth className="flex flex-col gap-y-4 px-6 pt-6">
+          {localState.reloadNecessary || !_.isEqual(configId(extensions), configId(oldExtensions))
+            ? this.renderReload()
+            : null}
+
+          <Table
+            actions={this.actions}
+            data={extensionsWithState}
+            multiSelect={false}
+            staticElements={this.staticColumns}
+            tableId="extensions"
+          />
+        </PageScroll>
+
+        <PageContent isFullWidth className="p-6">
+          <Dropzone
+            accept={["files"]}
+            dialogHint={t("Select extension file")}
+            drop={this.dropExtension}
+            icon="folder-download"
+            // The stand-alone dropzone insets itself by 10px; the page padding does that.
+            style={{ margin: 0, width: "100%" }}
+          />
+        </PageContent>
+      </Page>
     );
   }
 
@@ -225,8 +237,16 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
     this.props.onBrowseExtension();
   };
 
+  private onRefresh = () => {
+    this.props.onRefresh();
+  };
+
   private toggleBundled = () => {
     this.nextState.showBundled = !this.state.showBundled;
+  };
+
+  private resetDisplayOptions = () => {
+    this.nextState.showBundled = false;
   };
 
   private dropExtension = (type: DropType, extPaths: string[]): void => {
@@ -292,7 +312,8 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
     return (
       <Alert bsStyle="warning" style={{ display: "flex", alignItems: "center" }}>
         <div style={{ flexGrow: 1 }}>{t("You need to restart Vortex to apply changes.")}</div>
-        <Button onClick={this.restart}>{t("Restart")}</Button>
+
+        <BSButton onClick={this.restart}>{t("Restart")}</BSButton>
       </Alert>
     );
   }
@@ -337,7 +358,7 @@ class ExtensionManager extends ComponentEx<IProps, IComponentState> {
 
 function mapStateToProps(state: IState): IConnectedProps {
   return {
-    extensions: state.app.extensions ?? ({} as { [extId: string]: IExtensionState }),
+    extensions: state.app.extensions ?? {},
     loadFailures: state.session.base.extLoadFailures,
     downloads: state.persistent.downloads.files,
     downloadPath: selectors.downloadPath(state),

--- a/src/renderer/src/extensions/extension_manager/components/DisplayOptions.tsx
+++ b/src/renderer/src/extensions/extension_manager/components/DisplayOptions.tsx
@@ -1,0 +1,26 @@
+import type { TFunction } from "i18next";
+import React from "react";
+
+import { DisplayOptions as DisplayOptionsPanel } from "@/ui/components/display_options/DisplayOptions";
+import { DisplayOptionsItem } from "@/ui/components/display_options/DisplayOptionsItem";
+import { Switch } from "@/ui/components/form/switch/Switch";
+
+interface IDisplayOptionsProps {
+  t: TFunction;
+  showBundled: boolean;
+  onToggleBundled: () => void;
+  onReset: () => void;
+}
+
+export const DisplayOptions = ({
+  t,
+  showBundled,
+  onToggleBundled,
+  onReset,
+}: IDisplayOptionsProps) => (
+  <DisplayOptionsPanel onReset={onReset}>
+    <DisplayOptionsItem label={t("Show bundled extensions")}>
+      <Switch checked={showBundled} onChange={onToggleBundled} />
+    </DisplayOptionsItem>
+  </DisplayOptionsPanel>
+);

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -19,7 +19,7 @@ import makeReactive from "../../util/makeReactive";
 import { setAvailableExtensions, setExtensionsUpdate } from "./actions";
 import BrowseExtensions from "./BrowseExtensions";
 import type { IBrowseExtensionsProps } from "./BrowseExtensions";
-import ExtensionManager from "./ExtensionManager";
+import { ExtensionManager } from "./ExtensionManager";
 import type { IExtensionManagerProps } from "./ExtensionManager";
 import sessionReducer from "./reducers";
 import { downloadAndInstallExtension, fetchAvailableExtensions } from "./util";

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -1,3 +1,4 @@
+import { mdiPuzzleOutline } from "@mdi/js";
 import * as semver from "semver";
 
 import { log } from "@/logging";
@@ -326,6 +327,7 @@ function init(context: IExtensionContext) {
     priority: 20,
     hotkey: "X",
     group: "global",
+    newLayout: true,
     props: () =>
       ({
         localState,
@@ -333,16 +335,14 @@ function init(context: IExtensionContext) {
           signalRestartNeeded(context.api);
           return Promise.resolve();
         },
+        onRefresh: () => forceUpdateExtensions(),
       }) satisfies Partial<IExtensionManagerProps>,
+    mdi: mdiPuzzleOutline,
   });
 
   const forceUpdateExtensions = () => {
     void updateAvailableExtensions(context.api, true);
   };
-
-  context.registerAction("extensions-layout-icons", 500, "refresh", {}, "Update Extensions", () => {
-    forceUpdateExtensions();
-  });
 
   context.registerDialog(
     "browse-extensions",

--- a/src/renderer/src/extensions/gamemode_management/components/DisplayOptions.tsx
+++ b/src/renderer/src/extensions/gamemode_management/components/DisplayOptions.tsx
@@ -1,26 +1,11 @@
-import { mdiTune, mdiViewGrid, mdiViewList } from "@mdi/js";
+import { mdiViewGrid, mdiViewList } from "@mdi/js";
 import type { TFunction } from "i18next";
-import React, { type ReactNode } from "react";
+import React from "react";
 
+import { DisplayOptions as DisplayOptionsPanel } from "@/ui/components/display_options/DisplayOptions";
+import { DisplayOptionsItem } from "@/ui/components/display_options/DisplayOptionsItem";
 import { Switch } from "@/ui/components/form/switch/Switch";
 import { Picker } from "@/ui/components/picker/Picker";
-import { Popover } from "@/ui/components/popover/Popover";
-import { PopoverButton } from "@/ui/components/popover/PopoverButton";
-import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
-import { Typography } from "@/ui/components/typography/Typography";
-import { TypographyLink } from "@/ui/components/typography/TypographyLink";
-import { joinClasses } from "@/ui/utils/joinClasses";
-
-const PopoverItem = ({ children, className }: { children: ReactNode; className?: string }) => (
-  <div
-    className={joinClasses([
-      "flex min-h-12 items-center gap-x-6 px-4 not-last:border-b not-last:border-stroke-weak",
-      className,
-    ])}
-  >
-    {children}
-  </div>
-);
 
 interface IDisplayOptionsProps {
   t: TFunction;
@@ -39,54 +24,24 @@ export const DisplayOptions = ({
   onToggleHidden,
   onReset,
 }: IDisplayOptionsProps) => (
-  <Popover>
-    <PopoverButton appearance="subdued" brand="neutral" leftIconPath={mdiTune} size="sm" />
+  <DisplayOptionsPanel onReset={onReset}>
+    <DisplayOptionsItem label={t("Display as")}>
+      <Picker<"list" | "small" | "large">
+        button={{
+          leftIconPath: pickerLayout === "list" ? mdiViewList : mdiViewGrid,
+          size: "xs",
+        }}
+        options={[
+          { label: t("Grid"), value: "small", iconPath: mdiViewGrid },
+          { label: t("List"), value: "list", iconPath: mdiViewList },
+        ]}
+        value={pickerLayout}
+        onChange={onSetPickerLayout}
+      />
+    </DisplayOptionsItem>
 
-    <PopoverPanel>
-      {({ close }) => (
-        <>
-          <PopoverItem className="justify-between gap-x-6">
-            <Typography appearance="subdued" typographyType="body-sm">
-              {t("Display as")}
-            </Typography>
-
-            <Picker<"list" | "small" | "large">
-              button={{
-                leftIconPath: pickerLayout === "list" ? mdiViewList : mdiViewGrid,
-                size: "xs",
-              }}
-              options={[
-                { label: t("Grid"), value: "small", iconPath: mdiViewGrid },
-                { label: t("List"), value: "list", iconPath: mdiViewList },
-              ]}
-              value={pickerLayout}
-              onChange={onSetPickerLayout}
-            />
-          </PopoverItem>
-
-          <PopoverItem className="justify-between gap-x-6">
-            <Typography appearance="subdued" typographyType="body-sm">
-              {t("Show hidden items")}
-            </Typography>
-
-            <Switch checked={showHidden} onChange={onToggleHidden} />
-          </PopoverItem>
-
-          <PopoverItem className="justify-end">
-            <TypographyLink
-              brand="info"
-              typographyType="body-sm"
-              variant="secondary"
-              onClick={() => {
-                onReset();
-                close();
-              }}
-            >
-              {t("Reset to default")}
-            </TypographyLink>
-          </PopoverItem>
-        </>
-      )}
-    </PopoverPanel>
-  </Popover>
+    <DisplayOptionsItem label={t("Show hidden items")}>
+      <Switch checked={showHidden} onChange={onToggleHidden} />
+    </DisplayOptionsItem>
+  </DisplayOptionsPanel>
 );

--- a/src/renderer/src/extensions/health_check/components/beta_badge/BetaBadge.tsx
+++ b/src/renderer/src/extensions/health_check/components/beta_badge/BetaBadge.tsx
@@ -2,15 +2,20 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
 
 /** Small "Beta" pill shown next to the health check page titles. */
-export const BetaBadge = () => {
+export const BetaBadge = ({ isSubdued = false }: { isSubdued?: boolean }) => {
   const { t } = useTranslation(["health_check", "common"]);
 
   return (
     <Typography
+      appearance={isSubdued ? "subdued" : "strong"}
       as="div"
-      className="flex min-h-4 items-center justify-center rounded-sm border border-neutral-strong px-1"
+      className={joinClasses([
+        "flex min-h-4 items-center justify-center rounded-sm border px-1 transition-colors",
+        isSubdued ? "border-neutral-subdued" : "border-neutral-strong",
+      ])}
       typographyType="title-xs"
     >
       {t("common:::beta")}

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -114,15 +114,20 @@ function HealthCheckDetailPage({
       <IssueProvider entry={shownEntry}>
         <Page active={active} id="health-check-detail-page" scrollable={false}>
           <PageHeader
-            customTitle={
+            customTitle={(scrolled) => (
               <div className="flex items-center gap-x-1.5">
-                <Typography appearance="moderate" as="h2" typographyType="heading-xs">
+                <Typography
+                  appearance={scrolled ? "subdued" : "moderate"}
+                  as="h2"
+                  className="transition-colors"
+                  typographyType="heading-xs"
+                >
                   {t(`detail::title::${shownEntry.severity}`)}
                 </Typography>
 
-                <BetaBadge />
+                <BetaBadge isSubdued={scrolled} />
               </div>
-            }
+            )}
             pictogramName="health-check"
             subtitle={t(`detail::subtitle::${shownEntry.severity}`)}
           >

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -329,15 +329,20 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
     <HealthCheckTrackingProvider api={api}>
       <Page active={active} id="health-check-page" scrollable={false}>
         <PageHeader
-          customTitle={
+          customTitle={(scrolled) => (
             <div className="flex items-center gap-x-1.5">
-              <Typography appearance="moderate" as="h2" typographyType="heading-xs">
+              <Typography
+                appearance={scrolled ? "subdued" : "moderate"}
+                as="h2"
+                className="transition-colors"
+                typographyType="heading-xs"
+              >
                 {t("listing::title")}
               </Typography>
 
-              <BetaBadge />
+              <BetaBadge isSubdued={scrolled} />
             </div>
-          }
+          )}
           pictogramName="health-check"
           subtitle={t("listing::subtitle")}
         >

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -349,6 +349,23 @@ import { mdiTune } from "@mdi/js";
 
 > **Positioning note:** the panel is positioned manually (absolute) until `@headlessui/react` reaches v2, which brings dynamic anchor positioning and proper z-index handling.
 
+### DisplayOptions
+
+The tune-icon popover a listing puts in its page header, holding the controls for how that listing is shown (layout, what's included, …). It wraps `Popover` with the trigger, its tooltip and a reset link, so a page only supplies the rows. Compose those from `DisplayOptionsItem` — label on the left, control on the right, separated by rules. Every panel ends in the reset link: `onReset` puts the defaults back and the panel closes itself.
+
+```tsx
+import { DisplayOptions } from "../../ui/components/display_options/DisplayOptions";
+import { DisplayOptionsItem } from "../../ui/components/display_options/DisplayOptionsItem";
+
+<DisplayOptions onReset={onReset}>
+    <DisplayOptionsItem label={t("Show hidden items")}>
+        <Switch checked={showHidden} onChange={onToggleHidden} />
+    </DisplayOptionsItem>
+</DisplayOptions>;
+```
+
+**Props:** `onReset` and `children` are required. `label` (names the trigger — used as both its tooltip and `aria-label`) and `resetLabel` default to translated "Display options" and "Reset to default"; pass them only to say something else. `DisplayOptionsItem` takes `label` (omit it for a control-only row), `className` and `children`.
+
 ### Tooltip
 
 Rich, collision-aware tooltip built on `@floating-ui/react`. `content` is arbitrary React — headings, lists, icons — not just a string. Position is resolved against the window continuously: it flips to the opposite side when the preferred one would overflow, slides along an edge when a corner would, and clamps its own width and height to the room that is left. It renders into the `#overlays` host, so tables, dashlets and scroll panes cannot clip it.

--- a/src/renderer/src/ui/components/display_options/DisplayOptions.tsx
+++ b/src/renderer/src/ui/components/display_options/DisplayOptions.tsx
@@ -1,0 +1,72 @@
+import { mdiTune } from "@mdi/js";
+import React, { type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Popover } from "@/ui/components/popover/Popover";
+import { PopoverButton } from "@/ui/components/popover/PopoverButton";
+import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { TypographyLink } from "@/ui/components/typography/TypographyLink";
+
+import { DisplayOptionsItem } from "./DisplayOptionsItem";
+
+/**
+ * The tune-icon popover a listing puts in its page header, holding the controls
+ * for how that listing is shown. Compose the rows from `DisplayOptionsItem`.
+ *
+ * Every panel ends in a reset link, so there is always a way back to the
+ * defaults; `onReset` restores them and the panel closes itself.
+ *
+ * The trigger and reset labels default to "Display options" and "Reset to
+ * default"; pass them only to say something else.
+ */
+export const DisplayOptions = ({
+  children,
+  label,
+  resetLabel,
+  onReset,
+}: {
+  children: ReactNode;
+  label?: string;
+  resetLabel?: string;
+  onReset: () => void;
+}) => {
+  const { t } = useTranslation();
+  const triggerLabel = label ?? t("Display options");
+
+  return (
+    <Popover>
+      <Tooltip content={triggerLabel} placement="bottom">
+        <PopoverButton
+          appearance="subdued"
+          aria-label={triggerLabel}
+          brand="neutral"
+          leftIconPath={mdiTune}
+          size="sm"
+        />
+      </Tooltip>
+
+      <PopoverPanel>
+        {({ close }) => (
+          <>
+            {children}
+
+            <DisplayOptionsItem className="justify-end">
+              <TypographyLink
+                brand="info"
+                typographyType="body-sm"
+                variant="secondary"
+                onClick={() => {
+                  onReset();
+                  close();
+                }}
+              >
+                {resetLabel ?? t("Reset to default")}
+              </TypographyLink>
+            </DisplayOptionsItem>
+          </>
+        )}
+      </PopoverPanel>
+    </Popover>
+  );
+};

--- a/src/renderer/src/ui/components/display_options/DisplayOptionsItem.tsx
+++ b/src/renderer/src/ui/components/display_options/DisplayOptionsItem.tsx
@@ -1,0 +1,33 @@
+import React, { type PropsWithChildren } from "react";
+
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+/**
+ * One row of a `DisplayOptions` panel: a label on the left and its control on
+ * the right. Rows are separated by a rule, except the last one. Leave `label`
+ * off for a row that is only a control (the reset link uses that).
+ */
+export const DisplayOptionsItem = ({
+  children,
+  className,
+  label,
+}: PropsWithChildren<{ className?: string; label?: string }>) => (
+  <div
+    className={joinClasses(
+      [
+        "flex min-h-12 items-center gap-x-6 px-4 not-last:border-b not-last:border-stroke-weak",
+        className,
+      ],
+      { "justify-between": !!label },
+    )}
+  >
+    {!!label && (
+      <Typography appearance="subdued" typographyType="body-sm">
+        {label}
+      </Typography>
+    )}
+
+    {children}
+  </div>
+);

--- a/src/renderer/src/ui/components/pictogram/Pictogram.tsx
+++ b/src/renderer/src/ui/components/pictogram/Pictogram.tsx
@@ -26,7 +26,13 @@ const themeMap = {
   primary: "text-primary-moderate",
 } as const satisfies Record<ITheme, string>;
 
-export type IPictogramName = "game" | "health-check" | "preferences" | "settings" | "tools";
+export type IPictogramName =
+  | "game"
+  | "health-check"
+  | "preferences"
+  | "puzzle-piece"
+  | "settings"
+  | "tools";
 
 export const Pictogram = ({
   className,

--- a/src/renderer/src/ui/components/popover/PopoverButton.tsx
+++ b/src/renderer/src/ui/components/popover/PopoverButton.tsx
@@ -1,5 +1,5 @@
 import { Popover as HeadlessPopover } from "@headlessui/react";
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { Button, type IButtonProps } from "@/ui/components/button/Button";
 
@@ -9,7 +9,12 @@ export type IPopoverButtonProps = IButtonProps;
  * Popover trigger button. Renders a Button as the Headless UI `Popover.Button`,
  * so it takes all the same props as Button. Place it inside a `Popover`
  * alongside a `PopoverPanel`.
+ *
+ * The ref reaches the underlying `button`, so it can be a `Tooltip` trigger
+ * directly.
  */
-export const PopoverButton = (props: IPopoverButtonProps) => (
-  <HeadlessPopover.Button as={Button} {...props} />
-);
+export const PopoverButton = forwardRef<HTMLButtonElement, IPopoverButtonProps>((props, ref) => (
+  <HeadlessPopover.Button as={Button} ref={ref} {...props} />
+));
+
+PopoverButton.displayName = "PopoverButton";

--- a/src/renderer/src/ui/components/tooltip/Tooltip.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.tsx
@@ -23,6 +23,7 @@ import {
 import React, {
   cloneElement,
   isValidElement,
+  type PointerEvent as ReactPointerEvent,
   type ReactElement,
   type ReactNode,
   type Ref,
@@ -163,9 +164,20 @@ export const Tooltip = ({
     return children;
   }
 
+  const referenceProps = interactions.getReferenceProps({ ref: triggerRef, ...trigger.props });
+
+  // Close on press, so the tooltip never sits over a menu or popover the same
+  // trigger opens. `move: false` keeps it closed until the pointer re-enters.
+  const handlePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+    (
+      referenceProps.onPointerDown as ((event: ReactPointerEvent<HTMLElement>) => void) | undefined
+    )?.(event);
+    setOpen(false);
+  };
+
   return (
     <>
-      {cloneElement(trigger, interactions.getReferenceProps({ ref: triggerRef, ...trigger.props }))}
+      {cloneElement(trigger, { ...referenceProps, onPointerDown: handlePointerDown })}
 
       {isMounted && (
         <FloatingPortal id={OVERLAY_HOST_ID}>

--- a/src/renderer/src/views/components/Page/PageHeader.tsx
+++ b/src/renderer/src/views/components/Page/PageHeader.tsx
@@ -13,7 +13,7 @@ export type IPageHeaderProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> 
   children?: ReactNode | ((scrolled: boolean) => ReactNode);
   pictogramName?: IPictogramName;
   subtitle?: string;
-} & XOr<{ title: string }, { customTitle: ReactNode }>;
+} & XOr<{ title: string }, { customTitle: ReactNode | ((scrolled: boolean) => ReactNode) }>;
 
 /**
  * Full-bleed header for a non-scrolling `Page`. The bar itself spans the full
@@ -24,7 +24,8 @@ export type IPageHeaderProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> 
  *
  * Pass `title` for the common heading, or `customTitle` when the title needs
  * more than a string (e.g. a badge alongside it); `subtitle` renders below
- * either.
+ * either. `title` goes subdued once scrolled — `customTitle` takes a
+ * render-prop so it can match.
  */
 export const PageHeader = ({
   children,
@@ -42,7 +43,7 @@ export const PageHeader = ({
     <div
       className={joinClasses([
         "relative z-10 w-full pb-3 transition-[padding]",
-        scrolled ? "pt-3 shadow-md" : "border-b border-stroke-weak pt-6",
+        scrolled ? "py-2.5 shadow-md" : "border-b border-stroke-weak pt-6 pb-3",
         className,
       ])}
       {...rest}
@@ -61,8 +62,13 @@ export const PageHeader = ({
           )}
 
           <div className="grow">
-            {customTitle ?? (
-              <Typography appearance="moderate" as="h2" typographyType="heading-xs">
+            {(typeof customTitle === "function" ? customTitle(scrolled) : customTitle) ?? (
+              <Typography
+                appearance={scrolled ? "subdued" : "moderate"}
+                as="h2"
+                className="transition-colors"
+                typographyType="heading-xs"
+              >
                 {title}
               </Typography>
             )}

--- a/src/renderer/src/views/components/Page/PageHeader.tsx
+++ b/src/renderer/src/views/components/Page/PageHeader.tsx
@@ -19,8 +19,10 @@ export type IPageHeaderProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> 
  * Full-bleed header for a non-scrolling `Page`. The bar itself spans the full
  * width (so its background/shadow reach the viewport edges) and stays pinned
  * above the `PageScroll` sibling, while its content is centred and capped at
- * `max-w-8xl` so it lines up with the scrolled content. It gains a shadow once
- * that sibling is scrolled; pass a render-prop child to react to it too.
+ * `max-w-8xl` so it lines up with the scrolled content. It trades its hairline
+ * for a shadow once that sibling is scrolled — unless `isFullWidth`, where
+ * content reaches the bar itself, so the hairline stays and the shadow is
+ * skipped; pass a render-prop child to react to the scroll too.
  *
  * Pass `title` for the common heading, or `customTitle` when the title needs
  * more than a string (e.g. a badge alongside it); `subtitle` renders below
@@ -41,11 +43,17 @@ export const PageHeader = ({
 
   return (
     <div
-      className={joinClasses([
-        "relative z-10 w-full pb-3 transition-[padding]",
-        scrolled ? "py-2.5 shadow-md" : "border-b border-stroke-weak pt-6 pb-3",
-        className,
-      ])}
+      className={joinClasses(
+        [
+          "relative z-10 w-full pb-3 transition-[padding]",
+          scrolled ? "py-2.5" : "pt-6 pb-3",
+          className,
+        ],
+        {
+          "border-b border-stroke-weak": !scrolled || isFullWidth,
+          "shadow-md": scrolled && !isFullWidth,
+        },
+      )}
       {...rest}
     >
       <PageContent className="flex items-center gap-x-6 px-6" isFullWidth={isFullWidth}>

--- a/src/stylesheets/vortex/supertable.scss
+++ b/src/stylesheets/vortex/supertable.scss
@@ -29,20 +29,20 @@
 
 .table-highlighted {
     background-color: $brand-secondary;
-
-    .table-sort-column {
-        background-color: $brand-secondary;
-    }
 }
 
 .table-filter-column {
     background-color: $brand-info !important;
 }
 
-// Tints the whole sorted column. On the hovered row it layers over the row
-// tint, which is what keeps the column readable there.
-.table-sort-column {
-    background-color: var(--color-surface-translucent-low);
+// The sorted column is called out by its header alone, not by tinting the whole
+// column — so the headers read as one row with the active one picked out.
+.table-container .xthead .table-header-cell {
+    color: var(--color-neutral-subdued);
+
+    &.table-sort-column {
+        color: var(--color-neutral-strong);
+    }
 }
 
 .table-header-pane {
@@ -102,7 +102,9 @@
     }
 }
 
-.table-container .table-main-pane .xthead {
+// The header in the body only reserves the column widths — the header pane
+// draws the one you see. Unless the table sticks its own header (see below).
+.table-container:not(.sticky-header) .table-main-pane .xthead {
     .table-header-cell.xth {
         padding: 0 !important;
         border: 0 !important;
@@ -111,6 +113,65 @@
             max-height: 0 !important;
             visibility: hidden;
             margin-top: -100%;
+        }
+    }
+}
+
+// Rows run to the page edges — so hover and the sticky header read as full-width
+// bands — and the outer cells carry the page padding the page itself dropped.
+// !important because the cell padding above is set that way too.
+.table-container.edge-to-edge .xtr {
+    > .xth:first-child,
+    > .xtd:first-child {
+        padding-left: 1.5rem !important;
+    }
+
+    > .xth:last-child,
+    > .xtd:last-child {
+        padding-right: 1.5rem !important;
+    }
+}
+
+// A table that scrolls with the page instead of in its own pane: there is no
+// header pane to pin, so the header in the body sticks to the top of the page
+// scroll — the underside of the page header — as the rows pass beneath it.
+.table-container.sticky-header {
+    height: auto;
+    overflow: visible;
+
+    .table-main-pane {
+        overflow: visible;
+    }
+
+    .xthead {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        margin-right: 0;
+        container-type: scroll-state;
+        background-color: var(--color-surface-low);
+
+        .xth {
+            padding-top: 10px !important;
+        }
+    }
+}
+
+@container scroll-state(stuck: top) {
+    // Blink paints no box-shadow on the cells of a border-collapse table, so the
+    // lift is a gradient strip hung under each of them. They tile seamlessly.
+    .table-container.sticky-header .xthead .xth {
+        position: relative;
+
+        &::after {
+            top: 100%;
+            left: 0;
+            right: 0;
+            content: "";
+            height: 10px;
+            position: absolute;
+            pointer-events: none;
+            background: linear-gradient(to bottom, rgb(0 0 0 / 50%), transparent);
         }
     }
 }

--- a/src/stylesheets/vortex/supertable.scss
+++ b/src/stylesheets/vortex/supertable.scss
@@ -18,19 +18,13 @@
 }
 
 .table-selected {
-    background-color: $table-bg-active;
-
-    // the following is needed so the row color takes precedence over the
-    // column color
-    .table-sort-column {
-        background-color: $table-bg-active;
-    }
+    background-color: var(--color-surface-translucent-low);
 }
 
-.table-hover > .xtbody > .xtr:hover {
-    .table-sort-column {
-        background-color: $table-bg-hover;
-    }
+// Hovering the selected row lifts it a step, so it stays apart from the plain
+// hover tint.
+.table-hover > .xtbody > .xtr.table-selected:hover {
+    background-color: var(--color-surface-translucent-mid);
 }
 
 .table-highlighted {
@@ -45,8 +39,10 @@
     background-color: $brand-info !important;
 }
 
+// Tints the whole sorted column. On the hovered row it layers over the row
+// tint, which is what keeps the column readable there.
 .table-sort-column {
-    background-color: color.adjust($table-bg, $lightness: -5%);
+    background-color: var(--color-surface-translucent-low);
 }
 
 .table-header-pane {
@@ -98,8 +94,6 @@
     }
 
     .xtbody {
-        background-color: $brand-menu;
-
         .xtr {
             > div {
                 padding: 4px 0px;

--- a/src/stylesheets/vortex/table.scss
+++ b/src/stylesheets/vortex/table.scss
@@ -1,8 +1,10 @@
 .xtable {
+    // bootstrap paints every `table`; tables sit on the page surface instead.
+    background-color: transparent;
+
     > .xthead,
     > .xtbody,
     > .xtfoot {
-        background-color: $table-bg;
         > .xtr {
             > .xth,
             > .xtd {
@@ -70,7 +72,7 @@
 
 .table-hover {
     > .xtbody > .xtr:hover {
-        background-color: $table-bg-hover;
+        background-color: var(--color-surface-translucent-low);
     }
 }
 


### PR DESCRIPTION
The Extensions page now registers with newLayout and renders Page/PageHeader/PageScroll at full width, replacing the legacy MainPage chrome and IconBar. Its header actions are refresh, browse and a display-options popover; the "Find more" button became the + browse icon and the "Show bundled" toolbar toggle moved inside the popover. The page has a puzzle-piece pictogram and menu icon, and its component is now a function component using useSelector/useDispatch/useMainContext rather than a ComponentEx class behind translate/connect.                                                              

The display-options popover is now a shared ui component (DisplayOptions/DisplayOptionsItem) used by both this page and the Games page, and every panel ends in a reset link.                                                      

The table scrolls with the page rather than in its own pane, so it keeps a sticky header pinned under the page header. Two opt-in Table props do that work — stickyHeader (drops the pinned header-pane copy, sticks the body header, adds a gradient strip once it leaves the top) and edgeToEdge (rows and their hover run to the page edges, with the outer cells taking the padding the page gave up). Tables also lose their opaque background in favour of translucent hover/selected tints, and the sorted column is called out by its header alone instead of a tint down the whole column.                

Shared component changes along the way: PopoverButton forwards its ref so it can be a Tooltip trigger; tooltips close when their trigger is pressed, so they can't sit over the menu they open; PageHeader's customTitle takes a render prop so the Health Check title and its beta pill can go subdued on scroll, and a full-width header keeps its hairline instead of a shadow.

<img width="1670" height="810" alt="image" src="https://github.com/user-attachments/assets/9a225c51-536a-46c1-aa08-ffd0222573e3" />
