### PR TITLE
add mod-list snapshot telemetry (LAZ-701)

### DIFF
--- a/packages/nexus-api-v3/package.json
+++ b/packages/nexus-api-v3/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "codegen": "pnpm exec openapi-typescript ./schema/openapi.yaml -o src/generated/nexus-api-v3.d.ts --immutable",
+    "codegen": "pnpm exec openapi-typescript ./schema/openapi.yaml -o src/generated/nexus-api-v3.d.ts --immutable && pnpm exec openapi-typescript ./schema/internal/telemetry.yaml -o src/generated/nexus-api-v3-internal.d.ts --immutable",
     "build": "pnpm exec tsdown",
     "test": "pnpm exec vitest run",
     "typecheck": "pnpm exec tsc",
@@ -42,10 +42,12 @@
         "cache": true,
         "inputs": [
           "default",
-          "{projectRoot}/schema/openapi.yaml"
+          "{projectRoot}/schema/openapi.yaml",
+          "{projectRoot}/schema/internal/telemetry.yaml"
         ],
         "outputs": [
-          "{projectRoot}/src/generated/nexus-api-v3.d.ts"
+          "{projectRoot}/src/generated/nexus-api-v3.d.ts",
+          "{projectRoot}/src/generated/nexus-api-v3-internal.d.ts"
         ]
       }
     }

--- a/packages/nexus-api-v3/schema/internal/telemetry.yaml
+++ b/packages/nexus-api-v3/schema/internal/telemetry.yaml
@@ -1,0 +1,157 @@
+# openapi/specs/telemetry/telemetry_openapi.yaml (path + components)
+# openapi/specs/shared/components.yaml (ProblemDetails, referenced by the error responses)
+
+openapi: 3.0.3
+info:
+  title: Telemetry — Vortex mod-list ingestion (internal)
+  version: 1.0.0
+
+paths:
+  /telemetry/mod-lists:
+    post:
+      tags:
+        - telemetry
+      summary: Submit a Vortex mod-list snapshot
+      description: |
+        Ingests a single mod-list snapshot from a Vortex client for one game.
+        The snapshot is accepted asynchronously: the request is validated, a domain event is
+        published, and the endpoint returns `202` immediately. A background subscriber batches
+        and writes the data to ClickHouse.
+      operationId: submitModLists
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModListSnapshot"
+      responses:
+        "202":
+          description: The snapshot was accepted for processing.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ModListSnapshotAck"
+        "413":
+          description: Payload Too Large - the snapshot exceeds the mod-count cap.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "422":
+          description: Unprocessable - the request body failed schema validation.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "503":
+          description: Service Unavailable - the snapshot could not be enqueued for processing.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+components:
+  schemas:
+    ModListSnapshot:
+      type: object
+      description: A single Vortex mod-list snapshot for one game.
+      required:
+        - instance_id
+        - game_id
+        - captured_at
+        - vortex_version
+        - mods
+      properties:
+        instance_id:
+          type: string
+          description: Anonymous Vortex install identifier. Retained to disambiguate installs and detect re-installs.
+          example: 9f2c1a7b-4e6d-8f03-1a2b-3c4d5e6f7a8b
+        game_id:
+          type: string
+          description: The game UID the snapshot is for.
+        captured_at:
+          type: string
+          format: date-time
+          description: When the snapshot was taken on the client.
+        vortex_version:
+          type: string
+          description: The Vortex client version that produced the snapshot.
+          example: 2.4.0
+        mods:
+          type: array
+          description: The mods in the loadout. Can run to a few thousand entries (see the 413 cap).
+          items:
+            $ref: "#/components/schemas/ModEntry"
+
+    ModEntry:
+      type: object
+      description: One mod in a loadout. `source` is the discriminator and is always present; `mod_id`/`file_id` are null for non-Nexus mods.
+      required:
+        - source
+        - enabled
+      properties:
+        source:
+          type: string
+          description: Where the mod came from, e.g. `nexus`, `unknown`, `curse`, `local`, `manual`. Free-form.
+          example: nexus
+        mod_id:
+          type: string
+          nullable: true
+          description: The Nexus mod UID, or null for non-Nexus mods.
+        file_id:
+          type: string
+          nullable: true
+          description: The Nexus file UID, or null for non-Nexus mods.
+        version:
+          type: string
+          nullable: true
+          description: The installed mod version, if known.
+          example: 3.0.1
+        enabled:
+          type: boolean
+          description: Whether the mod is enabled in the loadout.
+
+    ModListSnapshotAck:
+      type: object
+      description: Acknowledgement that a snapshot was accepted.
+      required:
+        - accepted
+      properties:
+        accepted:
+          type: integer
+          description: The number of mod entries accepted for processing.
+          example: 342
+
+    ProblemDetails:
+      type: object
+      description: An RFC 9457 Problem Details object.
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - instance
+      properties:
+        type:
+          type: string
+          format: uri
+          description: A URI reference that identifies the problem type.
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+        status:
+          type: integer
+          description: The HTTP status code.
+          example: 404
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem.
+        instance:
+          type: string
+          format: uri
+          description: A URI reference that identifies the specific occurrence of the problem.

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -2,6 +2,10 @@ import createClient, { type Middleware } from "openapi-fetch";
 
 import { V3ApiError } from "./errors";
 import type { components, paths } from "./generated/nexus-api-v3";
