### PR TITLE
Headless UI v2, and Switch on top of it - Laz 860

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,8 +258,8 @@ catalogs:
       specifier: 0.27.20
       version: 0.27.20
     '@headlessui/react':
-      specifier: 1.7.19
-      version: 1.7.19
+      specifier: 2.2.10
+      version: 2.2.10
     '@hot-updater/bsdiff':
       specifier: 0.30.6
       version: 0.30.6
@@ -4174,7 +4174,7 @@ importers:
         version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
       '@headlessui/react':
         specifier: 'catalog:'
-        version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
+        version: 2.2.10(react-dom@18.3.1)(react@18.3.1)
       '@hot-updater/bsdiff':
         specifier: 'catalog:'
         version: 0.30.6
@@ -4704,7 +4704,7 @@ importers:
         version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
       '@headlessui/react':
         specifier: 'catalog:'
-        version: 1.7.19(react-dom@18.3.1)(react@18.3.1)
+        version: 2.2.10(react-dom@18.3.1)(react@18.3.1)
       '@hot-updater/bsdiff':
         specifier: 'catalog:'
         version: 0.30.6
@@ -6233,6 +6233,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/react@0.27.20':
     resolution: {integrity: sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==}
     peerDependencies:
@@ -6242,12 +6248,12 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@headlessui/react@1.7.19':
-    resolution: {integrity: sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==}
+  '@headlessui/react@2.2.10':
+    resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16 || ^17 || ^18
-      react-dom: ^16 || ^17 || ^18
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   '@hot-updater/bsdiff@0.30.6':
     resolution: {integrity: sha512-Ux8WyYsYXlU13TahGCHHa3EQpfDQukGm0REFQEz7IxRXYFJf0+oOB0k8e+j+V9j53WXbUFdoRq+FIB+gMC2iLQ==}
@@ -6281,6 +6287,15 @@ packages:
     resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
     peerDependencies:
       react: '*'
