### PR TITLE
Health Check OR-requirement E2E tests + atomic step refactor (LAZ-911)

### DIFF
--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -45,6 +45,21 @@ export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN =
   /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/;
 
 /**
+ * SDV mod whose file requirement is satisfiable by more than one alternative file —
+ * an OR ("this file OR that file"). Installed on its own, with none of the
+ * alternatives owned, it raises one file-requirements warning whose detail asks the
+ * user to PICK one option: the list row shows a "Pick mod install" action (not
+ * "1-click install"), and the detail groups the alternatives under "Pick one of
+ * these" with a "…to be picked…" summary and an "Or" divider between the option
+ * cards. Satisfying any one alternative clears the warning. Like
+ * SDV_FILE_REQUIREMENT_MOD_URL the requirement must be file-level (a page-level
+ * "requires" rule auto-installs and surfaces nothing); if the OR pick stops
+ * appearing, re-confirm the fixture still declares an unsatisfied multi-alternative
+ * file requirement.
+ */
+export const SDV_OR_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/47938";
+
+/**
  * SDV mod that declares a single page-level ("mod") requirement — Generic Mod
  * Config Menu (5098), which requires SMAPI. Installed on its own (SMAPI absent) it
  * drives one blue Health Check *suggestion* ("Additional mod file may be required

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -1,8 +1,3 @@
-/**
- * Shared constants for E2E specs — keep hard-coded URLs here (rather than as
- * per-spec consts) so they're maintained in one place.
- */
-
 export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
 
 /**
@@ -12,61 +7,12 @@ export const SDV_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/2400";
  */
 export const SDV_VINTAGE_INTERFACE_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/4697";
 
-/**
- * SDV mod with a single main file that declares two file-level requirements.
- * Installed on its own (those required files absent) it drives one file-requirements
- * Health Check warning covering both — the fixture for the LAZ-684 warning/install
- * flow. Chosen to have a single main file so the download uses the main mod page
- * (the proven Mod-Manager flow), and not SMAPI, which Vortex special-cases with a
- * dedicated installer.
- */
 export const SDV_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/49786";
-
-/**
- * The two mods whose files SDV_FILE_REQUIREMENT_MOD_URL (49786) requires: Item Bags
- * (5382) and Pokemon Eggventure - Day Care (49098). Downloading both from the website
- * is the manual flow a free user follows to satisfy the requirements and clear the
- * warning (a free user can't 1-click install). Fixture-specific — if 49786's declared
- * requirements change, update this list.
- */
 export const SDV_FILE_REQUIREMENT_TARGET_URLS = [
   "https://www.nexusmods.com/stardewvalley/mods/5382",
   "https://www.nexusmods.com/stardewvalley/mods/49098",
 ];
-
-/**
- * Matches an externally-opened URL that points at one of the required mods' pages
- * (5382 / 49098) — used to assert the "Install via mod page" link targets a
- * required mod. A static literal with the '.' escaped (deriving it from
- * SDV_FILE_REQUIREMENT_TARGET_URLS trips CodeQL's "incomplete hostname regex");
- * keep the ids in sync with that list by hand.
- */
 export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN =
   /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/;
-
-/**
- * SDV mod whose file requirement is satisfiable by more than one alternative file —
- * an OR ("this file OR that file"). Installed on its own, with none of the
- * alternatives owned, it raises one file-requirements warning whose detail asks the
- * user to PICK one option: the list row shows a "Pick mod install" action (not
- * "1-click install"), and the detail groups the alternatives under "Pick one of
- * these" with a "…to be picked…" summary and an "Or" divider between the option
- * cards. Satisfying any one alternative clears the warning. Like
- * SDV_FILE_REQUIREMENT_MOD_URL the requirement must be file-level (a page-level
- * "requires" rule auto-installs and surfaces nothing); if the OR pick stops
- * appearing, re-confirm the fixture still declares an unsatisfied multi-alternative
- * file requirement.
- */
 export const SDV_OR_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/47938";
-
-/**
- * SDV mod that declares a single page-level ("mod") requirement — Generic Mod
- * Config Menu (5098), which requires SMAPI. Installed on its own (SMAPI absent) it
- * drives one blue Health Check *suggestion* ("Additional mod file may be required
- * for: …") — the mod-to-mod counterpart of SDV_FILE_REQUIREMENT_MOD_URL's
- * file-level warning. It must offer a Mod-Manager download (not manual-only) so the
- * install helper can drive it, and keep its legacy mod requirements enabled (not be
- * set to file-requirements-only) so the suggestion isn't suppressed for the
- * flag-enrolled E2E users (see LAZ-852).
- */
 export const SDV_MOD_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/5098";