+import type {
+  components as internalComponents,
+  paths as internalPaths,
+} from "./generated/nexus-api-v3-internal";
 
 export interface NexusV3ClientOptions {
   baseUrl: string;
@@ -20,7 +24,8 @@ export interface NexusV3ClientOptions {
 
 export type NexusV3Client = ReturnType<typeof createNexusV3Client>;
 
-export function createNexusV3Client(options: NexusV3ClientOptions) {
+/** User-Agent plus bearer-else-apikey auth, shared by the public and internal clients. */
+function authHeaders(options: NexusV3ClientOptions): Record<string, string> {
   const headers: Record<string, string> = {};
 
   if (options.userAgent) {
@@ -33,9 +38,13 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
     headers["apikey"] = options.apiKey;
   }
 
+  return headers;
+}
+
+export function createNexusV3Client(options: NexusV3ClientOptions) {
   const client = createClient<paths>({
     baseUrl: options.baseUrl,
-    headers,
+    headers: authHeaders(options),
     signal: options.signal,
   });
 
@@ -171,6 +180,38 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
       });
       if (error) throw toV3Error(error, response);
       return Array.from(data.data.mods);
+    },
+  };
+}
+
+export type NexusV3InternalClient = ReturnType<typeof createNexusV3InternalClient>;
+
+/**
+ * Client for Internal (`x-badges: Internal`) v3 endpoints, typed against the vendored telemetry
+ * fragment. Same auth and transport as the public client; kept as a separate client so the
+ * internal paths stay off the public surface.
+ */
+export function createNexusV3InternalClient(options: NexusV3ClientOptions) {
+  const client = createClient<internalPaths>({
+    baseUrl: options.baseUrl,
+    headers: authHeaders(options),
+    signal: options.signal,
+  });
+
+  for (const mw of options.middleware ?? []) {
+    client.use(mw);
+  }
+
+  return {
+    ...client,
+
+    /** Submit a Vortex mod-list snapshot. Returns the accepted-count ack; throws on a non-2xx. */
+    async submitModLists(snapshot: internalComponents["schemas"]["ModListSnapshot"]) {
+      const { data, error, response } = await client.POST("/telemetry/mod-lists", {
+        body: snapshot,
+      });
+      if (error) throw toV3Error(error, response);
+      return data.data;
     },
   };
 }

--- a/packages/nexus-api-v3/src/index.ts
+++ b/packages/nexus-api-v3/src/index.ts
@@ -1,5 +1,18 @@
 export type { paths, components, operations } from "./generated/nexus-api-v3";
-export { createNexusV3Client, type NexusV3Client, type NexusV3ClientOptions } from "./client";
+// Internal (x-badges: Internal) endpoints, codegen'd from the vendored telemetry fragment. Aliased
+// so they don't collide with the public paths/components above.
+export type {
+  paths as internalPaths,
+  components as internalComponents,
+  operations as internalOperations,
+} from "./generated/nexus-api-v3-internal";
+export {
+  createNexusV3Client,
+  createNexusV3InternalClient,
+  type NexusV3Client,
+  type NexusV3ClientOptions,
+  type NexusV3InternalClient,
+} from "./client";
 export { V3ApiError } from "./errors";
 export { uploadHeadersFor, type UploadHeaders } from "./uploadHeaders";
 export type { Middleware as NexusV3Middleware } from "openapi-fetch";

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
@@ -41,15 +41,21 @@ describe("buildModListSnapshot", () => {
     const snapshot = buildModListSnapshot(mods, modState, meta);
 
     expect(snapshot).toMatchObject({
-      user_id: 123,
-      instance_id: "inst-1",
+      user: { id: "123" },
+      instance: { id: "inst-1" },
       captured_at: "2026-07-16T10:00:00.000Z",
       vortex_version: "2.4.0",
-      game_id: 1704,
+      game: { id: "1704" },
     });
     expect(snapshot.mods).toEqual([
-      { source: "nexus", mod_id: 111, file_id: 98765, version: "1.0", enabled: true },
-      { source: "generic", mod_id: null, file_id: null, version: "manual-2.3", enabled: false },
+      {
+        source: "nexus",
+        mod: { id: "111" },
+        file: { id: "98765" },
+        version: "1.0",
+        enabled: true,
+      },
+      { source: "generic", mod: null, file: null, version: "manual-2.3", enabled: false },
     ]);
   });
 
