### PR TITLE
adopt untracked on-disk archives in start-download (LAZ-943)

### DIFF
--- a/src/renderer/src/IPCDownloadAdapter.existingFile.test.ts
+++ b/src/renderer/src/IPCDownloadAdapter.existingFile.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { AlreadyDownloaded } from "@vortex/shared/errors";
+import { afterEach, describe, expect } from "vitest";
+
+import { addLocalDownload } from "./extensions/download_management/actions/state";
+import { test } from "./test-utils/downloadAdapterTest";
+import type { IDownloadAdapterHarness } from "./test-utils/harnessTypes";
+
+// These tests exercise the "file already on disk" probe in #handleStartDownload, so the
+// caller-named file is written to the real download folder (test-setup roots getVortexPath in
+// the OS temp dir). File names are unique to this suite because that folder is shared across
+// suites.
+const TRACKED = "gh23885-tracked.7z";
+const ORPHAN = "gh23885-orphan.7z";
+const FILE_BYTES = "archive bytes";
+
+const onDisk: string[] = [];
+
+const putOnDisk = async (filePath: string) => {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, FILE_BYTES);
+  onDisk.push(filePath);
+};
+
+afterEach(async () => {
+  await Promise.all(onDisk.splice(0).map((filePath) => rm(filePath, { force: true })));
+});
+
+// the collection dependency downloader's emit shape: a caller-supplied fileName and
+// redownload "never", awaiting the callback
+const startDownload = (h: IDownloadAdapterHarness, fileName: string) =>
+  new Promise<{ err: Error | null; id?: string }>((resolve) => {
+    h.events.emit(
+      "start-download",
+      [`https://cdn.example/${fileName}`],
+      { game: "skyrimse" },
+      fileName,
+      (err: Error | null, id?: string) => resolve({ err, id }),
+      "never",
+      { allowInstall: false },
+    );
+  });
+
+describe("start-download for a file already on disk (GH #23885)", () => {
+  test("resolves AlreadyDownloaded with the id of the record tracking the file", async ({
+    makeDownloadAdapter,
+  }) => {
+    const h = makeDownloadAdapter({ download: { localPath: TRACKED } });
+    await putOnDisk(h.dest);
+
+    const result = await startDownload(h, TRACKED);
+
+    expect(result.err).toBeInstanceOf(AlreadyDownloaded);
+    expect((result.err as AlreadyDownloaded).downloadId).toBe(h.downloadId);
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  test("adopts an on-disk file that no record tracks as a local download", async ({
+    makeDownloadAdapter,
+  }) => {
+    const h = makeDownloadAdapter();
+    // on disk, but no download record has this localPath - the state a manual browser download
+    // or a file left behind by an earlier session produces
+    await putOnDisk(path.join(path.dirname(h.dest), ORPHAN));
+
+    const result = await startDownload(h, ORPHAN);
+
+    expect(result.err).toBeInstanceOf(AlreadyDownloaded);
+    const adoptedId = (result.err as AlreadyDownloaded).downloadId;
+    // registered like the download-folder scan registers unknown archives
+    expect(h.dispatched).toContainEqual(
+      addLocalDownload(adoptedId!, "skyrimse", ORPHAN, FILE_BYTES.length),
+    );
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/IPCDownloadAdapter.ts
+++ b/src/renderer/src/IPCDownloadAdapter.ts
@@ -24,12 +24,14 @@ import {
 } from "./extensions/analytics/mixpanel/MixpanelEvents";
 import { makeModAnalyticsIdentity } from "./extensions/analytics/mixpanel/modAnalyticsIdentity";
 import {
+  addLocalDownload,
   downloadProgress,
   finishDownload,
   initDownload,
   pauseDownload,
   removeDownload,
   removeDownloadSilent,
+  setCompatibleGames,
   setDownloadFilePath,
   setDownloadHash,
   setDownloadInterrupted,
@@ -186,6 +188,9 @@ export class IPCDownloadAdapter {
       this.#handleStartDownload(urls, modInfo, fileName, callback, redownload, options).catch(
         (err) => {
           log("error", "failed to start download", err);
+          // callers await the callback (collection installs block on it per dependency), so
+          // failures settle it too
+          callback?.(unknownToError(err));
         },
       );
     });
@@ -533,6 +538,7 @@ export class IPCDownloadAdapter {
         () => false,
       );
       if (fileExists && redownload !== "replace") {
+        let useExisting = true;
         if (redownload === "ask") {
           const result = await this.#api.showDialog?.(
             "question",
@@ -540,24 +546,34 @@ export class IPCDownloadAdapter {
             { text: `"${fileName}" is already on disk. Download again?` },
             [{ label: "Use existing" }, { label: "Re-download" }],
           );
-
-          if (result?.action !== "Re-download") {
-            const downloads = state.persistent.downloads.files;
-            const [existingId, _] = Object.entries(downloads).find(
-              ([_, download]) => download.localPath === fileName,
+          useExisting = result?.action !== "Re-download";
+        }
+        if (useExisting) {
+          const downloads = state.persistent.downloads.files;
+          let existingId = Object.keys(downloads).find(
+            (id) => downloads[id].localPath === fileName,
+          );
+          const gameId = gameIds[0];
+          if (existingId === undefined && gameId !== undefined) {
+            // A file no record tracks (dropped in manually, or its record was lost) is adopted
+            // the same way the download-folder scan adopts unknown archives, so the caller
+            // receives a usable download id. Adoption needs a game id: ADD_LOCAL_DOWNLOAD's
+            // sanity check blocks a record without one.
+            const { size } = await stat(namedDest);
+            existingId = randomUUID();
+            this.#api.store.dispatch(addLocalDownload(existingId, gameId, fileName, size));
+            this.#api.store.dispatch(
+              setCompatibleGames(
+                existingId,
+                gameIds.filter((game): game is string => game !== undefined),
+              ),
             );
-
+          }
+          if (existingId !== undefined) {
             callback?.(new AlreadyDownloaded(fileName, existingId));
             return;
           }
-        } else {
-          const downloads = state.persistent.downloads.files;
-          const [existingId, _] = Object.entries(downloads).find(
-            ([_, download]) => download.localPath === fileName,
-          );
-
-          callback?.(new AlreadyDownloaded(fileName, existingId));
-          return;
+          // untracked file with no game to record it under: fall through to a fresh download
         }
       }
     }


### PR DESCRIPTION
start-download with a fileName that is already on disk resolves AlreadyDownloaded with the tracking record's id; a file no record tracks is registered as a local download (the same way the download-folder scan registers unknown archives) so the caller still receives a usable id. Failures in the start handler settle the caller's callback so collection dependency installs never block on an unsettled download.

fixes #23885
fixes LAZ-943