### PR TITLE
fix: pnpm setup action

### DIFF
--- a/.github/workflows/actions-check.yml
+++ b/.github/workflows/actions-check.yml
@@ -43,7 +43,7 @@ jobs:
         uses: volta-cli/action@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.9
         with:
           cache: true
 
@@ -98,7 +98,7 @@ jobs:
         uses: volta-cli/action@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.9
         with:
           cache: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
         uses: volta-cli/action@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.9
         with:
           cache: true
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install volta, Node.js
         uses: volta-cli/action@v5
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.9
         with:
           cache: true
       - name: Fix pnpm node-gyp permissions

--- a/.github/workflows/game-extension-test.yml
+++ b/.github/workflows/game-extension-test.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.9
 
       - name: Read Node.js version from package.json
         id: node-version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: volta-cli/action@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.9
         with:
           cache: true
 


### PR DESCRIPTION
pnpm bootstrap version bumped from 11.7.0 → 11.19.0 between v6.0.9 and v6.0.10, and 11.19.0's self-update logic is  crashing under volta