### PR TITLE
feat: add Alert component to the design system

### DIFF
--- a/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
+++ b/src/renderer/src/extensions/design_system_dev/views/DesignSystemPage.tsx
@@ -7,6 +7,7 @@
 import React, { useState } from "react";
 
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import { AlertDemo } from "@/ui/components/alert/Alert.demo";
 import { BulletDemo } from "@/ui/components/bullet/Bullet.demo";
 import { ButtonDemo } from "@/ui/components/button/Button.demo";
 import { CollectionTileDemo } from "@/ui/components/collection_tile/CollectionTile.demo";
@@ -85,6 +86,8 @@ export const DesignSystemPage = ({ active, api }: { active?: boolean; api: IExte
             <TabButton name="Toolbar" panelId="toolbar" />
 
             <TabButton name="Tooltip" panelId="tooltip" />
+
+            <TabButton name="Alert" panelId="alert" />
           </TabBar>
 
           <div className="mt-6">
@@ -244,6 +247,10 @@ export const DesignSystemPage = ({ active, api }: { active?: boolean; api: IExte
 
             <TabPanel id="tooltip">
               <TooltipDemo />
+            </TabPanel>
+
+            <TabPanel id="alert">
+              <AlertDemo />
             </TabPanel>
           </div>
         </TabProvider>

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -4,7 +4,6 @@ import { mdiPlus, mdiRefresh } from "@mdi/js";
 import type { EndorsedStatus } from "@nexusmods/nexus-api";
 import * as _ from "lodash";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Alert, Button as BSButton } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -22,6 +21,7 @@ import Table from "@/controls/Table";
 import { log } from "@/logging";
 import type { IExtensionWithState } from "@/types/extensions";
 import type { IExtensionState, IState } from "@/types/IState";
+import { Alert } from "@/ui/components/alert/Alert";
 import { Button } from "@/ui/components/button/Button";
 import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
@@ -273,19 +273,23 @@ export const ExtensionManager = ({
         </div>
       </PageHeader>
 
-      <PageScroll isFullWidth className="flex flex-col gap-y-4">
-        {restartNeeded && (
+      {restartNeeded && (
+        <PageContent isFullWidth>
           <Alert
-            bsStyle="warning"
-            className="mx-6"
-            style={{ display: "flex", alignItems: "center" }}
+            action={
+              <Button brand="neutral" size="xs" onClick={() => relaunch()}>
+                {t("Restart Vortex")}
+              </Button>
+            }
+            className="shrink-0"
+            severity="warning"
           >
-            <div style={{ flexGrow: 1 }}>{t("You need to restart Vortex to apply changes.")}</div>
-
-            <BSButton onClick={() => relaunch()}>{t("Restart")}</BSButton>
+            {t("You need to restart Vortex to apply changes.")}
           </Alert>
-        )}
+        </PageContent>
+      )}
 
+      <PageScroll isFullWidth className="flex flex-col gap-y-4">
         <Table
           edgeToEdge
           stickyHeader

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -7,6 +7,7 @@ Components adapted from the web team's "next" project for use in Vortex.
 ```
 ui/
 ├── components/
+│   ├── alert/           - Full-width page-level message bar (replaces Bootstrap Alert)
 │   ├── bullet/          - Small rotated-square dot used as an inline marker/separator
 │   ├── button/          - Button system (brand × appearance matrix)
 │   ├── collectiontile/  - Collection card with image, metadata, and actions
@@ -269,6 +270,46 @@ const actions: IToolbarAction[] = [
 **`IToolbarAction` fields:** `label` (required — the accessible name, dropdown label, and button text when `showLabel`), `iconPath`, `onClick`, `disabled`, `brand` (defaults to `neutral`), `showLabel` (render the label as visible button text instead of icon-only, e.g. a "1 selected" pill).
 
 Actions are keyed internally by `label`, so labels should be unique within a group. The kebab is generated automatically — callers never author it.
+
+### Alert
+
+Full-width bar carrying a short message about the page it sits on, optionally with a control that acts on it. This is the replacement for react-bootstrap's `Alert` — prefer it for new work.
+
+Severity colours the **icon only**; the surface stays neutral in every state, so a stack of alerts reads as one band rather than several competing blocks.
+
+```tsx
+import { Alert } from "../../ui/components/alert/Alert";
+import { Button } from "../../ui/components/button/Button";
+
+<Alert
+    action={
+        <Button brand="neutral" size="xs" onClick={relaunch}>
+            {t("Restart Vortex")}
+        </Button>
+    }
+    severity="warning"
+>
+    {t("You need to restart Vortex to apply changes.")}
+</Alert>;
+
+{
+    /* The action is optional */
+}
+<Alert severity="success">{t("Action successful")}</Alert>;
+
+{
+    /* onDismiss adds a close button that hides the bar and calls back */
+}
+<Alert severity="info" onDismiss={() => markSeen(id)}>
+    {t("We suggest you do this")}
+</Alert>;
+```
+
+**Severities:** `info` (default), `success`, `warning`, `danger` — each picks its own icon and tints it with the matching `*-strong` token.
+
+**Dismissal:** pass `onDismiss` to get a close button at the far edge of the bar. The alert hides itself on click and then fires the callback, so callers only need the callback for the side effect (persisting the dismissal, say) — not for the hiding. The button is labelled "Dismiss"; override it with `dismissLabel`.
+
+The bar owns a 24px inline gutter and a bottom divider rather than a border and radius, so it's designed to sit edge-to-edge (no `mx-*` needed) above page content. It renders as `role="status"`; pass `role="alert"` explicitly for something genuinely interrupting. The message may wrap while the action keeps its width.
 
 ### Form Components
 

--- a/src/renderer/src/ui/components/alert/Alert.demo.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.demo.tsx
@@ -1,0 +1,153 @@
+/**
+ * Alert Demo Component
+ * Demonstrates the four severities, with and without an action, and dismissible.
+ */
+
+import React from "react";
+
+import { Alert } from "@/ui/components/alert/Alert";
+import { Button } from "@/ui/components/button/Button";
+import { Typography } from "@/ui/components/typography/Typography";
+
+export const AlertDemo = () => (
+  <div className="space-y-8">
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h2" typographyType="heading-sm">
+        Alert
+      </Typography>
+
+      <Typography appearance="subdued">
+        A full-width bar carrying a short message about the page it sits on, optionally with a
+        control that acts on it. Replaces the old Bootstrap alert.
+      </Typography>
+    </div>
+
+    <div>
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            Find out more
+          </Button>
+        }
+      >
+        We suggest you do this
+      </Alert>
+
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            Restart Vortex
+          </Button>
+        }
+        severity="warning"
+      >
+        You need to restart Vortex to apply changes
+      </Alert>
+
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            Free up disk space
+          </Button>
+        }
+        severity="danger"
+      >
+        Disk space full
+      </Alert>
+
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            View page
+          </Button>
+        }
+        severity="success"
+      >
+        Action successful
+      </Alert>
+    </div>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Without an action
+      </Typography>
+
+      <Typography appearance="subdued">
+        The action is optional — an alert can simply state something. Severity colours the icon
+        only, so a stack of them reads as one band rather than four competing blocks.
+      </Typography>
+    </div>
+
+    <div>
+      <Alert>Nothing needs doing right now</Alert>
+
+      <Alert severity="warning">Some extensions couldn't be loaded</Alert>
+    </div>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Dismissible
+      </Typography>
+
+      <Typography appearance="subdued">
+        Passing an onDismiss callback adds a close button at the far edge. Clicking it hides the
+        alert and fires the callback.
+      </Typography>
+    </div>
+
+    <div>
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            Find out more
+          </Button>
+        }
+        onDismiss={() => undefined}
+      >
+        We suggest you do this
+      </Alert>
+
+      <Alert severity="warning" onDismiss={() => undefined}>
+        You need to restart Vortex to apply changes
+      </Alert>
+
+      <Alert severity="danger" onDismiss={() => undefined}>
+        Disk space full
+      </Alert>
+    </div>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Long messages
+      </Typography>
+
+      <Typography appearance="subdued">
+        The message wraps onto as many lines as it needs while the action and close button keep
+        their width and stay on their own edges.
+      </Typography>
+    </div>
+
+    <div>
+      <Alert
+        action={
+          <Button brand="neutral" size="xs">
+            Restart Vortex
+          </Button>
+        }
+        severity="warning"
+        onDismiss={() => undefined}
+      >
+        You need to restart Vortex to apply changes. You need to restart Vortex to apply changes.
+        You need to restart Vortex to apply changes. You need to restart Vortex to apply changes.
+        You need to restart Vortex to apply changes. You need to restart Vortex to apply changes.
+        You need to restart Vortex to apply changes.
+      </Alert>
+
+      <Alert>
+        Nothing needs doing right now, but here is a much longer explanation of why that is the
+        case, long enough that it has to run onto a second line even on a wide window, so you can
+        see how a bare message behaves without an action or a close button alongside it.
+      </Alert>
+    </div>
+  </div>
+);

--- a/src/renderer/src/ui/components/alert/Alert.test.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import { Alert, type AlertSeverity } from "@/ui/components/alert/Alert";
+import { Button } from "@/ui/components/button/Button";
+
+// --- Helpers ---
+
+const getBar = () => screen.getByRole("status");
+
+const getIcon = () => document.querySelector(".nxm-alert-icon");
+
+const getDismiss = () => screen.getByRole("button", { name: "Dismiss" });
+
+// --- Tests ---
+
+describe("Alert", () => {
+  describe("rendering", () => {
+    it("renders its message", () => {
+      render(<Alert>Disk space full</Alert>);
+      expect(screen.getByText("Disk space full")).toBeInTheDocument();
+    });
+
+    it('exposes the bar as role="status"', () => {
+      render(<Alert>Heads up</Alert>);
+      expect(getBar()).toBeInTheDocument();
+    });
+
+    it("renders a severity icon", () => {
+      render(<Alert>Heads up</Alert>);
+      expect(getIcon()).toBeInTheDocument();
+    });
+
+    it("defaults to the info severity", () => {
+      render(<Alert>Heads up</Alert>);
+      expect(getBar()).toHaveClass("nxm-alert-info");
+    });
+
+    it("merges a custom className with the base classes", () => {
+      render(<Alert className="mx-6">Heads up</Alert>);
+      expect(getBar()).toHaveClass("nxm-alert", "nxm-alert-info", "mx-6");
+    });
+
+    it("passes through arbitrary HTML attributes", () => {
+      render(<Alert data-testid="banner">Heads up</Alert>);
+      expect(screen.getByTestId("banner")).toBeInTheDocument();
+    });
+
+    it("lets a caller override the role", () => {
+      render(<Alert role="alert">Disk space full</Alert>);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  describe("severity", () => {
+    const severities: AlertSeverity[] = ["info", "success", "warning", "danger"];
+
+    it.each(severities)("applies the %s severity class", (severity) => {
+      render(<Alert severity={severity}>Heads up</Alert>);
+      expect(getBar()).toHaveClass(`nxm-alert-${severity}`);
+    });
+
+    it("gives each severity a distinct icon", () => {
+      const paths = severities.map((severity) => {
+        const { unmount } = render(<Alert severity={severity}>Heads up</Alert>);
+        const path = getIcon()?.querySelector("path")?.getAttribute("d");
+        unmount();
+        return path;
+      });
+
+      expect(new Set(paths).size).toBe(severities.length);
+    });
+
+    it("leaves the surface class untouched across severities", () => {
+      // Severity colours the icon only, so the bar itself must not gain a
+      // severity-specific background utility.
+      render(<Alert severity="danger">Disk space full</Alert>);
+      expect(getBar().className).not.toMatch(/bg-/);
+    });
+  });
+
+  describe("action", () => {
+    it("renders no action region when none is given", () => {
+      render(<Alert>Heads up</Alert>);
+      expect(document.querySelector(".nxm-alert-action")).not.toBeInTheDocument();
+    });
+
+    it("renders an action after the message", () => {
+      render(
+        <Alert action={<Button size="xs">Restart Vortex</Button>}>
+          You need to restart Vortex to apply changes
+        </Alert>,
+      );
+      expect(screen.getByRole("button", { name: "Restart Vortex" })).toBeInTheDocument();
+    });
+
+    it("calls the action's onClick", async () => {
+      const onClick = vi.fn();
+      render(
+        <Alert
+          action={
+            <Button size="xs" onClick={onClick}>
+              Restart Vortex
+            </Button>
+          }
+        >
+          Restart needed
+        </Alert>,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Restart Vortex" }));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("dismissal", () => {
+    it("renders no close button without an onDismiss", () => {
+      render(<Alert>Heads up</Alert>);
+      expect(document.querySelector(".nxm-alert-dismiss")).not.toBeInTheDocument();
+    });
+
+    it("renders a close button when given an onDismiss", () => {
+      render(<Alert onDismiss={vi.fn()}>Heads up</Alert>);
+      expect(getDismiss()).toBeInTheDocument();
+    });
+
+    it("lets a caller relabel the close button", () => {
+      render(
+        <Alert dismissLabel="Hide this" onDismiss={vi.fn()}>
+          Heads up
+        </Alert>,
+      );
+      expect(screen.getByRole("button", { name: "Hide this" })).toBeInTheDocument();
+    });
+
+    it("hides the bar once dismissed", async () => {
+      render(<Alert onDismiss={vi.fn()}>Heads up</Alert>);
+
+      await userEvent.click(getDismiss());
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("calls onDismiss once", async () => {
+      const onDismiss = vi.fn();
+      render(<Alert onDismiss={onDismiss}>Heads up</Alert>);
+
+      await userEvent.click(getDismiss());
+      expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it("keeps the action working alongside the close button", async () => {
+      const onClick = vi.fn();
+      const onDismiss = vi.fn();
+      render(
+        <Alert
+          action={
+            <Button size="xs" onClick={onClick}>
+              Restart Vortex
+            </Button>
+          }
+          onDismiss={onDismiss}
+        >
+          Restart needed
+        </Alert>,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Restart Vortex" }));
+      expect(onClick).toHaveBeenCalledOnce();
+      expect(onDismiss).not.toHaveBeenCalled();
+      expect(getBar()).toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/src/ui/components/alert/Alert.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.tsx
@@ -1,0 +1,88 @@
+import {
+  mdiAlertOctagon,
+  mdiAlertOutline,
+  mdiCheckCircleOutline,
+  mdiClose,
+  mdiInformationOutline,
+} from "@mdi/js";
+import React, { type HTMLAttributes, type ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/ui/components/button/Button";
+import { Icon } from "@/ui/components/icon/Icon";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
+export type AlertSeverity = "info" | "success" | "warning" | "danger";
+
+export interface IAlertProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  severity?: AlertSeverity;
+  action?: ReactNode;
+  /** Supplying this adds a close button that hides the alert and calls back. */
+  onDismiss?: () => void;
+  dismissLabel?: string;
+}
+
+const severityIcons: Record<AlertSeverity, string> = {
+  danger: mdiAlertOctagon,
+  info: mdiInformationOutline,
+  success: mdiCheckCircleOutline,
+  warning: mdiAlertOutline,
+};
+
+/**
+ * Full-width bar carrying a short message about the page it sits on, optionally
+ * with a control that acts on it. Replaces react-bootstrap's `Alert`.
+ *
+ * The severity colours the icon only — the surface stays neutral in every state,
+ * so a row of these reads as one band rather than four competing blocks.
+ */
+export const Alert = ({
+  action,
+  children,
+  className,
+  dismissLabel,
+  onDismiss,
+  severity = "info",
+  ...props
+}: IAlertProps) => {
+  const { t } = useTranslation();
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const dismiss = () => {
+    setIsDismissed(true);
+    onDismiss?.();
+  };
+
+  return (
+    <div
+      className={joinClasses(["nxm-alert", `nxm-alert-${severity}`, className])}
+      role="status"
+      {...props}
+    >
+      <div className="nxm-alert-message">
+        <Icon className="nxm-alert-icon" path={severityIcons[severity]} size="sm" />
+
+        <p className="nxm-alert-text">{children}</p>
+      </div>
+
+      {!!action && <div className="nxm-alert-action">{action}</div>}
+
+      {!!onDismiss && (
+        <Button
+          appearance="weak"
+          aria-label={dismissLabel ?? t("Dismiss")}
+          brand="neutral"
+          className="nxm-alert-dismiss"
+          leftIconPath={mdiClose}
+          size="xs"
+          onClick={dismiss}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/views/components/Page/PageScroll.tsx
+++ b/src/renderer/src/views/components/Page/PageScroll.tsx
@@ -24,6 +24,10 @@ export type IPageScrollProps = HTMLAttributes<HTMLDivElement> & {
  * It reports its scroll position to the `Page` so a `PageHeader` can show its
  * shadow; any `onScroll` you pass still runs.
  *
+ * Focusable, so the region can be scrolled with the keyboard without first
+ * tabbing to a focusable child. No focus ring for now — the browser default
+ * clashed with the theme. Pass `tabIndex` to override.
+ *
  * Only use inside a `Page` with `scrollable={false}`; nesting it in a scrollable
  * `Page` stacks two scroll containers (double scrollbars).
  */
@@ -40,7 +44,13 @@ export const PageScroll = forwardRef<HTMLDivElement, IPageScrollProps>(
     );
 
     return (
-      <div className="min-h-0 flex-1 overflow-auto" ref={ref} onScroll={handleScroll} {...rest}>
+      <div
+        className="min-h-0 flex-1 overflow-auto outline-none"
+        ref={ref}
+        tabIndex={0}
+        onScroll={handleScroll}
+        {...rest}
+      >
         <PageContent className={className} isFullWidth={isFullWidth}>
           {children}
         </PageContent>

--- a/src/stylesheets/ui/elements/alert.css
+++ b/src/stylesheets/ui/elements/alert.css
@@ -1,0 +1,51 @@
+@layer components {
+    .nxm-alert {
+        display: flex;
+        align-items: center;
+        column-gap: calc(var(--spacing) * 4);
+
+        padding-inline: calc(var(--spacing) * 6);
+        padding-block: calc(var(--spacing) * 2.5);
+
+        background-color: var(--color-surface-low);
+        border-bottom: 1px solid var(--color-stroke-weak);
+
+        & .nxm-alert-message {
+            min-width: 0;
+            display: flex;
+            align-items: flex-start;
+            column-gap: calc(var(--spacing) * 2);
+        }
+
+        & .nxm-alert-text {
+            color: var(--color-neutral-moderate);
+            font-size: var(--text-body-sm);
+            line-height: var(--text-body-sm--line-height);
+            letter-spacing: var(--text-body-sm--letter-spacing);
+        }
+
+        & .nxm-alert-action {
+            flex-shrink: 0;
+        }
+
+        & .nxm-alert-dismiss {
+            margin-inline-start: auto;
+        }
+    }
+
+    .nxm-alert-info .nxm-alert-icon {
+        color: var(--color-info-strong);
+    }
+
+    .nxm-alert-success .nxm-alert-icon {
+        color: var(--color-success-strong);
+    }
+
+    .nxm-alert-warning .nxm-alert-icon {
+        color: var(--color-warning-strong);
+    }
+
+    .nxm-alert-danger .nxm-alert-icon {
+        color: var(--color-danger-strong);
+    }
+}

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -1,3 +1,4 @@
+@import "./alert.css";
 @import "./bullet.css";
 @import "./button.css";
 @import "./dropdown.css";


### PR DESCRIPTION
Add Alert component to the design system

Replaces react-bootstrap's Alert with a design-system component, renamed from Notification to Alert to match Figma (node 2914-34268). The old name also collided with Vortex's notification toasts, which are a different thing entirely.

### What it is

A full-width bar carrying a short message about the page it sits on, with an optional action control. Four severities — info (default), success, warning, danger — each picking its own icon. Severity colours the icon only; the surface stays neutral so a stack reads as one band rather than four competing blocks.                              

### Dismissal (new)

Passing onDismiss adds a close button at the far edge of the bar. The alert hides itself on click and then fires the callback, so callers only need the callback for side effects (persisting the dismissal), not for the hiding. dismissLabel overrides the  default t("Dismiss") accessible name. 