+
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -7208,6 +7223,18 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
+  '@react-aria/focus@3.22.1':
+    resolution: {integrity: sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.28.1':
+    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-dnd/asap@4.0.1':
     resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
 
@@ -7216,6 +7243,11 @@ packages:
 
   '@react-dnd/shallowequal@2.0.0':
     resolution: {integrity: sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==}
+
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -7370,6 +7402,9 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/cli@4.3.2':
     resolution: {integrity: sha512-Fzt+HrIZHDlkRYKdLMBeufaroaPvwCBG70sMLdmurdeadNMO/LxbmT8Sbb+P83ep0iAlAImettb7Y+rO+37rXw==}
@@ -8387,6 +8422,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -8742,9 +8781,6 @@ packages:
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
-
-  client-only@0.0.1:
-    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -11537,6 +11573,12 @@ packages:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-bootstrap@0.33.1:
     resolution: {integrity: sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==}
     peerDependencies:
@@ -11680,6 +11722,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-transition-group@2.9.0:
     resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
@@ -12721,6 +12768,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -14266,6 +14318,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@floating-ui/react@0.26.28(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1)(react@18.3.1)
+      '@floating-ui/utils': 0.2.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.5.0
+
   '@floating-ui/react@0.27.20(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1)(react@18.3.1)
@@ -14276,12 +14336,15 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@headlessui/react@1.7.19(react-dom@18.3.1)(react@18.3.1)':
+  '@headlessui/react@2.2.10(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@18.3.1)(react@18.3.1)
+      '@react-aria/focus': 3.22.1(react-dom@18.3.1)(react@18.3.1)
+      '@react-aria/interactions': 3.28.1(react-dom@18.3.1)(react@18.3.1)
       '@tanstack/react-virtual': 3.13.23(react-dom@18.3.1)(react@18.3.1)
-      client-only: 0.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   '@hot-updater/bsdiff@0.30.6': {}
 
@@ -14308,6 +14371,18 @@ snapshots:
   '@icons/material@0.2.4(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.10':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -15102,11 +15177,30 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
+  '@react-aria/focus@3.22.1(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      react: 18.3.1
+      react-aria: 3.51.0(react-dom@18.3.1)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@react-aria/interactions@3.28.1(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@react-types/shared': 3.36.1(react@18.3.1)
+      '@swc/helpers': 0.5.23
+      react: 18.3.1
+      react-aria: 3.51.0(react-dom@18.3.1)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
   '@react-dnd/asap@4.0.1': {}
 
   '@react-dnd/invariant@2.0.0': {}
 
   '@react-dnd/shallowequal@2.0.0': {}
+
+  '@react-types/shared@3.36.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@redocly/ajv@8.11.2':
     dependencies:
@@ -15236,6 +15330,10 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.4
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/cli@4.3.2':
     dependencies:
@@ -16325,6 +16423,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -16692,8 +16794,6 @@ snapshots:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.1
-
-  client-only@0.0.1: {}
 
   cliui@7.0.4:
     dependencies:
@@ -19610,6 +19710,20 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-aria@3.51.0(react-dom@18.3.1)(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@18.3.1)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-stately: 3.49.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   react-bootstrap@0.33.1(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime-corejs2': 7.29.2
@@ -19798,6 +19912,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
+
+  react-stately@3.49.0(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@18.3.1)
+      '@swc/helpers': 0.5.23
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   react-transition-group@2.9.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
@@ -20856,6 +20980,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   utf8-byte-length@1.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   "@eslint-react/eslint-plugin": 3.0.0
   "@eslint/js": 10.0.1
   "@floating-ui/react": 0.27.20
-  "@headlessui/react": 1.7.19
+  "@headlessui/react": 2.2.10
   "@hot-updater/bsdiff": 0.30.6
   "@iarna/toml": 2.2.5
   "@mdi/js": 7.4.47

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -286,8 +286,13 @@ function errorHandler(evt: any) {
       // it's almost certainly some callback invoked from a native library
       log("error", "script error");
       return;
-    } else if (error === "ResizeObserver loop limit exceeded") {
+    } else if (error.startsWith("ResizeObserver loop")) {
       // this error was called "benign" by one of the spec authors. I'll take their word for it.
+      // Matched by prefix because chromium has used two wordings: "loop limit exceeded" and,
+      // since chromium 92, "loop completed with undelivered notifications". preventDefault
+      // stops chromium printing it to the console on its own account, which is the only way
+      // it would still reach the log now that we're swallowing it here.
+      evt.preventDefault?.();
       return;
     }
   }
@@ -349,13 +354,20 @@ function errorHandler(evt: any) {
     return;
   }
 
-  if (error.stack.includes("packery")) {
+  // `error` isn't necessarily an Error: the fallback chain above ends at `evt.message`, so a
+  // browser-level ErrorEvent that carries no error object (a cross-origin "Script error.", a
+  // ResizeObserver loop warning) arrives here as a plain string with no `stack` at all. Read it
+  // once, as a string, so the sniffing below can't take the handler down with it — an exception
+  // thrown in here is itself uncaught, and reports as a bug in Vortex rather than the original.
+  const stack: string = typeof error.stack === "string" ? error.stack : "";
+
+  if (stack.includes("packery")) {
     // seems to be caused by an event triggered inside packery after cleanup so I don't see
     // a way to catch this cleanly
     return;
   }
 
-  if (error.stack.includes("react-sortable-tree")) {
+  if (stack.includes("react-sortable-tree")) {
     // matches the @nosferatu500/react-sortable-tree fork too (the scoped package
     // path still contains "react-sortable-tree").
     // bug in external library. I know where the bug is but fixing that causes a new problem and
@@ -371,10 +383,10 @@ function errorHandler(evt: any) {
   const dynPaths = ExtensionManager.getExtensionPaths().filter((extPath) => !extPath.bundled);
 
   if (dynPaths.length > 0) {
-    if (error.stack.includes(`at ${dynPaths[0].path}`)) {
+    if (stack.includes(`at ${dynPaths[0].path}`)) {
       const extPath = (dynPaths[0].path + path.sep).replace(/[\\]/g, "\\\\");
       const re = new RegExp(`at ${extPath}(Vortex Extension Update - )?([^/\\\\]*)`);
-      const reMatch = error.stack.match(re);
+      const reMatch = stack.match(re);
       const extName = reMatch?.[2] ?? "unknown";
 
       error["extension"] = extName;

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -355,26 +355,28 @@ import { FormFieldWrap } from "../../ui/components/form/formfield/FormField";
 
 ### Switch
 
-A tri-state toggle switch (xs) — `off`, `on`, and a programmatic `semi-on` ("mixed") state. Built on a visually-hidden native `<input type="checkbox">`; setting `indeterminate` renders `semi-on` and reports `aria-checked="mixed"`. Clicking only ever flips on/off — `semi-on` is set by the consumer (e.g. a master control whose children are partially on). It's controlled-visual (appearance follows the `checked`/`indeterminate` props, like `Checkbox`).
+A tri-state toggle switch (xs) — `off`, `on`, and a programmatic `semi-on` ("mixed") state. Setting `indeterminate` renders `semi-on` and reports `aria-checked="mixed"`. Clicking only ever flips on/off — `semi-on` is set by the consumer (e.g. a master control whose children are partially on).
+
+Built on Headless UI's **`Checkbox`**, not its `Switch`: ARIA only allows `aria-checked` to be true/false on `role="switch"`, and Headless UI controls that attribute, so `mixed` can't be forced onto a `Switch`. A tri-state master control is the checkbox pattern, which is what `Checkbox` implements.
 
 ```tsx
 import { Switch } from "../../ui/components/form/switch/Switch";
 
-// Controlled on/off
-<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} aria-label="Enable" />
+// Controlled on/off — onChange receives the new checked value, not an event
+<Switch checked={enabled} onChange={setEnabled} aria-label="Enable" />
 
 // Semi-on (mixed) — e.g. a "select all" with some children on
 <Switch
   checked={allOn}
   indeterminate={someOn && !allOn}
-  onChange={(e) => setAll(e.target.checked)}
+  onChange={setAll}
   aria-label="All settings"
 />
 ```
 
-**Props:** native `<input>` attributes (minus `type`) plus `indeterminate?: boolean`.
+**Props:** Headless UI `Checkbox` props — `checked`, `onChange(checked: boolean)`, `disabled`, `indeterminate`, `name`/`value`/`form` for form submission, `defaultChecked` for uncontrolled use — plus `className`.
 
-> **Porting note:** now that `@headlessui/react` is on v2, this can be reimplemented on top of HeadlessUI's `<Switch>`. The `nxm-switch` classes live on the track/thumb so they can move straight across. HeadlessUI's Switch is binary, so the tri-state stays the wrapper's responsibility (`data-state` + `indeterminate`/`aria-checked="mixed"`).
+The track and thumb style themselves off the attributes Headless UI sets (`data-checked`, `data-indeterminate`, `data-disabled`, `data-hover`, `data-active`, `data-focus`) rather than any state we derive ourselves. It renders a `<span role="checkbox">`, so pass `name` if the value needs to take part in form submission.
 
 ### Dropdown
 

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -374,7 +374,7 @@ import { Switch } from "../../ui/components/form/switch/Switch";
 
 **Props:** native `<input>` attributes (minus `type`) plus `indeterminate?: boolean`.
 
-> **Porting note:** when `@headlessui/react` reaches v2 (after the React upgrade), reimplement on top of HeadlessUI's `<Switch>`. The `nxm-switch` classes live on the track/thumb so they can move straight across. HeadlessUI's Switch is binary, so the tri-state stays the wrapper's responsibility (`data-state` + `indeterminate`/`aria-checked="mixed"`).
+> **Porting note:** now that `@headlessui/react` is on v2, this can be reimplemented on top of HeadlessUI's `<Switch>`. The `nxm-switch` classes live on the track/thumb so they can move straight across. HeadlessUI's Switch is binary, so the tri-state stays the wrapper's responsibility (`data-state` + `indeterminate`/`aria-checked="mixed"`).
 
 ### Dropdown
 
@@ -406,7 +406,7 @@ import { mdiTune } from "@mdi/js";
 </Popover>;
 ```
 
-> **Positioning note:** the panel is positioned manually (absolute) until `@headlessui/react` reaches v2, which brings dynamic anchor positioning and proper z-index handling.
+> **Positioning note:** the panel is placed by Headless UI's `anchor` prop, which uses Floating UI to flip and shift it into view and portals it out of any clipping ancestor. It defaults to `bottom end` with a 4px gap; pass `anchor` to place it elsewhere.
 
 ### DisplayOptions
 
@@ -670,7 +670,7 @@ import { mdiViewGrid } from "@mdi/js";
 />
 ```
 
-**Props:** `options` (`{ label, value, iconPath?/icon? }[]`), `value`, `onChange` (required); `button` (props forwarded to the trigger `ListboxButton` — Button props + `showChevron`; any `children` is ignored, the label is always the selected option), `placement` (`"left"`/`"right"`, default `"right"` — temporary until Headless UI v2), `className`.
+**Props:** `options` (`{ label, value, iconPath?/icon? }[]`), `value`, `onChange` (required); `button` (props forwarded to the trigger `ListboxButton` — Button props + `showChevron`; any `children` is ignored, the label is always the selected option), `placement` (`"left"`/`"right"`, default `"right"` — which edge of the trigger the panel aligns to), `className`.
 
 ### Pill
 

--- a/src/renderer/src/ui/components/dropdown/Dropdown.demo.tsx
+++ b/src/renderer/src/ui/components/dropdown/Dropdown.demo.tsx
@@ -3,7 +3,7 @@
  * Demonstrates the Dropdown component variants and features
  */
 
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import { mdiContentCopy, mdiDelete, mdiDotsVertical, mdiDownload, mdiPencil } from "@mdi/js";
 import React, { useCallback } from "react";
 
@@ -41,9 +41,9 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} brand="neutral" appearance="subdued">
+            <MenuButton as={Button} brand="neutral" appearance="subdued">
               Options
-            </Menu.Button>
+            </MenuButton>
 
             <DropdownItems className="right-auto left-0">
               <DropdownItem onClick={() => handleClick("Option 1")}>Option 1</DropdownItem>
@@ -63,9 +63,9 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} brand="neutral" appearance="subdued">
+            <MenuButton as={Button} brand="neutral" appearance="subdued">
               Actions
-            </Menu.Button>
+            </MenuButton>
 
             <DropdownItems className="right-auto left-0">
               <DropdownItem leftIconPath={mdiPencil} onClick={() => handleClick("Edit")}>
@@ -101,7 +101,7 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button
+            <MenuButton
               as={Button}
               brand="neutral"
               appearance="subdued"
@@ -133,9 +133,9 @@ export const DropdownDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Dropdown>
-            <Menu.Button as={Button} brand="neutral" appearance="subdued">
+            <MenuButton as={Button} brand="neutral" appearance="subdued">
               With Disabled
-            </Menu.Button>
+            </MenuButton>
 
             <DropdownItems className="right-auto left-0">
               <DropdownItem onClick={() => handleClick("Available")}>Available action</DropdownItem>

--- a/src/renderer/src/ui/components/dropdown/Dropdown.test.tsx
+++ b/src/renderer/src/ui/components/dropdown/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -16,7 +16,7 @@ const renderComponent = () => {
 
   render(
     <Dropdown>
-      <Menu.Button>Options</Menu.Button>
+      <MenuButton>Options</MenuButton>
 
       <DropdownItems>
         <DropdownItem onClick={onEdit}>Edit</DropdownItem>

--- a/src/renderer/src/ui/components/dropdown/Dropdown.tsx
+++ b/src/renderer/src/ui/components/dropdown/Dropdown.tsx
@@ -3,8 +3,6 @@ import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-// needs updating to headless v2 so we can have dynamic positioning and proper z-index usage
-
 export const Dropdown = ({ className, ...props }: ComponentProps<typeof Menu>) => (
   <Menu as="div" className={joinClasses(["nxm-dropdown", className])} {...props} />
 );

--- a/src/renderer/src/ui/components/dropdown/DropdownButton.tsx
+++ b/src/renderer/src/ui/components/dropdown/DropdownButton.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import React from "react";
 
 import { Button, type IButtonProps } from "@/ui/components/button/Button";
@@ -6,5 +6,5 @@ import { Button, type IButtonProps } from "@/ui/components/button/Button";
 export type IDropdownButtonProps = IButtonProps;
 
 export const DropdownButton = (props: IDropdownButtonProps) => (
-  <Menu.Button as={Button} {...props} />
+  <MenuButton as={Button} {...props} />
 );

--- a/src/renderer/src/ui/components/dropdown/DropdownItem.tsx
+++ b/src/renderer/src/ui/components/dropdown/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuItem } from "@headlessui/react";
 import React, { type ComponentProps, type ReactNode } from "react";
 
 import { Icon } from "@/ui/components/icon/Icon";
@@ -33,8 +33,8 @@ export const DropdownItem = ({
   rightIconPath,
   onClick,
   ...props
-}: ComponentProps<typeof Menu.Item> & IDropdownItemProps & { onClick?: () => void }) => (
-  <Menu.Item {...props}>
+}: ComponentProps<typeof MenuItem> & IDropdownItemProps & { onClick?: () => void }) => (
+  <MenuItem {...props}>
     {({ active, disabled }) => (
       <button
         className={joinClasses(["nxm-dropdown-item", className], {
@@ -54,5 +54,5 @@ export const DropdownItem = ({
         )}
       </button>
     )}
-  </Menu.Item>
+  </MenuItem>
 );

--- a/src/renderer/src/ui/components/dropdown/DropdownItems.tsx
+++ b/src/renderer/src/ui/components/dropdown/DropdownItems.tsx
@@ -1,8 +1,18 @@
-import { Menu } from "@headlessui/react";
+import { MenuItems } from "@headlessui/react";
 import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-export const DropdownItems = ({ className, ...props }: ComponentProps<typeof Menu.Items>) => (
-  <Menu.Items className={joinClasses(["nxm-dropdown-items", className])} {...props} />
+/**
+ * The menu surface of a `Dropdown`. `anchor` hands positioning to Headless UI's
+ * Floating UI integration, which also portals the panel — so it escapes any
+ * clipping ancestor and flips itself when there's no room below. `gap` replaces
+ * the margin the stylesheet used to carry. Pass `anchor` to place it elsewhere.
+ */
+export const DropdownItems = ({ className, ...props }: ComponentProps<typeof MenuItems>) => (
+  <MenuItems
+    anchor={{ gap: 4, to: "bottom end" }}
+    className={joinClasses(["nxm-dropdown-items", className])}
+    {...props}
+  />
 );

--- a/src/renderer/src/ui/components/form/switch/Switch.demo.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.demo.tsx
@@ -44,9 +44,11 @@ export const SwitchDemo = () => {
 
         <div className="grid w-max grid-cols-[auto_auto_auto] items-center gap-x-8 gap-y-3">
           <span />
+
           <Typography appearance="subdued" typographyType="body-sm">
             Enabled
           </Typography>
+
           <Typography appearance="subdued" typographyType="body-sm">
             Disabled
           </Typography>
@@ -54,19 +56,25 @@ export const SwitchDemo = () => {
           <Typography appearance="subdued" typographyType="body-sm">
             Off
           </Typography>
+
           <Switch aria-label="Off, enabled" checked={false} onChange={() => undefined} />
+
           <Switch aria-label="Off, disabled" checked={false} disabled={true} />
 
           <Typography appearance="subdued" typographyType="body-sm">
             On
           </Typography>
+
           <Switch aria-label="On, enabled" checked={true} onChange={() => undefined} />
+
           <Switch aria-label="On, disabled" checked={true} disabled={true} />
 
           <Typography appearance="subdued" typographyType="body-sm">
             Semi-on
           </Typography>
+
           <Switch aria-label="Semi-on, enabled" indeterminate={true} onChange={() => undefined} />
+
           <Switch aria-label="Semi-on, disabled" disabled={true} indeterminate={true} />
         </div>
       </div>
@@ -77,7 +85,7 @@ export const SwitchDemo = () => {
         </Typography>
 
         <div className="flex w-max items-center gap-3">
-          <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+          <Switch checked={enabled} onChange={setEnabled} />
 
           <Typography as="span" typographyType="body-sm">
             {enabled ? "Enabled" : "Disabled"}
@@ -99,7 +107,7 @@ export const SwitchDemo = () => {
           <Switch
             checked={allOn}
             indeterminate={!allOn && !noneOn}
-            onChange={(e) => setChildren(children.map(() => e.target.checked))}
+            onChange={(checked) => setChildren(children.map(() => checked))}
           />
 
           <Typography as="span" typographyType="body-sm">
@@ -110,10 +118,7 @@ export const SwitchDemo = () => {
         <div className="ml-6 space-y-2">
           {CHILD_LABELS.map((label, index) => (
             <div className="flex w-max items-center gap-3" key={label}>
-              <Switch
-                checked={children[index]}
-                onChange={(e) => setChild(index, e.target.checked)}
-              />
+              <Switch checked={children[index]} onChange={(checked) => setChild(index, checked)} />
 
               <Typography as="span" typographyType="body-sm">
                 {label}

--- a/src/renderer/src/ui/components/form/switch/Switch.test.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.test.tsx
@@ -23,15 +23,42 @@ describe("Switch", () => {
     expect(getSwitch()).toBePartiallyChecked();
   });
 
-  it("marks the track with the matching data-state", () => {
+  // The reason this is built on Headless UI's Checkbox rather than its Switch:
+  // ARIA only allows true/false on `role="switch"`, so semi-on needs a checkbox.
+  it('exposes semi-on as role="checkbox" with aria-checked="mixed"', () => {
+    render(<Switch aria-label="Setting" indeterminate={true} onChange={() => undefined} />);
+
+    expect(getSwitch()).toHaveAttribute("role", "checkbox");
+    expect(getSwitch()).toHaveAttribute("aria-checked", "mixed");
+  });
+
+  it("keeps semi-on even when checked is false, so a master control can show it", () => {
+    render(
+      <Switch
+        aria-label="Setting"
+        checked={false}
+        indeterminate={true}
+        onChange={() => undefined}
+      />,
+    );
+    expect(getSwitch()).toBePartiallyChecked();
+  });
+
+  // The track styles itself off the attributes Headless UI sets, so those are
+  // what the appearance of each state actually depends on.
+  it("marks the track with the state attributes for off, on and semi-on", () => {
+    const track = () => document.querySelector(".nxm-switch");
+
     const { rerender } = render(<Switch aria-label="Setting" checked={false} />);
-    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "off");
+    expect(track()).not.toHaveAttribute("data-checked");
+    expect(track()).not.toHaveAttribute("data-indeterminate");
 
     rerender(<Switch aria-label="Setting" checked={true} />);
-    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "on");
+    expect(track()).toHaveAttribute("data-checked");
+    expect(track()).not.toHaveAttribute("data-indeterminate");
 
     rerender(<Switch aria-label="Setting" indeterminate={true} />);
-    expect(document.querySelector(".nxm-switch")).toHaveAttribute("data-state", "semi-on");
+    expect(track()).toHaveAttribute("data-indeterminate");
   });
 
   it("calls onChange when clicked", async () => {

--- a/src/renderer/src/ui/components/form/switch/Switch.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.tsx
@@ -13,8 +13,8 @@ import { joinClasses } from "@/ui/utils/joinClasses";
  * `aria-checked="mixed"` — that is the `semi-on` state. The visible track/thumb
  * are styled spans whose appearance is keyed off `data-state` on the track.
  *
- * PORTING NOTE: once `@headlessui/react` is upgraded to v2 (after the React
- * upgrade), reimplement this on top of HeadlessUI's `<Switch>`. The `nxm-switch`
+ * PORTING NOTE: now that `@headlessui/react` is on v2, this can be reimplemented
+ * on top of HeadlessUI's `<Switch>`. The `nxm-switch`
  * classes live on the track/thumb specifically so they can move straight onto
  * the Switch's elements. HeadlessUI's Switch is binary, so the tri-state must be
  * preserved here in the wrapper — keep driving `data-state` (and the native

--- a/src/renderer/src/ui/components/form/switch/Switch.tsx
+++ b/src/renderer/src/ui/components/form/switch/Switch.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, type InputHTMLAttributes } from "react";
+import { Checkbox } from "@headlessui/react";
+import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
@@ -8,58 +9,24 @@ import { joinClasses } from "@/ui/utils/joinClasses";
  * Clicking only ever flips between on and off; semi-on is never reached by user
  * interaction.
  *
- * Implementation: a visually-hidden native `<input type="checkbox">` drives the
- * state and accessibility. Setting `indeterminate` makes the browser report
- * `aria-checked="mixed"` — that is the `semi-on` state. The visible track/thumb
- * are styled spans whose appearance is keyed off `data-state` on the track.
+ * Built on Headless UI's `Checkbox` rather than its `Switch`, because ARIA only
+ * allows `aria-checked` to be true/false on `role="switch"` — a switch is binary
+ * by definition, and Headless UI controls that attribute so `mixed` can't be
+ * forced onto it. A tri-state master control is the checkbox pattern, and
+ * `Checkbox` reports `indeterminate` as `aria-checked="mixed"`.
  *
- * PORTING NOTE: now that `@headlessui/react` is on v2, this can be reimplemented
- * on top of HeadlessUI's `<Switch>`. The `nxm-switch`
- * classes live on the track/thumb specifically so they can move straight onto
- * the Switch's elements. HeadlessUI's Switch is binary, so the tri-state must be
- * preserved here in the wrapper — keep driving `data-state` (and the native
- * `indeterminate`/`aria-checked="mixed"`) for the `semi-on` state.
+ * The visible track and thumb are styled off the `data-checked`,
+ * `data-indeterminate`, `data-disabled`, `data-hover`, `data-active` and
+ * `data-focus` attributes Headless UI sets from its own state.
  */
-export type ISwitchProps = Omit<InputHTMLAttributes<HTMLInputElement>, "type"> & {
+export type ISwitchProps = Omit<ComponentProps<typeof Checkbox>, "className"> & {
+  className?: string;
   /** Renders the "semi-on" state and reports `aria-checked="mixed"`. */
   indeterminate?: boolean;
 };
 
-export const Switch = ({
-  checked,
-  className,
-  disabled,
-  indeterminate,
-  ...inputProps
-}: ISwitchProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // `indeterminate` is a DOM property, not an attribute, so it must be set
-  // imperatively. This also drives the `:indeterminate` pseudo-class and makes
-  // the accessibility tree report `aria-checked="mixed"`.
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.indeterminate = !!indeterminate;
-    }
-  }, [indeterminate]);
-
-  return (
-    <label
-      className={joinClasses(["nxm-switch", className], {
-        "nxm-switch-disabled": disabled,
-      })}
-      data-state={indeterminate ? "semi-on" : checked ? "on" : "off"}
-    >
-      <input
-        checked={checked}
-        className="nxm-switch-input"
-        disabled={disabled}
-        ref={inputRef}
-        type="checkbox"
-        {...inputProps}
-      />
-
-      <span className="nxm-switch-thumb" />
-    </label>
-  );
-};
+export const Switch = ({ className, ...props }: ISwitchProps) => (
+  <Checkbox className={joinClasses(["nxm-switch", className])} {...props}>
+    <span className="nxm-switch-thumb" />
+  </Checkbox>
+);

--- a/src/renderer/src/ui/components/listbox/ListboxButton.tsx
+++ b/src/renderer/src/ui/components/listbox/ListboxButton.tsx
@@ -1,4 +1,4 @@
-import { Listbox as HeadlessListbox } from "@headlessui/react";
+import { ListboxButton as HeadlessListboxButton } from "@headlessui/react";
 import { mdiUnfoldMoreHorizontal } from "@mdi/js";
 import React from "react";
 
@@ -9,7 +9,7 @@ export type IListboxButtonProps = IButtonProps & {
 };
 
 export const ListboxButton = ({ showChevron = true, ...props }: IListboxButtonProps) => (
-  <HeadlessListbox.Button
+  <HeadlessListboxButton
     appearance="moderate"
     as={Button}
     brand="neutral"

--- a/src/renderer/src/ui/components/listbox/ListboxOption.tsx
+++ b/src/renderer/src/ui/components/listbox/ListboxOption.tsx
@@ -1,4 +1,4 @@
-import { Listbox as HeadlessListbox } from "@headlessui/react";
+import { ListboxOption as HeadlessListboxOption } from "@headlessui/react";
 import { mdiCheck } from "@mdi/js";
 import React, { type ComponentProps, Fragment, type ReactNode } from "react";
 
@@ -6,13 +6,13 @@ import { Icon } from "@/ui/components/icon/Icon";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import type { XOr } from "@/ui/utils/types";
 
-export type IListboxOption<T = unknown> = ComponentProps<typeof HeadlessListbox.Option> & {
+export type IListboxOption<T = unknown> = ComponentProps<typeof HeadlessListboxOption> & {
   label: string;
   value: T;
 } & XOr<{ iconPath?: string }, { icon?: ReactNode }>;
 
 export const ListboxOption = ({ className, icon, iconPath, label, ...props }: IListboxOption) => (
-  <HeadlessListbox.Option as={Fragment} {...props}>
+  <HeadlessListboxOption as={Fragment} {...props}>
     {({ active, selected }) => (
       <div
         className={joinClasses(["nxm-dropdown-item", className], {
@@ -30,5 +30,5 @@ export const ListboxOption = ({ className, icon, iconPath, label, ...props }: IL
         {selected && <Icon className="nxm-dropdown-item-icon" path={mdiCheck} size="none" />}
       </div>
     )}
-  </HeadlessListbox.Option>
+  </HeadlessListboxOption>
 );

--- a/src/renderer/src/ui/components/listbox/ListboxOptions.tsx
+++ b/src/renderer/src/ui/components/listbox/ListboxOptions.tsx
@@ -1,4 +1,4 @@
-import { Listbox as HeadlessListbox } from "@headlessui/react";
+import { ListboxOptions as HeadlessListboxOptions } from "@headlessui/react";
 import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
@@ -6,8 +6,9 @@ import { joinClasses } from "@/ui/utils/joinClasses";
 export const ListboxOptions = ({
   className,
   ...props
-}: ComponentProps<typeof HeadlessListbox.Options>) => (
-  <HeadlessListbox.Options
+}: ComponentProps<typeof HeadlessListboxOptions>) => (
+  <HeadlessListboxOptions
+    anchor={{ gap: 4, to: "bottom end" }}
     as="div"
     className={joinClasses(["nxm-dropdown-items", className])}
     {...props}

--- a/src/renderer/src/ui/components/modal/Modal.tsx
+++ b/src/renderer/src/ui/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@headlessui/react";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { mdiClose } from "@mdi/js";
 import React, { type PropsWithChildren, type RefObject } from "react";
 
@@ -29,7 +29,7 @@ export const ModalWrapper = ({
     open={isOpen}
     onClose={onClose}
   >
-    <Dialog.Overlay className="nxm-modal-overlay" />
+    <DialogBackdrop className="nxm-modal-overlay" />
 
     {children}
   </Dialog>
@@ -49,16 +49,16 @@ export const ModalPanel = ({
   title,
   onClose,
 }: PropsWithChildren<IModalPanelProps>) => (
-  <Dialog.Panel className={joinClasses(["nxm-modal-panel", className])}>
+  <DialogPanel className={joinClasses(["nxm-modal-panel", className])}>
     {!!title && (
-      <Dialog.Title
+      <DialogTitle
         as="div"
         className={joinClasses(["nxm-modal-title"], {
           "mr-7": showCloseButton,
         })}
       >
         {title}
-      </Dialog.Title>
+      </DialogTitle>
     )}
 
     {showCloseButton && (
@@ -68,7 +68,7 @@ export const ModalPanel = ({
     )}
 
     {children}
-  </Dialog.Panel>
+  </DialogPanel>
 );
 
 export const Modal = ({

--- a/src/renderer/src/ui/components/picker/Picker.tsx
+++ b/src/renderer/src/ui/components/picker/Picker.tsx
@@ -9,7 +9,6 @@ interface IPickerProps<T> {
   button?: IListboxButtonProps;
   className?: string;
   options: IListboxOption<T>[];
-  /** Which edge of the trigger the panel aligns to. Drives the `anchor`. */
   placement?: "left" | "right";
   value: T;
   onChange: (value: T) => void;

--- a/src/renderer/src/ui/components/picker/Picker.tsx
+++ b/src/renderer/src/ui/components/picker/Picker.tsx
@@ -5,12 +5,11 @@ import { ListboxButton, type IListboxButtonProps } from "@/ui/components/listbox
 import { ListboxOption, type IListboxOption } from "@/ui/components/listbox/ListboxOption";
 import { ListboxOptions } from "@/ui/components/listbox/ListboxOptions";
 
-// todo placement prop should be removed when you use headless ui v2
-
 interface IPickerProps<T> {
   button?: IListboxButtonProps;
   className?: string;
   options: IListboxOption<T>[];
+  /** Which edge of the trigger the panel aligns to. Drives the `anchor`. */
   placement?: "left" | "right";
   value: T;
   onChange: (value: T) => void;
@@ -30,7 +29,7 @@ export function Picker<T>({
     <Listbox className={className} value={value} onChange={onChange}>
       <ListboxButton {...button}>{selectedOption?.label}</ListboxButton>
 
-      <ListboxOptions className={placement === "left" && "right-auto left-0"}>
+      <ListboxOptions anchor={{ gap: 4, to: placement === "left" ? "bottom start" : "bottom end" }}>
         {options.map(({ ...option }) => (
           <ListboxOption key={option.label} {...option} />
         ))}

--- a/src/renderer/src/ui/components/popover/Popover.demo.tsx
+++ b/src/renderer/src/ui/components/popover/Popover.demo.tsx
@@ -79,7 +79,7 @@ export const PopoverDemo = () => {
                 <Switch
                   aria-label="Show hidden items"
                   checked={showHidden}
-                  onChange={(e) => setShowHidden(e.target.checked)}
+                  onChange={setShowHidden}
                 />
               </div>
 

--- a/src/renderer/src/ui/components/popover/Popover.tsx
+++ b/src/renderer/src/ui/components/popover/Popover.tsx
@@ -3,8 +3,6 @@ import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-// needs updating to headless v2 so we can have dynamic positioning and proper z-index usage
-
 export const Popover = ({ className, ...props }: ComponentProps<typeof HeadlessPopover>) => (
   <HeadlessPopover as="div" className={joinClasses(["nxm-popover", className])} {...props} />
 );

--- a/src/renderer/src/ui/components/popover/PopoverButton.tsx
+++ b/src/renderer/src/ui/components/popover/PopoverButton.tsx
@@ -1,4 +1,4 @@
-import { Popover as HeadlessPopover } from "@headlessui/react";
+import { PopoverButton as HeadlessPopoverButton } from "@headlessui/react";
 import React, { forwardRef } from "react";
 
 import { Button, type IButtonProps } from "@/ui/components/button/Button";
@@ -6,7 +6,7 @@ import { Button, type IButtonProps } from "@/ui/components/button/Button";
 export type IPopoverButtonProps = IButtonProps;
 
 /**
- * Popover trigger button. Renders a Button as the Headless UI `Popover.Button`,
+ * Popover trigger button. Renders a Button as the Headless UI `PopoverButton`,
  * so it takes all the same props as Button. Place it inside a `Popover`
  * alongside a `PopoverPanel`.
  *
@@ -14,7 +14,7 @@ export type IPopoverButtonProps = IButtonProps;
  * directly.
  */
 export const PopoverButton = forwardRef<HTMLButtonElement, IPopoverButtonProps>((props, ref) => (
-  <HeadlessPopover.Button as={Button} ref={ref} {...props} />
+  <HeadlessPopoverButton as={Button} ref={ref} {...props} />
 ));
 
 PopoverButton.displayName = "PopoverButton";

--- a/src/renderer/src/ui/components/popover/PopoverPanel.tsx
+++ b/src/renderer/src/ui/components/popover/PopoverPanel.tsx
@@ -1,4 +1,4 @@
-import { Popover as HeadlessPopover } from "@headlessui/react";
+import { PopoverPanel as HeadlessPopoverPanel } from "@headlessui/react";
 import React, { type ComponentProps } from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
@@ -6,12 +6,19 @@ import { joinClasses } from "@/ui/utils/joinClasses";
 /**
  * Floating panel for a Popover. Unlike a Dropdown's menu, this holds arbitrary
  * interactive content (pickers, switches, buttons) and stays open until an
- * outside click or Escape. Positioned manually (absolute) until Headless UI v2
- * gives us dynamic anchor positioning.
+ * outside click or Escape.
+ *
+ * `anchor` hands positioning to Headless UI's Floating UI integration, which also
+ * portals the panel — so it escapes any clipping ancestor and flips itself when
+ * there's no room below. Pass `anchor` to place it elsewhere.
  */
 export const PopoverPanel = ({
   className,
   ...props
-}: ComponentProps<typeof HeadlessPopover.Panel>) => (
-  <HeadlessPopover.Panel className={joinClasses(["nxm-popover-panel", className])} {...props} />
+}: ComponentProps<typeof HeadlessPopoverPanel>) => (
+  <HeadlessPopoverPanel
+    anchor={{ gap: 4, to: "bottom end" }}
+    className={joinClasses(["nxm-popover-panel", className])}
+    {...props}
+  />
 );

--- a/src/renderer/src/ui/components/table/Table.demo.tsx
+++ b/src/renderer/src/ui/components/table/Table.demo.tsx
@@ -79,7 +79,7 @@ const ActionsCell = ({ mod }: { mod: IDemoMod }) => {
         <Switch
           aria-label={`${enabled ? "Disable" : "Enable"} ${mod.name}`}
           checked={enabled}
-          onChange={(event) => setEnabled(event.target.checked)}
+          onChange={setEnabled}
         />
       ) : (
         <Button appearance="moderate" brand="primary" size="xs">

--- a/src/renderer/src/ui/components/table/TableColumnToggle.tsx
+++ b/src/renderer/src/ui/components/table/TableColumnToggle.tsx
@@ -1,4 +1,4 @@
-import { Listbox as HeadlessListbox } from "@headlessui/react";
+import { ListboxButton as HeadlessListboxButton } from "@headlessui/react";
 import { mdiArrowExpandHorizontal, mdiCog } from "@mdi/js";
 import React from "react";
 
@@ -68,7 +68,7 @@ export const TableColumnToggle = <T,>({
       value={visibleIds}
       onChange={handleChange}
     >
-      <HeadlessListbox.Button
+      <HeadlessListboxButton
         appearance="weak"
         aria-label="Manage columns"
         as={Button}
@@ -78,7 +78,7 @@ export const TableColumnToggle = <T,>({
         title="Manage columns"
       />
 
-      <ListboxOptions className="right-0 left-auto">
+      <ListboxOptions>
         <DropdownTitle>Columns</DropdownTitle>
 
         {hideableColumns.map((column) => (
@@ -102,7 +102,7 @@ export const TableColumnToggle = <T,>({
                 onResetWidths();
                 // This is a multi-select Listbox, so it stays open on clicks and
                 // v1 exposes no programmatic close. Mimic Escape (handled by
-                // Listbox.Options) to dismiss the menu after resetting.
+                // ListboxOptions) to dismiss the menu after resetting.
                 event.currentTarget.dispatchEvent(
                   new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
                 );

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import { mdiDotsHorizontal } from "@mdi/js";
 import React, { type HTMLAttributes } from "react";
 
@@ -84,7 +84,7 @@ export const ToolbarGroup = ({ actions, className, maxVisible, ...props }: ITool
       {/* Kept mounted through the measuring pass so its width is measured too. */}
       {(isMeasuring || !!hiddenActions.length) && (
         <Dropdown>
-          <Menu.Button
+          <MenuButton
             appearance="weak"
             aria-label="More actions"
             as={Button}
@@ -93,7 +93,7 @@ export const ToolbarGroup = ({ actions, className, maxVisible, ...props }: ITool
             size="sm"
           />
 
-          <DropdownItems className="right-0 left-auto">
+          <DropdownItems>
             {hiddenActions.map((action) => (
               <DropdownItem
                 disabled={action.disabled || action.isLoading}

--- a/src/renderer/src/views/components/Header/HelpSection.tsx
+++ b/src/renderer/src/views/components/Header/HelpSection.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import {
   mdiBugOutline,
   mdiFileDocumentOutline,
@@ -63,7 +63,7 @@ export const HelpSection: FC<React.PropsWithChildren<unknown>> = () => {
 
   return (
     <Dropdown>
-      <Menu.Button as={IconButton} iconPath={mdiHelpCircleOutline} title={t("Help")} />
+      <MenuButton as={IconButton} iconPath={mdiHelpCircleOutline} title={t("Help")} />
 
       <DropdownItems>
         {extensionActions.map((action) => (

--- a/src/renderer/src/views/components/Header/Notifications/index.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/index.tsx
@@ -1,4 +1,4 @@
-import { Popover } from "@headlessui/react";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { mdiBell, mdiBellOutline } from "@mdi/js";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
@@ -71,7 +71,7 @@ const NotificationsContent: React.FC<React.PropsWithChildren<{ popoverOpen: bool
 
   return (
     <>
-      <Popover.Button
+      <PopoverButton
         as={IconButton}
         disabled={visibleCount === 0}
         iconPath={visibleCount > 0 ? mdiBell : mdiBellOutline}
@@ -88,7 +88,10 @@ const NotificationsContent: React.FC<React.PropsWithChildren<{ popoverOpen: bool
       />
 
       {popoverOpen && items.length > 0 && (
-        <Popover.Panel className="absolute right-0 z-popover mt-2.5 max-h-[50vh] w-sm space-y-0.5 overflow-y-auto rounded-sm border border-stroke-weak bg-surface-base p-1 shadow-md">
+        <PopoverPanel
+          anchor={{ gap: 10, to: "bottom end" }}
+          className="z-popover max-h-[50vh] w-sm space-y-0.5 overflow-y-auto rounded-sm border border-stroke-weak bg-surface-base p-1 shadow-md"
+        >
           {items.map((notification) => (
             <NotificationItem
               collapsed={collapsed[notification.group]}
@@ -100,7 +103,7 @@ const NotificationsContent: React.FC<React.PropsWithChildren<{ popoverOpen: bool
               onTriggerAction={triggerAction}
             />
           ))}
-        </Popover.Panel>
+        </PopoverPanel>
       )}
     </>
   );

--- a/src/renderer/src/views/components/Header/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/ProfileSection.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import { mdiAccountCircle, mdiLogout, mdiMessageReplyText, mdiRefresh } from "@mdi/js";
 import React, { forwardRef, type ButtonHTMLAttributes, type FC, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -94,7 +94,7 @@ export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
 
   return (
     <Dropdown>
-      <Menu.Button
+      <MenuButton
         as={ActionButton}
         imageSrc={userInfo.profileUrl}
         title={userInfo.name ?? t("Profile")}

--- a/src/renderer/src/views/pages/Tools/ToolRow.tsx
+++ b/src/renderer/src/views/pages/Tools/ToolRow.tsx
@@ -1,6 +1,6 @@
 import { pathToFileURL } from "url";
 
-import { Menu } from "@headlessui/react";
+import { MenuButton } from "@headlessui/react";
 import {
   mdiArrowDown,
   mdiArrowUp,
@@ -147,7 +147,7 @@ export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
           )}
 
           <Dropdown>
-            <Menu.Button
+            <MenuButton
               as={Button}
               brand="neutral"
               appearance="weak"

--- a/src/stylesheets/ui/elements/dropdown.css
+++ b/src/stylesheets/ui/elements/dropdown.css
@@ -3,9 +3,6 @@
         position: relative;
     }
 
-    /* Placement, and the gap to the trigger, come from the `anchor` prop — which
-       also portals this to the body, so the z-index is what keeps it above the
-       page rather than a stacking context here. */
     .nxm-dropdown-items {
         outline: none;
         display: flex;
@@ -16,9 +13,6 @@
         padding: calc(var(--spacing) * 1);
         max-width: calc(var(--spacing) * 72);
         min-width: calc(var(--spacing) * 52);
-        /* `anchor` sets an inline `max-height: min(var(--anchor-max-height), …)`
-           from the space available, and an inline style beats this rule — so the
-           cap goes through its variable to survive. */
         --anchor-max-height: calc(var(--spacing) * 128);
         border-radius: var(--radius-sm);
         border: 1px solid var(--color-stroke-weak);

--- a/src/stylesheets/ui/elements/dropdown.css
+++ b/src/stylesheets/ui/elements/dropdown.css
@@ -3,20 +3,23 @@
         position: relative;
     }
 
+    /* Placement, and the gap to the trigger, come from the `anchor` prop — which
+       also portals this to the body, so the z-index is what keeps it above the
+       page rather than a stacking context here. */
     .nxm-dropdown-items {
-        right: 0;
         outline: none;
         display: flex;
         overflow-y: auto;
-        position: absolute;
         flex-direction: column;
         box-shadow: var(--shadow-md);
         z-index: var(--z-index-dropdown);
         padding: calc(var(--spacing) * 1);
         max-width: calc(var(--spacing) * 72);
         min-width: calc(var(--spacing) * 52);
-        margin-top: calc(var(--spacing) * 1);
-        max-height: calc(var(--spacing) * 128);
+        /* `anchor` sets an inline `max-height: min(var(--anchor-max-height), …)`
+           from the space available, and an inline style beats this rule — so the
+           cap goes through its variable to survive. */
+        --anchor-max-height: calc(var(--spacing) * 128);
         border-radius: var(--radius-sm);
         border: 1px solid var(--color-stroke-weak);
         background-color: var(--color-surface-mid);

--- a/src/stylesheets/ui/elements/popover.css
+++ b/src/stylesheets/ui/elements/popover.css
@@ -3,14 +3,14 @@
         position: relative;
     }
 
+    /* Placement, and the gap to the trigger, come from the `anchor` prop — which
+       also portals this to the body, so the z-index is what keeps it above the
+       page rather than a stacking context here. */
     .nxm-popover-panel {
-        right: 0;
         outline: none;
-        position: absolute;
         box-shadow: var(--shadow-md);
         z-index: var(--z-index-dropdown);
         min-width: calc(var(--spacing) * 70);
-        margin-top: calc(var(--spacing) * 1);
         border-radius: var(--radius-sm);
         border: 1px solid var(--color-stroke-weak);
         background-color: var(--color-surface-mid);

--- a/src/stylesheets/ui/elements/popover.css
+++ b/src/stylesheets/ui/elements/popover.css
@@ -3,9 +3,6 @@
         position: relative;
     }
 
-    /* Placement, and the gap to the trigger, come from the `anchor` prop — which
-       also portals this to the body, so the z-index is what keeps it above the
-       page rather than a stacking context here. */
     .nxm-popover-panel {
         outline: none;
         box-shadow: var(--shadow-md);

--- a/src/stylesheets/ui/form/switch.css
+++ b/src/stylesheets/ui/form/switch.css
@@ -17,26 +17,17 @@
         transition-timing-function: var(--default-transition-timing-function);
 
         /* override bootstrap styles */
-        &,
-        .nxm-switch-input {
-            margin: 0;
-        }
+        margin: 0;
 
-        &[data-state="on"],
-        &[data-state="semi-on"] {
+        &[data-checked],
+        &[data-indeterminate] {
             border-color: transparent;
             background-color: var(--color-translucent-strong);
         }
 
-        &:has(.nxm-switch-input:focus-visible) {
+        &[data-focus] {
             outline: 2px solid var(--color-focus-subdued);
             outline-offset: 2px;
-        }
-
-        .nxm-switch-input {
-            opacity: 0;
-            position: absolute;
-            pointer-events: none;
         }
 
         .nxm-switch-thumb {
@@ -77,40 +68,40 @@
             }
         }
 
-        &[data-state="on"] .nxm-switch-thumb,
-        &[data-state="semi-on"] .nxm-switch-thumb {
+        &[data-checked] .nxm-switch-thumb,
+        &[data-indeterminate] .nxm-switch-thumb {
             width: calc(var(--spacing) * 3);
             height: calc(var(--spacing) * 3);
             transform: translate(calc(var(--spacing) * 3.5), -50%);
         }
 
-        &[data-state="on"] .nxm-switch-thumb {
+        &[data-checked] .nxm-switch-thumb {
             background-color: var(--color-surface-mid);
         }
 
-        &[data-state="semi-on"] .nxm-switch-thumb {
+        &[data-indeterminate] .nxm-switch-thumb {
             background-color: transparent;
             border-color: var(--color-surface-mid);
         }
 
-        &:not(.nxm-switch-disabled) {
-            &:hover .nxm-switch-thumb::before {
+        &:not([data-disabled]) {
+            &[data-hover] .nxm-switch-thumb::before {
                 background-color: var(--color-translucent-50);
             }
 
-            &:active .nxm-switch-thumb::before {
+            &[data-active] .nxm-switch-thumb::before {
                 background-color: var(--color-translucent-100);
             }
         }
 
-        .nxm-switch-input:focus-visible ~ .nxm-switch-thumb::before {
+        &[data-focus] .nxm-switch-thumb::before {
             background-color: var(--color-translucent-100);
         }
 
-        &.nxm-switch-disabled {
+        &[data-disabled] {
             cursor: not-allowed;
 
-            &[data-state="off"] {
+            &:not([data-checked]):not([data-indeterminate]) {
                 border-color: var(--color-translucent-50);
 
                 .nxm-switch-thumb {
@@ -118,16 +109,16 @@
                 }
             }
 
-            &[data-state="on"],
-            &[data-state="semi-on"] {
+            &[data-checked],
+            &[data-indeterminate] {
                 background-color: var(--color-translucent-100);
             }
 
-            &[data-state="on"] .nxm-switch-thumb {
+            &[data-checked] .nxm-switch-thumb {
                 background-color: var(--color-surface-low);
             }
 
-            &[data-state="semi-on"] .nxm-switch-thumb {
+            &[data-indeterminate] .nxm-switch-thumb {
                 border-color: var(--color-surface-low);
             }
         }


### PR DESCRIPTION
## Why now                                                                                                                                                                        
                                                                                                                                                                                    
  v2 requires React 18's `useId`, which is why this was deferred. The workspace is on `react: 18.3.1` (verified: the renderer resolves 18.3.1 and React DevTools reports 18.3.1 in  
  the running app), so the blocker is gone. There was a stale `react@17.0.2` plus a Headless UI built against it in `node_modules/.pnpm`, but the lockfile has zero references to   
  either — orphaned artifacts, not real dependencies.                                                                                                                               
                                                                                                                                                                                    
  ## Commit 1 — `@headlessui/react` 1.7.19 → 2.2.10                                                                                                                                 
                                                                                                                                                                                    
  The migration was far smaller than expected, for two reasons: **v2 keeps dot notation as deprecated aliases**, so nothing was forced to change to compile, and **there is no      
  `Transition` usage anywhere** in Vortex, which is normally the bulk of a v1→v2 migration.                                                                                         
                                                                                                                                                                                    
  - **`Dialog.Overlay` is the only genuinely removed API** → `DialogBackdrop`. One site, in `Modal.tsx`.                                                                            
  - ~20 call sites moved off deprecated dot notation (`Menu.Button`, `Popover.Panel`, `Listbox.Options`, …) to the flat exports. Several of our own components share names with v2's
  exports, so those imports are aliased (`PopoverButton as HeadlessPopoverButton`).                                                                                                 
                                                                                                                                                                                    
  ### `anchor` positioning                                                                                                                                                          
                                                                                                                                                                                    
  `DropdownItems`, `PopoverPanel` and `ListboxOptions` now take placement from `anchor={{ gap: 4, to: "bottom end" }}`, replacing hand-written absolute positioning. Three things   
  worth knowing, all confirmed from the compiled source rather than assumed:                                                                                                        
                                                                                                                                                                                    
  - **`anchor` forces `portal: true`** (`_&&(s=!0)` in `menu.js`). Panels move to `#headlessui-portal-root` at body level, so they escape clipping ancestors — but z-index becomes  
  the only thing keeping them above the page.                                                                                                                                       
  - **It writes inline Floating UI styles**, so the stylesheets' `position: absolute; right: 0; margin-top` had to go or they fight it. The 4px margin became `gap: 4`.             
  - **It also sets an inline `max-height: min(var(--anchor-max-height, 100vh), …)`**, and inline beats the stylesheet — so our designed 512px dropdown cap was silently becoming    
  856px. Moving it to `--anchor-max-height` restores the cap *and* keeps the viewport-awareness.                                                                                    
                                                                                                                                                                                    
  Also removed the now-obsolete `right-0 left-auto` / `absolute … mt-2.5` overrides at three call sites, since they'd fight the inline styles, and converted `Picker`'s `placement` 
  prop to drive `anchor` rather than CSS classes. I kept the prop rather than deleting it as its TODO suggested — v2 removes the class hack, not the start/end choice the prop      
  expresses.                                                                                                                                                                        
                                                                                                                                                                                    
  ## Commit 2 — `Switch` on Headless UI's `Checkbox`                                                                                                                                
                                                                                                                                                                                    
  **Not** HUI's `Switch`: ARIA only allows `aria-checked` to be true/false on `role="switch"`, and HUI controls that attribute (`SwitchPropsWeControl` omits it from the public     
  props), so `mixed` cannot be expressed there. A tri-state master control is the *checkbox* pattern — which is what this component already was underneath (`role="checkbox"` +     
  native `indeterminate`). HUI's `Checkbox` takes `indeterminate` and emits `aria-checked": l?"mixed":a?"true":"false"`, so the tri-state is preserved exactly.                     
                                                                                                                                                                                    
  A three-way radio group was considered and rejected: `semi-on` is never user-selectable (clicking only flips on↔off), so radios would expose a state the user can't legitimately  
  choose and announce it as "1 of 3".                                                                                                                                               
                                                                                                                                                                                    
  - The visually-hidden native input and the `useEffect` that imperatively set `indeterminate` are both gone; the component is 67 lines lighter.                                    
  - CSS moved off our hand-derived `data-state="on|semi-on|off"` onto HUI's own `data-checked`, `data-indeterminate`, `data-disabled`, `data-hover`, `data-active`, `data-focus` —  
  so hover/active/focus now come from HUI's state and get proper pointer-vs-keyboard semantics.                                                                                     
  - `onChange(event)` → `onChange(checked: boolean)`. Both real consumers (the `DisplayOptions` wrappers) pass `() => void`, so were unaffected; five demo call sites that          
  destructured `event.target.checked` were updated.

## Testing                                                                                                                                                                                                                                                       
                                                                                                                                                                                    
  | primitive | result |                                                                                                                                                            
  | -- | -- |                                                                                                                                                                       
  | Menu (Help dropdown, toolbar kebab) | portalled, 4px gap, end-aligned, in viewport |                                                                                            
  | Listbox (Picker) | portalled, height capped from available space |                                                                                                              
  | Popover | portalled, z-index preserved |                                                                                                                                        
  | Dialog | `DialogBackdrop` dims correctly behind the panel |                                                                                                                     
  | Picker `placement="left"` | start-aligned, no leftover classes |                                                                                                                
                                                                                                                                                                                    
  Switch verified across all six states — off / on / semi-on, each enabled and disabled — with semi-on reporting `aria-checked="mixed"`. The "select all" master switch goes `mixed`
  → all on → all off, never landing on mixed.                                                                                                                                       
                                                                                                                                                                                    
  Switch tests went 6 → 8, adding explicit coverage for `role="checkbox"` + `aria-checked="mixed"` and for semi-on holding when `checked={false}`, since that pairing is the whole  
  reason for the `Checkbox` choice.