### PR TITLE
fix renderer OOM when changing the revision of a large collection

### DIFF
--- a/src/renderer/src/store/persistDiffMiddleware.test.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.test.ts
@@ -1,6 +1,9 @@
+import type { DiffOperation } from "@vortex/shared/ipc";
 import { applyMiddleware, createStore, type Reducer } from "redux";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { IModRule } from "../extensions/mod_management/types/IMod";
+import { makeDownload, makeMod, makeReference, makeRule } from "../test-utils/builders";
 import { createPersistDiffMiddleware, flushPendingDiffsSync } from "./persistDiffMiddleware";
 
 type S = Record<string, unknown>;
@@ -9,6 +12,191 @@ const reducer: Reducer<S> = (state = initial, action: { type: string; payload?: 
   action.type === "SET_PERSISTENT" ? { ...state, persistent: action.payload } : state;
 
 afterEach(() => vi.useRealTimers());
+
+// large enough that a whole-array operation dominates the queued volume
+const RULE_COUNT = 800;
+
+/** Rules below `reconciledUpTo` carry the archive's tag, the rest the collection revision's. */
+function makeRules(reconciledUpTo: number): IModRule[] {
+  return Array.from({ length: RULE_COUNT }, (_, i) =>
+    makeRule({
+      reference: makeReference({
+        tag: i < reconciledUpTo ? `rev54-tag-${i}` : `rev62-tag-${i}`,
+        fileMD5: `md5-${i}`,
+        logicalFileName: `Mod ${i}`,
+        versionMatch: "1.0.0",
+      }),
+    }),
+  );
+}
+
+function makeCollectionState(reconciledUpTo: number): S {
+  return {
+    mods: {
+      cyberpunk2077: {
+        "collection-1": makeMod({
+          id: "collection-1",
+          type: "collection",
+          rules: makeRules(reconciledUpTo),
+        }),
+      },
+    },
+  };
+}
+
+const RULES_PATH = "mods.cyberpunk2077.collection-1.rules";
+
+/**
+ * The invariant is about the QUEUE, not about rule updates: any code path writing the same state
+ * path repeatedly within one debounce window costs the size of the state, not the size multiplied
+ * by the number of writes. A collection revision change reconciles member tags one dispatch at a
+ * time against a `rules` array that diffs as one whole-array operation (GH#23904).
+ */
+describe("diff coalescing (GH#23904 renderer OOM)", () => {
+  /** exact segment-array comparison - join-based comparison is what these tests guard against */
+  const samePath = (op: DiffOperation, parts: string[]) =>
+    op.path.length === parts.length && parts.every((seg, i) => op.path[i] === seg);
+
+  /**
+   * Drive `ticks` successive writes of the persistent hive through the real middleware, then let
+   * the debounce fire. Returns the operations of each resulting sendDiff call.
+   */
+  const writeTicks = (ticks: number, stateAt: (tick: number) => S): DiffOperation[][] => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn();
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff }));
+    const store = createStore(reducer, applyMiddleware(mw));
+
+    store.dispatch({ type: "INIT" });
+    for (let tick = 0; tick <= ticks; ++tick) {
+      store.dispatch({ type: "SET_PERSISTENT", payload: stateAt(tick) });
+    }
+    vi.runAllTimers();
+
+    return sendDiff.mock.calls.map((call) => (call as [string, DiffOperation[]])[1]);
+  };
+
+  const rulesOpsIn = (ops: DiffOperation[]) => ops.filter((op) => op.path.join(".") === RULES_PATH);
+
+  it("queues one operation per path regardless of how many writes hit it", () => {
+    const [ops] = writeTicks(200, makeCollectionState);
+
+    const ruleOps = rulesOpsIn(ops);
+    expect(ruleOps).toHaveLength(1);
+
+    // the surviving operation carries the last write's value
+    const rules = ruleOps[0].value as IModRule[];
+    expect(rules[199].reference.tag).toBe("rev54-tag-199");
+    expect(rules[200].reference.tag).toBe("rev62-tag-200");
+  });
+
+  it("keeps queued volume bounded by state size, not by write count", () => {
+    const [ops] = writeTicks(200, makeCollectionState);
+    // one snapshot of the array is the floor; 2x headroom asserts the shape, not a byte count
+    expect(JSON.stringify(ops).length).toBeLessThan(JSON.stringify(makeRules(200)).length * 2);
+  });
+
+  it("keeps concurrent writes to other paths while coalescing the hot one", () => {
+    // coalescing is per PATH, not per hive: concurrent downloads and installs each keep their
+    // own final value while the repeatedly-written path collapses
+    const [ops] = writeTicks(200, (tick) => ({
+      mods: {
+        cyberpunk2077: {
+          "collection-1": makeMod({
+            id: "collection-1",
+            type: "collection",
+            rules: makeRules(tick),
+          }),
+          "installed-a": makeMod({
+            id: "installed-a",
+            installationPath: `mods/installed-a-${tick}`,
+          }),
+        },
+      },
+      downloads: { files: { "dl-a": makeDownload({ id: "dl-a", received: tick }) } },
+    }));
+
+    expect(rulesOpsIn(ops)).toHaveLength(1);
+
+    const byPath = new Map(ops.map((op) => [op.path.join("."), op.value]));
+    expect(byPath.get("downloads.files.dl-a.received")).toBe(200);
+    expect(byPath.get("mods.cyberpunk2077.installed-a.installationPath")).toBe(
+      "mods/installed-a-200",
+    );
+  });
+
+  it("applies a re-added subtree's writes after the subtree remove", () => {
+    // set attribute -> remove mod -> re-add mod, all inside one debounce window. The container
+    // remove is a subtree DELETE in the persistor (LevelPersist.removeItem), so the re-added
+    // attribute write must sort after it: a queue that kept the attribute's original position
+    // would let the remove destroy the re-added row inside the same flush.
+    const [ops] = writeTicks(2, (tick) =>
+      tick === 1
+        ? { mods: { cyberpunk2077: {} } }
+        : {
+            mods: {
+              cyberpunk2077: {
+                m1: makeMod({ id: "m1", attributes: { a: tick === 0 ? "one" : "two" } }),
+              },
+            },
+          },
+    );
+
+    const removeIdx = ops.findIndex(
+      (op) => op.type === "remove" && samePath(op, ["mods", "cyberpunk2077", "m1"]),
+    );
+    const attrOps = ops.filter((op) =>
+      samePath(op, ["mods", "cyberpunk2077", "m1", "attributes", "a"]),
+    );
+
+    expect(removeIdx).toBeGreaterThanOrEqual(0);
+    expect(attrOps).toHaveLength(1);
+    expect(attrOps[0].value).toBe("two");
+    expect(ops.indexOf(attrOps[0])).toBeGreaterThan(removeIdx);
+  });
+
+  it("distinguishes paths that a separator-joined key would merge", () => {
+    // mod ids containing dots are common, so ["mods", g, "m1", "attributes", "state"] and
+    // ["mods", g, "m1.attributes", "state"] are distinct paths that dot-join to the same
+    // string - the queue key must keep them apart or one write is silently dropped
+    const [ops] = writeTicks(0, () => ({
+      mods: {
+        cyberpunk2077: {
+          m1: makeMod({ id: "m1", attributes: { state: "attr-value" } }),
+          "m1.attributes": makeMod({ id: "m1.attributes" }),
+        },
+      },
+    }));
+
+    const attrOp = ops.find((op) =>
+      samePath(op, ["mods", "cyberpunk2077", "m1", "attributes", "state"]),
+    );
+    const fieldOp = ops.find((op) =>
+      samePath(op, ["mods", "cyberpunk2077", "m1.attributes", "state"]),
+    );
+
+    expect(attrOp?.value).toBe("attr-value");
+    expect(fieldOp?.value).toBe("installed");
+  });
+
+  it("still coalesces across separate debounce windows without losing the newest value", () => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn();
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff }));
+    const store = createStore(reducer, applyMiddleware(mw));
+
+    store.dispatch({ type: "INIT" });
+    store.dispatch({ type: "SET_PERSISTENT", payload: makeCollectionState(1) });
+    vi.runAllTimers();
+    store.dispatch({ type: "SET_PERSISTENT", payload: makeCollectionState(2) });
+    vi.runAllTimers();
+
+    expect(sendDiff).toHaveBeenCalledTimes(2);
+    const [, ops] = sendDiff.mock.calls[1] as [string, DiffOperation[]];
+    const rules = rulesOpsIn(ops)[0].value as IModRule[];
+    expect(rules[1].reference.tag).toBe("rev54-tag-1");
+  });
+});
 
 describe("flushPendingDiffsSync (GH#23363 quit flush)", () => {
   it("flushes pending diffs synchronously via sendDiffSync before the debounce fires", () => {

--- a/src/renderer/src/store/persistDiffMiddleware.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.ts
@@ -53,9 +53,34 @@ export function getPersistedHives(): string[] {
  */
 const DEBOUNCE_MS = 100;
 
+/**
+ * Queued operations for one hive, keyed by serialized path. Persistence is last-write-wins per
+ * path, so only the newest operation for a path is kept: the queue costs the size of the state
+ * rather than the number of writes. An array diffs as a single leaf operation carrying the whole
+ * array, so a repeatedly-written one (a collection's `rules`) would dominate otherwise (GH#23904).
+ *
+ * Insertion order is preserved and a rewrite moves its key to the end, so operations apply in the
+ * order of their newest write.
+ */
+type PendingHiveDiffs = Map<string, DiffOperation>;
+
 type PendingDiffs = {
-  [H in PersistedHive]?: DiffOperation[];
+  [H in PersistedHive]?: PendingHiveDiffs;
 };
+
+/**
+ * Key a diff operation by its path. Each segment is length-prefixed so segment content cannot
+ * make two paths collide: key segments may contain dots (mod ids) or control characters (see
+ * isClobberedKeySegment), so no separator-joined key is collision-free, and a collision here
+ * silently drops an operation from the queue.
+ */
+function pathKey(path: string[]): string {
+  let key = "";
+  for (const segment of path) {
+    key += `${segment.length}:${segment}`;
+  }
+  return key;
+}
 
 /**
  * Serialize a diff operation's value for IPC transport.
@@ -149,11 +174,11 @@ export function createPersistDiffMiddleware(
 
     for (const [hive, operations] of Object.entries(pendingDiffs) as [
       PersistedHive,
-      DiffOperation[],
+      PendingHiveDiffs,
     ][]) {
-      if (operations.length > 0) {
+      if (operations.size > 0) {
         // Serialize operations to ensure IPC compatibility
-        const serializedOps = operations.map(serializeOperation);
+        const serializedOps = Array.from(operations.values(), serializeOperation);
         persistApi.sendDiff(hive, serializedOps);
       }
     }
@@ -179,10 +204,10 @@ export function createPersistDiffMiddleware(
     }
     for (const [hive, operations] of Object.entries(pendingDiffs) as [
       PersistedHive,
-      DiffOperation[],
+      PendingHiveDiffs,
     ][]) {
-      if (operations.length > 0) {
-        const serializedOps = operations.map(serializeOperation);
+      if (operations.size > 0) {
+        const serializedOps = Array.from(operations.values(), serializeOperation);
         if (persistApi.sendDiffSync != null) {
           persistApi.sendDiffSync(hive, serializedOps);
         } else {
@@ -209,10 +234,18 @@ export function createPersistDiffMiddleware(
    * Add diff operations to the pending queue
    */
   const queueDiffs = (hive: PersistedHive, operations: DiffOperation[]) => {
-    if (pendingDiffs[hive] === undefined) {
-      pendingDiffs[hive] = [];
+    let hiveDiffs = pendingDiffs[hive];
+    if (hiveDiffs === undefined) {
+      hiveDiffs = new Map();
+      pendingDiffs[hive] = hiveDiffs;
     }
-    pendingDiffs[hive].push(...operations);
+    for (const op of operations) {
+      const key = pathKey(op.path);
+      // Map.set keeps an existing key's position, so delete first: the newest write to a path
+      // must sort after anything queued since the previous one
+      hiveDiffs.delete(key);
+      hiveDiffs.set(key, op);
+    }
     scheduleFlush();
   };
 

--- a/src/renderer/src/store/stateDiff.ts
+++ b/src/renderer/src/store/stateDiff.ts
@@ -54,9 +54,11 @@ export function computeStateDiff<T>(
         // was stored as a JSON blob at the intermediate path (non-plain
         // objects, e.g. Date or Error instances, take that branch in
         // collectSetOperations and end up as one row at currentPath).
-        // For object subtrees, also emit leaf removes as a fallback for
-        // exact-match persistors (tests, mocks). For primitives the
-        // container-path remove already covers it.
+        // For object subtrees, also emit leaf removes: exact-match persistors
+        // (tests, mocks) need them, and so does persistDiffMiddleware's
+        // per-path coalescing - a later set to the container path supersedes
+        // this remove in the pending queue, leaving the leaf removes to clear
+        // the old rows. For primitives the container-path remove covers it.
         operations.push({ type: "remove", path: currentPath });
         if (isObject(oldState[key])) {
           operations.push(...collectRemoveOperations(currentPath, oldState[key]));
@@ -90,8 +92,7 @@ export function computeStateDiff<T>(
     } else {
       // Value was removed. Always emit a remove at this path (see the
       // object-key removal branch above for why the container-path remove
-      // matters under prefix-delete). For object subtrees, also emit the
-      // leaf removes as a fallback for exact-match persistors.
+      // matters under prefix-delete and why the leaf removes are required).
       operations.push({ type: "remove", path });
       if (isObject(oldState)) {
         operations.push(...collectRemoveOperations(path, oldState));


### PR DESCRIPTION
A collection revision change rewrites one rule per member, and each write queues a persistence diff carrying a full copy of the collection's rules array. The queue drains on a 100ms timer and keeps every copy, so at 2852 members it accumulates ~4.5 GB against the renderer's 4 GB heap cap and the renderer dies with reason "oom" on every attempt (GH#23904, LAZ-913).

Key the pending queue by operation path: persistence is last-write-wins per path, so only the newest operation is kept and the queue is bounded by state size instead of write count. A rewrite re-inserts its key at the end so subtree removes stay ordered against re-added descendants; path keys are length-prefixed since mod ids may contain dots.

closes LAZ-913
closes #23904