### PR TITLE
Collapse toolbar controls that don't fit into the overflow menu LAZ-872

### DIFF
--- a/src/renderer/src/extensions/category_management/views/CategoryAddParent.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryAddParent.tsx
@@ -65,11 +65,9 @@ export function CategoryAddParent({
           />
         </div>
 
-        <div>
-          <Toolbar>
-            <ToolbarGroup actions={actions} maxVisible={2} />
-          </Toolbar>
-        </div>
+        <Toolbar>
+          <ToolbarGroup actions={actions} maxVisible={2} />
+        </Toolbar>
       </div>
     </div>
   );

--- a/src/renderer/src/extensions/category_management/views/CategoryListItem.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListItem.tsx
@@ -231,11 +231,9 @@ export default function CategoryListItem({
           </div>
         </div>
 
-        <div>
-          <Toolbar>
-            <ToolbarGroup actions={actions} maxVisible={4} />
-          </Toolbar>
-        </div>
+        <Toolbar>
+          <ToolbarGroup actions={actions} maxVisible={4} />
+        </Toolbar>
       </div>
 
       {addNew && (

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -241,9 +241,11 @@ function MyTabs() {
 
 ### Toolbar
 
-Horizontal toolbar made of one or more rounded `ToolbarGroup` "pills". A group is **data-driven**: pass it an array of `IToolbarAction` descriptors and it renders each as an icon `Button`. When a group has more than `maxVisible` actions (default `7`), the trailing slot becomes a kebab (`⋮`) menu and the overflow actions move into its dropdown — the same descriptor renders as a `Button` while visible and a `DropdownItem` once collapsed.
+Horizontal toolbar made of one or more rounded `ToolbarGroup` "pills". A group is **data-driven**: pass it an array of `IToolbarAction` descriptors and it renders each as an icon `Button`. When the actions don't all fit, the trailing slot becomes a kebab (`⋮`) menu and the overflow actions move into its dropdown — the same descriptor renders as a `Button` while visible and a `DropdownItem` once collapsed.
 
-**Defaults:** `maxVisible={7}`. Pass `maxVisible={null}` to disable collapsing and always render every action.
+**Responsive by default.** The `Toolbar` measures the width available to it and each group renders as many actions as fit, so the rest stay reachable in the kebab as the window narrows. This needs a width that doesn't come from the toolbar's own content, which a block-level or stretched parent gives it for free. As a flex item the toolbar is `flex-shrink: 0` and keeps every control instead, because a toolbar sized by its content can't tell how much room it has — add `flex-1` (or `shrink`) to opt it into collapsing.
+
+**`maxVisible`** (optional) caps the number of slots regardless of available width, for groups that should stay short. Omit it to let width be the only limit. Whichever is more restrictive wins.
 
 ```tsx
 import { Toolbar } from "../../ui/components/toolbar/Toolbar";
@@ -259,8 +261,8 @@ const actions: IToolbarAction[] = [
 <Toolbar>
     <ToolbarGroup actions={actions} />
 
-    {/* Never collapse — show every action regardless of count */}
-    <ToolbarGroup actions={contextualActions} maxVisible={null} />
+    {/* Never use more than 4 slots, however wide the toolbar gets */}
+    <ToolbarGroup actions={contextualActions} maxVisible={4} />
 </Toolbar>;
 ```
 

--- a/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+/** Layout facts a `Toolbar` publishes to the groups rendered inside it. */
+export interface IToolbarContext {
+  /** The toolbar row, or `null` for a group rendered without a `Toolbar`. */
+  element: HTMLElement | null;
+  /**
+   * Content width of the row, or `null` while it can't be measured — no
+   * `ResizeObserver`, or the toolbar is hidden. Groups read `null` as "no width
+   * constraint" and fall back to their slot cap alone.
+   */
+  width: number | null;
+  /**
+   * Changes whenever the row or any of its children changes size. A group's
+   * budget depends on the controls ahead of it, so it has to re-fit when an
+   * earlier group collapses and frees space.
+   */
+  signature: string;
+}
+
+export const ToolbarContext = createContext<IToolbarContext>({
+  element: null,
+  width: null,
+  signature: "",
+});
+export const useToolbarContext = (): IToolbarContext => useContext(ToolbarContext);

--- a/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
@@ -44,9 +44,9 @@ const contextualActions: IToolbarAction[] = [
   { label: "Disable", iconPath: mdiClose },
 ];
 
-// More than `maxVisible` (7) actions: the first six render as buttons and the
-// rest collapse into the trailing kebab dropdown.
-const overflowActions: IToolbarAction[] = [
+// Ten actions, used below to show both limits: a `maxVisible` slot cap, and the
+// width of the toolbar itself.
+const manyActions: IToolbarAction[] = [
   ...generalActions,
   { label: "Combine", iconPath: mdiCallMerge },
   { label: "Highlight", iconPath: mdiEyeOutline },
@@ -79,13 +79,54 @@ export const ToolbarDemo = () => (
       </Typography>
 
       <Typography appearance="subdued">
-        When a group has more than <code>maxVisible</code> (7) actions, the trailing slot becomes a
-        kebab menu and the remaining actions move into its dropdown.
+        Passing <code>maxVisible</code> caps how many slots a group ever uses. Past that, the
+        trailing slot becomes a kebab menu and the remaining actions move into its dropdown.
       </Typography>
     </div>
 
     <Toolbar>
-      <ToolbarGroup actions={overflowActions} />
+      <ToolbarGroup actions={manyActions} maxVisible={7} />
     </Toolbar>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Responsive
+      </Typography>
+
+      <Typography appearance="subdued">
+        A group also collapses whatever won't fit the width the toolbar has, so the same actions
+        stay reachable as the window narrows. Drag the bottom-right corner of the box below to
+        resize it. This group has no <code>maxVisible</code> cap, leaving width as the only limit.
+      </Typography>
+    </div>
+
+    {/* `resize` needs a non-visible overflow, so the box is padded low enough for
+        an opened overflow menu to sit inside it rather than being clipped. */}
+    <div className="w-104 resize-x overflow-auto rounded-sm border border-stroke-weak px-2 pt-2 pb-40">
+      <Toolbar>
+        <ToolbarGroup actions={manyActions} />
+      </Toolbar>
+    </div>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Competing groups
+      </Typography>
+
+      <Typography appearance="subdued">
+        When several groups share a toolbar, the earlier ones keep their controls and the later ones
+        collapse first, so the leading group stays stable as space runs out. Every group holds onto
+        its own overflow menu, and each reserves room for the ones after it, so the row never
+        overflows. Resize the box below to watch the second group give way before the first.
+      </Typography>
+    </div>
+
+    <div className="w-104 resize-x overflow-auto rounded-sm border border-stroke-weak px-2 pt-2 pb-40">
+      <Toolbar>
+        <ToolbarGroup actions={generalActions} />
+
+        <ToolbarGroup actions={contextualActions} />
+      </Toolbar>
+    </div>
   </div>
 );

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { Toolbar } from "./Toolbar";
 import { ToolbarGroup, type IToolbarAction } from "./ToolbarGroup";
+import { fitVisibleCount, type IToolbarGroupMetrics } from "./useToolbarOverflow.hook";
 
 // --- Helpers ---
 
@@ -12,6 +13,80 @@ const makeActions = (count: number): IToolbarAction[] =>
   Array.from({ length: count }, (_, i) => ({ label: `Action ${i + 1}`, iconPath: "mdi-test" }));
 
 const getKebab = () => screen.getByRole("button", { name: /more actions/i });
+
+const countActionButtons = () =>
+  screen
+    .getAllByRole("button")
+    .filter((button) => !/more actions/i.test(button.getAttribute("aria-label") ?? "")).length;
+
+/**
+ * happy-dom lays nothing out, so every control reports a width of 0. These stubs
+ * stand in for a real layout: a uniform width per control and a row width the
+ * test drives.
+ */
+const CONTROL_WIDTH = 28;
+
+let rowWidth = 0;
+const resizeCallbacks: Array<() => void> = [];
+
+// Captured before anything is stubbed so each test can hand the environment's
+// own definitions back, wherever on the prototype chain they came from.
+const nativeWidths = (["offsetWidth", "clientWidth"] as const).map((property) => ({
+  property,
+  descriptor: Object.getOwnPropertyDescriptor(HTMLElement.prototype, property),
+}));
+
+const restoreWidths = () => {
+  nativeWidths.forEach(({ descriptor, property }) => {
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, property, descriptor);
+    } else {
+      delete (HTMLElement.prototype as Partial<HTMLElement>)[property];
+    }
+  });
+};
+
+const stubLayout = (initialRowWidth: number) => {
+  rowWidth = initialRowWidth;
+
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get(this: HTMLElement) {
+      const isControl = this.tagName === "BUTTON" || this.classList.contains("nxm-dropdown");
+      return isControl ? CONTROL_WIDTH : 0;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.classList.contains("nxm-toolbar") ? rowWidth : 0;
+    },
+  });
+
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      public observe = vi.fn();
+      public disconnect = vi.fn();
+
+      constructor(callback: () => void) {
+        resizeCallbacks.push(callback);
+      }
+    },
+  );
+};
+
+const resizeRowTo = (width: number) => {
+  rowWidth = width;
+  act(() => resizeCallbacks.forEach((callback) => callback()));
+};
+
+afterEach(() => {
+  resizeCallbacks.length = 0;
+  vi.unstubAllGlobals();
+  restoreWidths();
+});
 
 // --- Tests ---
 
@@ -101,13 +176,13 @@ describe("ToolbarGroup", () => {
 
   describe("overflow", () => {
     it("does not render a kebab when the action count is within maxVisible", () => {
-      render(<ToolbarGroup actions={makeActions(7)} />);
+      render(<ToolbarGroup actions={makeActions(7)} maxVisible={7} />);
       expect(screen.getAllByRole("button")).toHaveLength(7);
       expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
     });
 
     it("collapses the tail into a kebab once maxVisible is exceeded", () => {
-      render(<ToolbarGroup actions={makeActions(8)} />);
+      render(<ToolbarGroup actions={makeActions(8)} maxVisible={7} />);
       // 6 visible action buttons + the kebab = 7 slots.
       expect(screen.getAllByRole("button")).toHaveLength(7);
       expect(screen.getByRole("button", { name: "Action 6" })).toBeInTheDocument();
@@ -118,7 +193,7 @@ describe("ToolbarGroup", () => {
     });
 
     it("reveals the overflow actions when the kebab is opened", async () => {
-      render(<ToolbarGroup actions={makeActions(8)} />);
+      render(<ToolbarGroup actions={makeActions(8)} maxVisible={7} />);
       await userEvent.click(getKebab());
       expect(screen.getByText("Action 7")).toBeInTheDocument();
       expect(screen.getByText("Action 8")).toBeInTheDocument();
@@ -127,7 +202,7 @@ describe("ToolbarGroup", () => {
     it("calls an overflowed action's onClick from the dropdown", async () => {
       const onClick = vi.fn();
       const actions = [...makeActions(7), { label: "Overflowed", iconPath: "mdi-test", onClick }];
-      render(<ToolbarGroup actions={actions} />);
+      render(<ToolbarGroup actions={actions} maxVisible={7} />);
       await userEvent.click(getKebab());
       await userEvent.click(screen.getByText("Overflowed"));
       expect(onClick).toHaveBeenCalledOnce();
@@ -142,10 +217,127 @@ describe("ToolbarGroup", () => {
       expect(getKebab()).toBeInTheDocument();
     });
 
-    it("never collapses when maxVisible is null", () => {
-      render(<ToolbarGroup actions={makeActions(10)} maxVisible={null} />);
+    it("never collapses when maxVisible is omitted", () => {
+      render(<ToolbarGroup actions={makeActions(10)} />);
       expect(screen.getAllByRole("button")).toHaveLength(10);
       expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
     });
+  });
+
+  describe("width-based overflow", () => {
+    // The stubs give every control a 28px width with no gap or padding, so a row
+    // of N pixels holds floor(N / 28) controls — the kebab being one of them.
+    const renderRow = (rowPixels: number, actionCount = 5) => {
+      stubLayout(rowPixels);
+      render(
+        <Toolbar>
+          <ToolbarGroup actions={makeActions(actionCount)} />
+        </Toolbar>,
+      );
+    };
+
+    it("keeps every action when the row has room for them all", () => {
+      renderRow(200);
+      expect(countActionButtons()).toBe(5);
+      expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+    });
+
+    it("collapses the actions that don't fit, leaving room for the kebab", () => {
+      renderRow(100);
+      // 5 actions need 140px. Two actions plus the kebab is 84px; three would be 112px.
+      expect(countActionButtons()).toBe(2);
+      expect(getKebab()).toBeInTheDocument();
+    });
+
+    it("puts the actions that didn't fit into the kebab's dropdown", async () => {
+      renderRow(100);
+      await userEvent.click(getKebab());
+      expect(screen.getByText("Action 3")).toBeInTheDocument();
+      expect(screen.getByText("Action 5")).toBeInTheDocument();
+    });
+
+    it("collapses further as the row narrows", () => {
+      renderRow(200);
+      expect(countActionButtons()).toBe(5);
+
+      resizeRowTo(100);
+      expect(countActionButtons()).toBe(2);
+    });
+
+    it("restores the collapsed actions when the row grows again", () => {
+      renderRow(100);
+      expect(countActionButtons()).toBe(2);
+
+      resizeRowTo(200);
+      expect(countActionButtons()).toBe(5);
+      expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+    });
+
+    it("shows only the kebab when not even one action fits", () => {
+      renderRow(40);
+      expect(countActionButtons()).toBe(0);
+      expect(getKebab()).toBeInTheDocument();
+    });
+
+    it("still honours maxVisible as a ceiling on a wide row", () => {
+      stubLayout(1000);
+      render(
+        <Toolbar>
+          <ToolbarGroup actions={makeActions(10)} maxVisible={4} />
+        </Toolbar>,
+      );
+      expect(countActionButtons()).toBe(3);
+      expect(getKebab()).toBeInTheDocument();
+    });
+  });
+});
+
+describe("fitVisibleCount", () => {
+  // A mixed row: four icon-only controls and one wide labelled one.
+  const metrics: IToolbarGroupMetrics = {
+    itemWidths: [28, 28, 28, 92, 28],
+    kebabWidth: 28,
+    gap: 8,
+    padding: 8,
+  };
+
+  const fit = (availableWidth: number | null, maxVisible?: number) =>
+    fitVisibleCount({
+      actionCount: metrics.itemWidths.length,
+      availableWidth,
+      maxVisible,
+      metrics,
+    });
+
+  it("shows everything when it all fits", () => {
+    // 204px of controls + 32px of gaps + 8px of padding = 244px.
+    expect(fit(300)).toBe(5);
+    expect(fit(244)).toBe(5);
+  });
+
+  it("drops actions one at a time as the budget tightens", () => {
+    expect(fit(243)).toBe(3); // 4 actions include the 92px one, so it skips straight to 3.
+    expect(fit(144)).toBe(3);
+    expect(fit(143)).toBe(2);
+    expect(fit(100)).toBe(1);
+  });
+
+  it("keeps only the kebab when nothing fits alongside it", () => {
+    expect(fit(50)).toBe(0);
+    expect(fit(0)).toBe(0);
+  });
+
+  it("ignores width when it hasn't been measured", () => {
+    expect(fit(null)).toBe(5);
+    expect(fit(null, 3)).toBe(2);
+  });
+
+  it("takes whichever of width and maxVisible is more restrictive", () => {
+    expect(fit(300, 3)).toBe(2); // The cap wins: 2 actions plus the kebab is 3 slots.
+    expect(fit(100, 3)).toBe(1); // The width wins.
+  });
+
+  it("treats missing metrics as unconstrained", () => {
+    expect(fitVisibleCount({ actionCount: 5, availableWidth: 10, metrics: null })).toBe(5);
   });
 });

--- a/src/renderer/src/ui/components/toolbar/Toolbar.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.tsx
@@ -1,18 +1,116 @@
-import React, { type HTMLAttributes, type ReactNode } from "react";
+import React, {
+  type HTMLAttributes,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-export interface IToolbarProps extends HTMLAttributes<HTMLDivElement> {
+import { type IToolbarContext, ToolbarContext } from "./Toolbar.context";
+
+interface IToolbarProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
+
+/**
+ * The row's width followed by each child's, e.g. `"600:216:284"`. Doubles as the
+ * store snapshot below: it's a string, so React can compare it by value, and it
+ * changes exactly when a group needs to re-fit — the row resizing, or a sibling
+ * collapsing and freeing space.
+ */
+const layoutSignature = (row: HTMLElement | null): string =>
+  row ? [row.clientWidth, ...Array.from(row.children, (child) => child.clientWidth)].join(":") : "";
+
+/** The row width a signature recorded, or `null` when the row isn't measurable. */
+const rowWidthFrom = (signature: string): number | null => {
+  const width = Number(signature.split(":")[0]);
+  return Number.isFinite(width) && width > 0 ? width : null;
+};
+
+/**
+ * Subscribes to the size of the row and of every child. Going through a store
+ * rather than an effect means the measurement reaches a render without being
+ * copied into state first, and React does the change detection.
+ */
+const useRowLayout = (row: HTMLElement | null): IToolbarContext => {
+  const subscribe = useCallback(
+    (onSizeChange: () => void) => {
+      if (!row || typeof ResizeObserver === "undefined") {
+        return () => undefined;
+      }
+
+      const sizes = new ResizeObserver(onSizeChange);
+      const observeRow = () => {
+        sizes.disconnect();
+        sizes.observe(row);
+        Array.from(row.children).forEach((child) => sizes.observe(child));
+      };
+
+      observeRow();
+
+      if (typeof MutationObserver === "undefined") {
+        return () => sizes.disconnect();
+      }
+
+      // Children are observed one by one, so the set has to be rebuilt whenever a
+      // group is added or removed.
+      const structure = new MutationObserver(() => {
+        observeRow();
+        onSizeChange();
+      });
+
+      structure.observe(row, { childList: true });
+
+      return () => {
+        sizes.disconnect();
+        structure.disconnect();
+      };
+    },
+    [row],
+  );
+
+  const signature = useSyncExternalStore(
+    subscribe,
+    useCallback(() => layoutSignature(row), [row]),
+  );
+
+  return useMemo(
+    () => ({ element: row, signature, width: rowWidthFrom(signature) }),
+    [row, signature],
+  );
+};
 
 /**
  * Horizontal container for one or more {@link ToolbarGroup}s. Lays the groups
  * out in a row with consistent spacing; the visual "pill" surface lives on the
  * groups, not the toolbar itself.
+ *
+ * The toolbar measures the width available to it and shares it with its groups,
+ * which move the controls that don't fit into their overflow menu. That needs a
+ * width that doesn't come from the toolbar's own content, which a block-level or
+ * stretched parent gives it for free.
+ *
+ * As a flex item it instead defaults to `flex-shrink: 0` and keeps every control,
+ * because a toolbar sized by its content can't tell how much room it actually
+ * has. Add a `flex-1` (or `shrink`) class to opt such a toolbar into collapsing.
  */
-export const Toolbar = ({ children, className, ...props }: IToolbarProps) => (
-  <div className={joinClasses(["nxm-toolbar", className])} role="toolbar" {...props}>
-    {children}
-  </div>
-);
+export const Toolbar = ({ children, className, ...props }: IToolbarProps) => {
+  const [row, setRow] = useState<HTMLDivElement | null>(null);
+  const layout = useRowLayout(row);
+
+  return (
+    <ToolbarContext.Provider value={layout}>
+      <div
+        className={joinClasses(["nxm-toolbar", className])}
+        ref={setRow}
+        role="toolbar"
+        {...props}
+      >
+        {children}
+      </div>
+    </ToolbarContext.Provider>
+  );
+};

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -8,6 +8,8 @@ import { DropdownItem } from "@/ui/components/dropdown/DropdownItem";
 import { DropdownItems } from "@/ui/components/dropdown/DropdownItems";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
+import { useToolbarOverflow } from "./useToolbarOverflow.hook";
+
 export interface IToolbarAction {
   label: string;
   iconPath?: string;
@@ -18,34 +20,42 @@ export interface IToolbarAction {
   testId?: string;
 }
 
-export type IToolbarGroupProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
+type IToolbarGroupProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
   actions: IToolbarAction[];
-  /**
-   * Maximum number of slots to show before collapsing the tail into a kebab
-   * dropdown. When there are more actions than this, the last slot becomes the
-   * kebab and every remaining action moves into it. Pass `null` to disable
-   * collapsing and always render every action.
-   */
-  maxVisible?: number | null;
+  maxVisible?: number;
 };
 
 /**
- * A rounded "pill" cluster of related toolbar controls sharing a single raised
- * surface. Renders up to `max` slots; any overflow collapses into a kebab
- * dropdown occupying the final slot.
+ * Identity of everything about the actions that affects how wide they render:
+ * the count, whether each has an icon, and any label shown as visible text.
+ * Colon-separated and count-prefixed like the row's signature, so two different
+ * action lists can't produce the same string and reuse each other's widths.
  */
-export const ToolbarGroup = ({
-  actions,
-  className,
-  maxVisible = 7,
-  ...props
-}: IToolbarGroupProps) => {
-  const overflows = maxVisible != null && actions.length > maxVisible;
-  const visible = overflows ? actions.slice(0, maxVisible - 1) : actions;
-  const hidden = overflows ? actions.slice(maxVisible - 1) : [];
+const widthSignature = (actions: IToolbarAction[]): string =>
+  [
+    actions.length,
+    ...actions.map(
+      (action) => `${action.iconPath ? "i" : ""}${action.showLabel ? action.label : ""}`,
+    ),
+  ].join(":");
+
+/**
+ * A rounded "pill" cluster of related toolbar controls sharing a single raised
+ * surface. Renders as many actions as fit the width the toolbar has; the rest
+ * collapse into a kebab dropdown occupying the final slot.
+ */
+export const ToolbarGroup = ({ actions, className, maxVisible, ...props }: IToolbarGroupProps) => {
+  const { groupRef, isMeasuring, visibleCount } = useToolbarOverflow({
+    actionCount: actions.length,
+    maxVisible,
+    signature: widthSignature(actions),
+  });
+
+  const visible = actions.slice(0, visibleCount);
+  const hidden = actions.slice(visibleCount);
 
   return (
-    <div className={joinClasses(["nxm-toolbar-group", className])} {...props}>
+    <div className={joinClasses(["nxm-toolbar-group", className])} ref={groupRef} {...props}>
       {visible.map((action) => (
         <Button
           appearance="weak"
@@ -62,7 +72,8 @@ export const ToolbarGroup = ({
         </Button>
       ))}
 
-      {!!hidden.length && (
+      {/* Kept mounted through the measuring pass so its width is measured too. */}
+      {(isMeasuring || !!hidden.length) && (
         <Dropdown>
           <Menu.Button
             appearance="weak"

--- a/src/renderer/src/ui/components/toolbar/useToolbarOverflow.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarOverflow.hook.ts
@@ -1,0 +1,194 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { useToolbarContext } from "./Toolbar.context";
+
+/** Intrinsic widths of one group's controls, in CSS pixels. */
+export interface IToolbarGroupMetrics {
+  /** Width of each action button, in action order. */
+  itemWidths: number[];
+  /** Width of the overflow kebab. */
+  kebabWidth: number;
+  /** Gap between two adjacent controls. */
+  gap: number;
+  /** Combined left and right padding of the pill surface. */
+  padding: number;
+}
+
+interface IToolbarMeasurement {
+  signature: string;
+  metrics: IToolbarGroupMetrics;
+}
+
+interface IFitParams {
+  actionCount: number;
+  availableWidth: number | null;
+  maxVisible?: number;
+  metrics: IToolbarGroupMetrics | null;
+}
+
+interface IOverflowParams {
+  actionCount: number;
+  maxVisible?: number;
+  /** Changes whenever the actions' rendered widths could have changed. */
+  signature: string;
+}
+
+const parsePx = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * Reads the intrinsic width of every control in the group. Only valid while the
+ * group renders all of its actions plus the kebab, and relies on
+ * `.nxm-toolbar-group > *` being `flex-shrink: 0` so the widths hold even in the
+ * frame where the row is too narrow to hold them all.
+ */
+const measureGroup = (group: HTMLElement, actionCount: number): IToolbarGroupMetrics => {
+  const widths = Array.from(group.children, (child) => (child as HTMLElement).offsetWidth);
+  const style = getComputedStyle(group);
+
+  return {
+    itemWidths: widths.slice(0, actionCount),
+    kebabWidth: widths[actionCount] ?? 0,
+    gap: parsePx(style.columnGap),
+    padding: parsePx(style.paddingLeft) + parsePx(style.paddingRight),
+  };
+};
+
+/**
+ * Width left for `group` once everything ahead of it in the row is placed, less a
+ * reserve for what comes after it.
+ *
+ * Only the *measured* width of preceding siblings counts, so a group's budget
+ * never depends on its own width — that's what stops one collapse from feeding
+ * another. Following siblings can't be measured without that circularity, so each
+ * is reserved `minimumFootprint`: a group always keeps its overflow menu, and
+ * claiming the whole row would push a later group out of it. Every group uses the
+ * same control size, so its own footprint is a good estimate of a sibling's.
+ */
+const measureAvailableWidth = (
+  group: HTMLElement | null,
+  row: HTMLElement | null,
+  rowWidth: number | null,
+  minimumFootprint: number,
+): number | null => {
+  if (!group || !row || rowWidth === null) {
+    return null;
+  }
+
+  const gap = parsePx(getComputedStyle(row).columnGap);
+  let used = 0;
+
+  for (let ahead = group.previousElementSibling; ahead; ahead = ahead.previousElementSibling) {
+    used += (ahead as HTMLElement).offsetWidth + gap;
+  }
+
+  for (let after = group.nextElementSibling; after; after = after.nextElementSibling) {
+    used += minimumFootprint + gap;
+  }
+
+  return Math.max(0, rowWidth - used);
+};
+
+/**
+ * Largest number of action buttons that fits `availableWidth` without exceeding
+ * the `maxVisible` slot cap. A result below `actionCount` means the kebab is
+ * rendered and takes one of those slots.
+ */
+export const fitVisibleCount = ({
+  actionCount,
+  availableWidth,
+  maxVisible,
+  metrics,
+}: IFitParams): number => {
+  const slots = maxVisible ?? Number.POSITIVE_INFINITY;
+
+  const fits = (count: number, withKebab: boolean): boolean => {
+    // `availableWidth` is checked against null rather than falsiness: 0 is a real
+    // budget (a group with no room left), and must not be read as "not measured".
+    if (!metrics || availableWidth === null) {
+      return true;
+    }
+
+    const widths = metrics.itemWidths.slice(0, count);
+
+    if (withKebab) {
+      widths.push(metrics.kebabWidth);
+    }
+
+    if (widths.length === 0) {
+      return true;
+    }
+
+    return (
+      widths.reduce((total, width) => total + width, 0) +
+        metrics.gap * (widths.length - 1) +
+        metrics.padding <=
+      availableWidth
+    );
+  };
+
+  if (actionCount <= slots && fits(actionCount, false)) {
+    return actionCount;
+  }
+
+  for (let count = Math.min(actionCount - 1, slots - 1); count > 0; count--) {
+    if (fits(count, true)) {
+      return count;
+    }
+  }
+
+  return 0;
+};
+
+/**
+ * Decides how many of a group's actions to render as buttons, collapsing the
+ * rest into the overflow menu once they no longer fit the width the toolbar has.
+ *
+ * Control widths are measured once, in a pass where the group renders everything
+ * (`isMeasuring`), and cached against `signature`; resizing then only re-runs the
+ * arithmetic in {@link fitVisibleCount}. Both passes happen in layout effects, so
+ * the un-collapsed row is never painted.
+ */
+export const useToolbarOverflow = ({ actionCount, maxVisible, signature }: IOverflowParams) => {
+  const { element: row, signature: rowSignature, width: rowWidth } = useToolbarContext();
+
+  const groupRef = useRef<HTMLDivElement>(null);
+  const [measurement, setMeasurement] = useState<IToolbarMeasurement | null>(null);
+  const [availableWidth, setAvailableWidth] = useState<number | null>(null);
+
+  const isMeasuring = !!actionCount && measurement?.signature !== signature;
+
+  useLayoutEffect(() => {
+    if (!isMeasuring || !groupRef.current) {
+      return;
+    }
+
+    // Writing to state from an effect is the mechanism here, not an oversight:
+    // the widths only exist once the controls are in the DOM, so the pass that
+    // renders them all has to hand what it measured to the pass that collapses
+    // them. Runs at most once per distinct action list, before paint.
+    // eslint-disable-next-line @eslint-react/set-state-in-effect
+    setMeasurement({ metrics: measureGroup(groupRef.current, actionCount), signature });
+  }, [actionCount, isMeasuring, signature]);
+
+  const minimumFootprint = measurement
+    ? measurement.metrics.kebabWidth + measurement.metrics.padding
+    : 0;
+
+  useLayoutEffect(() => {
+    setAvailableWidth(measureAvailableWidth(groupRef.current, row, rowWidth, minimumFootprint));
+  }, [minimumFootprint, row, rowSignature, rowWidth]);
+
+  const visibleCount = isMeasuring
+    ? actionCount
+    : fitVisibleCount({
+        actionCount,
+        availableWidth,
+        maxVisible,
+        metrics: measurement?.metrics ?? null,
+      });
+
+  return { groupRef, isMeasuring, visibleCount };
+};

--- a/src/stylesheets/ui/elements/toolbar.css
+++ b/src/stylesheets/ui/elements/toolbar.css
@@ -2,6 +2,8 @@
     .nxm-toolbar {
         display: flex;
         align-items: center;
+        min-width: 0;
+        flex-shrink: 0;
         column-gap: calc(var(--spacing) * 2);
     }
 
@@ -13,5 +15,9 @@
         padding: calc(var(--spacing) * 1);
         border-radius: var(--radius-lg);
         background-color: var(--color-surface-mid);
+
+        > * {
+            flex-shrink: 0;
+        }
     }
 }


### PR DESCRIPTION
ToolbarGroup previously collapsed on a hardcoded count only. Now Toolbar measures the width available to it and shares it with its groups, which render as many actions as fit and move the rest into the kebab — so nothing becomes unreachable as the window narrows.

### How it works

- Control widths are measured once per action list and cached; resizing then only re-runs the arithmetic (fitVisibleCount).                                               
- Measurement happens in layout effects, so the un-collapsed row is never painted.
- With several groups, the leading one keeps priority: each group's budget is the row width minus the measured width of everything before it, minus a reserve for those after it. A group's budget never depends on its own width, so one collapse can't cascade into another.
- maxVisible is now an optional cap on top of width, not the only mechanism.