--- a/packages/e2e/src/constants.ts
+++ b/packages/e2e/src/constants.ts
@@ -38,6 +38,21 @@ export const SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN =
   /nexusmods\.com\/stardewvalley\/mods\/(5382|49098)$/;
 
 /**
+ * SDV mod whose file requirement is satisfiable by more than one alternative file —
+ * an OR ("this file OR that file"). Installed on its own, with none of the
+ * alternatives owned, it raises one file-requirements warning whose detail asks the
+ * user to PICK one option: the list row shows a "Pick mod install" action (not
+ * "1-click install"), and the detail groups the alternatives under "Pick one of
+ * these" with a "…to be picked…" summary and an "Or" divider between the option
+ * cards. Satisfying any one alternative clears the warning. Like
+ * SDV_FILE_REQUIREMENT_MOD_URL the requirement must be file-level (a page-level
+ * "requires" rule auto-installs and surfaces nothing); if the OR pick stops
+ * appearing, re-confirm the fixture still declares an unsatisfied multi-alternative
+ * file requirement.
+ */
+export const SDV_OR_FILE_REQUIREMENT_MOD_URL = "https://www.nexusmods.com/stardewvalley/mods/47938";
+
+/**
  * SDV mod that declares a single page-level ("mod") requirement — Generic Mod
  * Config Menu (5098), which requires SMAPI. Installed on its own (SMAPI absent) it
  * drives one blue Health Check *suggestion* ("Additional mod file may be required

--- a/packages/e2e/src/helpers/healthCheck.ts
+++ b/packages/e2e/src/helpers/healthCheck.ts
@@ -1,6 +1,10 @@
 import { type ElectronApplication, expect, type Page } from "@playwright/test";
 
-import { SDV_FILE_REQUIREMENT_MOD_URL, SDV_MOD_REQUIREMENT_MOD_URL } from "../constants";
+import {
+  SDV_FILE_REQUIREMENT_MOD_URL,
+  SDV_MOD_REQUIREMENT_MOD_URL,
+  SDV_OR_FILE_REQUIREMENT_MOD_URL,
+} from "../constants";
 import { test } from "../fixtures/vortex-app";
 import {
   HealthCheckDetail,
@@ -14,23 +18,25 @@ import { dismissAllNotifications } from "./notifications";
 import { Timeouts } from "./timeouts";
 
 /**
- * Install the file-requirement fixture mod (49786) with its required files absent,
- * open Health Check and refresh — leaving the single file-requirements warning
- * visible on the list. Returns the page + warnings POMs for the caller to drive.
+ * Install a file-requirement fixture mod (with its requirements unsatisfied), open
+ * Health Check and refresh — leaving the single file-requirements warning visible
+ * on the list. Returns the page + warnings POMs for the caller to drive.
  *
- * Shared by every file-requirement test so the download → open → refresh flow lives
- * in one place; uses `test.step` internally so each test's trace stays granular.
+ * Shared by the missing- and OR-requirement openers so the download → open →
+ * refresh → dismiss-notifications flow lives in one place; uses `test.step`
+ * internally so each test's trace stays granular.
  */