@@ -62,7 +68,7 @@ describe("buildModListSnapshot", () => {
     const snapshot = buildModListSnapshot(mods, {}, meta);
 
     expect(snapshot.mods).toHaveLength(1);
-    expect(snapshot.mods[0]?.mod_id).toBe(1);
+    expect(snapshot.mods[0]?.mod).toEqual({ id: "1" });
   });
 
   it('defaults a missing source to "unknown"', () => {
@@ -140,15 +146,19 @@ describe("emitModListSnapshot", () => {
 
     const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
 
-    expect(snapshot).toMatchObject({ user_id: 123, instance_id: "inst-1", game_id: 1704 });
+    expect(snapshot).toMatchObject({
+      user: { id: "123" },
+      instance: { id: "inst-1" },
+      game: { id: "1704" },
+    });
     expect(snapshot?.mods).toEqual([
-      { source: "nexus", mod_id: 111, file_id: 98765, version: "1.0", enabled: true },
+      { source: "nexus", mod: { id: "111" }, file: { id: "98765" }, version: "1.0", enabled: true },
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain("/v3/");
     const body = JSON.parse(init.body as string) as ModListSnapshot;
-    expect(body.user_id).toBe(123);
+    expect(body.user).toEqual({ id: "123" });
   });
 
   test("skips (no post) when analytics consent is off", async ({ makeApi }) => {

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeMod, makeProfile, makeProfileMod } from "../../../test-utils/builders";
+import { test } from "../../../test-utils/harnessTest";
+import type { IApiHarness } from "../../../test-utils/harnessTypes";
+import { numericNexusGameId } from "../mixpanel/numericGameId";
+import {
+  buildModListSnapshot,
+  emitModListSnapshot,
+  type ModListSnapshot,
+  type ModListSnapshotMeta,
+} from "./modListSnapshot";
+
+vi.mock("../mixpanel/numericGameId", () => ({ numericNexusGameId: vi.fn() }));
+
+const meta: ModListSnapshotMeta = {
+  userId: 123,
+  instanceId: "inst-1",
+  capturedAt: "2026-07-16T10:00:00.000Z",
+  vortexVersion: "2.4.0",
+  gameId: 1704,
+};
+
+describe("buildModListSnapshot", () => {
+  it("maps installed mods and reads enabled from the profile mod state", () => {
+    const mods = {
+      a: makeMod({
+        id: "a",
+        state: "installed",
+        attributes: { source: "nexus", modId: 111, fileId: 98765, version: "1.0" },
+      }),
+      // Non-Nexus mod: no numeric ids -> nulls, and absent from modState -> disabled.
+      b: makeMod({
+        id: "b",
+        state: "installed",
+        attributes: { source: "generic", version: "manual-2.3" },
+      }),
+    };
+    const modState = { a: makeProfileMod({ enabled: true }) };
+
+    const snapshot = buildModListSnapshot(mods, modState, meta);
+
+    expect(snapshot).toMatchObject({
+      user_id: 123,
+      instance_id: "inst-1",
+      captured_at: "2026-07-16T10:00:00.000Z",
+      vortex_version: "2.4.0",
+      game_id: 1704,
+    });
+    expect(snapshot.mods).toEqual([
+      { source: "nexus", mod_id: 111, file_id: 98765, version: "1.0", enabled: true },
+      { source: "generic", mod_id: null, file_id: null, version: "manual-2.3", enabled: false },
+    ]);
+  });
+
+  it("excludes mods that are not fully installed", () => {
+    const mods = {
+      a: makeMod({ id: "a", state: "installed", attributes: { source: "nexus", modId: 1 } }),
+      d: makeMod({ id: "d", state: "downloading", attributes: { source: "nexus", modId: 2 } }),
+    };
+
+    const snapshot = buildModListSnapshot(mods, {}, meta);
+
+    expect(snapshot.mods).toHaveLength(1);
+    expect(snapshot.mods[0]?.mod_id).toBe(1);
+  });
+
+  it('defaults a missing source to "unknown"', () => {
+    const mods = { a: makeMod({ id: "a", state: "installed", attributes: {} }) };
+
+    const snapshot = buildModListSnapshot(mods, {}, meta);
+
+    expect(snapshot.mods[0]?.source).toBe("unknown");
+  });
+});
+
+// Slices the api harness does not model (analytics consent, login, instance id, credentials),
+// seeded onto its live state through setState for the emit gating tests.
+interface SeedState {
+  settings: {
+    analytics: { enabled: boolean };
+    profiles: { lastActiveProfile: Record<string, string> };
+  };
+  persistent: { nexus: { userInfo?: { userId: number } } };
+  app: { instanceId: string };
+  confidential: { account: Record<string, unknown> };
+}
+
+function seed(
+  harness: IApiHarness,
+  { enabled = true, loggedIn = true }: { enabled?: boolean; loggedIn?: boolean } = {},
+): void {
+  harness.setState((draft) => {
+    const state = draft as unknown as SeedState;
+    state.settings.analytics = { enabled };
+    state.settings.profiles.lastActiveProfile = { skyrimse: "p1" };
+    state.persistent.nexus = loggedIn ? { userInfo: { userId: 123 } } : {};
+    state.app = { instanceId: "inst-1" };
+    state.confidential = { account: {} };
+  });
+}
+
+function seededHarness(makeApi: (overrides?: object) => IApiHarness): IApiHarness {
+  return makeApi({
+    mods: {
+      skyrimse: {
+        a: makeMod({
+          id: "a",
+          state: "installed",
+          attributes: { source: "nexus", modId: 111, fileId: 98765, version: "1.0" },
+        }),
+      },
+    },
+    profiles: {
+      p1: makeProfile({
+        id: "p1",
+        gameId: "skyrimse",
+        modState: { a: makeProfileMod({ enabled: true }) },
+      }),
+    },
+  });
+}
+
+describe("emitModListSnapshot", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset().mockResolvedValue({ ok: true, status: 200 });
+    vi.mocked(numericNexusGameId).mockReturnValue(1704);
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("builds and posts the snapshot when consented and logged in", async ({ makeApi }) => {
+    const harness = seededHarness(makeApi);
+    seed(harness);
+
+    const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
+
+    expect(snapshot).toMatchObject({ user_id: 123, instance_id: "inst-1", game_id: 1704 });
+    expect(snapshot?.mods).toEqual([
+      { source: "nexus", mod_id: 111, file_id: 98765, version: "1.0", enabled: true },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/v3/");
+    const body = JSON.parse(init.body as string) as ModListSnapshot;
+    expect(body.user_id).toBe(123);
+  });
+
+  test("skips (no post) when analytics consent is off", async ({ makeApi }) => {
+    const harness = seededHarness(makeApi);
+    seed(harness, { enabled: false });
+
+    const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
+
+    expect(snapshot).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("skips (no post) when the user is not logged in", async ({ makeApi }) => {
+    const harness = seededHarness(makeApi);
+    seed(harness, { loggedIn: false });
+
+    const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
+
+    expect(snapshot).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.test.ts
@@ -1,25 +1,31 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { makeMod, makeProfile, makeProfileMod } from "../../../test-utils/builders";
 import { test } from "../../../test-utils/harnessTest";
 import type { IApiHarness } from "../../../test-utils/harnessTypes";
+import { createVortexNexusV3InternalClient } from "../../nexus_integration/nexusV3Client";
+import { makeFileUID, makeModUID } from "../../nexus_integration/util/UIDs";
 import { numericNexusGameId } from "../mixpanel/numericGameId";
 import {
   buildModListSnapshot,
   emitModListSnapshot,
-  type ModListSnapshot,
   type ModListSnapshotMeta,
 } from "./modListSnapshot";
 
 vi.mock("../mixpanel/numericGameId", () => ({ numericNexusGameId: vi.fn() }));
+vi.mock("../../nexus_integration/nexusV3Client", () => ({
+  createVortexNexusV3InternalClient: vi.fn(),
+}));
 
 const meta: ModListSnapshotMeta = {
-  userId: 123,
   instanceId: "inst-1",
   capturedAt: "2026-07-16T10:00:00.000Z",
   vortexVersion: "2.4.0",
   gameId: 1704,
 };
+
+// The endpoint expects Nexus UIDs; assert against the real UID helpers rather than re-deriving.
+const NEXUS_A = { gameId: "1704", modId: "111", fileId: "98765" };
 
 describe("buildModListSnapshot", () => {
   it("maps installed mods and reads enabled from the profile mod state", () => {
@@ -41,21 +47,20 @@ describe("buildModListSnapshot", () => {
     const snapshot = buildModListSnapshot(mods, modState, meta);
 
     expect(snapshot).toMatchObject({
-      user: { id: "123" },
-      instance: { id: "inst-1" },
+      instance_id: "inst-1",
       captured_at: "2026-07-16T10:00:00.000Z",
       vortex_version: "2.4.0",
-      game: { id: "1704" },
+      game_id: "1704",
     });
     expect(snapshot.mods).toEqual([
       {
         source: "nexus",
-        mod: { id: "111" },
-        file: { id: "98765" },
+        mod_id: makeModUID(NEXUS_A),
+        file_id: makeFileUID(NEXUS_A),
         version: "1.0",
         enabled: true,
       },
-      { source: "generic", mod: null, file: null, version: "manual-2.3", enabled: false },
+      { source: "generic", mod_id: null, file_id: null, version: "manual-2.3", enabled: false },
     ]);
   });
 
@@ -68,7 +73,7 @@ describe("buildModListSnapshot", () => {
     const snapshot = buildModListSnapshot(mods, {}, meta);
 
     expect(snapshot.mods).toHaveLength(1);
-    expect(snapshot.mods[0]?.mod).toEqual({ id: "1" });
+    expect(snapshot.mods[0]?.mod_id).toBe(makeModUID({ gameId: "1704", modId: "1", fileId: "" }));
   });
 
   it('defaults a missing source to "unknown"', () => {
@@ -80,16 +85,16 @@ describe("buildModListSnapshot", () => {
   });
 });
 
-// Slices the api harness does not model (analytics consent, login, instance id, credentials),
-// seeded onto its live state through setState for the emit gating tests.
+// Slices the api harness does not model (analytics consent, login credentials, instance id),
+// seeded onto its live state through setState for the emit gating tests. `loggedIn` sets the
+// Nexus api key, which is what `isLoggedIn` (and the send's auth) reads.
 interface SeedState {
   settings: {
     analytics: { enabled: boolean };
     profiles: { lastActiveProfile: Record<string, string> };
   };
-  persistent: { nexus: { userInfo?: { userId: number } } };
   app: { instanceId: string };
-  confidential: { account: Record<string, unknown> };
+  confidential: { account: { nexus?: { APIKey?: string } } };
 }
 
 function seed(
@@ -100,9 +105,8 @@ function seed(
     const state = draft as unknown as SeedState;
     state.settings.analytics = { enabled };
     state.settings.profiles.lastActiveProfile = { skyrimse: "p1" };
-    state.persistent.nexus = loggedIn ? { userInfo: { userId: 123 } } : {};
     state.app = { instanceId: "inst-1" };
-    state.confidential = { account: {} };
+    state.confidential = { account: loggedIn ? { nexus: { APIKey: "test-api-key" } } : {} };
   });
 }
 
@@ -128,16 +132,14 @@ function seededHarness(makeApi: (overrides?: object) => IApiHarness): IApiHarnes
 }
 
 describe("emitModListSnapshot", () => {
-  const fetchMock = vi.fn();
+  const submitModLists = vi.fn();
 
   beforeEach(() => {
-    fetchMock.mockReset().mockResolvedValue({ ok: true, status: 200 });
+    submitModLists.mockReset().mockResolvedValue({ accepted: 1 });
+    vi.mocked(createVortexNexusV3InternalClient).mockReturnValue({
+      submitModLists,
+    } as unknown as ReturnType<typeof createVortexNexusV3InternalClient>);
     vi.mocked(numericNexusGameId).mockReturnValue(1704);
-    vi.stubGlobal("fetch", fetchMock);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
   });
 
   test("builds and posts the snapshot when consented and logged in", async ({ makeApi }) => {
@@ -146,19 +148,22 @@ describe("emitModListSnapshot", () => {
 
     const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
 
-    expect(snapshot).toMatchObject({
-      user: { id: "123" },
-      instance: { id: "inst-1" },
-      game: { id: "1704" },
-    });
+    expect(snapshot).toMatchObject({ instance_id: "inst-1", game_id: "1704" });
     expect(snapshot?.mods).toEqual([
-      { source: "nexus", mod: { id: "111" }, file: { id: "98765" }, version: "1.0", enabled: true },
+      {
+        source: "nexus",
+        mod_id: makeModUID(NEXUS_A),
+        file_id: makeFileUID(NEXUS_A),
+        version: "1.0",
+        enabled: true,
+      },
     ]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/v3/");
-    const body = JSON.parse(init.body as string) as ModListSnapshot;
-    expect(body.user).toEqual({ id: "123" });
+    expect(submitModLists).toHaveBeenCalledTimes(1);
+    const sent = submitModLists.mock.calls[0]?.[0];
+    // No user id in the body - the server derives it from the auth token.
+    expect(sent).not.toHaveProperty("user");
+    expect(sent).not.toHaveProperty("user_id");
+    expect(sent.game_id).toBe("1704");
   });
 
   test("skips (no post) when analytics consent is off", async ({ makeApi }) => {
@@ -168,7 +173,7 @@ describe("emitModListSnapshot", () => {
     const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
 
     expect(snapshot).toBeUndefined();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(submitModLists).not.toHaveBeenCalled();
   });
 
   test("skips (no post) when the user is not logged in", async ({ makeApi }) => {
@@ -178,6 +183,6 @@ describe("emitModListSnapshot", () => {
     const snapshot = await emitModListSnapshot(harness.api, "skyrimse");
 
     expect(snapshot).toBeUndefined();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(submitModLists).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
@@ -13,28 +13,37 @@ import type { IProfileMod } from "../../profile_management/types/IProfile";
 import { numericNexusGameId } from "../mixpanel/numericGameId";
 
 /**
+ * Reference to a related entity. Nexus REST API guidelines: relations are nested objects
+ * (`user: { id }`) not flat `_id` fields, and every id is typed String, never a number.
+ */
+export interface EntityRef {
+  id: string;
+}
+
+/**
  * One mod in a snapshot. All sources are supported: `source` is the mod's
- * `attributes.source` (nexus / site / generic / ...); `mod_id` and `file_id` are the numeric
- * Nexus ids and are null for mods that did not come from Nexus.
+ * `attributes.source` (nexus / site / generic / ...); `mod` and `file` carry the Nexus ids and
+ * are null for mods that did not come from Nexus.
  */
 export interface ModSnapshotEntry {
   source: string;
-  mod_id: number | null;
-  file_id: number | null;
+  mod: EntityRef | null;
+  file: EntityRef | null;
   version: string | null;
   enabled: boolean;
 }
 
 /**
  * The LAZ-701 mod-list payload for one game. Sent as-is (a single JSON) to the ingest endpoint;
- * the ClickHouse side flattens `mods[]` into one row per mod.
+ * the ClickHouse side flattens `mods[]` into one row per mod. Shape follows the Nexus REST API
+ * guidelines: related entities nested, all ids String.
  */
 export interface ModListSnapshot {
-  user_id: number;
-  instance_id: string;
+  user: EntityRef;
+  instance: EntityRef;
+  game: EntityRef;
   captured_at: string;
   vortex_version: string;
-  game_id: number;
   mods: ModSnapshotEntry[];
 }
 
@@ -51,6 +60,11 @@ export interface ModListSnapshotMeta {
 // already functional against it the moment it exists.
 const MOD_LIST_INGEST_URL = `${NEXUS_API_URL}/v3/telemetry/mod-lists`;
 
+/** Nest an id as an entity reference, stringifying it. Null when the id is absent. */
+function entityRef(id: number | string | undefined | null): EntityRef | null {
+  return id === undefined || id === null ? null : { id: String(id) };
+}
+
 /**
  * Build the mod-list snapshot from a game's installed mods and the active profile's mod state.
  * Pure: the caller resolves `meta` and passes the mods + mod state read from persistence.
@@ -66,19 +80,19 @@ export function buildModListSnapshot(
       const attributes = mod.attributes ?? {};
       return {
         source: attributes.source ?? "unknown",
-        mod_id: attributes.modId ?? null,
-        file_id: attributes.fileId ?? null,
+        mod: entityRef(attributes.modId),
+        file: entityRef(attributes.fileId),
         version: attributes.version ?? null,
         enabled: modState[mod.id]?.enabled ?? false,
       };
     });
 
   return {
-    user_id: meta.userId,
-    instance_id: meta.instanceId,
+    user: { id: String(meta.userId) },
+    instance: { id: meta.instanceId },
+    game: { id: String(meta.gameId) },
     captured_at: meta.capturedAt,
     vortex_version: meta.vortexVersion,
-    game_id: meta.gameId,
     mods: entries,
   };
 }

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
@@ -1,0 +1,165 @@
+import { getErrorMessageOrDefault } from "@vortex/shared";
+
+import { isTelemetryEnabled } from "../../../telemetry/selectors";
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { getApplication } from "../../../util/application";
+import { log } from "../../../util/log";
+import type { IMod } from "../../mod_management/types/IMod";
+import { NEXUS_API_URL } from "../../nexus_integration/constants";
+import { apiKey, userInfo } from "../../nexus_integration/selectors";
+import { getOAuthTokenFromState } from "../../nexus_integration/util";
+import { lastActiveProfileForGame, profileById } from "../../profile_management/selectors";
+import type { IProfileMod } from "../../profile_management/types/IProfile";
+import { numericNexusGameId } from "../mixpanel/numericGameId";
+
+/**
+ * One mod in a snapshot. All sources are supported: `source` is the mod's
+ * `attributes.source` (nexus / site / generic / ...); `mod_id` and `file_id` are the numeric
+ * Nexus ids and are null for mods that did not come from Nexus.
+ */
+export interface ModSnapshotEntry {
+  source: string;
+  mod_id: number | null;
+  file_id: number | null;
+  version: string | null;
+  enabled: boolean;
+}
+
+/**
+ * The LAZ-701 mod-list payload for one game. Sent as-is (a single JSON) to the ingest endpoint;
+ * the ClickHouse side flattens `mods[]` into one row per mod.
+ */
+export interface ModListSnapshot {
+  user_id: number;
+  instance_id: string;
+  captured_at: string;
+  vortex_version: string;
+  game_id: number;
+  mods: ModSnapshotEntry[];
+}
+
+/** Ambient values the caller resolves (identity, timestamp, numeric game id). */
+export interface ModListSnapshotMeta {
+  userId: number;
+  instanceId: string;
+  capturedAt: string;
+  vortexVersion: string;
+  gameId: number;
+}
+
+// v3 ingest endpoint. Provisional path (renamed once the backend finalises it); the client is
+// already functional against it the moment it exists.
+const MOD_LIST_INGEST_URL = `${NEXUS_API_URL}/v3/telemetry/mod-lists`;
+
+/**
+ * Build the mod-list snapshot from a game's installed mods and the active profile's mod state.
+ * Pure: the caller resolves `meta` and passes the mods + mod state read from persistence.
+ */
+export function buildModListSnapshot(
+  mods: Record<string, IMod>,
+  modState: Record<string, IProfileMod>,
+  meta: ModListSnapshotMeta,
+): ModListSnapshot {
+  const entries = Object.values(mods)
+    .filter((mod) => mod.state === "installed")
+    .map((mod): ModSnapshotEntry => {
+      const attributes = mod.attributes ?? {};
+      return {
+        source: attributes.source ?? "unknown",
+        mod_id: attributes.modId ?? null,
+        file_id: attributes.fileId ?? null,
+        version: attributes.version ?? null,
+        enabled: modState[mod.id]?.enabled ?? false,
+      };
+    });
+
+  return {
+    user_id: meta.userId,
+    instance_id: meta.instanceId,
+    captured_at: meta.capturedAt,
+    vortex_version: meta.vortexVersion,
+    game_id: meta.gameId,
+    mods: entries,
+  };
+}
+
+/**
+ * POST the snapshot to the v3 ingest endpoint, authenticated the same way as the generated v3
+ * client (OAuth bearer token, else api key). Throws on a non-2xx response.
+ */
+async function sendModListSnapshot(api: IExtensionApi, snapshot: ModListSnapshot): Promise<void> {
+  const state = api.getState();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": `Vortex/${getApplication().version}`,
+  };
+  const bearerToken = getOAuthTokenFromState(api);
+  const key = apiKey(state);
+  if (bearerToken !== undefined) {
+    headers["Authorization"] = `Bearer ${bearerToken}`;
+  } else if (key !== undefined) {
+    headers["apikey"] = key;
+  }
+
+  const response = await fetch(MOD_LIST_INGEST_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(snapshot),
+  });
+  if (response?.ok !== true) {
+    throw new Error(`mod-list ingest returned HTTP ${response?.status ?? "unknown"}`);
+  }
+}
+
+/**
+ * Build and send the mod-list snapshot for `internalGameId`, returning the snapshot that was
+ * sent (or undefined when skipped). A no-op unless the user has consented to analytics, is
+ * logged in, the game resolves to a numeric Nexus id, and an app instance id exists. Send errors
+ * are logged, never thrown.
+ */
+export async function emitModListSnapshot(
+  api: IExtensionApi,
+  internalGameId: string,
+): Promise<ModListSnapshot | undefined> {
+  const state = api.getState();
+  if (!isTelemetryEnabled(state)) {
+    return undefined;
+  }
+
+  const userId = userInfo(state)?.userId;
+  if (userId === undefined) {
+    return undefined;
+  }
+
+  const gameId = numericNexusGameId(internalGameId);
+  if (gameId === null) {
+    return undefined;
+  }
+
+  const instanceId = state.app.instanceId;
+  if (!instanceId) {
+    return undefined;
+  }
+
+  const profileId = lastActiveProfileForGame(state, internalGameId);
+  const modState = profileById(state, profileId)?.modState ?? {};
+  const mods = state.persistent.mods[internalGameId] ?? {};
+
+  const snapshot = buildModListSnapshot(mods, modState, {
+    userId,
+    instanceId,
+    capturedAt: new Date().toISOString(),
+    vortexVersion: getApplication().version,
+    gameId,
+  });
+
+  try {
+    await sendModListSnapshot(api, snapshot);
+  } catch (err) {
+    log("warn", "[modList] failed to send snapshot", {
+      error: getErrorMessageOrDefault(err),
+    });
+  }
+
+  return snapshot;
+}

--- a/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
+++ b/src/renderer/src/extensions/analytics/utils/modListSnapshot.ts
@@ -1,68 +1,56 @@
+import type { internalComponents } from "@vortex/nexus-api-v3";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 
 import { isTelemetryEnabled } from "../../../telemetry/selectors";
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import { getApplication } from "../../../util/application";
 import { log } from "../../../util/log";
-import type { IMod } from "../../mod_management/types/IMod";
-import { NEXUS_API_URL } from "../../nexus_integration/constants";
-import { apiKey, userInfo } from "../../nexus_integration/selectors";
-import { getOAuthTokenFromState } from "../../nexus_integration/util";
+import type { IMod, IModRepoId } from "../../mod_management/types/IMod";
+import { createVortexNexusV3InternalClient } from "../../nexus_integration/nexusV3Client";
+import { isLoggedIn } from "../../nexus_integration/selectors";
+import { makeFileUID, makeModUID } from "../../nexus_integration/util/UIDs";
 import { lastActiveProfileForGame, profileById } from "../../profile_management/selectors";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 import { numericNexusGameId } from "../mixpanel/numericGameId";
 
-/**
- * Reference to a related entity. Nexus REST API guidelines: relations are nested objects
- * (`user: { id }`) not flat `_id` fields, and every id is typed String, never a number.
- */
-export interface EntityRef {
-  id: string;
-}
+// The request-body types are the ones generated from the vendored telemetry OpenAPI fragment, so
+// the snapshot we build is checked against the endpoint's own schema (a backend shape change that
+// regenerates the client breaks this build). `user_id` is not part of the body - the server reads
+// it from the auth token.
+export type ModEntry = internalComponents["schemas"]["ModEntry"];
+export type ModListSnapshot = internalComponents["schemas"]["ModListSnapshot"];
 
-/**
- * One mod in a snapshot. All sources are supported: `source` is the mod's
- * `attributes.source` (nexus / site / generic / ...); `mod` and `file` carry the Nexus ids and
- * are null for mods that did not come from Nexus.
- */
-export interface ModSnapshotEntry {
-  source: string;
-  mod: EntityRef | null;
-  file: EntityRef | null;
-  version: string | null;
-  enabled: boolean;
-}
-
-/**
- * The LAZ-701 mod-list payload for one game. Sent as-is (a single JSON) to the ingest endpoint;
- * the ClickHouse side flattens `mods[]` into one row per mod. Shape follows the Nexus REST API
- * guidelines: related entities nested, all ids String.
- */
-export interface ModListSnapshot {
-  user: EntityRef;
-  instance: EntityRef;
-  game: EntityRef;
-  captured_at: string;
-  vortex_version: string;
-  mods: ModSnapshotEntry[];
-}
-
-/** Ambient values the caller resolves (identity, timestamp, numeric game id). */
+/** Ambient values the caller resolves (install id, timestamp, version, numeric game id). */
 export interface ModListSnapshotMeta {
-  userId: number;
   instanceId: string;
   capturedAt: string;
   vortexVersion: string;
   gameId: number;
 }
 
-// v3 ingest endpoint. Provisional path (renamed once the backend finalises it); the client is
-// already functional against it the moment it exists.
-const MOD_LIST_INGEST_URL = `${NEXUS_API_URL}/v3/telemetry/mod-lists`;
+function hasValue(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined;
+}
 
-/** Nest an id as an entity reference, stringifying it. Null when the id is absent. */
-function entityRef(id: number | string | undefined | null): EntityRef | null {
-  return id === undefined || id === null ? null : { id: String(id) };
+/**
+ * The Nexus mod/file UIDs ((gameId << 32) | id) for an installed mod, computed independently so a
+ * Nexus mod keeps its `mod_id` even when `file_id` is missing. Null for non-Nexus / id-less mods.
+ */
+function nexusUIDs(
+  gameId: number,
+  attributes: { modId?: number; fileId?: number },
+): { mod_id: string | null; file_id: string | null } {
+  const repo: IModRepoId = {
+    gameId: String(gameId),
+    modId: hasValue(attributes.modId) ? String(attributes.modId) : undefined,
+    fileId: hasValue(attributes.fileId) ? String(attributes.fileId) : "",
+  };
+  return {
+    mod_id: hasValue(attributes.modId) ? ((makeModUID(repo) as string | undefined) ?? null) : null,
+    file_id: hasValue(attributes.fileId)
+      ? ((makeFileUID(repo) as string | undefined) ?? null)
+      : null,
+  };
 }
 
 /**
@@ -76,53 +64,23 @@ export function buildModListSnapshot(
 ): ModListSnapshot {
   const entries = Object.values(mods)
     .filter((mod) => mod.state === "installed")
-    .map((mod): ModSnapshotEntry => {
+    .map((mod): ModEntry => {
       const attributes = mod.attributes ?? {};
       return {
         source: attributes.source ?? "unknown",
-        mod: entityRef(attributes.modId),
-        file: entityRef(attributes.fileId),
+        ...nexusUIDs(meta.gameId, attributes),
         version: attributes.version ?? null,
         enabled: modState[mod.id]?.enabled ?? false,
       };
     });
 
   return {
-    user: { id: String(meta.userId) },
-    instance: { id: meta.instanceId },
-    game: { id: String(meta.gameId) },
+    instance_id: meta.instanceId,
+    game_id: String(meta.gameId),
     captured_at: meta.capturedAt,
     vortex_version: meta.vortexVersion,
     mods: entries,
   };
-}
-
-/**
- * POST the snapshot to the v3 ingest endpoint, authenticated the same way as the generated v3
- * client (OAuth bearer token, else api key). Throws on a non-2xx response.
- */
-async function sendModListSnapshot(api: IExtensionApi, snapshot: ModListSnapshot): Promise<void> {
-  const state = api.getState();
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "User-Agent": `Vortex/${getApplication().version}`,
-  };
-  const bearerToken = getOAuthTokenFromState(api);
-  const key = apiKey(state);
-  if (bearerToken !== undefined) {
-    headers["Authorization"] = `Bearer ${bearerToken}`;
-  } else if (key !== undefined) {
-    headers["apikey"] = key;
-  }
-
-  const response = await fetch(MOD_LIST_INGEST_URL, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(snapshot),
-  });
-  if (response?.ok !== true) {
-    throw new Error(`mod-list ingest returned HTTP ${response?.status ?? "unknown"}`);
-  }
 }
 
 /**
@@ -140,8 +98,9 @@ export async function emitModListSnapshot(
     return undefined;
   }
 
-  const userId = userInfo(state)?.userId;
-  if (userId === undefined) {
+  // The server derives the user id from the auth token, so we gate on being logged in with
+  // credentials (bearer token or api key) rather than on a cached user id.
+  if (!isLoggedIn(state)) {
     return undefined;
   }
 
@@ -157,10 +116,9 @@ export async function emitModListSnapshot(
 
   const profileId = lastActiveProfileForGame(state, internalGameId);
   const modState = profileById(state, profileId)?.modState ?? {};
-  const mods = state.persistent.mods[internalGameId] ?? {};
+  const mods = state.persistent.mods?.[internalGameId] ?? {};
 
   const snapshot = buildModListSnapshot(mods, modState, {
-    userId,
     instanceId,
     capturedAt: new Date().toISOString(),
     vortexVersion: getApplication().version,
@@ -168,7 +126,7 @@ export async function emitModListSnapshot(
   });
 
   try {
-    await sendModListSnapshot(api, snapshot);
+    await createVortexNexusV3InternalClient(api).submitModLists(snapshot);
   } catch (err) {
     log("warn", "[modList] failed to send snapshot", {
       error: getErrorMessageOrDefault(err),

--- a/src/renderer/src/extensions/mod_management/index.ts
+++ b/src/renderer/src/extensions/mod_management/index.ts
@@ -56,6 +56,7 @@ import { batchDispatch, isChildPath, truthy, wrapExtCBAsync } from "../../util/u
 import { waitForCondition } from "../../util/waitForCondition";
 import { emitModsDeployed } from "../analytics/mixpanel/deployAnalytics";
 import { emitModStateChanged } from "../analytics/mixpanel/modChangeAnalytics";
+import { emitModListSnapshot } from "../analytics/utils/modListSnapshot";
 import { setDownloadModInfo } from "../download_management/actions/state";
 import { getGame } from "../gamemode_management/util/getGame";
 import { getModType } from "../gamemode_management/util/modTypeExtensions";
@@ -885,6 +886,7 @@ function genUpdateModDeployment(installManager: InstallManager) {
               manual,
               isCollectionPostprocess: deployOptions?.isCollectionPostprocessCall ?? false,
             });
+            void emitModListSnapshot(api, gameId);
           } catch (unknownErr) {
             const err = unknownToError(unknownErr);
             if (err instanceof UserCanceled) {

--- a/src/renderer/src/extensions/nexus_integration/nexusV3Client.ts
+++ b/src/renderer/src/extensions/nexus_integration/nexusV3Client.ts
@@ -1,7 +1,9 @@
 import {
   createNexusV3Client,
+  createNexusV3InternalClient,
   type NexusV3Client,
   type NexusV3ClientOptions,
+  type NexusV3InternalClient,
 } from "@vortex/nexus-api-v3";
 
 import type { IExtensionApi } from "../../types/IExtensionContext";
@@ -14,6 +16,25 @@ export type VortexNexusV3ClientOptions = Omit<NexusV3ClientOptions, "baseUrl" | 
 
 const NEXUS_V3_API_URL = `${NEXUS_API_URL}/v3`;
 
+/** Resolve Vortex's credentials, base URL and user agent into client options. */
+function vortexV3Options(
+  api: IExtensionApi,
+  options: VortexNexusV3ClientOptions,
+): NexusV3ClientOptions {
+  const { confidential } = api.getState();
+  const apiKey = hasConfidentialWithNexus(confidential)
+    ? confidential.account.nexus?.APIKey
+    : undefined;
+
+  return {
+    bearerToken: getOAuthTokenFromState(api),
+    apiKey,
+    ...options,
+    baseUrl: NEXUS_V3_API_URL,
+    userAgent: `Vortex/${getApplication().version}`,
+  };
+}
+
 /**
  * Creates a Nexus v3 API client pre-configured for Vortex.
  * Credentials can still be overridden via `options`.
@@ -22,16 +43,13 @@ export function createVortexNexusV3Client(
   api: IExtensionApi,
   options: VortexNexusV3ClientOptions = {},
 ): NexusV3Client {
-  const { confidential } = api.getState();
-  const apiKey = hasConfidentialWithNexus(confidential)
-    ? confidential.account.nexus?.APIKey
-    : undefined;
+  return createNexusV3Client(vortexV3Options(api, options));
+}
 
-  return createNexusV3Client({
-    bearerToken: getOAuthTokenFromState(api),
-    apiKey,
-    ...options,
-    baseUrl: NEXUS_V3_API_URL,
-    userAgent: `Vortex/${getApplication().version}`,
-  });
+/** As `createVortexNexusV3Client`, for the Internal v3 endpoints (telemetry ingest). */
+export function createVortexNexusV3InternalClient(
+  api: IExtensionApi,
+  options: VortexNexusV3ClientOptions = {},
+): NexusV3InternalClient {
+  return createNexusV3InternalClient(vortexV3Options(api, options));
 }

--- a/src/renderer/src/util/StarterInfo.ts
+++ b/src/renderer/src/util/StarterInfo.ts
@@ -6,6 +6,7 @@ import PromiseBB from "bluebird";
 
 import { setToolRunning, setToolStopped } from "../actions";
 import { ApplicationData } from "../applicationData";
+import { emitModListSnapshot } from "../extensions/analytics/utils/modListSnapshot";
 import type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { IToolStored } from "../extensions/gamemode_management/types/IToolStored";
@@ -161,6 +162,9 @@ class StarterInfo implements IStarterInfo {
     const onSpawned = () => {
       api.store.dispatch(setToolRunning(info.exePath, Date.now(), info.exclusive));
       emitGameLaunched(api, info);
+      if (info.isGame) {
+        void emitModListSnapshot(api, info.gameId);
+      }
 
       // Flatpak can't reliably observe host game exit for now, so emulate stop after a short delay
       // for now. We'll come up with a better solution/design in the future.


### PR DESCRIPTION
Emit a per-game mod-list snapshot to the internal v3 telemetry ingest endpoint (POST /v3/telemetry/mod-lists) on game launch and on deploy, gated on analytics consent and being logged in.

The snapshot is a flat payload: instance_id, game_id, captured_at, vortex_version, and one entry per installed mod (source, mod_id, file_id, version, enabled). mod_id/file_id are Nexus UIDs, null for non-Nexus mods. The server reads the account id from the auth token, so no user_id is sent.

Request types are generated from a vendored internal OpenAPI fragment (nexus-api-v3/schema/internal/telemetry.yaml) via a second codegen output, so the payload is checked against the endpoint schema at build time. A typed internal v3 client (createNexusV3InternalClient / submitModLists) carries the request and shares auth and transport with the public client.

closes LAZ-701