### PR TITLE
Toolbar tooltips, pinned actions, and header layout (laz-898)

### DIFF
--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -239,11 +239,15 @@ export const ExtensionManager = ({
         subtitle={t("Manage extensions that add features and game support to Vortex.")}
         title={t("Extensions")}
       >
+        {/* Not a `Toolbar`: its delay group only covers the actions it renders, so
+            the display options' own tooltip would sit outside it and re-delay when
+            the pointer reaches the tune icon. One group over all three keeps the
+            sweep instant. */}
         <div className="flex shrink-0 items-center gap-x-2">
           <TooltipDelayGroup>
             <Tooltip content={t("Update extensions")} placement="bottom">
               <Button
-                appearance="subdued"
+                appearance="weak"
                 aria-label={t("Update extensions")}
                 brand="neutral"
                 leftIconPath={mdiRefresh}
@@ -254,7 +258,7 @@ export const ExtensionManager = ({
 
             <Tooltip content={t("Browse extensions")} placement="bottom">
               <Button
-                appearance="subdued"
+                appearance="weak"
                 aria-label={t("Browse extensions")}
                 brand="neutral"
                 leftIconPath={mdiPlus}

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -52,7 +52,7 @@ const BackButton = ({ onBack }: { onBack: () => void }) => {
 
   return (
     <Button
-      appearance="subdued"
+      appearance="weak"
       brand="neutral"
       leftIconPath={mdiArrowLeft}
       size="sm"

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -21,8 +21,9 @@ import { TabBar } from "@/ui/components/tabs/TabBar";
 import { TabButton } from "@/ui/components/tabs/TabButton";
 import { TabPanel } from "@/ui/components/tabs/TabPanel";
 import { TabProvider } from "@/ui/components/tabs/Tabs.context";
-import { Tooltip } from "@/ui/components/tooltip/Tooltip";
-import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
+import { Toolbar } from "@/ui/components/toolbar/Toolbar";
+import type { IToolbarAction } from "@/ui/components/toolbar/ToolbarGroup";
+import { ToolbarGroup } from "@/ui/components/toolbar/ToolbarGroup";
 import { Typography } from "@/ui/components/typography/Typography";
 import { UserCanceled } from "@/util/CustomErrors";
 import { useRelativeTime } from "@/util/useRelativeTime";
@@ -154,6 +155,27 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
   const activeItems = useMemo(() => items.filter((item) => !item.hidden), [items]);
   const hiddenItems = useMemo(() => items.filter((item) => item.hidden), [items]);
   const supportsHide = useMemo(() => items.some((item) => item.content.supportsHide), [items]);
+
+  const toolbarActions = useMemo<IToolbarAction[]>(
+    () => [
+      {
+        label: t("common:::refresh"),
+        iconPath: mdiRefresh,
+        isLoading: isRefreshing,
+        onClick: () => onRefresh?.(),
+      },
+      {
+        label: t("common:::settings"),
+        iconPath: mdiCogOutline,
+        onClick: () => {
+          trackSettingsOpened();
+          dispatch(setOpenMainPage("application_settings", false));
+          dispatch(setSettingsPage("Vortex"));
+        },
+      },
+    ],
+    [dispatch, isRefreshing, onRefresh, t, trackSettingsOpened],
+  );
 
   // page_viewed fires each time the page becomes active (it stays mounted across
   // navigation, so key off the active-prop transition rather than mount). lastHealthCheckRun
@@ -349,34 +371,9 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
           <div className="flex shrink-0 items-center gap-x-2">
             <LastUpdated />
 
-            <TooltipDelayGroup>
-              <Tooltip content={t("common:::refresh")} placement="bottom">
-                <Button
-                  appearance="subdued"
-                  aria-label={t("common:::refresh")}
-                  brand="neutral"
-                  isLoading={isRefreshing}
-                  leftIconPath={mdiRefresh}
-                  size="sm"
-                  onClick={() => onRefresh?.()}
-                />
-              </Tooltip>
-
-              <Tooltip content={t("common:::settings")} placement="bottom">
-                <Button
-                  appearance="subdued"
-                  aria-label={t("common:::settings")}
-                  brand="neutral"
-                  leftIconPath={mdiCogOutline}
-                  size="sm"
-                  onClick={() => {
-                    trackSettingsOpened();
-                    dispatch(setOpenMainPage("application_settings", false));
-                    dispatch(setSettingsPage("Vortex"));
-                  }}
-                />
-              </Tooltip>
-            </TooltipDelayGroup>
+            <Toolbar>
+              <ToolbarGroup actions={toolbarActions} />
+            </Toolbar>
           </div>
         </PageHeader>
 

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -244,7 +244,9 @@ function MyTabs() {
 
 Horizontal toolbar made of one or more rounded `ToolbarGroup` "pills". A group is **data-driven**: pass it an array of `IToolbarAction` descriptors and it renders each as an icon `Button`. When the actions don't all fit, the trailing slot becomes a kebab (`⋮`) menu and the overflow actions move into its dropdown — the same descriptor renders as a `Button` while visible and a `DropdownItem` once collapsed.
 
-**Responsive by default.** The `Toolbar` measures the width available to it and each group renders as many actions as fit, so the rest stay reachable in the kebab as the window narrows. This needs a width that doesn't come from the toolbar's own content, which a block-level or stretched parent gives it for free. As a flex item the toolbar is `flex-shrink: 0` and keeps every control instead, because a toolbar sized by its content can't tell how much room it has — add `flex-1` (or `shrink`) to opt it into collapsing.
+**Responsive by default.** The `Toolbar` measures the width available to it and each group renders as many actions as fit, so the rest stay reachable in the kebab as the window narrows. This needs a width that doesn't come from the toolbar's own content, which a block-level or stretched parent gives it for free. As a flex item the toolbar is `flex-shrink: 0` and keeps every control instead, because a toolbar sized by its content can't tell how much room it has — add `flex-1` to opt it into collapsing.
+
+Use `flex-1` specifically, **not** `shrink`. Both let the toolbar narrow, but `shrink` leaves `flex-basis: auto`, so the width still comes from the content: collapsing shrinks the toolbar, the smaller toolbar reports a smaller budget, and the controls never come back out of the kebab when the window widens again. `flex-1` sets a zero basis, so the width comes from the parent and collapsing is reversible. Pair it with `justify-end` where the controls should sit against the trailing edge.
 
 **`maxVisible`** (optional) caps the number of slots regardless of available width, for groups that should stay short. Omit it to let width be the only limit. Whichever is more restrictive wins.
 
@@ -267,9 +269,23 @@ const actions: IToolbarAction[] = [
 </Toolbar>;
 ```
 
-**`IToolbarAction` fields:** `label` (required — the accessible name, dropdown label, and button text when `showLabel`), `iconPath`, `onClick`, `disabled`, `brand` (defaults to `neutral`), `showLabel` (render the label as visible button text instead of icon-only, e.g. a "1 selected" pill).
+**`IToolbarAction` fields:** `label` (required — the accessible name, tooltip, dropdown label, and button text when `showLabel`), `iconPath`, `onClick`, `disabled`, `brand` (defaults to `neutral`), `showLabel` (render the label as visible button text instead of icon-only, e.g. a "1 selected" pill), `pinned` (see below).
 
 Actions are keyed internally by `label`, so labels should be unique within a group. The kebab is generated automatically — callers never author it.
+
+**`pinned`** keeps an action out of the overflow menu, wherever it sits in the list — the unpinned actions then share whatever width is left, still collapsing from the end. The row keeps the order you gave it, so a pin holds its place rather than jumping to the front as its neighbours collapse.
+
+```tsx
+const actions: IToolbarAction[] = [
+    { label: "Install mod", iconPath: mdiPlusCircleOutline, onClick: install, pinned: true },
+    { label: "Open mods folder", iconPath: mdiFolderOpenOutline, onClick: openFolder },
+    { label: "History", iconPath: mdiHistory, onClick: showHistory },
+];
+```
+
+Use it sparingly. Pinning wins over fitting, so a group with no room for its pinned actions shows them anyway and overflows its pill rather than dropping them — and `maxVisible` won't hold them back either.
+
+**Tooltips come for free.** The controls are icon-only, so each visible one renders as a `ToolbarButton` — a `Button` wrapped in a `Tooltip` showing its `label`. The group shares one hover delay, so sweeping along the row swaps tooltips instead of re-waiting on each. Two cases deliberately get no tooltip: an action in the overflow menu (the menu already shows its label as text) and one with `showLabel` (its text is already on screen). The `label` stays the single source for the accessible name — the tooltip describes the control, it doesn't rename it.
 
 ### Alert
 

--- a/src/renderer/src/ui/components/display_options/DisplayOptions.tsx
+++ b/src/renderer/src/ui/components/display_options/DisplayOptions.tsx
@@ -38,7 +38,7 @@ export const DisplayOptions = ({
     <Popover>
       <Tooltip content={triggerLabel} placement="bottom">
         <PopoverButton
-          appearance="subdued"
+          appearance="weak"
           aria-label={triggerLabel}
           brand="neutral"
           leftIconPath={mdiTune}

--- a/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.demo.tsx
@@ -54,6 +54,13 @@ const manyActions: IToolbarAction[] = [
   { label: "Untrack", iconPath: mdiPawOutline },
 ];
 
+// The same ten with a pin at each end, to show that a pin holds its place rather
+// than being pulled to the front.
+const pinnedActions: IToolbarAction[] = manyActions.map((action) => ({
+  ...action,
+  pinned: action.label === "Install mod" || action.label === "Untrack",
+}));
+
 export const ToolbarDemo = () => (
   <div className="space-y-8">
     <div className="rounded-sm bg-surface-mid p-4">
@@ -64,6 +71,12 @@ export const ToolbarDemo = () => (
       <Typography appearance="subdued">
         A horizontal toolbar made of one or more rounded groups of related controls. Groups share a
         raised surface; controls are typically icon-only buttons.
+      </Typography>
+
+      <Typography appearance="subdued">
+        Because the controls carry no visible text, each shows its label on hover — hover one below,
+        then move along the row to see the delay shared across the group. Actions in an overflow
+        menu show no tooltip: the menu already lists their labels.
       </Typography>
     </div>
 
@@ -105,6 +118,25 @@ export const ToolbarDemo = () => (
     <div className="w-104 resize-x overflow-auto rounded-sm border border-stroke-weak px-2 pt-2 pb-40">
       <Toolbar>
         <ToolbarGroup actions={manyActions} />
+      </Toolbar>
+    </div>
+
+    <div className="rounded-sm bg-surface-mid p-4">
+      <Typography as="h3" typographyType="heading-sm">
+        Pinned actions
+      </Typography>
+
+      <Typography appearance="subdued">
+        A <code>pinned</code> action stays out of the overflow menu wherever it sits in the list,
+        and the unpinned ones share whatever width is left. Resize the box: "Install mod" and
+        "Untrack" hold their places while everything between them collapses. Narrow it far enough
+        and only the pinned pair is left — pinning wins over fitting, so keep the set small.
+      </Typography>
+    </div>
+
+    <div className="w-104 resize-x overflow-auto rounded-sm border border-stroke-weak px-2 pt-2 pb-40">
+      <Toolbar>
+        <ToolbarGroup actions={pinnedActions} />
       </Toolbar>
     </div>
 

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -1,11 +1,11 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { Toolbar } from "./Toolbar";
 import { ToolbarGroup, type IToolbarAction } from "./ToolbarGroup";
-import { fitVisibleCount, type IToolbarGroupMetrics } from "./useToolbarOverflow.hook";
+import { fitVisibleActions, type IToolbarGroupMetrics } from "./useToolbarOverflow.hook";
 
 // --- Helpers ---
 
@@ -224,6 +224,79 @@ describe("ToolbarGroup", () => {
     });
   });
 
+  describe("tooltips", () => {
+    const getTooltip = () => screen.queryByRole("tooltip");
+
+    /** Tooltips open on a delay, so absence has to outlast it to mean anything. */
+    const expectNoTooltip = async () => {
+      await expect(screen.findByRole("tooltip", {}, { timeout: 400 })).rejects.toThrow();
+    };
+
+    it("shows a tooltip with the label when a visible control is hovered", async () => {
+      render(<ToolbarGroup actions={[{ label: "Update extensions", iconPath: "mdi-test" }]} />);
+
+      expect(getTooltip()).not.toBeInTheDocument();
+
+      await userEvent.hover(screen.getByRole("button", { name: "Update extensions" }));
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Update extensions");
+    });
+
+    it("hides the tooltip again once the pointer leaves", async () => {
+      render(<ToolbarGroup actions={[{ label: "Refresh", iconPath: "mdi-test" }]} />);
+      const button = screen.getByRole("button", { name: "Refresh" });
+
+      await userEvent.hover(button);
+      expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+      await userEvent.unhover(button);
+      await waitFor(() => expect(getTooltip()).not.toBeInTheDocument());
+    });
+
+    it("gives an overflowed action no tooltip, since the dropdown shows its label", async () => {
+      render(<ToolbarGroup actions={makeActions(8)} maxVisible={7} />);
+      await userEvent.click(getKebab());
+
+      await userEvent.hover(screen.getByText("Action 8"));
+
+      await expectNoTooltip();
+    });
+
+    it("gives a showLabel action no tooltip repeating its visible text", async () => {
+      render(
+        <ToolbarGroup actions={[{ label: "1 selected", iconPath: "mdi-test", showLabel: true }]} />,
+      );
+
+      await userEvent.hover(screen.getByRole("button", { name: "1 selected" }));
+
+      await expectNoTooltip();
+    });
+
+    it("keeps one accessible name per control, not a name plus a duplicate", async () => {
+      render(<ToolbarGroup actions={[{ label: "Refresh", iconPath: "mdi-test" }]} />);
+      const button = screen.getByRole("button", { name: "Refresh" });
+
+      // Icon-only, so the name comes from aria-label and nothing else.
+      expect(button).toHaveAttribute("aria-label", "Refresh");
+      expect(button).not.toHaveTextContent("Refresh");
+
+      // While open the tooltip describes the control; it must not rename it.
+      await userEvent.hover(button);
+      await screen.findByRole("tooltip");
+
+      expect(screen.getByRole("button", { name: "Refresh" })).toBe(button);
+      expect(button).toHaveAttribute("aria-label", "Refresh");
+    });
+
+    it("labels a showLabel action from its visible text, with no aria-label", () => {
+      render(<ToolbarGroup actions={[{ label: "1 selected", showLabel: true }]} />);
+      const button = screen.getByRole("button", { name: "1 selected" });
+
+      expect(button).not.toHaveAttribute("aria-label");
+      expect(button).toHaveTextContent("1 selected");
+    });
+  });
+
   describe("width-based overflow", () => {
     // The stubs give every control a 28px width with no gap or padding, so a row
     // of N pixels holds floor(N / 28) controls — the kebab being one of them.
@@ -290,9 +363,92 @@ describe("ToolbarGroup", () => {
       expect(getKebab()).toBeInTheDocument();
     });
   });
+
+  describe("pinned actions", () => {
+    /** Pins the named actions within an otherwise ordinary five-action row. */
+    const renderPinned = (rowPixels: number, pinnedLabels: string[]) => {
+      stubLayout(rowPixels);
+      render(
+        <Toolbar>
+          <ToolbarGroup
+            actions={makeActions(5).map((action) => ({
+              ...action,
+              pinned: pinnedLabels.includes(action.label),
+            }))}
+          />
+        </Toolbar>,
+      );
+    };
+
+    it("keeps a pinned action visible while the rest collapse", () => {
+      // 100px holds three controls. Unpinned, "Action 5" would be first to go.
+      renderPinned(100, ["Action 5"]);
+
+      expect(screen.getByRole("button", { name: "Action 5" })).toBeInTheDocument();
+      expect(getKebab()).toBeInTheDocument();
+    });
+
+    it("collapses an unpinned action to make room for a pinned one", async () => {
+      renderPinned(100, ["Action 5"]);
+
+      expect(screen.queryByRole("button", { name: "Action 3" })).not.toBeInTheDocument();
+
+      await userEvent.click(getKebab());
+      expect(screen.getByText("Action 3")).toBeInTheDocument();
+    });
+
+    it("pins an action wherever it sits, not just at the front", () => {
+      renderPinned(100, ["Action 4"]);
+
+      expect(screen.getByRole("button", { name: "Action 4" })).toBeInTheDocument();
+    });
+
+    it("keeps the row in the caller's order, so a pin doesn't reshuffle it", () => {
+      // 120px holds four controls: the two pins, one unpinned action, and the
+      // kebab. Rendering the pins first would give "Action 4, Action 5, Action 1".
+      renderPinned(120, ["Action 4", "Action 5"]);
+
+      const names = screen
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label"))
+        .filter((name) => name !== "More actions");
+
+      expect(names).toEqual(["Action 1", "Action 4", "Action 5"]);
+    });
+
+    it("keeps pinned actions even when the row has room for nothing", () => {
+      renderPinned(10, ["Action 2"]);
+
+      expect(screen.getByRole("button", { name: "Action 2" })).toBeInTheDocument();
+      expect(countActionButtons()).toBe(1);
+    });
+
+    it("keeps a pinned action past the maxVisible ceiling", () => {
+      stubLayout(1000);
+      render(
+        <Toolbar>
+          <ToolbarGroup
+            actions={makeActions(6).map((action, index) => ({ ...action, pinned: index >= 4 }))}
+            maxVisible={2}
+          />
+        </Toolbar>,
+      );
+
+      // Both pins show even though they plus the kebab exceed the two-slot cap.
+      expect(screen.getByRole("button", { name: "Action 5" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Action 6" })).toBeInTheDocument();
+      expect(countActionButtons()).toBe(2);
+    });
+
+    it("still collapses normally when nothing is pinned", () => {
+      renderPinned(100, []);
+      expect(countActionButtons()).toBe(2);
+      expect(getKebab()).toBeInTheDocument();
+    });
+  });
 });
 
-describe("fitVisibleCount", () => {
+describe("fitVisibleActions", () => {
   // A mixed row: four icon-only controls and one wide labelled one.
   const metrics: IToolbarGroupMetrics = {
     itemWidths: [28, 28, 28, 92, 28],
@@ -301,43 +457,81 @@ describe("fitVisibleCount", () => {
     padding: 8,
   };
 
-  const fit = (availableWidth: number | null, maxVisible?: number) =>
-    fitVisibleCount({
-      actionCount: metrics.itemWidths.length,
-      availableWidth,
-      maxVisible,
-      metrics,
-    });
+  const noPins = metrics.itemWidths.map(() => false);
+
+  /** Visible indices, ascending, so the expectations read as positions. */
+  const fit = (availableWidth: number | null, maxVisible?: number, pinnedIndices: number[] = []) =>
+    [
+      ...fitVisibleActions({
+        availableWidth,
+        maxVisible,
+        metrics,
+        pinned: metrics.itemWidths.map((_, index) => pinnedIndices.includes(index)),
+      }),
+    ].sort((a, b) => a - b);
 
   it("shows everything when it all fits", () => {
     // 204px of controls + 32px of gaps + 8px of padding = 244px.
-    expect(fit(300)).toBe(5);
-    expect(fit(244)).toBe(5);
+    expect(fit(300)).toEqual([0, 1, 2, 3, 4]);
+    expect(fit(244)).toEqual([0, 1, 2, 3, 4]);
   });
 
-  it("drops actions one at a time as the budget tightens", () => {
-    expect(fit(243)).toBe(3); // 4 actions include the 92px one, so it skips straight to 3.
-    expect(fit(144)).toBe(3);
-    expect(fit(143)).toBe(2);
-    expect(fit(100)).toBe(1);
+  it("drops actions from the end as the budget tightens", () => {
+    expect(fit(243)).toEqual([0, 1, 2]); // 4 actions include the 92px one, so it skips to 3.
+    expect(fit(144)).toEqual([0, 1, 2]);
+    expect(fit(143)).toEqual([0, 1]);
+    expect(fit(100)).toEqual([0]);
   });
 
   it("keeps only the kebab when nothing fits alongside it", () => {
-    expect(fit(50)).toBe(0);
-    expect(fit(0)).toBe(0);
+    expect(fit(50)).toEqual([]);
+    expect(fit(0)).toEqual([]);
   });
 
   it("ignores width when it hasn't been measured", () => {
-    expect(fit(null)).toBe(5);
-    expect(fit(null, 3)).toBe(2);
+    expect(fit(null)).toEqual([0, 1, 2, 3, 4]);
+    expect(fit(null, 3)).toEqual([0, 1]);
   });
 
   it("takes whichever of width and maxVisible is more restrictive", () => {
-    expect(fit(300, 3)).toBe(2); // The cap wins: 2 actions plus the kebab is 3 slots.
-    expect(fit(100, 3)).toBe(1); // The width wins.
+    expect(fit(300, 3)).toEqual([0, 1]); // The cap wins: 2 actions plus the kebab is 3 slots.
+    expect(fit(100, 3)).toEqual([0]); // The width wins.
   });
 
   it("treats missing metrics as unconstrained", () => {
-    expect(fitVisibleCount({ actionCount: 5, availableWidth: 10, metrics: null })).toBe(5);
+    expect([...fitVisibleActions({ availableWidth: 10, metrics: null, pinned: noPins })]).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+  });
+
+  describe("pinning", () => {
+    it("keeps a pinned action at the end while the earlier ones collapse", () => {
+      // Unpinned, 100px leaves just index 0; pinning 4 spends that budget on it.
+      expect(fit(100, undefined, [4])).toEqual([4]);
+    });
+
+    it("spends the remaining width on the unpinned actions, in order", () => {
+      // 28 (pinned 4) + 28 (0) + 28 kebab + 16 gaps + 8 padding = 108px.
+      expect(fit(108, undefined, [4])).toEqual([0, 4]);
+    });
+
+    it("keeps every pin even when there is no room at all", () => {
+      expect(fit(0, undefined, [1, 3])).toEqual([1, 3]);
+      expect(fit(10, undefined, [4])).toEqual([4]);
+    });
+
+    it("keeps pins past the maxVisible ceiling", () => {
+      // Two pins plus a kebab is three slots, over the cap, and they still show.
+      expect(fit(null, 2, [0, 4])).toEqual([0, 4]);
+    });
+
+    it("drops the kebab when every action is pinned", () => {
+      const allPinned = [0, 1, 2, 3, 4];
+      expect(fit(0, undefined, allPinned)).toEqual(allPinned);
+    });
+
+    it("behaves exactly as before when nothing is pinned", () => {
+      expect(fit(143, undefined, [])).toEqual([0, 1]);
+    });
   });
 });

--- a/src/renderer/src/ui/components/toolbar/ToolbarButton.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarButton.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from "react";
+
+import { Button, type IButtonProps } from "@/ui/components/button/Button";
+import { Tooltip, type ITooltipPlacement } from "@/ui/components/tooltip/Tooltip";
+
+export type IToolbarButtonProps = IButtonProps & {
+  label: string;
+  showLabel?: boolean;
+  placement?: ITooltipPlacement;
+};
+
+/**
+ * A toolbar control: an icon-only `Button` whose label is shown on hover.
+ *
+ * Toolbar controls carry no visible text, so the tooltip is the only on-screen
+ * hint of what they do. `label` is the single source for that, for the accessible
+ * name, and for the text when `showLabel` is set — where the name is already on
+ * screen, so the tooltip steps aside instead of repeating it.
+ *
+ * Only for the slots a `ToolbarGroup` renders as buttons. An overflowed action
+ * becomes a `DropdownItem`, which shows its label as text and needs no tooltip.
+ */
+export const ToolbarButton = forwardRef<HTMLButtonElement, IToolbarButtonProps>(
+  ({ label, placement = "bottom", showLabel = false, ...props }, ref) => (
+    <Tooltip content={label} disabled={showLabel} placement={placement}>
+      <Button {...props} aria-label={showLabel ? undefined : label} ref={ref} size="sm">
+        {showLabel && label}
+      </Button>
+    </Tooltip>
+  ),
+);
+
+ToolbarButton.displayName = "ToolbarButton";

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -1,13 +1,15 @@
 import { Menu } from "@headlessui/react";
-import { mdiDotsVertical } from "@mdi/js";
+import { mdiDotsHorizontal } from "@mdi/js";
 import React, { type HTMLAttributes } from "react";
 
 import { Button, type IButtonBrand } from "@/ui/components/button/Button";
 import { Dropdown } from "@/ui/components/dropdown/Dropdown";
 import { DropdownItem } from "@/ui/components/dropdown/DropdownItem";
 import { DropdownItems } from "@/ui/components/dropdown/DropdownItems";
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
+import { ToolbarButton } from "./ToolbarButton";
 import { useToolbarOverflow } from "./useToolbarOverflow.hook";
 
 export interface IToolbarAction {
@@ -18,6 +20,8 @@ export interface IToolbarAction {
   brand?: IButtonBrand;
   showLabel?: boolean;
   testId?: string;
+  isLoading?: boolean;
+  pinned?: boolean;
 }
 
 type IToolbarGroupProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
@@ -42,52 +46,57 @@ const widthSignature = (actions: IToolbarAction[]): string =>
 /**
  * A rounded "pill" cluster of related toolbar controls sharing a single raised
  * surface. Renders as many actions as fit the width the toolbar has; the rest
- * collapse into a kebab dropdown occupying the final slot.
+ * collapse into a kebab dropdown occupying the final slot. A `pinned` action is
+ * held back from that, whatever its position.
  */
 export const ToolbarGroup = ({ actions, className, maxVisible, ...props }: IToolbarGroupProps) => {
-  const { groupRef, isMeasuring, visibleCount } = useToolbarOverflow({
-    actionCount: actions.length,
+  const { groupRef, isMeasuring, visible } = useToolbarOverflow({
     maxVisible,
+    pinned: actions.map((action) => action.pinned ?? false),
     signature: widthSignature(actions),
   });
 
-  const visible = actions.slice(0, visibleCount);
-  const hidden = actions.slice(visibleCount);
+  const visibleActions = actions.filter((_, index) => visible.has(index));
+  const hiddenActions = actions.filter((_, index) => !visible.has(index));
 
   return (
-    <div className={joinClasses(["nxm-toolbar-group", className])} ref={groupRef} {...props}>
-      {visible.map((action) => (
-        <Button
+    <TooltipDelayGroup
+      as="div"
+      className={joinClasses(["nxm-toolbar-group", className])}
+      ref={groupRef}
+      {...props}
+    >
+      {visibleActions.map((action) => (
+        <ToolbarButton
           appearance="weak"
-          aria-label={!action.showLabel ? action.label : undefined}
           brand={action.brand ?? "neutral"}
           data-testid={action.testId}
           disabled={action.disabled}
+          isLoading={action.isLoading}
           key={action.label}
+          label={action.label}
           leftIconPath={action.iconPath}
-          size="sm"
+          showLabel={action.showLabel}
           onClick={action.onClick}
-        >
-          {action.showLabel ? action.label : undefined}
-        </Button>
+        />
       ))}
 
       {/* Kept mounted through the measuring pass so its width is measured too. */}
-      {(isMeasuring || !!hidden.length) && (
+      {(isMeasuring || !!hiddenActions.length) && (
         <Dropdown>
           <Menu.Button
             appearance="weak"
             aria-label="More actions"
             as={Button}
             brand="neutral"
-            leftIconPath={mdiDotsVertical}
+            leftIconPath={mdiDotsHorizontal}
             size="sm"
           />
 
           <DropdownItems className="right-0 left-auto">
-            {hidden.map((action) => (
+            {hiddenActions.map((action) => (
               <DropdownItem
-                disabled={action.disabled}
+                disabled={action.disabled || action.isLoading}
                 key={action.label}
                 leftIconPath={action.iconPath}
                 onClick={action.onClick}
@@ -98,6 +107,6 @@ export const ToolbarGroup = ({ actions, className, maxVisible, ...props }: ITool
           </DropdownItems>
         </Dropdown>
       )}
-    </div>
+    </TooltipDelayGroup>
   );
 };

--- a/src/renderer/src/ui/components/toolbar/useToolbarOverflow.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarOverflow.hook.ts
@@ -4,13 +4,9 @@ import { useToolbarContext } from "./Toolbar.context";
 
 /** Intrinsic widths of one group's controls, in CSS pixels. */
 export interface IToolbarGroupMetrics {
-  /** Width of each action button, in action order. */
   itemWidths: number[];
-  /** Width of the overflow kebab. */
   kebabWidth: number;
-  /** Gap between two adjacent controls. */
   gap: number;
-  /** Combined left and right padding of the pill surface. */
   padding: number;
 }
 
@@ -20,16 +16,15 @@ interface IToolbarMeasurement {
 }
 
 interface IFitParams {
-  actionCount: number;
   availableWidth: number | null;
   maxVisible?: number;
   metrics: IToolbarGroupMetrics | null;
+  pinned: readonly boolean[];
 }
 
 interface IOverflowParams {
-  actionCount: number;
   maxVisible?: number;
-  /** Changes whenever the actions' rendered widths could have changed. */
+  pinned: readonly boolean[];
   signature: string;
 }
 
@@ -92,26 +87,35 @@ const measureAvailableWidth = (
 };
 
 /**
- * Largest number of action buttons that fits `availableWidth` without exceeding
- * the `maxVisible` slot cap. A result below `actionCount` means the kebab is
- * rendered and takes one of those slots.
+ * Which actions render as buttons, by index. Pinned actions always do, wherever
+ * they sit in the list; the unpinned ones then fill whatever room is left, in
+ * order, so the tail of the row collapses first.
+ *
+ * Returning a set rather than a count is what lets a pin sit anywhere: the
+ * visible actions are no longer necessarily a leading run of the list.
+ *
+ * A row too narrow for the pinned actions alone keeps them regardless — that is
+ * what pinning asks for, so the group overflows rather than dropping them.
  */
-export const fitVisibleCount = ({
-  actionCount,
+export const fitVisibleActions = ({
   availableWidth,
   maxVisible,
   metrics,
-}: IFitParams): number => {
+  pinned,
+}: IFitParams): Set<number> => {
   const slots = maxVisible ?? Number.POSITIVE_INFINITY;
 
-  const fits = (count: number, withKebab: boolean): boolean => {
+  const pinnedIndices = pinned.flatMap((isPinned, index) => (isPinned ? [index] : []));
+  const unpinnedIndices = pinned.flatMap((isPinned, index) => (isPinned ? [] : [index]));
+
+  const fits = (indices: number[], withKebab: boolean): boolean => {
     // `availableWidth` is checked against null rather than falsiness: 0 is a real
     // budget (a group with no room left), and must not be read as "not measured".
     if (!metrics || availableWidth === null) {
       return true;
     }
 
-    const widths = metrics.itemWidths.slice(0, count);
+    const widths = indices.map((index) => metrics.itemWidths[index] ?? 0);
 
     if (withKebab) {
       widths.push(metrics.kebabWidth);
@@ -129,29 +133,38 @@ export const fitVisibleCount = ({
     );
   };
 
-  if (actionCount <= slots && fits(actionCount, false)) {
-    return actionCount;
-  }
+  // Give up unpinned actions from the end until what's left fits.
+  for (let taken = unpinnedIndices.length; taken >= 0; taken--) {
+    const visible = [...pinnedIndices, ...unpinnedIndices.slice(0, taken)];
+    const withKebab = taken < unpinnedIndices.length;
 
-  for (let count = Math.min(actionCount - 1, slots - 1); count > 0; count--) {
-    if (fits(count, true)) {
-      return count;
+    if (visible.length + (withKebab ? 1 : 0) > slots) {
+      continue;
+    }
+
+    if (fits(visible, withKebab)) {
+      return new Set(visible);
     }
   }
 
-  return 0;
+  return new Set(pinnedIndices);
 };
 
 /**
- * Decides how many of a group's actions to render as buttons, collapsing the
- * rest into the overflow menu once they no longer fit the width the toolbar has.
+ * Decides which of a group's actions render as buttons, collapsing the rest into
+ * the overflow menu once they no longer fit the width the toolbar has.
  *
  * Control widths are measured once, in a pass where the group renders everything
  * (`isMeasuring`), and cached against `signature`; resizing then only re-runs the
- * arithmetic in {@link fitVisibleCount}. Both passes happen in layout effects, so
- * the un-collapsed row is never painted.
+ * arithmetic in {@link fitVisibleActions}. Both passes happen in layout effects,
+ * so the un-collapsed row is never painted.
+ *
+ * `pinned` is deliberately absent from `signature`: pinning changes which controls
+ * show, not how wide any of them is, so the cached measurements still hold.
  */
-export const useToolbarOverflow = ({ actionCount, maxVisible, signature }: IOverflowParams) => {
+export const useToolbarOverflow = ({ maxVisible, pinned, signature }: IOverflowParams) => {
+  const actionCount = pinned.length;
+
   const { element: row, signature: rowSignature, width: rowWidth } = useToolbarContext();
 
   const groupRef = useRef<HTMLDivElement>(null);
@@ -181,14 +194,14 @@ export const useToolbarOverflow = ({ actionCount, maxVisible, signature }: IOver
     setAvailableWidth(measureAvailableWidth(groupRef.current, row, rowWidth, minimumFootprint));
   }, [minimumFootprint, row, rowSignature, rowWidth]);
 
-  const visibleCount = isMeasuring
-    ? actionCount
-    : fitVisibleCount({
-        actionCount,
+  const visible = isMeasuring
+    ? new Set(pinned.map((_, index) => index))
+    : fitVisibleActions({
         availableWidth,
         maxVisible,
         metrics: measurement?.metrics ?? null,
+        pinned,
       });
 
-  return { groupRef, isMeasuring, visibleCount };
+  return { groupRef, isMeasuring, visible };
 };

--- a/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
+++ b/src/renderer/src/ui/components/tooltip/TooltipDelayGroup.tsx
@@ -1,5 +1,5 @@
 import { FloatingDelayGroup } from "@floating-ui/react";
-import React, { type ElementType, type HTMLAttributes, type ReactNode } from "react";
+import React, { type ElementType, forwardRef, type HTMLAttributes, type ReactNode } from "react";
 
 import type { ITooltipDelay } from "@/ui/components/tooltip/Tooltip";
 
@@ -16,14 +16,22 @@ interface ITooltipDelayGroupProps extends HTMLAttributes<HTMLElement> {
  *
  * Renders no DOM of its own. Where the row needs a layout element anyway, pass
  * `as` and its props so the group and that element are one node, not two.
+ *
+ * The ref reaches that element, so a caller that has to measure the row can still
+ * do so. Without `as` there is no node to attach it to and it goes unused.
  */
-export const TooltipDelayGroup = ({
-  as: Wrapper,
-  children,
-  delay = { close: 50, open: 250 },
-  ...props
-}: ITooltipDelayGroupProps) => (
-  <FloatingDelayGroup delay={delay}>
-    {Wrapper ? <Wrapper {...props}>{children}</Wrapper> : children}
-  </FloatingDelayGroup>
+export const TooltipDelayGroup = forwardRef<HTMLElement, ITooltipDelayGroupProps>(
+  ({ as: Wrapper, children, delay = { close: 50, open: 250 }, ...props }, ref) => (
+    <FloatingDelayGroup delay={delay}>
+      {Wrapper ? (
+        <Wrapper ref={ref} {...props}>
+          {children}
+        </Wrapper>
+      ) : (
+        children
+      )}
+    </FloatingDelayGroup>
+  ),
 );
+
+TooltipDelayGroup.displayName = "TooltipDelayGroup";

--- a/src/renderer/src/views/components/Page/PageHeader.tsx
+++ b/src/renderer/src/views/components/Page/PageHeader.tsx
@@ -43,53 +43,48 @@ export const PageHeader = ({
 
   return (
     <div
-      className={joinClasses(
-        [
-          "relative z-10 w-full pb-3 transition-[padding]",
-          scrolled ? "py-2.5" : "pt-6 pb-3",
-          className,
-        ],
-        {
-          "border-b border-stroke-weak": !scrolled || isFullWidth,
-          "shadow-md": scrolled && !isFullWidth,
-        },
-      )}
+      className={joinClasses(["relative z-10 w-full py-3 pb-3", className], {
+        "border-b border-stroke-weak": !scrolled || isFullWidth,
+        "shadow-md": scrolled && !isFullWidth,
+      })}
       {...rest}
     >
-      <PageContent className="flex items-center gap-x-6 px-6" isFullWidth={isFullWidth}>
-        <div className="flex grow items-center gap-x-2">
-          {!!pictogramName && (
-            <Pictogram
-              className={joinClasses([
-                "transition-[width,height]",
-                scrolled ? "size-7" : "size-14",
-              ])}
-              name={pictogramName}
-              size="none"
-            />
-          )}
+      <PageContent className="flex items-start gap-x-2 px-6" isFullWidth={isFullWidth}>
+        {!!pictogramName && (
+          <Pictogram
+            className={joinClasses(["transition-[width,height]", scrolled ? "size-7" : "size-14"])}
+            name={pictogramName}
+            size="none"
+          />
+        )}
 
-          <div className="grow">
-            {(typeof customTitle === "function" ? customTitle(scrolled) : customTitle) ?? (
-              <Typography
-                appearance={scrolled ? "subdued" : "moderate"}
-                as="h2"
-                className="transition-colors"
-                typographyType="heading-xs"
-              >
-                {title}
-              </Typography>
-            )}
+        <div className="min-w-0 grow">
+          <div className="flex items-center justify-between gap-x-6">
+            <div className="min-w-0">
+              {(typeof customTitle === "function" ? customTitle(scrolled) : customTitle) ?? (
+                <Typography
+                  appearance={scrolled ? "subdued" : "moderate"}
+                  as="h2"
+                  className="transition-colors"
+                  typographyType="heading-xs"
+                >
+                  {title}
+                </Typography>
+              )}
+            </div>
 
-            {!!subtitle && (
-              <Typography appearance="subdued" className={joinClasses({ hidden: scrolled })}>
-                {subtitle}
-              </Typography>
-            )}
+            {typeof children === "function" ? children(scrolled) : children}
           </div>
-        </div>
 
-        {typeof children === "function" ? children(scrolled) : children}
+          {!!subtitle && (
+            <Typography
+              appearance="subdued"
+              className={joinClasses("truncate", { hidden: scrolled })}
+            >
+              {subtitle}
+            </Typography>
+          )}
+        </div>
       </PageContent>
     </div>
   );

--- a/src/stylesheets/ui/elements/toolbar.css
+++ b/src/stylesheets/ui/elements/toolbar.css
@@ -12,10 +12,6 @@
         align-items: center;
         column-gap: calc(var(--spacing) * 2);
 
-        padding: calc(var(--spacing) * 1);
-        border-radius: var(--radius-lg);
-        background-color: var(--color-surface-mid);
-
         > * {
             flex-shrink: 0;
         }


### PR DESCRIPTION
## Tooltips on toolbar controls                                                                                                                                                                                              
                                                                                                                                                                                                                               
  Toolbar controls are icon-only, so their label was only ever an `aria-label` — no hint on hover. Each visible action now renders as a new **`ToolbarButton`** (`Button` wrapped in `Tooltip`), with one delay shared across  
  the group so sweeping along a row swaps tooltips instead of re-waiting on each.                                                                                                                                              
                                                                                                                                                                                                                               
  Two cases deliberately get no tooltip: an action in the overflow menu (the dropdown already shows its label as text) and one with `showLabel` (its text is already on screen). `label` stays the single source for the       
  accessible name — the tooltip is attached as `aria-describedby`, so it describes the control rather than renaming it.                                                                                                        
                                                                                                                                                                                                                               
  `TooltipDelayGroup` gained a `forwardRef` so it can *be* the group element via `as="div"` rather than wrapping one. That matters: the overflow measuring reads the controls as the group's direct children by position, so an
  extra wrapper element would have hidden them, and a dropped ref would have silently disabled collapsing altogether.                                                                                                          
                                                                                                                                                                                                                               
  ## Pinned actions                                                                                                                                                                                                            
                                                                                                                                                                                                                               
  `IToolbarAction.pinned` keeps an action out of the overflow menu **wherever it sits** in the list; the unpinned ones then share whatever width is left, still collapsing from the end.                                       
                                                                                                                                                                                                                               
  Supporting arbitrary positions meant `fitVisibleCount` becoming `fitVisibleActions`, returning the *set* of visible indices rather than a count — the visible actions are no longer necessarily a leading run, so a single   
  count can't express them. `ToolbarGroup` filters by index instead of slicing, which keeps the caller's order so a pin holds its place rather than jumping to the front as its neighbours collapse.                           
                                                                                                                                                                                                                               
  Pinning wins over both fitting and `maxVisible`: a group with no room shows its pins anyway and overflows. That's documented on the prop and in the README — worth a look, since it's a behaviour change to what `maxVisible`
  guarantees.                                                                                                                                                                                                                  
                                                                                                                                                                                                                               
  Also added `isLoading` to `IToolbarAction`, which Health Check's refresh control needs. It maps to `Button`'s spinner on the visible path and to `disabled` in the dropdown. It's kept out of `widthSignature` — a spinner   
  occupies the same 16px box, so toggling it doesn't force a re-measure.                                                                                                                                                       
                                                                                                                                                                                                                               
  ## Page header layout                                                                                                                                                                                                        
                                                                                                                                                                                                                               
  The subtitle now sits **below** the title row rather than inside it. Previously it was part of the same flex row, so `hidden`-ing it on scroll freed ~370px that the title block and any growing child split between them —  
  on a populated toolbar that popped several controls in and out of the overflow purely from scrolling (measured 7 → 12 buttons).                                                                                              
                                                                                                                                                                                                                               
  The title also takes its content width instead of growing, with `justify-between` on the row, so a growing child gets *all* the slack rather than half. That moved the collapse threshold a long way — with a 14-action test 
  row, all 14 fit down to 800px instead of needing 1600px. Non-growing children are still pinned right, so the Games header is unchanged (verified its search sits flush at the row's right edge).                             
                                                                                                                                                                                                                               
  ## Health Check + appearances                                                                                                                                                                                                
                                                                                                                                                                                                                               
  Health Check's header refresh/settings buttons are now a `Toolbar`. Buttons in a `PageHeader` children slot moved from `appearance="subdued"` to `"weak"` to match: Health Check's two, `HealthCheckDetailPage`'s back       
  button, and the shared `DisplayOptions` trigger (which reaches the Games header).                                                                                                                                            
                                                                                                                                                                                                                               
  ## What this deliberately does *not* do                                                                                                                                                                                      
                                                                                                                                                                                                                               
  Despite the branch name, **the Extensions header keeps plain buttons.** A `ToolbarGroup` owns its delay group, so it can only ever span the actions it renders — `DisplayOptions` brings its own `Tooltip` and can't get     
  inside, which broke the hover sweep exactly at the boundary between the toolbar and the tune icon. One `TooltipDelayGroup` over all three controls keeps it instant. There's a comment in place so it doesn't get "improved" 
  back.                                                                                                                                                                                                                        
                                                                                                                                                                                                                               
  That's the same underlying gap as moving `DisplayOptions` into a toolbar group, which is still unticketed: Headless UI 1.7's `Popover` has no controlled `open` (only a read-only `open` on the render prop), and            
  `.nxm-popover-panel` anchors to its `.nxm-popover` wrapper, so an `onClick`-driven approach can't work — the action would need to carry the panel and have `ToolbarGroup` render that slot as the `PopoverButton`. Worth     
  noting React is now 18.3.1, so the Headless UI v2 upgrade that removes the positioning constraint is no longer blocked.