-export async function openFileRequirementWarning(
+async function installAndSurfaceFileWarning(
   nexusPage: Page,
   vortexApp: ElectronApplication,
   vortexWindow: Page,
+  modUrl: string,
 ): Promise<{ hc: HealthCheckPage; warnings: HealthCheckWarnings }> {
   const hc = new HealthCheckPage(vortexWindow);
   const warnings = new HealthCheckWarnings(vortexWindow);
 
   await test.step("Install the requiring mod with its required files absent", async () => {
-    await downloadModViaModManager(nexusPage, vortexApp, SDV_FILE_REQUIREMENT_MOD_URL);
+    await downloadModViaModManager(nexusPage, vortexApp, modUrl);
   });
 
   await test.step("Open Health Check and refresh", async () => {
@@ -44,6 +50,40 @@ export async function openFileRequirementWarning(
   });
 
   return { hc, warnings };
+}
+
+/**
+ * The 49786 fixture: a mod whose main file declares two missing file requirements,
+ * surfaced as one "download" warning.
+ */
+export function openFileRequirementWarning(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<{ hc: HealthCheckPage; warnings: HealthCheckWarnings }> {
+  return installAndSurfaceFileWarning(
+    nexusPage,
+    vortexApp,
+    vortexWindow,
+    SDV_FILE_REQUIREMENT_MOD_URL,
+  );
+}
+
+/**
+ * The 47938 fixture: a mod whose file requirement is satisfiable by more than one
+ * alternative — an OR — surfaced as one "pick one of these" warning.
+ */
+export function openOrFileRequirementWarning(
+  nexusPage: Page,
+  vortexApp: ElectronApplication,
+  vortexWindow: Page,
+): Promise<{ hc: HealthCheckPage; warnings: HealthCheckWarnings }> {
+  return installAndSurfaceFileWarning(
+    nexusPage,
+    vortexApp,
+    vortexWindow,
+    SDV_OR_FILE_REQUIREMENT_MOD_URL,
+  );
 }
 
 /**

--- a/packages/e2e/src/helpers/healthCheck.ts
+++ b/packages/e2e/src/helpers/healthCheck.ts
@@ -17,15 +17,6 @@ import { navigateToHealthCheck } from "./navigation";
 import { dismissAllNotifications } from "./notifications";
 import { Timeouts } from "./timeouts";
 
-/**
- * Install a file-requirement fixture mod (with its requirements unsatisfied), open
- * Health Check and refresh — leaving the single file-requirements warning visible
- * on the list. Returns the page + warnings POMs for the caller to drive.
- *
- * Shared by the missing- and OR-requirement openers so the download → open →
- * refresh → dismiss-notifications flow lives in one place; uses `test.step`
- * internally so each test's trace stays granular.
- */
 async function installAndSurfaceFileWarning(
   nexusPage: Page,
   vortexApp: ElectronApplication,
@@ -43,19 +34,12 @@ async function installAndSurfaceFileWarning(
     await navigateToHealthCheck(vortexWindow);
     await hc.refreshButton.click();
     await expect(warnings.row()).toBeVisible({ timeout: Timeouts.NETWORK });
-    // Persistent notifications auto-open a tray that overlays the top-right and
-    // intercepts clicks on the tabs' buttons and a row's hide/feedback icons;
-    // clear it once the check has settled so it stays shut.
     await dismissAllNotifications(vortexWindow);
   });
 
   return { hc, warnings };
 }
 
-/**
- * The 49786 fixture: a mod whose main file declares two missing file requirements,
- * surfaced as one "download" warning.
- */
 export function openFileRequirementWarning(
   nexusPage: Page,
   vortexApp: ElectronApplication,
@@ -69,10 +53,6 @@ export function openFileRequirementWarning(
   );
 }
 
-/**
- * The 47938 fixture: a mod whose file requirement is satisfiable by more than one
- * alternative — an OR — surfaced as one "pick one of these" warning.
- */
 export function openOrFileRequirementWarning(
   nexusPage: Page,
   vortexApp: ElectronApplication,
@@ -86,10 +66,6 @@ export function openOrFileRequirementWarning(
   );
 }
 
-/**
- * Open the sole warning's detail view from the list and confirm it rendered.
- * Returns the detail POM.
- */
 export async function openWarningDetail(
   vortexWindow: Page,
   warnings: HealthCheckWarnings,
@@ -104,14 +80,6 @@ export async function openWarningDetail(
   return detail;
 }
 
-/**
- * Install the mod-requirement fixture mod (46415) with its required mod absent,
- * open Health Check and refresh — leaving the single page-level requirement
- * "suggestion" visible on the list. Returns the page + suggestions POMs.
- *
- * The suggestion is populated by the mod-requirements check's Nexus round-trip
- * (slower than the file check), so the wait uses the network budget.
- */
 export async function openModRequirementSuggestion(
   nexusPage: Page,
   vortexApp: ElectronApplication,

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -109,6 +109,16 @@ export class HealthCheckWarnings {
   }
 
   /**
+   * The "Pick mod install" button on an OR-requirement row — the list action for a
+   * requirement satisfiable by several alternatives (category "or"). Unlike
+   * "1-click install" it opens the detail to choose one (see file_requirement/
+   * ListingRow), so it's how an OR warning is distinguished in the list.
+   */
+  pickModInstall(requiredModName?: string | RegExp): Locator {
+    return this.row(requiredModName).getByRole("button", { name: "Pick mod install", exact: true });
+  }
+
+  /**
    * The per-row EntryActions controls (thumbs-down + hide eye). In the list they're
    * `invisible` until the row is hovered/focused, so hover the row first
    * (`await warnings.row().hover()`) before asserting/clicking these. Names are
@@ -142,6 +152,9 @@ export class HealthCheckDetail {
   readonly installOneClickButton: Locator;
   readonly installRequiredHeader: Locator;
   readonly installAllInGroupButton: Locator;
+  readonly pickOneHeader: Locator;
+  readonly requiresPickLine: Locator;
+  readonly orDivider: Locator;
   readonly feedbackPrompt: Locator;
   readonly feedbackThanks: Locator;
   readonly notHelpfulButton: Locator;
@@ -167,6 +180,15 @@ export class HealthCheckDetail {
     this.installAllInGroupButton = this.root
       .getByRole("button", { name: /1-click install all/ })
       .first();
+    // OR requirement ("pick one of these") detail: the group header, the
+    // "…to be picked…" summary (shared::requires_pick), and the "Or" divider drawn
+    // between the option cards. The divider's container is aria-hidden, but its text
+    // is visually rendered, so getByText / toBeVisible still resolve it.
+    this.pickOneHeader = this.root.getByText("Pick one of these", { exact: true });
+    this.requiresPickLine = this.root.getByText(
+      /Requires \d+ additional mod files? to be picked to work correctly/,
+    );
+    this.orDivider = this.root.getByText("Or", { exact: true });
     // EntryActions (detail variant): a prompt that flips to a thank-you once
     // feedback is given, plus the thumbs-down control (exact name so it doesn't
     // match a "Helpful" button).

--- a/packages/e2e/src/selectors/healthCheck.ts
+++ b/packages/e2e/src/selectors/healthCheck.ts
@@ -24,44 +24,25 @@ export class HealthCheckPage {
   constructor(page: Page) {
     this.page = page;
     this.root = page.locator("#health-check-page");
-    // Page heading (PageHeader renders the title as an <h2>). Capitalised
-    // "Health Check" distinguishes it from both the lower-case "Health check"
-    // sidebar entry and the "Health check passed" empty-state title.
     this.title = this.root.getByRole("heading", { name: "Health Check" });
-    // "Beta" pill next to the title (BetaBadge → common:::beta).
     this.betaBadge = this.root.getByText("Beta", { exact: true });
     this.subtitle = this.root.getByText(
       "Review your Loadout for any issues and learn how to resolve them if needed.",
     );
-    // Icon-only header buttons; their accessible name comes from the `title` prop.
     this.refreshButton = this.root.getByRole("button", { name: "Refresh" });
     this.settingsButton = this.root.getByRole("button", { name: "Settings" });
     this.lastUpdated = this.root.getByText(/Last updated:/);
     this.emptyStateTitle = this.root.getByText("Health check passed");
     this.emptyStateMessage = this.root.getByText("Ready for gaming");
-    // Free-user upsell banner; the "<premiumLink>Go premium</premiumLink>" is a
-    // separate node, so match on the leading sentence only.
     this.premiumBanner = this.root.getByText(
       "Download requirements in 1-click. No page visits or waiting.",
     );
-    // Active / Hidden tabs (TabButton renders role="tab"; the label carries a
-    // "(N)" count suffix, so match the name loosely and read the count via text).
     this.activeTab = this.root.getByRole("tab", { name: /Active/ });
     this.hiddenTab = this.root.getByRole("tab", { name: /Hidden/ });
-    // Page-level batch action in the tabs header ("1-click install all (N)");
-    // installs the download candidates across all active warnings. Free users get
-    // a Premium badge on it. Distinct from the detail group's install-all, which
-    // lives under #health-check-detail-page.
     this.installAllButton = this.root.getByRole("button", { name: /1-click install all/ });
   }
 }
 
-/**
- * File-requirement warnings as they appear in the Health Check *list*. A missing
- * required mod renders a row titled "Missing required mod for: <source mod>" with
- * the required mod's name and a "1-click install" action (see
- * components/file_requirement/ListingRow.tsx + hooks/useReportCopy.ts).
- */
 export class HealthCheckWarnings {
   readonly page: Page;
   readonly root: Locator;
@@ -71,16 +52,6 @@ export class HealthCheckWarnings {
     this.root = page.locator("#health-check-page");
   }
 
-  /**
-   * The list row for a missing-requirement warning, identified by its
-   * "Missing required mod(s) for:" title (singular or plural, depending on how
-   * many requirements the source file has). Pass the required mod's name (e.g.
-   * /SMAPI/i) only to disambiguate when several such warnings are present; omit
-   * it to target the sole warning. The row is a `role="button"` container;
-   * filtering by the title text excludes the header/action buttons that also
-   * carry that role, and the mod-requirement ("Additional mod file may be
-   * required for:") rows, so this matches file-requirement warnings only.
-   */
   row(requiredModName?: string | RegExp): Locator {
     const rows = this.root
       .locator('[role="button"]')
@@ -90,46 +61,22 @@ export class HealthCheckWarnings {
     ).first();
   }
 
-  /**
-   * The warning's title text element ("Missing required mod(s) for: …"). Use for
-   * hover/click targets and title-copy assertions; the regex tolerates the
-   * singular/plural forms. Pass the required mod name only to disambiguate.
-   */
   title(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByText(/Missing required mods? for:/);
   }
 
-  /**
-   * The "1-click install" button inside a warning row. Label is "1-click install"
-   * for a single requirement and "1-click install (N)" for several, so match on
-   * the prefix rather than an exact string.
-   */
   installOneClick(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: /1-click install/ });
   }
 
-  /**
-   * The "Pick mod install" button on an OR-requirement row — the list action for a
-   * requirement satisfiable by several alternatives (category "or"). Unlike
-   * "1-click install" it opens the detail to choose one (see file_requirement/
-   * ListingRow), so it's how an OR warning is distinguished in the list.
-   */
   pickModInstall(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: "Pick mod install", exact: true });
   }
 
-  /**
-   * The per-row EntryActions controls (thumbs-down + hide eye). In the list they're
-   * `invisible` until the row is hovered/focused, so hover the row first
-   * (`await warnings.row().hover()`) before asserting/clicking these. Names are
-   * exact so "Hide" doesn't also match the header "Hide all" and "Not helpful"
-   * matches only the thumbs-down.
-   */
   notHelpfulButton(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: "Not helpful", exact: true });
   }
 
