### PR TITLE
Shift the Button size scale down a step (LAZ-879)

### DIFF
--- a/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
+++ b/src/renderer/src/extensions/browse_nexus/views/BrowseNexusPage.tsx
@@ -293,7 +293,6 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                   appearance="moderate"
                   brand="neutral"
                   leftIconPath={mdiMagnify}
-                  size="sm"
                   title={t("common:actions.search")}
                   type="submit"
                 />
@@ -305,7 +304,6 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                     appearance="moderate"
                     brand="neutral"
                     leftIconPath={mdiRefresh}
-                    size="sm"
                     title={t("collection:browse.refresh")}
                     onClick={handleRefresh}
                   />
@@ -344,7 +342,6 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                     appearance="moderate"
                     brand="neutral"
                     leftIconPath={mdiOpenInNew}
-                    size="sm"
                     onClick={() =>
                       window.api.shell.openUrl(
                         `https://www.nexusmods.com/games/${gameDomainName}/mods`,
@@ -396,7 +393,6 @@ function BrowseNexusPage(props: IBrowseNexusPageProps) {
                 appearance="moderate"
                 brand="neutral"
                 leftIconPath={mdiOpenInNew}
-                size="sm"
                 onClick={() =>
                   window.api.shell.openUrl(`https://www.nexusmods.com/games/${gameDomainName}/mods`)
                 }

--- a/src/renderer/src/extensions/category_management/views/CategoryListFetchError.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListFetchError.tsx
@@ -36,13 +36,7 @@ const CustomCategoryFetchError = ({ fetch, clear, error, t }: ICustomCategoryFet
         </Typography>
       )}
 
-      <Button
-        appearance="subdued"
-        brand="neutral"
-        leftIconPath={mdiUpdate}
-        size="sm"
-        onClick={fetch}
-      >
+      <Button appearance="subdued" brand="neutral" leftIconPath={mdiUpdate} onClick={fetch}>
         {t("Try again")}
       </Button>
     </div>

--- a/src/renderer/src/extensions/category_management/views/CategoryListItem.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListItem.tsx
@@ -211,7 +211,6 @@ export default function CategoryListItem({
                   brand="primary"
                   data-testid="category-rename-save"
                   leftIconPath={mdiPlus}
-                  size="sm"
                   onClick={rename}
                 />
 
@@ -221,7 +220,6 @@ export default function CategoryListItem({
                   brand="neutral"
                   data-testid="category-rename-cancel"
                   leftIconPath={mdiCancel}
-                  size="sm"
                   onClick={() => setEditMode()}
                 />
               </div>
@@ -266,7 +264,6 @@ export default function CategoryListItem({
             brand="neutral"
             data-testid="category-subcategory-cancel"
             leftIconPath={mdiCancel}
-            size="sm"
             onClick={() => setEditMode()}
           />
         </div>

--- a/src/renderer/src/extensions/category_management/views/CategoryListNoResults.tsx
+++ b/src/renderer/src/extensions/category_management/views/CategoryListNoResults.tsx
@@ -26,23 +26,11 @@ const CustomNoCategoryResults = ({
         {!!searchTerm && t(`No categories matching "{{searchTerm}}"`, { searchTerm })}
       </Typography>
 
-      <Button
-        appearance="subdued"
-        brand="neutral"
-        leftIconPath={mdiFolderPlus}
-        size="sm"
-        onClick={create}
-      >
+      <Button appearance="subdued" brand="neutral" leftIconPath={mdiFolderPlus} onClick={create}>
         {t("Create Category")}
       </Button>
 
-      <Button
-        appearance="subdued"
-        brand="neutral"
-        leftIconPath={mdiUpdate}
-        size="sm"
-        onClick={fetch}
-      >
+      <Button appearance="subdued" brand="neutral" leftIconPath={mdiUpdate} onClick={fetch}>
         {t("Sync with Nexus Mods")}
       </Button>
     </div>

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -251,7 +251,6 @@ export const ExtensionManager = ({
                 aria-label={t("Update extensions")}
                 brand="neutral"
                 leftIconPath={mdiRefresh}
-                size="sm"
                 onClick={onRefresh}
               />
             </Tooltip>
@@ -262,7 +261,6 @@ export const ExtensionManager = ({
                 aria-label={t("Browse extensions")}
                 brand="neutral"
                 leftIconPath={mdiPlus}
-                size="sm"
                 onClick={() => dispatch(setDialogVisible("browse-extensions"))}
               />
             </Tooltip>
@@ -281,7 +279,7 @@ export const ExtensionManager = ({
         <PageContent isFullWidth>
           <Alert
             action={
-              <Button brand="neutral" size="xs" onClick={() => relaunch()}>
+              <Button brand="neutral" size="sm" onClick={() => relaunch()}>
                 {t("Restart Vortex")}
               </Button>
             }

--- a/src/renderer/src/extensions/gamemode_management/components/DisplayOptions.tsx
+++ b/src/renderer/src/extensions/gamemode_management/components/DisplayOptions.tsx
@@ -29,7 +29,7 @@ export const DisplayOptions = ({
       <Picker<"list" | "small" | "large">
         button={{
           leftIconPath: pickerLayout === "list" ? mdiViewList : mdiViewGrid,
-          size: "xs",
+          size: "sm",
         }}
         options={[
           { label: t("Grid"), value: "small", iconPath: mdiViewGrid },

--- a/src/renderer/src/extensions/gamemode_management/components/NoGamesFound.tsx
+++ b/src/renderer/src/extensions/gamemode_management/components/NoGamesFound.tsx
@@ -21,7 +21,6 @@ export const NoGamesFound = ({ className, t }: INoGamesFoundProps) => (
       appearance="moderate"
       brand="neutral"
       leftIconPath={mdiOpenInNew}
-      size="sm"
       onClick={() =>
         window.api.shell.openUrl(
           "https://github.com/Nexus-Mods/Vortex/wiki/MODDINGWIKI-Developers-General-Creating-a-game-extension",

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -320,7 +320,7 @@ const GamePicker = ({
         <CollapsibleSection
           actions={
             <Picker
-              button={{ appearance: "subdued", size: "xs" }}
+              button={{ appearance: "subdued", size: "sm" }}
               options={[
                 { label: t("Name A-Z"), value: "alphabetical" },
                 { label: t("Recently used"), value: "recentlyused" },
@@ -380,7 +380,7 @@ const GamePicker = ({
         <CollapsibleSection
           actions={
             <Picker
-              button={{ appearance: "subdued", size: "xs" }}
+              button={{ appearance: "subdued", size: "sm" }}
               options={[
                 { label: t("Most Popular"), value: "popular" },
                 { label: t("Name A-Z"), value: "alphabetical" },

--- a/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
+++ b/src/renderer/src/extensions/health_check/components/entry_actions/EntryActions.tsx
@@ -71,7 +71,6 @@ export function EntryActions({
             data-testid="health-check-feedback-helpful"
             disabled={givenFeedback}
             leftIconPath={mdiThumbUpOutline}
-            size="sm"
             onClick={handle(() => {
               trackFeedbackHelpful({ issue_type: issueType, resolution_type: resolutionType });
               onHelpful();
@@ -87,7 +86,6 @@ export function EntryActions({
             data-testid="health-check-feedback-not-helpful"
             disabled={givenFeedback}
             leftIconPath={mdiThumbDownOutline}
-            size="sm"
             onClick={handle(() => setShowFeedbackModal(true))}
           />
         </Tooltip>
@@ -101,7 +99,6 @@ export function EntryActions({
             brand="neutral"
             data-testid="health-check-entry-hide"
             leftIconPath={isHidden ? mdiEyeOutline : mdiEyeOffOutline}
-            size="sm"
             onClick={handle(onToggleHide)}
           />
         </Tooltip>

--- a/src/renderer/src/extensions/health_check/components/feedback_modal/FeedbackModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/feedback_modal/FeedbackModal.tsx
@@ -54,7 +54,6 @@ export const FeedbackModal = ({
           appearance="moderate"
           className="w-full"
           data-testid="health-check-feedback-cancel"
-          size="sm"
           onClick={onClose}
         >
           {t("detail::feedback_modal::buttons::cancel")}
@@ -64,7 +63,6 @@ export const FeedbackModal = ({
           brand="primary"
           className="w-full"
           data-testid="health-check-feedback-confirm"
-          size="sm"
           onClick={() => {
             onSuccess(checkedOptions);
           }}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -137,7 +137,6 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               appearance="moderate"
               brand="neutral"
               leftIconPath={mdiCallSplit}
-              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 trackViewPickOptionsClicked({});
@@ -151,7 +150,6 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
               appearance="moderate"
               brand="neutral"
               leftIconPath={mdiSwapHorizontal}
-              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 trackEnableThisVersionClicked({
@@ -172,7 +170,6 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
                 appearance="moderate"
                 brand="neutral"
                 leftIconPath={mdiCheck}
-                size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
 

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -59,7 +59,6 @@ export const CandidateCard = ({
             appearance="subdued"
             brand="neutral"
             leftIconPath={mdiOpenInNew}
-            size="sm"
             onClick={handleModPage}
           >
             {t("detail::item::install_via_mod_page")}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/EnableCard.tsx
@@ -59,7 +59,6 @@ export const EnableCard = ({
             appearance="subdued"
             brand="neutral"
             leftIconPath={nxmModOutline}
-            size="sm"
             onClick={handleViewInMods}
           >
             {t("detail::item::view_in_mods")}
@@ -69,7 +68,6 @@ export const EnableCard = ({
             appearance="strong"
             brand="neutral"
             leftIconPath={mdiSwapHorizontal}
-            size="sm"
             onClick={handleEnable}
           >
             {t("detail::item::enable_this_version")}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/InstallDownloadedCard.tsx
@@ -66,7 +66,6 @@ export const InstallDownloadedCard = ({
             appearance="subdued"
             brand="neutral"
             leftIconPath={nxmModOutline}
-            size="sm"
             onClick={handleViewInMods}
           >
             {t("detail::item::view_in_mods")}
@@ -77,7 +76,6 @@ export const InstallDownloadedCard = ({
             brand="neutral"
             isLoading={isLoading}
             leftIconPath={isSwitch ? mdiSwapHorizontal : mdiCheck}
-            size="sm"
             onClick={handleInstall}
           >
             {isLoading

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ReplaceRows.tsx
@@ -55,7 +55,6 @@ export const ReplaceRows = ({
               appearance="subdued"
               brand="neutral"
               leftIconPath={nxmModOutline}
-              size="sm"
               onClick={handleViewInMods}
             >
               {t("detail::item::view_in_mods")}

--- a/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/rows/ToggleRows.tsx
@@ -55,7 +55,6 @@ export const ToggleRows = ({
               appearance="subdued"
               brand="neutral"
               leftIconPath={nxmModOutline}
-              size="sm"
               onClick={handleViewInMods}
             >
               {t("detail::item::view_in_mods")}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/DetailView.tsx
@@ -184,7 +184,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                     appearance="moderate"
                     brand="neutral"
                     leftIconPath={mdiOpenInNew}
-                    size="sm"
                     onClick={openModPage}
                   >
                     {t("detail::item::open_external_mod_page")}
@@ -197,7 +196,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                       appearance="moderate"
                       brand="neutral"
                       leftIconPath={mdiOpenInNew}
-                      size="sm"
                       onClick={handleModPage}
                     >
                       {t("detail::item::install_via_mod_page")}
@@ -250,7 +248,6 @@ export const DetailView = ({ entry, api, onBack }: IDetailViewProps) => {
                   appearance="moderate"
                   brand="neutral"
                   leftIconPath={mdiCheck}
-                  size="sm"
                   onClick={handleConfirmInstall}
                 >
                   {t("detail::item::confirm_install")}

--- a/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/mod_requirement/ListingRow.tsx
@@ -63,7 +63,6 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
             <Button
               appearance="moderate"
               brand="neutral"
-              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 onOpen();

--- a/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
+++ b/src/renderer/src/extensions/health_check/components/premium_modal/PremiumModal.tsx
@@ -128,7 +128,6 @@ export const PremiumModal = ({
           brand="neutral"
           className="w-full"
           leftIconPath={downloadScope === "single" && mdiOpenInNew}
-          size="sm"
           onClick={() => {
             trackPremiumModalFallbackClicked({
               ...identity,
@@ -147,7 +146,6 @@ export const PremiumModal = ({
           brand="premium"
           className="w-full"
           leftIconPath={mdiDiamondStone}
-          size="sm"
           onClick={() => {
             trackPremiumModalUnlockClicked({
               ...identity,

--- a/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckDetailPage.tsx
@@ -55,7 +55,6 @@ const BackButton = ({ onBack }: { onBack: () => void }) => {
       appearance="weak"
       brand="neutral"
       leftIconPath={mdiArrowLeft}
-      size="sm"
       onClick={() => {
         trackBackClicked({ time_spent_on_detail_ms: Date.now() - openedAtRef.current });
         onBack();

--- a/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
+++ b/src/renderer/src/extensions/health_check/views/HealthCheckPage.tsx
@@ -318,7 +318,7 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
       message={t("listing::no_results_logged_out::message")}
       title={t("listing::no_results_logged_out::title")}
     >
-      <Button data-testid="health-check-login" size="sm" onClick={requestLogin}>
+      <Button data-testid="health-check-login" onClick={requestLogin}>
         {t("listing::no_results_logged_out::action")}
       </Button>
     </NoResults>
@@ -401,7 +401,6 @@ const HealthCheckPage = ({ api, onRefresh, active, registerReset }: IHealthCheck
                       (selectedTab === "hidden" && !hiddenCount)
                     }
                     leftIconPath={selectedTab === "active" ? mdiEyeOffOutline : mdiEyeOutline}
-                    size="sm"
                     onClick={selectedTab === "active" ? hideAllActive : unhideAll}
                   >
                     {selectedTab === "active"

--- a/src/renderer/src/extensions/settings_application/SettingsVortex.tsx
+++ b/src/renderer/src/extensions/settings_application/SettingsVortex.tsx
@@ -47,7 +47,7 @@ class SettingsVortex extends ComponentEx<IProps, IComponentState> {
             {t("You need to restart Vortex to activate this change")}
           </Typography>
 
-          <Button brand="neutral" size="sm" onClick={this.restart}>
+          <Button brand="neutral" onClick={this.restart}>
             {t("Restart now")}
           </Button>
         </div>

--- a/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
+++ b/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
@@ -157,7 +157,7 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
           {t("You need to restart Vortex to activate this change")}
         </Typography>
 
-        <Button brand="neutral" size="sm" onClick={this.restart}>
+        <Button brand="neutral" onClick={this.restart}>
           {t("Restart now")}
         </Button>
       </div>
@@ -316,7 +316,7 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
           <ControlLabel>{t("Notifications")}</ControlLabel>
 
           <div className="flex items-center gap-x-2">
-            <Button brand="neutral" size="sm" onClick={this.resetSuppression}>
+            <Button brand="neutral" onClick={this.resetSuppression}>
               {t("Reset suppressed notifications")}
             </Button>
 

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -132,7 +132,6 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
               <Button
                 brand="neutral"
                 disabled={checkUpdateButtonDisabled}
-                size="sm"
                 onClick={this.manualUpdateCheck}
               >
                 {t("Check now")}

--- a/src/renderer/src/ui/README.md
+++ b/src/renderer/src/ui/README.md
@@ -104,7 +104,7 @@ import { Button } from "../../ui/components/button/Button";
 <Button>Click Me</Button>
 
 // Only override what differs from the default
-<Button size="xs">Small</Button>
+<Button size="sm">Small</Button>
 <Button brand="neutral" appearance="subdued">Outlined</Button>
 <Button brand="neutral" appearance="weak">Quiet</Button>
 <Button brand="success">Saved</Button>
@@ -122,7 +122,7 @@ import { mdiDownload } from "@mdi/js";
 
 **Brands:** `primary`, `info`, `neutral`, `success`, `premium`
 **Appearances:** `strong` (solid fill), `moderate` (subtle surface), `subdued` (outline), `weak` (text only)
-**Sizes:** `xs`, `sm`, `md`
+**Sizes:** `sm` (24px), `md` (28px, default), `lg` (36px)
 
 A button with no `children`/`customContent` but an icon renders icon-only (square). Every brand supports every appearance; `success`/`premium` derive their full ramps to match. `appearance` defaults to `strong` so a bare `<Button>` is a solid primary button.
 

--- a/src/renderer/src/ui/components/alert/Alert.demo.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.demo.tsx
@@ -23,46 +23,17 @@ export const AlertDemo = () => (
     </div>
 
     <div>
-      <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            Find out more
-          </Button>
-        }
-      >
-        We suggest you do this
-      </Alert>
+      <Alert action={<Button brand="neutral">Find out more</Button>}>We suggest you do this</Alert>
 
-      <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            Restart Vortex
-          </Button>
-        }
-        severity="warning"
-      >
+      <Alert action={<Button brand="neutral">Restart Vortex</Button>} severity="warning">
         You need to restart Vortex to apply changes
       </Alert>
 
-      <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            Free up disk space
-          </Button>
-        }
-        severity="danger"
-      >
+      <Alert action={<Button brand="neutral">Free up disk space</Button>} severity="danger">
         Disk space full
       </Alert>
 
-      <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            View page
-          </Button>
-        }
-        severity="success"
-      >
+      <Alert action={<Button brand="neutral">View page</Button>} severity="success">
         Action successful
       </Alert>
     </div>
@@ -96,14 +67,7 @@ export const AlertDemo = () => (
     </div>
 
     <div>
-      <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            Find out more
-          </Button>
-        }
-        onDismiss={() => undefined}
-      >
+      <Alert action={<Button brand="neutral">Find out more</Button>} onDismiss={() => undefined}>
         We suggest you do this
       </Alert>
 
@@ -129,11 +93,7 @@ export const AlertDemo = () => (
 
     <div>
       <Alert
-        action={
-          <Button brand="neutral" size="xs">
-            Restart Vortex
-          </Button>
-        }
+        action={<Button brand="neutral">Restart Vortex</Button>}
         severity="warning"
         onDismiss={() => undefined}
       >

--- a/src/renderer/src/ui/components/alert/Alert.test.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.test.tsx
@@ -89,7 +89,7 @@ describe("Alert", () => {
 
     it("renders an action after the message", () => {
       render(
-        <Alert action={<Button size="xs">Restart Vortex</Button>}>
+        <Alert action={<Button>Restart Vortex</Button>}>
           You need to restart Vortex to apply changes
         </Alert>,
       );
@@ -99,15 +99,7 @@ describe("Alert", () => {
     it("calls the action's onClick", async () => {
       const onClick = vi.fn();
       render(
-        <Alert
-          action={
-            <Button size="xs" onClick={onClick}>
-              Restart Vortex
-            </Button>
-          }
-        >
-          Restart needed
-        </Alert>,
+        <Alert action={<Button onClick={onClick}>Restart Vortex</Button>}>Restart needed</Alert>,
       );
 
       await userEvent.click(screen.getByRole("button", { name: "Restart Vortex" }));
@@ -154,14 +146,7 @@ describe("Alert", () => {
       const onClick = vi.fn();
       const onDismiss = vi.fn();
       render(
-        <Alert
-          action={
-            <Button size="xs" onClick={onClick}>
-              Restart Vortex
-            </Button>
-          }
-          onDismiss={onDismiss}
-        >
+        <Alert action={<Button onClick={onClick}>Restart Vortex</Button>} onDismiss={onDismiss}>
           Restart needed
         </Alert>,
       );

--- a/src/renderer/src/ui/components/alert/Alert.tsx
+++ b/src/renderer/src/ui/components/alert/Alert.tsx
@@ -79,7 +79,7 @@ export const Alert = ({
           brand="neutral"
           className="nxm-alert-dismiss"
           leftIconPath={mdiClose}
-          size="xs"
+          size="sm"
           onClick={dismiss}
         />
       )}

--- a/src/renderer/src/ui/components/button/Button.demo.tsx
+++ b/src/renderer/src/ui/components/button/Button.demo.tsx
@@ -73,11 +73,11 @@ export const ButtonDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap items-center gap-4">
-          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+
+          <Button>Medium (default)</Button>
 
           <Button size="sm">Small</Button>
-
-          <Button size="xs">Extra Small</Button>
         </div>
       </div>
 
@@ -123,7 +123,7 @@ export const ButtonDemo = () => {
             Next
           </Button>
 
-          <Button brand="success" leftIconPath={mdiCheck} size="sm">
+          <Button brand="success" leftIconPath={mdiCheck}>
             Confirm
           </Button>
 
@@ -154,11 +154,11 @@ export const ButtonDemo = () => {
         </div>
 
         <div className="flex flex-wrap items-center gap-4">
-          <Button aria-label="Settings (md)" leftIconPath={mdiCog} size="md" />
+          <Button aria-label="Settings (lg)" leftIconPath={mdiCog} size="lg" />
+
+          <Button aria-label="Settings (md)" leftIconPath={mdiCog} />
 
           <Button aria-label="Settings (sm)" leftIconPath={mdiCog} size="sm" />
-
-          <Button aria-label="Settings (xs)" leftIconPath={mdiCog} size="xs" />
         </div>
       </div>
     </div>

--- a/src/renderer/src/ui/components/button/Button.test.tsx
+++ b/src/renderer/src/ui/components/button/Button.test.tsx
@@ -92,20 +92,20 @@ describe("Button", () => {
   });
 
   describe("size", () => {
-    it('applies xs class for size="xs"', () => {
-      render(<Button size="xs">Click</Button>);
-      expect(getButton()).toHaveClass("nxm-button-xs");
-    });
-
     it('applies sm class for size="sm"', () => {
       render(<Button size="sm">Click</Button>);
       expect(getButton()).toHaveClass("nxm-button-sm");
     });
 
-    it('does not apply size class for size="md" (default)', () => {
+    it('applies lg class for size="lg"', () => {
+      render(<Button size="lg">Click</Button>);
+      expect(getButton()).toHaveClass("nxm-button-lg");
+    });
+
+    it('does not apply a size class for size="md" (default)', () => {
       render(<Button>Click</Button>);
-      expect(getButton()).not.toHaveClass("nxm-button-xs");
       expect(getButton()).not.toHaveClass("nxm-button-sm");
+      expect(getButton()).not.toHaveClass("nxm-button-lg");
     });
   });
 

--- a/src/renderer/src/ui/components/button/Button.tsx
+++ b/src/renderer/src/ui/components/button/Button.tsx
@@ -19,7 +19,7 @@ export type IButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   brand?: IButtonBrand;
   appearance?: IButtonAppearance;
   isLoading?: boolean;
-  size?: "xs" | "sm" | "md";
+  size?: "sm" | "md" | "lg";
   children?: string;
   customContent?: ReactNode;
   disabled?: boolean;
@@ -91,8 +91,9 @@ export const Button = forwardRef<HTMLButtonElement, IButtonProps>(
         {
           "nxm-button-disabled": !!disabled || !!ariaDisabled || isLoading,
           "nxm-button-icon-only": !customContent && !children,
-          "nxm-button-xs": size === "xs",
+          // `md` is the base class, so only the sizes either side of it modify it.
           "nxm-button-sm": size === "sm",
+          "nxm-button-lg": size === "lg",
         },
       )}
       disabled={disabled || isLoading}

--- a/src/renderer/src/ui/components/collection_tile/CollectionTile.tsx
+++ b/src/renderer/src/ui/components/collection_tile/CollectionTile.tsx
@@ -215,13 +215,13 @@ export const CollectionTile: ComponentType<React.PropsWithChildren<ICollectionTi
             brand="neutral"
             disabled={true}
             leftIconPath={!isLoggedIn ? undefined : mdiCheck}
-            size="xs"
+            size="sm"
             title={!isLoggedIn ? "Log in to add collections" : undefined}
           >
             {!isLoggedIn ? "Log in to add" : "Added"}
           </Button>
         ) : (
-          <Button size="xs" onClick={addCollection}>
+          <Button size="sm" onClick={addCollection}>
             Add collection
           </Button>
         )}
@@ -230,7 +230,7 @@ export const CollectionTile: ComponentType<React.PropsWithChildren<ICollectionTi
           appearance="weak"
           brand="neutral"
           leftIconPath={mdiOpenInNew}
-          size="xs"
+          size="sm"
           onClick={onViewPage}
         >
           View page

--- a/src/renderer/src/ui/components/listing/Listing.demo.tsx
+++ b/src/renderer/src/ui/components/listing/Listing.demo.tsx
@@ -71,7 +71,6 @@ export const ListingDemo = () => {
             brand="neutral"
             appearance="subdued"
             {...(isLoading ? { appearance: "strong" } : {})}
-            size="sm"
             onClick={() => {
               setIsLoading(!isLoading);
               setIsError(false);
@@ -84,7 +83,6 @@ export const ListingDemo = () => {
             brand="neutral"
             appearance="subdued"
             {...(isError ? { appearance: "strong" } : {})}
-            size="sm"
             onClick={() => {
               setIsError(!isError);
               setIsLoading(false);
@@ -97,7 +95,6 @@ export const ListingDemo = () => {
             brand="neutral"
             appearance="subdued"
             {...(isEmpty ? { appearance: "strong" } : {})}
-            size="sm"
             onClick={() => {
               setIsEmpty(!isEmpty);
               setIsError(false);
@@ -187,7 +184,7 @@ export const ListingDemo = () => {
                   No mods installed yet
                 </Typography>
 
-                <Button brand="neutral" appearance="subdued" size="sm">
+                <Button brand="neutral" appearance="subdued">
                   Browse mods
                 </Button>
               </div>

--- a/src/renderer/src/ui/components/no_results/NoResults.tsx
+++ b/src/renderer/src/ui/components/no_results/NoResults.tsx
@@ -59,7 +59,6 @@ export const NoResults = ({
             appearance="moderate"
             brand="neutral"
             leftIconPath={mdiOpenInNew}
-            size="sm"
             onClick={() =>
               window.api.shell.openUrl("https://help.nexusmods.com/article/125-contact-us")
             }

--- a/src/renderer/src/ui/components/pagination/JumpToPage.tsx
+++ b/src/renderer/src/ui/components/pagination/JumpToPage.tsx
@@ -54,13 +54,7 @@ export const JumpToPage = ({
         }}
       />
 
-      <Button
-        aria-disabled={!isValid}
-        brand="neutral"
-        appearance="moderate"
-        size="sm"
-        type="submit"
-      >
+      <Button aria-disabled={!isValid} brand="neutral" appearance="moderate" type="submit">
         Go
       </Button>
     </form>

--- a/src/renderer/src/ui/components/popover/Popover.demo.tsx
+++ b/src/renderer/src/ui/components/popover/Popover.demo.tsx
@@ -52,7 +52,7 @@ export const PopoverDemo = () => {
 
         <div className="flex flex-wrap gap-4">
           <Popover>
-            <PopoverButton appearance="subdued" brand="neutral" leftIconPath={mdiTune} size="sm" />
+            <PopoverButton appearance="subdued" brand="neutral" leftIconPath={mdiTune} />
 
             <PopoverPanel className="right-auto left-0">
               <div className="flex min-h-12 items-center justify-between gap-x-6 border-b border-stroke-weak px-4">
@@ -63,7 +63,7 @@ export const PopoverDemo = () => {
                 <Picker
                   button={{
                     leftIconPath: layout === "list" ? mdiViewList : mdiViewGrid,
-                    size: "xs",
+                    size: "sm",
                   }}
                   options={layoutOptions}
                   value={layout}

--- a/src/renderer/src/ui/components/table/Table.demo.tsx
+++ b/src/renderer/src/ui/components/table/Table.demo.tsx
@@ -82,7 +82,7 @@ const ActionsCell = ({ mod }: { mod: IDemoMod }) => {
           onChange={setEnabled}
         />
       ) : (
-        <Button appearance="moderate" brand="primary" size="xs">
+        <Button appearance="moderate" brand="primary">
           Install
         </Button>
       )}
@@ -92,7 +92,6 @@ const ActionsCell = ({ mod }: { mod: IDemoMod }) => {
         aria-label={`More actions for ${mod.name}`}
         brand="neutral"
         leftIconPath={mdiDotsVertical}
-        size="xs"
       />
     </div>
   );

--- a/src/renderer/src/ui/components/toolbar/ToolbarButton.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarButton.tsx
@@ -23,7 +23,7 @@ export type IToolbarButtonProps = IButtonProps & {
 export const ToolbarButton = forwardRef<HTMLButtonElement, IToolbarButtonProps>(
   ({ label, placement = "bottom", showLabel = false, ...props }, ref) => (
     <Tooltip content={label} disabled={showLabel} placement={placement}>
-      <Button {...props} aria-label={showLabel ? undefined : label} ref={ref} size="sm">
+      <Button {...props} aria-label={showLabel ? undefined : label} ref={ref}>
         {showLabel && label}
       </Button>
     </Tooltip>

--- a/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
@@ -263,7 +263,6 @@ export const TooltipDemo = () => (
               aria-label={action.label}
               brand="neutral"
               leftIconPath={action.iconPath}
-              size="sm"
             />
           </Tooltip>
         ))}
@@ -277,7 +276,6 @@ export const TooltipDemo = () => (
               aria-label={action.label}
               brand="neutral"
               leftIconPath={action.iconPath}
-              size="sm"
             />
           </Tooltip>
         ))}

--- a/src/renderer/src/views/AppLayout.tsx
+++ b/src/renderer/src/views/AppLayout.tsx
@@ -31,7 +31,6 @@ const LayoutSwitcher = () => {
       brand="primary"
       className="fixed right-4 bottom-4 z-toast"
       leftIconPath={useModernLayout ? mdiMonitor : mdiMonitorShimmer}
-      size="sm"
       title={useModernLayout ? "Switch to Classic" : "Switch to Modern"}
       onClick={() => dispatch(setUseModernLayout(!useModernLayout))}
     />

--- a/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationActions.tsx
@@ -30,7 +30,7 @@ export const NotificationActions: FC<React.PropsWithChildren<NotificationActions
           brand="neutral"
           appearance="moderate"
           key={action.title ?? action.icon}
-          size="xs"
+          size="sm"
           onClick={onActionClick(action.title)}
         >
           {t(action.title, { count: collapsed })}
@@ -38,7 +38,7 @@ export const NotificationActions: FC<React.PropsWithChildren<NotificationActions
       ))}
 
       {collapsed > 1 && onExpand && (
-        <Button brand="neutral" appearance="moderate" size="xs" onClick={onExpand}>
+        <Button brand="neutral" appearance="moderate" size="sm" onClick={onExpand}>
           {t("{{ count }} More", { count: collapsed - 1 })}
         </Button>
       )}

--- a/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
+++ b/src/renderer/src/views/components/Header/Notifications/NotificationControls.tsx
@@ -32,7 +32,7 @@ export const NotificationControls: FC<React.PropsWithChildren<NotificationContro
           brand="neutral"
           appearance="weak"
           leftIconPath={mdiEyeOff}
-          size="xs"
+          size="sm"
           title={t("Never show again")}
           onClick={onSuppress}
         />
@@ -43,7 +43,7 @@ export const NotificationControls: FC<React.PropsWithChildren<NotificationContro
           brand="neutral"
           appearance="weak"
           leftIconPath={mdiClose}
-          size="xs"
+          size="sm"
           title={collapsed > 1 ? t("Dismiss All") : t("Dismiss")}
           onClick={onDismiss}
         />

--- a/src/renderer/src/views/components/Header/PremiumIndicator.tsx
+++ b/src/renderer/src/views/components/Header/PremiumIndicator.tsx
@@ -39,7 +39,7 @@ export const PremiumIndicator: FC<React.PropsWithChildren<unknown>> = () => {
 
   if (showAd) {
     return (
-      <Button brand="premium" leftIconPath={mdiDiamondStone} size="sm" onClick={handleGoPremium}>
+      <Button brand="premium" leftIconPath={mdiDiamondStone} onClick={handleGoPremium}>
         {t("Go premium")}
       </Button>
     );

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -56,6 +56,7 @@ const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
           className="w-full transition-all"
           disabled={disabled}
           leftIconPath={mdiPlay}
+          size="lg"
           onClick={onClick}
         >
           {!isCollapsed && label}

--- a/src/renderer/src/views/pages/Tools/ToolRow.tsx
+++ b/src/renderer/src/views/pages/Tools/ToolRow.tsx
@@ -107,7 +107,6 @@ export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
                 appearance="weak"
                 disabled={isFirst}
                 leftIconPath={mdiArrowUp}
-                size="sm"
                 title={isFirst ? t("Already at the top") : t("Move up")}
                 onClick={() => onMoveUp?.(starter)}
               />
@@ -117,7 +116,6 @@ export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
                 appearance="weak"
                 disabled={isLast}
                 leftIconPath={mdiArrowDown}
-                size="sm"
                 title={isLast ? t("Already at the bottom") : t("Move down")}
                 onClick={() => onMoveDown?.(starter)}
               />
@@ -134,7 +132,6 @@ export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
               appearance="weak"
               disabled={!isPinned && pinDisabled}
               leftIconPath={isPinned ? mdiPinOff : mdiPin}
-              size="sm"
               title={
                 !isPinned && pinDisabled
                   ? pinDisabledReason
@@ -188,7 +185,6 @@ export const ToolRow: FC<React.PropsWithChildren<ToolRowProps>> = ({
           appearance="strong"
           disabled={!isValid}
           leftIconPath={mdiPlay}
-          size="sm"
           title={t("Launch tool")}
           onClick={() => onRun(starterInfo)}
         />

--- a/src/renderer/src/views/pages/Tools/index.tsx
+++ b/src/renderer/src/views/pages/Tools/index.tsx
@@ -169,7 +169,6 @@ export const ToolsPage: FC<React.PropsWithChildren<{ active?: boolean }>> = ({ a
                   appearance="moderate"
                   brand="neutral"
                   leftIconPath={mdiPlus}
-                  size="sm"
                   title={t("Add tool")}
                   onClick={addNewTool}
                 />

--- a/src/stylesheets/ui/elements/button.css
+++ b/src/stylesheets/ui/elements/button.css
@@ -9,14 +9,14 @@
         align-items: center;
         justify-content: center;
 
-        white-space: nowrap;
-        font-size: var(--text-body-lg);
-        letter-spacing: var(--text-body-lg--letter-spacing);
-        line-height: var(--text-body-lg--line-height);
+        min-width: 0;
+        min-height: calc(var(--spacing) * 7);
+        padding-inline: calc(var(--spacing) * 2);
 
-        min-width: calc(var(--spacing) * 24);
-        min-height: calc(var(--spacing) * 9);
-        padding-inline: calc(var(--spacing) * 3);
+        white-space: nowrap;
+        font-size: var(--text-body-sm);
+        letter-spacing: var(--text-body-sm--letter-spacing);
+        line-height: var(--text-body-sm--line-height);
 
         transition-property:
             color, background-color, border-color, outline-color, fill, stroke, opacity,
@@ -41,8 +41,8 @@
 
         & .nxm-button-icon {
             flex-shrink: 0;
-            width: calc(var(--spacing) * 5);
-            height: calc(var(--spacing) * 5);
+            width: calc(var(--spacing) * 4);
+            height: calc(var(--spacing) * 4);
 
             &:first-child {
                 margin-left: calc(var(--spacing) * -0.5);
@@ -55,7 +55,7 @@
 
         &.nxm-button-icon-only {
             min-width: 0;
-            width: calc(var(--spacing) * 9);
+            width: calc(var(--spacing) * 7);
         }
 
         &:not(.nxm-button-icon-only) .nxm-button-icon {
@@ -69,12 +69,6 @@
         }
     }
 
-    /*
-     * Appearance structure (brand-independent).
-     * The "strong" appearance is a solid brand fill (background set per brand
-     * below); the others sit on shared translucent surfaces and only differ by
-     * the brand text colour.
-     */
     .nxm-button-strong {
         color: var(--color-neutral-inverted);
     }
@@ -110,16 +104,10 @@
         }
     }
 
-    /* Outlines: only the "subdued" appearance carries a border. */
     .nxm-button-subdued {
         border: 1px solid var(--color-stroke-weak);
     }
 
-    /*
-     * Per-brand colours. Colour brands share one ramp (moderate -> strong on
-     * hover -> subdued on pressed), used as the fill for "strong" and as the
-     * text colour for the other appearances.
-     */
     .nxm-button-primary {
         &.nxm-button-strong {
             background-color: var(--color-primary-moderate);
@@ -223,11 +211,6 @@
     }
 
     .nxm-button-premium {
-        /*
-         * Premium's solid fill carries light text (not the inverted dark default),
-         * so its fill must darken on interaction rather than brighten — otherwise
-         * the light label washes out against the lighter "strong" violet.
-         */
         &.nxm-button-strong {
             color: var(--color-neutral-strong);
             background-color: var(--color-premium-moderate);
@@ -262,11 +245,6 @@
         }
     }
 
-    /*
-     * Neutral is the odd brand out: its solid fill darkens (strong -> weak)
-     * rather than brightening, "moderate" keeps a constant solid text colour,
-     * and "subdued"/"weak" use the translucent neutral text ramp.
-     */
     .nxm-button-neutral {
         &.nxm-button-strong {
             background-color: var(--color-neutral-strong);
@@ -301,52 +279,31 @@
         }
     }
 
-    .nxm-button-xs,
     .nxm-button-sm {
-        min-width: 0;
-        padding-inline: calc(var(--spacing) * 2);
-
-        font-size: var(--text-body-sm);
-        line-height: var(--text-body-sm--line-height);
-        letter-spacing: var(--text-body-sm--letter-spacing);
-
-        & .nxm-button-icon {
-            width: calc(var(--spacing) * 4);
-            height: calc(var(--spacing) * 4);
-
-            &:first-child {
-                margin-left: calc(var(--spacing) * -0.5);
-            }
-
-            &:last-child {
-                margin-right: calc(var(--spacing) * -0.5);
-            }
-        }
-
-        &:not(.nxm-button-icon-only) .nxm-button-icon {
-            &:first-child {
-                margin-right: calc(var(--spacing) * 1.5);
-            }
-
-            &:last-child {
-                margin-left: calc(var(--spacing) * 1.5);
-            }
-        }
-    }
-
-    .nxm-button-sm {
-        min-height: calc(var(--spacing) * 7);
-
-        &.nxm-button-icon-only {
-            width: calc(var(--spacing) * 7);
-        }
-    }
-
-    .nxm-button-xs {
         min-height: calc(var(--spacing) * 6);
 
         &.nxm-button-icon-only {
             width: calc(var(--spacing) * 6);
+        }
+    }
+
+    .nxm-button-lg {
+        min-width: calc(var(--spacing) * 24);
+        min-height: calc(var(--spacing) * 9);
+        padding-inline: calc(var(--spacing) * 3);
+
+        font-size: var(--text-body-lg);
+        line-height: var(--text-body-lg--line-height);
+        letter-spacing: var(--text-body-lg--letter-spacing);
+
+        & .nxm-button-icon {
+            width: calc(var(--spacing) * 5);
+            height: calc(var(--spacing) * 5);
+        }
+
+        &.nxm-button-icon-only {
+            min-width: 0;
+            width: calc(var(--spacing) * 9);
         }
     }
 }


### PR DESCRIPTION
`md` -> `lg`, `sm` -> `md`, `xs` -> `sm`. Nothing renders differently: every button keeps the box it had, and the two sizes either side of the new default measure 36px and 24px exactly as `md` and `xs` did.

The names were upside down. Of the call sites outside the demo page, 48 asked for `sm` and 9 for `xs`, while the default was used twice — both by omission rather than choice. So the most-used size was the small one and the least-used was the default. After the shift the common case is `md`, and it is also the default, so those 48 call sites stop spelling out a size at all.

The CSS is a restructure rather than a rename, because the base `.nxm-button` *was* the largest size: the block mixed structural rules with `md`'s metrics, and the small-text/small-icon treatment lived in a rule shared by `.nxm-button-xs` and `.nxm-button-sm`. The base now carries the new default, `.nxm-button-sm` restates only the metrics that differ, and `.nxm-button-lg` takes back what the base used to hold.

The two buttons that relied on the default are resolved deliberately:

- `CategoryListItem`'s expand/collapse chevron adopts the new default, dropping 36px -> 28px. It sits in a row of otherwise-`sm` siblings, so its size looked like an oversight rather than an intent.
- `ToolsSection`'s Play button takes an explicit `size="lg"` and is unchanged. It is meant to be the largest thing in the menu.

Sizes also reach `Button` as object props — `Picker`'s `button={{ size }}` — which a sweep over JSX attributes alone would miss.