### PR TITLE
Keep a game's info box on screen in a small window (LAZ-932)

### DIFF
--- a/src/renderer/src/extensions/gamemode_management/components/GamesGrid.tsx
+++ b/src/renderer/src/extensions/gamemode_management/components/GamesGrid.tsx
@@ -14,8 +14,6 @@ interface IGamesGridProps {
   type: string;
   gameMode: string;
   discoveredGames: { [id: string]: IDiscoveryResult };
-  container: HTMLElement | null;
-  getBounds: () => ClientRect;
   onRefreshGameInfo: (gameId: string) => PromiseBB<void>;
 }
 
@@ -25,8 +23,6 @@ export const GamesGrid = ({
   type,
   gameMode,
   discoveredGames,
-  container,
-  getBounds,
   onRefreshGameInfo,
 }: IGamesGridProps) => {
   const isDiscovered = (gameId: string) =>
@@ -38,10 +34,8 @@ export const GamesGrid = ({
         <GameThumbnail
           active={game.id === gameMode}
           className="w-full!"
-          container={container}
           discovered={isDiscovered(game.id)}
           game={game}
-          getBounds={getBounds}
           imageClassName="rounded-md"
           key={game.id + "_" + (game.contributed ?? "official")}
           t={t}

--- a/src/renderer/src/extensions/gamemode_management/components/GamesList.tsx
+++ b/src/renderer/src/extensions/gamemode_management/components/GamesList.tsx
@@ -13,8 +13,6 @@ interface IGamesListProps {
   type: string;
   gameMode: string;
   discoveredGames: { [id: string]: IDiscoveryResult };
-  container: HTMLElement | null;
-  getBounds: () => ClientRect;
   onRefreshGameInfo: (gameId: string) => PromiseBB<void>;
   onBrowseGameLocation: (gameId: string) => PromiseBB<void>;
 }
@@ -25,8 +23,6 @@ export const GamesList = ({
   type,
   gameMode,
   discoveredGames,
-  container,
-  getBounds,
   onRefreshGameInfo,
   onBrowseGameLocation,
 }: IGamesListProps) => (
@@ -34,10 +30,8 @@ export const GamesList = ({
     {games.map((game) => (
       <GameRow
         active={game.id === gameMode}
-        container={container}
         discovery={discoveredGames[game.id]}
         game={game}
-        getBounds={getBounds}
         key={game.id}
         t={t}
         type={type}

--- a/src/renderer/src/extensions/gamemode_management/views/GameInfoPopover.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameInfoPopover.tsx
@@ -14,7 +14,11 @@ export interface IBaseProps {
   t: TFunction;
   game: IGameStored;
   onRefreshGameInfo: (gameId: string) => PromiseBB<void>;
-  onChange: () => void;
+  /**
+   * Only for a host that has to reposition itself when the info arrives. The
+   * design-system popover follows its own content, so it doesn't pass one.
+   */
+  onChange?: () => void;
 }
 
 interface IConnectedProps {
@@ -63,7 +67,7 @@ class GameInfoPopover extends ComponentEx<IProps, { loading: boolean }> {
     }
 
     if (this.props.gameInfo !== nextProps.gameInfo) {
-      nextProps.onChange();
+      nextProps.onChange?.();
     }
   }
 

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -106,7 +106,6 @@ const GamePicker = ({
   const [currentFilterValue, setCurrentFilterValue] = useState("");
   const [unmanagedPage, setUnmanagedPage] = useState(1);
 
-  const [rootEl, setRootEl] = useState<HTMLElement | null>(null);
   const nameLookupRef = useRef<{ [name: string]: string }>({});
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const unmanagedSectionRef = useRef<HTMLDivElement>(null);
@@ -132,8 +131,6 @@ const GamePicker = ({
       ),
     [],
   );
-
-  const getBounds = useCallback(() => rootEl.getBoundingClientRect(), [rootEl]);
 
   const getTabGameNumber = (unfiltered: IGameStored[], filtered: IGameStored[]): string =>
     currentFilterValue ? `${filtered.length}/${unfiltered.length}` : `${unfiltered.length}`;
@@ -280,7 +277,7 @@ const GamePicker = ({
   );
 
   return (
-    <Page active={active} domRef={(el) => setRootEl(el)} pageId={pageId} scrollable={false}>
+    <Page active={active} pageId={pageId} scrollable={false}>
       <PageHeader
         pictogramName="game"
         subtitle={t("Manage games to get started.")}
@@ -352,11 +349,9 @@ const GamePicker = ({
           >
             {pickerLayout === "list" ? (
               <GamesList
-                container={rootEl}
                 discoveredGames={discoveredGames}
                 gameMode={gameMode}
                 games={filteredManaged}
-                getBounds={getBounds}
                 t={t}
                 type="managed"
                 onBrowseGameLocation={onBrowseGameLocation}
@@ -364,11 +359,9 @@ const GamePicker = ({
               />
             ) : (
               <GamesGrid
-                container={rootEl}
                 discoveredGames={discoveredGames}
                 gameMode={gameMode}
                 games={filteredManaged}
-                getBounds={getBounds}
                 t={t}
                 type="managed"
                 onRefreshGameInfo={onRefreshGameInfo}
@@ -411,11 +404,9 @@ const GamePicker = ({
             >
               {pickerLayout === "list" ? (
                 <GamesList
-                  container={rootEl}
                   discoveredGames={discoveredGames}
                   gameMode={gameMode}
                   games={pagedUnmanaged}
-                  getBounds={getBounds}
                   t={t}
                   type="unmanaged"
                   onBrowseGameLocation={onBrowseGameLocation}
@@ -423,11 +414,9 @@ const GamePicker = ({
                 />
               ) : (
                 <GamesGrid
-                  container={rootEl}
                   discoveredGames={discoveredGames}
                   gameMode={gameMode}
                   games={pagedUnmanaged}
-                  getBounds={getBounds}
                   t={t}
                   type="unmanaged"
                   onRefreshGameInfo={onRefreshGameInfo}

--- a/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameRow.tsx
@@ -4,15 +4,18 @@ import { pathToFileURL } from "url";
 import type PromiseBB from "bluebird";
 import type { TFunction } from "i18next";
 import * as React from "react";
-import { ListGroupItem, Media, Popover } from "react-bootstrap";
+import { ListGroupItem, Media } from "react-bootstrap";
 import { Provider } from "react-redux";
 
+import Icon from "@/controls/Icon";
 import { Image } from "@/ui/components/image/Image";
+import { Popover } from "@/ui/components/popover/Popover";
+import { PopoverButton } from "@/ui/components/popover/PopoverButton";
+import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 
 import { ComponentEx } from "../../../controls/ComponentEx";
 import IconBar from "../../../controls/IconBar";
-import OverlayTrigger from "../../../controls/OverlayTrigger";
-import { IconButton } from "../../../controls/TooltipControls";
 import { gameTileImageURL } from "../../../extensions/nexus_integration/util/gameTileImageURL";
 import type { IActionDefinition } from "../../../types/IActionDefinition";
 import opn from "../../../util/opn";
@@ -28,8 +31,6 @@ export interface IProps {
   mods?: { [modId: string]: IMod };
   active: boolean;
   type: string;
-  getBounds: () => ClientRect;
-  container: HTMLElement;
   onRefreshGameInfo: (gameId: string) => PromiseBB<void>;
   onBrowseGameLocation: (gameId: string) => PromiseBB<void>;
 }
@@ -40,11 +41,8 @@ export interface IProps {
  * @class GameThumbnail
  */
 class GameRow extends ComponentEx<IProps, {}> {
-  private mRef = null;
-
   public render(): JSX.Element {
-    const { t, active, container, discovery, game, getBounds, onRefreshGameInfo, type } =
-      this.props;
+    const { t, active, discovery, game, onRefreshGameInfo, type } = this.props;
 
     if (game === undefined) {
       return null;
@@ -72,32 +70,6 @@ class GameRow extends ComponentEx<IProps, {}> {
     if (discovery === undefined) {
       classes.push("game-list-undiscovered");
     }
-
-    const gameInfoPopover = (
-      <Popover className="popover-game-info" id={`popover-info-${game.id}`}>
-        <Provider store={this.context.api.store}>
-          <IconBar
-            buttonType="text"
-            className="buttons"
-            collapse={false}
-            filter={this.lowPriorityButtons}
-            group={`game-${type}-buttons`}
-            id={`game-thumbnail-${game.id}`}
-            instanceId={game.id}
-            orientation="vertical"
-            staticElements={[]}
-            t={t}
-          />
-
-          <GameInfoPopover
-            game={game}
-            t={t}
-            onChange={this.redraw}
-            onRefreshGameInfo={onRefreshGameInfo}
-          />
-        </Provider>
-      </Popover>
-    );
 
     let imgurl = null;
     if (logoPath != null) {
@@ -139,23 +111,44 @@ class GameRow extends ComponentEx<IProps, {}> {
           </Media.Body>
 
           <Media.Right>
-            <OverlayTrigger
-              container={container}
-              getBounds={getBounds}
-              orientation="horizontal"
-              overlay={gameInfoPopover}
-              rootClose={true}
-              shouldUpdatePosition={true}
-              trigger="click"
-              triggerRef={this.setRef}
-            >
-              <IconButton
-                className="btn-embed"
-                icon="game-menu"
-                id={`btn-info-${game.id}`}
-                tooltip={t("Show Details")}
-              />
-            </OverlayTrigger>
+            {/* `contents` so the wrapper the popover needs doesn't split the row. */}
+            <Popover className="contents">
+              {({ open }) => (
+                <>
+                  <Tooltip content={t("Show Details")} disabled={open} placement="bottom">
+                    <PopoverButton
+                      appearance="weak"
+                      aria-label={t("Show Details")}
+                      brand="neutral"
+                      className="btn-embed"
+                      id={`btn-info-${game.id}`}
+                      leftIcon={<Icon name="game-menu" />}
+                    />
+                  </Tooltip>
+
+                  <PopoverPanel anchor={{ gap: 8, to: "bottom end" }} className="popover-game-info">
+                    <div className="popover-content">
+                      <Provider store={this.context.api.store}>
+                        <IconBar
+                          buttonType="text"
+                          className="buttons"
+                          collapse={false}
+                          filter={this.lowPriorityButtons}
+                          group={`game-${type}-buttons`}
+                          id={`game-thumbnail-${game.id}`}
+                          instanceId={game.id}
+                          orientation="vertical"
+                          staticElements={[]}
+                          t={t}
+                        />
+
+                        <GameInfoPopover game={game} t={t} onRefreshGameInfo={onRefreshGameInfo} />
+                      </Provider>
+                    </div>
+                  </PopoverPanel>
+                </>
+              )}
+            </Popover>
 
             <IconBar
               buttonType="icon"
@@ -174,21 +167,6 @@ class GameRow extends ComponentEx<IProps, {}> {
       </ListGroupItem>
     );
   }
-
-  private setRef = (ref) => {
-    this.mRef = ref;
-  };
-
-  private redraw = () => {
-    if (this.mRef !== null) {
-      this.mRef.hide();
-      setTimeout(() => {
-        if (this.mRef !== null) {
-          this.mRef.show();
-        }
-      }, 100);
-    }
-  };
 
   private openLocation = () => {
     const { discovery } = this.props;

--- a/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GameThumbnail.tsx
@@ -4,18 +4,20 @@ import * as url from "url";
 import type PromiseBB from "bluebird";
 import type { TFunction } from "i18next";
 import * as React from "react";
-import { Button, Panel, Popover } from "react-bootstrap";
+import { Button, Panel } from "react-bootstrap";
 import { Provider } from "react-redux";
 
 import { connect, PureComponentEx } from "@/controls/ComponentEx";
 import Icon from "@/controls/Icon";
 import IconBar from "@/controls/IconBar";
-import OverlayTrigger from "@/controls/OverlayTrigger";
-import { IconButton } from "@/controls/TooltipControls";
 import { gameTileImageURL } from "@/extensions/nexus_integration/util/gameTileImageURL";
 import type { IActionDefinition } from "@/types/api";
 import type { IMod, IProfile, IState } from "@/types/IState";
 import { Image } from "@/ui/components/image/Image";
+import { Popover } from "@/ui/components/popover/Popover";
+import { PopoverButton } from "@/ui/components/popover/PopoverButton";
+import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import { getSafe } from "@/util/storeHelper";
 import { countIf } from "@/util/util";
@@ -32,8 +34,6 @@ export interface IBaseProps {
   discovered?: boolean;
   onRefreshGameInfo?: (gameId: string) => PromiseBB<void>;
   type: string;
-  getBounds?: () => ClientRect;
-  container?: HTMLElement;
   onLaunch?: () => void;
   // artwork-only tile for tight spots like the Recently Managed dashlet:
   // hides the name (exposed as a tooltip on the tile instead) and reduces
@@ -58,8 +58,6 @@ type IProps = IBaseProps & IConnectedProps;
  * @class GameThumbnail
  */
 class GameThumbnail extends PureComponentEx<IProps, {}> {
-  private mRef = null;
-
   public render(): JSX.Element {
     const { t, active, className, compact, discovered, game, imageClassName, mods, profile, type } =
       this.props;
@@ -168,32 +166,7 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
   }
 
   private renderMenu(): JSX.Element[] {
-    const { t, container, game, getBounds, onRefreshGameInfo, type } = this.props;
-    const gameInfoPopover = (
-      <Popover className="popover-game-info" id={`popover-info-${game.id}`}>
-        <Provider store={this.context.api.store}>
-          <IconBar
-            buttonType="text"
-            className="buttons"
-            collapse={false}
-            filter={this.lowPriorityButtons}
-            group={`game-${type}-buttons`}
-            id={`game-thumbnail-${game.id}`}
-            instanceId={game.id}
-            orientation="vertical"
-            staticElements={[]}
-            t={t}
-          />
-
-          <GameInfoPopover
-            game={game}
-            t={t}
-            onChange={this.redraw}
-            onRefreshGameInfo={onRefreshGameInfo}
-          />
-        </Provider>
-      </Popover>
-    );
+    const { t, game, onRefreshGameInfo, type } = this.props;
 
     return [
       <div className="hover-content" key="primary-buttons">
@@ -211,51 +184,51 @@ class GameThumbnail extends PureComponentEx<IProps, {}> {
           t={t}
         />
       </div>,
-      <OverlayTrigger
-        container={container}
-        getBounds={getBounds || this.getWindowBounds}
-        key="info-overlay"
-        orientation="horizontal"
-        overlay={gameInfoPopover}
-        rootClose={true}
-        shouldUpdatePosition={true}
-        trigger="click"
-        triggerRef={this.setRef}
-      >
-        <IconButton
-          className="game-thumbnail-info btn-embed"
-          icon="game-menu"
-          id={`btn-info-${game.id}`}
-          tooltip={t("Show Details")}
-        />
-      </OverlayTrigger>,
+      // `contents` so the wrapper the popover needs doesn't take part in the tile's
+      // layout, which positions the button itself.
+      <Popover className="contents" key="info-overlay">
+        {({ open }) => (
+          <>
+            <Tooltip content={t("Show Details")} disabled={open} placement="bottom">
+              <PopoverButton
+                appearance="weak"
+                aria-label={t("Show Details")}
+                brand="neutral"
+                className="game-thumbnail-info"
+                id={`btn-info-${game.id}`}
+                leftIcon={<Icon name="game-menu" />}
+              />
+            </Tooltip>
+
+            <PopoverPanel anchor={{ gap: 8, to: "bottom end" }} className="popover-game-info">
+              <div className="popover-content">
+                <Provider store={this.context.api.store}>
+                  <IconBar
+                    buttonType="text"
+                    className="buttons"
+                    collapse={false}
+                    filter={this.lowPriorityButtons}
+                    group={`game-${type}-buttons`}
+                    id={`game-thumbnail-${game.id}`}
+                    instanceId={game.id}
+                    orientation="vertical"
+                    staticElements={[]}
+                    t={t}
+                  />
+
+                  <GameInfoPopover game={game} t={t} onRefreshGameInfo={onRefreshGameInfo} />
+                </Provider>
+              </div>
+            </PopoverPanel>
+          </>
+        )}
+      </Popover>,
     ];
   }
 
   private priorityButtons = (action: IActionDefinition) => action.position < 100;
 
   private lowPriorityButtons = (action: IActionDefinition) => action.position >= 100;
-
-  private getWindowBounds = (): DOMRect => {
-    return {
-      top: 0,
-      left: 0,
-      height: window.innerHeight,
-      width: window.innerWidth,
-      bottom: window.innerHeight,
-      right: window.innerWidth,
-    } as any;
-  };
-
-  private setRef = (ref) => {
-    this.mRef = ref;
-  };
-
-  private redraw = () => {
-    if (this.mRef !== null) {
-      this.mRef.forceUpdate();
-    }
-  };
 }
 
 const emptyObj = {};


### PR DESCRIPTION
The box could open beyond the left edge of the games page and be cut off there, reading as though it had gone behind the side panel.

Two things put it there, and neither was a z-index. It was portalled into the page rather than the body, and the page is `overflow: hidden`, so anything reaching past its edge was clipped away. Meanwhile the old overlay picked a side by comparing the tile against the midpoint of that page and then, for a left or right placement, never clamped horizontally — react-overlays only does that for top and bottom. An 800px box hung off a tile just right of centre therefore started at a negative offset, which the clip then hid. Narrowing the window took its width out of the page alone, since the spine and side panel don't shrink, so it took a small window to expose.

Hosting it on the design-system popover answers both: Floating UI portals out of any clipping ancestor and shifts the panel back into view rather than letting it overhang. The reset that follows is that the page no longer has to hand its own element and bounds down through the grid and list to be measured, and the two components no longer nudge the overlay to reposition when the game info arrives — `GameInfoPopover`'s `onChange` exists only for a host that needs that, so it is now optional.

`controls/OverlayTrigger` stays: it is exported from the extension API, so it is not ours to remove even with no callers left in tree.