-  /** The hide (eye-off) control; becomes "Unhide" once the row is hidden. */
   hideButton(requiredModName?: string | RegExp): Locator {
     return this.row(requiredModName).getByRole("button", { name: "Hide", exact: true });
   }
@@ -138,11 +85,6 @@ export class HealthCheckWarnings {
     return this.row(requiredModName).getByRole("button", { name: "Unhide", exact: true });
   }
 }
-
-/**
- * The expanded Health Check detail page (HealthCheckDetailPage + the file
- * requirement DetailView). Shown after opening a warning row; replaces the list.
- */
 export class HealthCheckDetail {
   readonly page: Page;
   readonly root: Locator;
@@ -162,64 +104,38 @@ export class HealthCheckDetail {
   constructor(page: Page) {
     this.page = page;
     this.root = page.locator("#health-check-detail-page");
-    // Severity title heading ("Warning") + a "BETA" badge sit in the header.
     this.warningTitle = this.root.getByRole("heading", { name: "Warning" });
     this.backButton = this.root.getByRole("button", { name: "Back", exact: true });
-    // With several requirements the detail renders one card per required mod, so
-    // these controls can appear multiple times — take the first.
     this.installViaModPageButton = this.root
       .getByRole("button", { name: "Install via mod page" })
       .first();
     this.installOneClickButton = this.root
       .getByRole("button", { name: /^1-click install$/ })
       .first();
-    // "Install required" group header for the download report type (RequirementBody).
     this.installRequiredHeader = this.root.getByText("Install required", { exact: true });
-    // Section-level batch button, rendered only when the group has >1 candidate
-    // ("1-click install all (N)"); free users additionally get a Premium badge.
     this.installAllInGroupButton = this.root
       .getByRole("button", { name: /1-click install all/ })
       .first();
-    // OR requirement ("pick one of these") detail: the group header, the
-    // "…to be picked…" summary (shared::requires_pick), and the "Or" divider drawn
-    // between the option cards. The divider's container is aria-hidden, but its text
-    // is visually rendered, so getByText / toBeVisible still resolve it.
     this.pickOneHeader = this.root.getByText("Pick one of these", { exact: true });
     this.requiresPickLine = this.root.getByText(
       /Requires \d+ additional mod files? to be picked to work correctly/,
     );
     this.orDivider = this.root.getByText("Or", { exact: true });
-    // EntryActions (detail variant): a prompt that flips to a thank-you once
-    // feedback is given, plus the thumbs-down control (exact name so it doesn't
-    // match a "Helpful" button).
     this.feedbackPrompt = this.root.getByText("Was this warning helpful?");
     this.feedbackThanks = this.root.getByText("Thanks for your feedback");
     this.notHelpfulButton = this.root.getByRole("button", { name: "Not helpful", exact: true });
   }
 
-  /**
-   * The "download" requirement summary for a given outstanding count
-   * (shared::requires_files via useReportCopy), e.g. requiresFileSummary(2) →
-   * "Requires 2 additional mod files to be installed to work correctly". Encodes
-   * the singular/plural copy so tests assert the count without an inline string.
-   */
   requiresFileSummary(count: number): Locator {
     return this.root.getByText(
       `Requires ${count} additional mod ${count === 1 ? "file" : "files"} to be installed to work correctly`,
     );
   }
 
-  /** The requirement card row for a required mod (e.g. /SMAPI/i). */
   requirementCard(requiredModName: string | RegExp): Locator {
     return this.root.getByText(requiredModName).first();
   }
 }
-
-/**
- * Health Check settings section, rendered on Settings > Vortex tab
- * (see SettingsHealthCheck.tsx). The file-requirements toggle only renders when
- * the Unleash flag is present for the current user.
- */
 export class HealthCheckSettings {
   readonly page: Page;
   readonly sectionTitle: Locator;
@@ -237,26 +153,10 @@ export class HealthCheckSettings {
     this.fileRequirementsToggle = this.toggle("Missing file requirements warnings");
   }
 
-  /**
-   * The clickable `.toggle` element for a labelled Health Check toggle. Mirrors
-   * SettingsPage.automationToggle: the shared Toggle control
-   * (src/renderer/src/controls/Toggle.tsx) exposes no accessible role, name, or
-   * checked state — identity comes from the visible label via `.filter({ hasText })`
-   * and on/off state from the `toggle-on` / `toggle-off` class (assert with
-   * toHaveClass). The app-side fix is to give Toggle `role="switch"` + `aria-checked`.
-   */
   private toggle(label: string): Locator {
     return this.page.locator(".toggle-container").filter({ hasText: label }).locator(".toggle");
   }
 }
-
-/**
- * The Premium upsell modal (PremiumModal) a free user gets when clicking a
- * 1-click install action. Copy differs by scope: a single requirement shows the
- * "…install instantly." variant; several show the "…install all requirements
- * instantly." variant (see premium::modal in locales/en/health_check.json).
- * Rendered as a role="dialog" only while open.
- */
 export class HealthCheckPremiumModal {
   readonly page: Page;
   readonly root: Locator;
@@ -275,10 +175,6 @@ export class HealthCheckPremiumModal {
   }
 }
 
-/**
- * The "Not helpful" feedback modal (FeedbackModal), opened from the thumbs-down
- * control. Rendered as a role="dialog" only while open.
- */
 export class HealthCheckFeedbackModal {
   readonly page: Page;
   readonly root: Locator;
@@ -295,13 +191,6 @@ export class HealthCheckFeedbackModal {
   }
 }
 
-/**
- * Mod-requirement "suggestions" as they appear in the Health Check list. A missing
- * page-level (mod-to-mod) requirement renders a blue Suggestion row titled
- * "Additional mod file may be required for: <requiring mod>" (severity "suggestion"
- * → info/blue; see components/mod_requirement/ListingRow.tsx). Distinct from the
- * yellow file-requirement warnings ("Missing required mods for: …").
- */
 export class HealthCheckSuggestions {
   readonly page: Page;
   readonly root: Locator;
@@ -311,11 +200,6 @@ export class HealthCheckSuggestions {
     this.root = page.locator("#health-check-page");
   }
 
-  /**
-   * The suggestion row, identified by its "Additional mod file may be required
-   * for:" title. Pass the requiring mod's name to disambiguate when several are
-   * present; omit it to target the sole suggestion.
-   */
   row(requiringModName?: string | RegExp): Locator {
     const rows = this.root
       .locator('[role="button"]')
@@ -325,32 +209,19 @@ export class HealthCheckSuggestions {
     ).first();
   }
 
-  /**
-   * The suggestion's title text element ("Additional mod file(s) may be required
-   * for: …"); use for click/visibility. The regex tolerates the singular/plural
-   * forms. Pass the requiring mod name only to disambiguate.
-   */
   title(requiringModName?: string | RegExp): Locator {
     return this.row(requiringModName).getByText(/Additional mod files? may be required for:/);
   }
 
-  /** The "Missing mod: <name>" line inside a suggestion row. */
   missingMod(requiringModName?: string | RegExp): Locator {
     return this.row(requiringModName).getByText(/Missing mod:/);
   }
 
-  /** The "1-click install" button inside a suggestion row (always a single required mod). */
   installOneClick(requiringModName?: string | RegExp): Locator {
     return this.row(requiringModName).getByRole("button", { name: /1-click install/ });
   }
 }
 
-/**
- * The expanded detail for a mod-requirement suggestion (mod_requirement/DetailView,
- * inside #health-check-detail-page). The severity heading is "Suggestion" (vs the
- * file requirement's "Warning"), and it carries the distinctive "identified from the
- * mod page" disclaimer plus a suggestion-worded feedback prompt.
- */
 export class HealthCheckSuggestionDetail {
   readonly page: Page;
   readonly root: Locator;
@@ -362,13 +233,10 @@ export class HealthCheckSuggestionDetail {
   constructor(page: Page) {
     this.page = page;
     this.root = page.locator("#health-check-detail-page");
-    // Severity heading rendered by HealthCheckDetailPage as detail::title::suggestion.
     this.suggestionTitle = this.root.getByRole("heading", { name: "Suggestion" });
     this.mayRequireLine = this.root.getByText(
       "May require this additional mod file to be installed to work correctly",
     );
-    // The "identified from the mod page rather than the file-level requirement
-    // system" disclaimer that marks this as a page-level suggestion, not a warning.
     this.modPageSourceNote = this.root.getByText(
       /identified from the mod page rather than the file-level requirement system/,
     );

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -1,47 +1,3 @@
-/**
- * File Requirements Health Check — warning, detail, feedback + list-management
- * flows (LAZ-684).
- *
- * Fixture: SDV mod 49786 has a single main file declaring two file-level
- * requirements. Installed on its own (those required files absent) it raises one
- * file-requirements "download" warning covering both required mods (category
- * `download` / kind `missing`). The tests here cover:
- *   - the list warning (plural title / count / 1-click action)
- *   - the expanded detail view (Warning header, "Install required" group,
- *     requirement cards + buttons, section-level install-all)
- *   - progressive count: resolving one requirement decrements the summary
- *   - free user: list 1-click opens the multi-file Premium upsell
- *   - free user: a manual website download, and the "Install via mod page" link,
- *     resolve the warning
- *   - premium user: the list / header / detail 1-click installs resolve it
- *   - hide/unhide moves the warning between the Active and Hidden tabs
- *   - the warning's feedback controls (thumbs + FeedbackModal)
- *   - singular/plural copy (two requirements ⇒ the plural strings)
- *   - an OR requirement (SDV 47938, alternatives): the "pick one of these" warning,
- *     and (premium) picking one alternative satisfies the OR and clears it
- *
- * The warning is targeted by its title rather than the required mod's name, so
- * the spec doesn't hard-code the fixture's requirement target. SMAPI is
- * deliberately avoided here — Vortex special-cases it with a dedicated installer,
- * which interferes with a clean warning/install flow.
- *
- * The shared "install the fixture mod → open Health Check → surface the warning"
- * setup lives in helpers/healthCheck.ts (openFileRequirementWarning); each test
- * starts from there.
- *
- * These are heavy (real Mod-Manager download + install) and, like every
- * authenticated / managed-game spec, currently need CI to run — locally the OAuth
- * login is captcha-blocked (mitigated by a captured auth snapshot; see
- * helpers/authState.ts). Kept in their own file so the fast foundation suite
- * (health-check.spec.ts) isn't slowed.
- *
- * Assumption: 49786's requirements are file-level only, not page-level "requires"
- * rules. Enabling a mod silently auto-installs its page-level dependencies
- * (mod_management/index.ts "mod-enabled" handler); a page-level rule would
- * auto-install and no warning would surface. If these tests fail at the first
- * warnings.row() assertion, re-confirm the fixture is file-level only (or pick
- * another source mod).
- */
 import {
   SDV_FILE_REQUIREMENT_TARGET_URL_PATTERN,
   SDV_FILE_REQUIREMENT_TARGET_URLS,
@@ -127,15 +83,10 @@ test.describe("Health Check - file requirement warnings", () => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
       await test.step("The warning starts on the Active tab", async () => {
-        // Track the file-requirement warning by its own row, not the tab's aggregate
-        // "(N)" count: a page-level mod-requirement "suggestion" can also be active
-        // (see LAZ-852), which would inflate that count. warnings.row() is scoped to
-        // the file-warning title, so it stays correct regardless of what else is listed.
         await expect(warnings.row()).toBeVisible();
       });
 
       await test.step("Hidden tab starts empty", async () => {
-        // Only the file warning is ever hidden here, so the Hidden count is safe.
         await expect(hc.hiddenTab).toContainText("(0)");
       });
 
@@ -230,8 +181,6 @@ test.describe("Health Check - file requirement warnings", () => {
         await test.step(`Manually download required mod ${index + 1} and refresh`, async () => {
           await downloadModViaModManager(nexusPage, vortexApp, url);
           await hc.refreshButton.click();
-          // The warning covers every requirement, so it only clears once the last
-          // one is satisfied; earlier downloads leave it on the list.
           await expect(warnings.row()).toHaveCount(isLast ? 0 : 1, { timeout: Timeouts.LIFECYCLE });
         });
       }
@@ -253,8 +202,6 @@ test.describe("Health Check - file requirement warnings", () => {
       let modPageUrl = "";
 
       await test.step("Arm the external-open spy", async () => {
-        // The link opens the OS browser via shell.openExternal, which Playwright
-        // can't follow — spy on the main process to capture (and suppress) the URL.
         await installExternalOpenSpy(vortexApp);
         expect(await readExternalOpens(vortexApp)).toEqual([]);
       });
@@ -370,7 +317,6 @@ test.describe("Health Check - file requirement warnings", () => {
       await test.step("Trigger the detail's 1-click install all", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installAllInGroupButton.click();
-        // The requirement group unmounts once every candidate installs.
         await expect(detail.installAllInGroupButton).toBeHidden({ timeout: Timeouts.LIFECYCLE });
       });
 
@@ -416,7 +362,6 @@ test.describe("Health Check - file requirement warnings", () => {
       await test.step("Pick one alternative to install", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installOneClickButton.click();
-        // Satisfying any one alternative resolves the OR, so its group unmounts.
         await expect(detail.pickOneHeader).toBeHidden({ timeout: Timeouts.LIFECYCLE });
       });
 

--- a/packages/e2e/src/tests/health-check-file-requirement.spec.ts
+++ b/packages/e2e/src/tests/health-check-file-requirement.spec.ts
@@ -17,6 +17,8 @@
  *   - hide/unhide moves the warning between the Active and Hidden tabs
  *   - the warning's feedback controls (thumbs + FeedbackModal)
  *   - singular/plural copy (two requirements ⇒ the plural strings)
+ *   - an OR requirement (SDV 47938, alternatives): the "pick one of these" warning,
+ *     and (premium) picking one alternative satisfies the OR and clears it
  *
  * The warning is targeted by its title rather than the required mod's name, so
  * the spec doesn't hard-code the fixture's requirement target. SMAPI is
@@ -46,7 +48,11 @@ import {
 } from "../constants";
 import { test, expect } from "../fixtures/vortex-app";
 import { installExternalOpenSpy, readExternalOpens } from "../helpers/externalOpen";
-import { openFileRequirementWarning, openWarningDetail } from "../helpers/healthCheck";
+import {
+  openFileRequirementWarning,
+  openOrFileRequirementWarning,
+  openWarningDetail,
+} from "../helpers/healthCheck";
 import { downloadModViaModManager } from "../helpers/modDownload";
 import { dismissAllNotifications } from "../helpers/notifications";
 import { Timeouts } from "../helpers/timeouts";
@@ -133,9 +139,13 @@ test.describe("Health Check - file requirement warnings", () => {
         await expect(hc.hiddenTab).toContainText("(0)");
       });
 
-      await test.step("Hide the warning via its row control", async () => {
+      await test.step("Reveal the warning's row actions on hover", async () => {
         await dismissAllNotifications(vortexWindow);
         await warnings.title().hover();
+        await expect(warnings.hideButton()).toBeVisible();
+      });
+
+      await test.step("Hide the warning via its row control", async () => {
         await warnings.hideButton().click();
         await expect(hc.hiddenTab).toContainText("(1)");
       });
@@ -149,9 +159,13 @@ test.describe("Health Check - file requirement warnings", () => {
         await expect(warnings.row()).toBeVisible();
       });
 
-      await test.step("Unhide the warning via its row control", async () => {
+      await test.step("Reveal the hidden warning's row actions on hover", async () => {
         await dismissAllNotifications(vortexWindow);
         await warnings.title().hover();
+        await expect(warnings.unhideButton()).toBeVisible();
+      });
+
+      await test.step("Unhide the warning via its row control", async () => {
         await warnings.unhideButton().click();
         await expect(hc.hiddenTab).toContainText("(0)");
       });
@@ -191,8 +205,12 @@ test.describe("Health Check - file requirement warnings", () => {
         await expect(feedback.sendButton).toBeVisible();
       });
 
-      await test.step("Sending feedback records it", async () => {
+      await test.step("Select a feedback reason", async () => {
         await feedback.incorrectRequirement.click();
+        await expect(feedback.sendButton).toBeEnabled();
+      });
+
+      await test.step("Sending the feedback records it", async () => {
         await feedback.sendButton.click();
         await expect(detail.feedbackThanks).toBeVisible();
       });
@@ -206,16 +224,17 @@ test.describe("Health Check - file requirement warnings", () => {
     }) => {
       const { hc, warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
 
-      await test.step("Manually download each required mod from the website", async () => {
-        for (const url of SDV_FILE_REQUIREMENT_TARGET_URLS) {
-          await downloadModViaModManager(nexusPage, vortexApp, url);
-        }
-      });
+      for (const [index, url] of SDV_FILE_REQUIREMENT_TARGET_URLS.entries()) {
+        const isLast = index === SDV_FILE_REQUIREMENT_TARGET_URLS.length - 1;
 
-      await test.step("The ingested downloads clear the warning", async () => {
-        await hc.refreshButton.click();
-        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
-      });
+        await test.step(`Manually download required mod ${index + 1} and refresh`, async () => {
+          await downloadModViaModManager(nexusPage, vortexApp, url);
+          await hc.refreshButton.click();
+          // The warning covers every requirement, so it only clears once the last
+          // one is satisfied; earlier downloads leave it on the list.
+          await expect(warnings.row()).toHaveCount(isLast ? 0 : 1, { timeout: Timeouts.LIFECYCLE });
+        });
+      }
     });
 
     test("Check the 'Install via mod page' link opens the required mod and its download resolves the requirement", async ({
@@ -233,10 +252,14 @@ test.describe("Health Check - file requirement warnings", () => {
 
       let modPageUrl = "";
 
-      await test.step("'Install via mod page' targets the required mod's Nexus page", async () => {
+      await test.step("Arm the external-open spy", async () => {
         // The link opens the OS browser via shell.openExternal, which Playwright
         // can't follow — spy on the main process to capture (and suppress) the URL.
         await installExternalOpenSpy(vortexApp);
+        expect(await readExternalOpens(vortexApp)).toEqual([]);
+      });
+
+      await test.step("'Install via mod page' targets the required mod's Nexus page", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installViaModPageButton.click();
         const opened = await readExternalOpens(vortexApp);
@@ -249,6 +272,37 @@ test.describe("Health Check - file requirement warnings", () => {
       await test.step("Downloading from that page resolves the requirement (count 2 → 1)", async () => {
         await downloadModViaModManager(nexusPage, vortexApp, modPageUrl);
         await expect(detail.requiresFileSummary(1)).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+      });
+    });
+
+    test("Check an OR file requirement surfaces as a warning that asks the user to pick one of several options", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const { warnings } = await openOrFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
+
+      await test.step("The OR requirement surfaces as a file-requirements warning", async () => {
+        await expect(warnings.title()).toBeVisible();
+      });
+
+      await test.step("The list row offers 'Pick mod install' rather than a direct 1-click install", async () => {
+        await expect(warnings.pickModInstall()).toBeVisible();
+      });
+
+      const detail = await openWarningDetail(vortexWindow, warnings);
+
+      await test.step("Detail states the requirement must be picked (not just installed)", async () => {
+        await expect(detail.requiresPickLine).toBeVisible();
+      });
+
+      await test.step("Detail groups the alternatives under 'Pick one of these'", async () => {
+        await expect(detail.pickOneHeader).toBeVisible();
+      });
+
+      await test.step("Detail separates the alternatives with an 'Or' divider (a choice of options)", async () => {
+        await expect(detail.orDivider).toBeVisible();
       });
     });
   });
@@ -313,11 +367,16 @@ test.describe("Health Check - file requirement warnings", () => {
       const { warnings } = await openFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
       const detail = await openWarningDetail(vortexWindow, warnings);
 
-      await test.step("The detail 1-click install all installs the requirements, clearing the warning", async () => {
+      await test.step("Trigger the detail's 1-click install all", async () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installAllInGroupButton.click();
+        // The requirement group unmounts once every candidate installs.
+        await expect(detail.installAllInGroupButton).toBeHidden({ timeout: Timeouts.LIFECYCLE });
+      });
+
+      await test.step("Returning to the list shows the warning cleared", async () => {
         await detail.backButton.click();
-        await expect(warnings.row()).toHaveCount(0, { timeout: Timeouts.LIFECYCLE });
+        await expect(warnings.row()).toHaveCount(0);
       });
     });
 
@@ -338,6 +397,32 @@ test.describe("Health Check - file requirement warnings", () => {
         await dismissAllNotifications(vortexWindow);
         await detail.installOneClickButton.click();
         await expect(detail.requiresFileSummary(1)).toBeVisible({ timeout: Timeouts.LIFECYCLE });
+      });
+    });
+
+    test("Check picking one alternative of an OR requirement resolves it", async ({
+      vortexApp,
+      vortexWindow,
+      managedGame: _game,
+      nexusPage,
+    }) => {
+      const { warnings } = await openOrFileRequirementWarning(nexusPage, vortexApp, vortexWindow);
+      const detail = await openWarningDetail(vortexWindow, warnings);
+
+      await test.step("The detail offers a choice of alternatives to pick", async () => {
+        await expect(detail.pickOneHeader).toBeVisible();
+      });
+
+      await test.step("Pick one alternative to install", async () => {
+        await dismissAllNotifications(vortexWindow);
+        await detail.installOneClickButton.click();
+        // Satisfying any one alternative resolves the OR, so its group unmounts.
+        await expect(detail.pickOneHeader).toBeHidden({ timeout: Timeouts.LIFECYCLE });
+      });
+
+      await test.step("Returning to the list shows the OR resolved", async () => {
+        await detail.backButton.click();
+        await expect(warnings.row()).toHaveCount(0);
       });
     });
   });


### PR DESCRIPTION
## What

Adds E2E coverage for the File Requirements Health Check **OR case** — a requirement satisfiable by more than one alternative ("this file *or* that file"), where the user must pick one:

- **Fixture**: `SDV_OR_FILE_REQUIREMENT_MOD_URL` (SDV mod 47938) + a DRY-shared `openOrFileRequirementWarning` helper (`installAndSurfaceFileWarning`).
- **POM**: `HealthCheckWarnings.pickModInstall()`, and `HealthCheckDetail.pickOneHeader` / `requiresPickLine` / `orDivider`.
- **Free — render**: the OR surfaces as a warning offering a choice ("Pick mod install" → detail "Pick one of these" + "…to be picked…" + an "Or" divider between the option cards).
- **Premium — resolve**: picking one alternative satisfies the OR and clears the warning.

Also refactors the file-requirement spec to the **one-action / one-assertion** pattern from `E2E-BEST-PRACTICES.md` (split hover-reveal from click, reason-select from send, per-mod manual downloads, spy-arm from link-open, and install from the return-to-list observation).

## Why draft

The tests are **statically green** (typecheck + lint + format) but **not yet runtime-validated** — local E2E is captcha-blocked, so the `e2e (vortex-e2e)` CI leg is the first real run. Leaving as a draft until CI confirms:

1. **Fixture 47938** actually surfaces a *file-level* OR pick (not page-level; both alternatives unowned).
2. Three best-guess **intermediate assertions** hold: the requirement group unmounting (`toBeHidden`) after install; `sendButton` enabling after a feedback reason is chosen; the warning persisting until the last manual download.

If any of those fails, I'll adjust the fixture/assertions before marking it ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
