### PR TITLE
Rework `ExtensionInfo` parsing and `IExtensionState` building

### DIFF
--- a/src/main/src/cli.ts
+++ b/src/main/src/cli.ts
@@ -16,7 +16,6 @@ const ARG_COUNTS: Record<string, number> = {
   "--download": 1,
   "--install": 1,
   "--install-archive": 1,
-  "--install-extension": 1,
   "--start-minimized": 1,
   "--game": 1,
   "--profile": 1,
@@ -119,7 +118,6 @@ const SKIP_ARGS: Record<string, number> = {
   "--profile": 1,
   "--install": 1,
   "--install-archive": 1,
-  "--install-extension": 1,
   "--restore": 1,
   "--merge": 1,
 };
@@ -216,11 +214,6 @@ export function parseCommandline(argv: string[], electronIsShitHack: boolean): I
     .option(
       "--install-archive <path>",
       "Start installing the specified archive. Use absolute path.",
-    )
-    .option(
-      "--install-extension <id>",
-      "Start downloading & installing the specified " +
-        'vortex extension. id can be "modId:<number>".',
     )
     .option(
       "-g, --get <path>",

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -38,6 +38,7 @@ import {
 import { suppressNotification } from "./actions/notificationSettings";
 import { setExtensionLoadFailures } from "./actions/session";
 import { setOptionalExtensions } from "./extensions/extension_manager/actions";
+import { parseExtensionInfo } from "./extensions/extension_manager/extensionInfo";
 import type { IModReference, IModRepoId } from "./extensions/mod_management/types/IMod";
 import { IPCDownloadAdapter } from "./IPCDownloadAdapter";
 import { log } from "./logging";
@@ -738,7 +739,7 @@ class ExtensionManager {
   // Pending actions to dispatch when setStore() is called (renderer-only architecture)
   private mPendingDisables: string[] = [];
   private mPendingRemoves: string[] = [];
-  private mPendingAdds: Array<{ extId: string; info: IExtension }> = [];
+  private mPendingAdds: IExtensionState[] = [];
   // Extension-registered persistors for custom hives (e.g., loadOrder -> plugins.txt)
   private mExtensionPersistors: {
     [hive: string]: { persistor: IPersistor; debounce: number };
@@ -974,8 +975,8 @@ class ExtensionManager {
     });
     this.mPendingRemoves = [];
 
-    this.mPendingAdds.forEach(({ extId, info }) => {
-      store.dispatch(addExtension(extId, info));
+    this.mPendingAdds.forEach((state) => {
+      store.dispatch(addExtension(state));
     });
     this.mPendingAdds = [];
 
@@ -2777,30 +2778,13 @@ class ExtensionManager {
       .map((format) => path.join(extensionPath, format))
       .find((iter) => fs.existsSync(iter));
     if (indexPath !== undefined) {
-      let info: IExtension = {
-        name: "",
-        author: "",
-        description: "",
-        version: "",
-      };
-      try {
-        info = JSON.parse(
+      const info = parseExtensionInfo(
+        JSON.parse(
           fs.readFileSync(path.join(extensionPath, "info.json"), {
             encoding: "utf8",
           }),
-        );
-      } catch (err) {
-        const errorCode = getErrorCode(err);
-        const errMessage =
-          errorCode === "ENOENT"
-            ? "extension has no info.json file"
-            : "failed to parse info.json file";
-
-        log("warn", errMessage, {
-          extensionPath,
-          error: getErrorMessageOrDefault(err),
-        });
-      }
+        ),
+      );
 
       const pathName = path.basename(extensionPath);
       const name = info.id || pathName;
@@ -3083,7 +3067,19 @@ class ExtensionManager {
     );
     for (const ext of scanned) {
       if (!loadedFromState.has(ext.name)) {
-        this.mPendingAdds.push({ extId: ext.name, info: { ...ext.info, path: ext.path } });
+        const state: IExtensionState = {
+          name: ext.name,
+          author: ext.info?.author ?? "<unknown>",
+          description: ext.info?.description ?? "<missing>",
+          version: ext.info?.version ?? "0.0.1",
+          infoJsonId: ext.info?.id,
+          path: ext.path,
+          enabled: true,
+          endorsed: "Undecided",
+          remove: false,
+        };
+
+        this.mPendingAdds.push(state);
         result.push(ext);
         loadedExtensions.add(ext.name);
       }

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -844,12 +844,30 @@ class ExtensionManager {
       const disableExtensions = fs
         .readdirSync(getVortexPath("temp"))
         .filter((name) => name.startsWith("__disable_"));
+
+      const extensionsPath = path.join(getVortexPath("userData"), "plugins");
+
       disableExtensions.forEach((ext) => {
-        const extId = ext.substr(10);
-        log("info", "disabling extension that caused a crash before", {
-          extId,
-        });
-        this.mPendingDisables.push(extId);
+        const extensionName = ext.substring(10);
+        const extensionPath = path.join(extensionsPath, extensionName);
+
+        const existingExtension = Object.entries(this.mExtensionState).find(
+          ([_, entry]) =>
+            path.normalize(entry.path).toLowerCase() ===
+            path.normalize(extensionPath).toLowerCase(),
+        );
+
+        if (existingExtension === undefined) {
+          log("info", "skipping disable file for unknown extension", { extensionName });
+        } else {
+          const [extensionKey] = existingExtension;
+
+          log("info", "disabling extension that caused a crash before", {
+            extensionName,
+          });
+          this.mPendingDisables.push(extensionKey);
+        }
+
         fs.unlinkSync(path.join(getVortexPath("temp"), ext));
       });
     } catch (err) {
@@ -1824,7 +1842,8 @@ class ExtensionManager {
       .filter((ext) => ext.dynamic && !ext.info?.bundled)
       .forEach((ext) => {
         const [existingExtensionKey, existingExtension] = Object.entries(state.app.extensions).find(
-          ([_, entry]) => entry.path === ext.path,
+          ([_, entry]) =>
+            path.normalize(entry.path).toLowerCase() === path.normalize(ext.path).toLowerCase(),
         ) ?? [undefined, undefined];
 
         if (existingExtension === undefined) return;

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -1819,12 +1819,21 @@ class ExtensionManager {
       setdefault(migrations, call.extension, []).push(call.arguments[0]);
     });
 
-    const state: IState = this.mApi.store.getState();
+    const state = this.mApi.getState();
     this.mExtensions
       .filter((ext) => ext.dynamic && !ext.info?.bundled)
       .forEach((ext) => {
+        const [existingExtensionKey, existingExtension] = Object.entries(state.app.extensions).find(
+          ([_, entry]) => entry.path === ext.path,
+        ) ?? [undefined, undefined];
+
+        if (existingExtension === undefined) return;
+
+        const newVersion = ext.info?.version;
+        if (newVersion === undefined) return;
+
         try {
-          let oldVersion = getSafe(state.app, ["extensions", ext.name, "version"], "0.0.0");
+          let oldVersion = existingExtension.version;
           if (!semver.valid(oldVersion)) {
             log("error", "invalid version stored for extension", {
               extension: ext.name,
@@ -1832,9 +1841,10 @@ class ExtensionManager {
             });
             oldVersion = "0.0.0";
           }
+
           if (oldVersion !== ext.info.version) {
             if (migrations[ext.name] === undefined) {
-              this.mApi.store.dispatch(setExtensionVersion(ext.name, ext.info.version));
+              this.mApi.store.dispatch(setExtensionVersion(existingExtensionKey, newVersion));
             } else {
               PromiseBB.mapSeries(migrations[ext.name], (mig) => mig(oldVersion))
                 .then(() => {
@@ -1842,7 +1852,7 @@ class ExtensionManager {
                     name: ext.name,
                     info: JSON.stringify(ext.info),
                   });
-                  this.mApi.store.dispatch(setExtensionVersion(ext.name, ext.info.version));
+                  this.mApi.store.dispatch(setExtensionVersion(existingExtensionKey, newVersion));
                 })
                 .catch((err) => {
                   const error = unknownToError(err);

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -54,6 +54,7 @@ import type {
   IExtension,
   IExtensionReducer,
   IRegisteredExtension,
+  ExtensionInfo,
 } from "./types/extensions";
 import type {
   ArchiveHandlerCreator,
@@ -2796,18 +2797,24 @@ class ExtensionManager {
     extensionPath: string,
     alreadyLoaded: IRegisteredExtension[],
     bundled: boolean,
-  ): IRegisteredExtension {
+  ): IRegisteredExtension | undefined {
     const indexPath = this.mExtensionFormats
       .map((format) => path.join(extensionPath, format))
       .find((iter) => fs.existsSync(iter));
     if (indexPath !== undefined) {
-      const info = parseExtensionInfo(
-        JSON.parse(
-          fs.readFileSync(path.join(extensionPath, "info.json"), {
-            encoding: "utf8",
-          }),
-        ),
-      );
+      let info: ExtensionInfo;
+      try {
+        info = parseExtensionInfo(
+          JSON.parse(
+            fs.readFileSync(path.join(extensionPath, "info.json"), {
+              encoding: "utf8",
+            }),
+          ),
+        );
+      } catch (err) {
+        log("error", "failed to parse info.json file from an extension", { err, extensionPath });
+        return undefined;
+      }
 
       const pathName = path.basename(extensionPath);
       const name = info.id || pathName;

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -39,6 +39,7 @@ import { suppressNotification } from "./actions/notificationSettings";
 import { setExtensionLoadFailures } from "./actions/session";
 import { setOptionalExtensions } from "./extensions/extension_manager/actions";
 import { parseExtensionInfo } from "./extensions/extension_manager/extensionInfo";
+import { findInstalled } from "./extensions/extension_manager/queries";
 import type { IModReference, IModRepoId } from "./extensions/mod_management/types/IMod";
 import { IPCDownloadAdapter } from "./IPCDownloadAdapter";
 import { log } from "./logging";
@@ -850,22 +851,17 @@ class ExtensionManager {
       disableExtensions.forEach((ext) => {
         const extensionName = ext.substring(10);
         const extensionPath = path.join(extensionsPath, extensionName);
-
-        const existingExtension = Object.entries(this.mExtensionState).find(
-          ([_, entry]) =>
-            path.normalize(entry.path).toLowerCase() ===
-            path.normalize(extensionPath).toLowerCase(),
-        );
+        const existingExtension = findInstalled(this.mExtensionState, { path: extensionsPath });
 
         if (existingExtension === undefined) {
           log("info", "skipping disable file for unknown extension", { extensionName });
         } else {
-          const [extensionKey] = existingExtension;
+          const { key } = existingExtension;
 
           log("info", "disabling extension that caused a crash before", {
             extensionName,
           });
-          this.mPendingDisables.push(extensionKey);
+          this.mPendingDisables.push(key);
         }
 
         fs.unlinkSync(path.join(getVortexPath("temp"), ext));
@@ -1841,12 +1837,10 @@ class ExtensionManager {
     this.mExtensions
       .filter((ext) => ext.dynamic && !ext.info?.bundled)
       .forEach((ext) => {
-        const [existingExtensionKey, existingExtension] = Object.entries(state.app.extensions).find(
-          ([_, entry]) =>
-            path.normalize(entry.path).toLowerCase() === path.normalize(ext.path).toLowerCase(),
-        ) ?? [undefined, undefined];
+        const existing = findInstalled(state.app.extensions, { path: ext.path });
+        if (existing === undefined) return;
 
-        if (existingExtension === undefined) return;
+        const { key: existingExtensionKey, extension: existingExtension } = existing;
 
         const newVersion = ext.info?.version;
         if (newVersion === undefined) return;

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -2897,68 +2897,70 @@ class ExtensionManager {
         }
         return true;
       })
-      .reduce((prev: { [id: string]: IRegisteredExtension }, name: string) => {
-        if (!getSafe(this.mExtensionState, [name, "enabled"], true)) {
-          log("debug", "extension disabled", { name });
+      .reduce((prev: Record<string, IRegisteredExtension>, directoryName: string) => {
+        const extensionPath = path.join(extension.path, directoryName);
+        const installedExtension = findInstalled(this.mExtensionState, { path: extensionPath });
+
+        if (installedExtension && !installedExtension.extension.enabled) {
+          log("debug", "extension disabled", { name: directoryName });
           return prev;
         }
+
         try {
           // first, mark this extension as loaded. If this is a user extension and there is an
           // extension with the same name in the bundle we could otherwise end up loading the
           // bundled one if this one fails to load which could be convenient but also massively
           // confusing.
           const before = Date.now();
-          const ext = this.loadDynamicExtension(
-            path.join(extension.path, name),
+          const loadedExtension = this.loadDynamicExtension(
+            extensionPath,
             alreadyLoaded,
             extension.bundled,
           );
-          if (ext !== undefined) {
-            if (this.mExtensionState?.[ext.name]?.enabled === false) {
-              log("debug", "extension disabled", { name: ext.name });
-              return prev;
-            }
-            loadedExtensions.add(ext.name);
-            const loadTime = Date.now() - before;
-            log("debug", "loaded extension", {
-              name,
-              loadTime,
-              location: extension.path,
-            });
-            if (prev[ext.name] !== undefined) {
-              // loadDynamicExtension already handles the case where the same extension was found
-              // in a different directory, but if the same directory contains multiple copies
-              // of the same extension, we have to deal with that slightly differently
-              log("warn", "multiple copies of the same extension installed", {
-                first: ext.path,
-                second: prev[ext.name].path,
-              });
 
-              if (
-                ext.info === undefined ||
-                semver.gt(prev[ext.name].info?.version, ext.info?.version)
-              ) {
-                // the copy we loaded previously is newer so mark this one for removal and not
-                // load it
-                this.mOutdated.push(path.basename(ext.path));
-              } else {
-                // this copy is actually the newer one so replace the one previously found and
-                // mark that for deletion
-                this.mOutdated.push(path.basename(prev[ext.name].path));
-                prev[ext.name] = ext;
-              }
+          if (loadedExtension === undefined) return prev;
+          loadedExtensions.add(loadedExtension.name);
+
+          const loadTime = Date.now() - before;
+          log("debug", "loaded extension", {
+            name: directoryName,
+            loadTime,
+            location: extension.path,
+          });
+
+          if (prev[loadedExtension.name] !== undefined) {
+            // loadDynamicExtension already handles the case where the same extension was found
+            // in a different directory, but if the same directory contains multiple copies
+            // of the same extension, we have to deal with that slightly differently
+            log("warn", "multiple copies of the same extension installed", {
+              first: loadedExtension.path,
+              second: prev[loadedExtension.name].path,
+            });
+
+            if (
+              loadedExtension.info === undefined ||
+              semver.gt(prev[loadedExtension.name].info?.version, loadedExtension.info?.version)
+            ) {
+              // the copy we loaded previously is newer so mark this one for removal and not
+              // load it
+              this.mOutdated.push(path.basename(loadedExtension.path));
             } else {
-              prev[ext.name] = ext;
+              // this copy is actually the newer one so replace the one previously found and
+              // mark that for deletion
+              this.mOutdated.push(path.basename(prev[loadedExtension.name].path));
+              prev[loadedExtension.name] = loadedExtension;
             }
+          } else {
+            prev[loadedExtension.name] = loadedExtension;
           }
         } catch (unknownError) {
           const err = unknownToError(unknownError);
           log("warn", "failed to load dynamic extension", {
-            name,
+            name: directoryName,
             error: err.message,
             stack: err.stack,
           });
-          this.mLoadFailures[name] = [{ id: "exception", args: { message: err.message } }];
+          this.mLoadFailures[directoryName] = [{ id: "exception", args: { message: err.message } }];
         }
         return prev;
       }, {});

--- a/src/renderer/src/actions/app.ts
+++ b/src/renderer/src/actions/app.ts
@@ -1,7 +1,8 @@
 import type { EndorsedStatus } from "@nexusmods/nexus-api";
 import { createAction } from "redux-act";
 
-import type { IExtension } from "../types/extensions";
+import type { IExtensionState } from "@/types/IState";
+
 import type { VortexInstallType } from "../types/VortexInstallType";
 
 const id = <T>(input: T): T => input;
@@ -10,10 +11,9 @@ export const setStateVersion = createAction("SET_STATE_VERSION", id<string>);
 
 export const setApplicationVersion = createAction("SET_APPLICATION_VERSION", id<string>);
 
-export const addExtension = createAction(
-  "ADD_EXTENSION",
-  (extensionId: string, info: IExtension) => ({ extensionId, info }),
-);
+export const addExtension = createAction("ADD_EXTENSION", (extension: IExtensionState) => ({
+  extension,
+}));
 
 export const setExtensionEnabled = createAction(
   "SET_EXTENSION_ENABLED",

--- a/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
+++ b/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
@@ -17,6 +17,7 @@ import { getApplication } from "../../util/application";
 import opn from "../../util/opn";
 import { largeNumToString } from "../../util/util";
 import { NEXUS_BASE_URL } from "../nexus_integration/constants";
+import { findInCatalog } from "./queries";
 import { downloadAndInstallExtension, selectorMatch } from "./util";
 
 const NEXUS_MODS_URL: string = `${NEXUS_BASE_URL}/site/mods/`;
@@ -399,8 +400,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
     const modIdStr = evt.currentTarget.getAttribute("data-modid");
     const modId = modIdStr !== null ? parseInt(modIdStr, 10) : undefined;
 
-    const ext = availableExtensions.find((iter) => selectorMatch(iter, { modId }));
-
+    const ext = findInCatalog(availableExtensions, { modId });
     this.nextState.installing.push(ext.name);
 
     void (async () => {
@@ -429,7 +429,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
     const modIdStr = evt.currentTarget.getAttribute("data-modid");
     const modId = modIdStr !== null ? parseInt(modIdStr, 10) : undefined;
 
-    const ext = availableExtensions.find((iter) => selectorMatch(iter, { modId }));
+    const ext = findInCatalog(availableExtensions, { modId });
     if (ext.modId !== undefined) {
       opn(NEXUS_MODS_URL + ext.modId).catch(() => null);
     }

--- a/src/renderer/src/extensions/extension_manager/extensionInfo.ts
+++ b/src/renderer/src/extensions/extension_manager/extensionInfo.ts
@@ -1,10 +1,6 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-
 import { z } from "zod";
 
-import type { ExtensionInfo, IAvailableExtension } from "@/types/extensions";
-import type { IExtensionState } from "@/types/IState";
+import type { ExtensionInfo } from "@/types/extensions";
 
 const schema = z.looseObject({
   name: z.string(),
@@ -14,11 +10,6 @@ const schema = z.looseObject({
   id: z.string().optional(),
   namespace: z.string().optional(),
 });
-
-export function readExtensionInfo(extensionPath: string): Promise<string> {
-  const infoJsonPath = join(extensionPath, "info.json");
-  return readFile(infoJsonPath, { encoding: "utf8" });
-}
 
 export function parseExtensionInfo(data: unknown): ExtensionInfo {
   const parsed = schema.parse(data);
@@ -30,32 +21,6 @@ export function parseExtensionInfo(data: unknown): ExtensionInfo {
     description: parsed.description ?? "<missing>",
     id: parsed.id,
     namespace: parsed.namespace,
-  };
-
-  return result;
-}
-
-export function infoToState(
-  info: ExtensionInfo,
-  extensionPath: string,
-  catalogEntry?: IAvailableExtension,
-): IExtensionState {
-  const result: IExtensionState = {
-    name: catalogEntry?.name ?? info.name,
-    author: catalogEntry?.author ?? info.author,
-    description: catalogEntry?.description?.short ?? info.description,
-    version: catalogEntry?.version ?? info.version,
-
-    endorsed: "Undecided",
-    remove: false,
-    enabled: true,
-    path: extensionPath,
-
-    infoJsonId: info.id,
-
-    modId: catalogEntry?.modId,
-    fileId: catalogEntry?.fileId,
-    type: catalogEntry?.type,
   };
 
   return result;

--- a/src/renderer/src/extensions/extension_manager/extensionInfo.ts
+++ b/src/renderer/src/extensions/extension_manager/extensionInfo.ts
@@ -1,0 +1,62 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import type { ExtensionInfo, IAvailableExtension } from "@/types/extensions";
+import type { IExtensionState } from "@/types/IState";
+
+const schema = z.looseObject({
+  name: z.string(),
+  author: z.string().optional(),
+  description: z.string().optional(),
+  version: z.string(),
+  id: z.string().optional(),
+  namespace: z.string().optional(),
+});
+
+export function readExtensionInfo(extensionPath: string): Promise<string> {
+  const infoJsonPath = join(extensionPath, "info.json");
+  return readFile(infoJsonPath, { encoding: "utf8" });
+}
+
+export function parseExtensionInfo(data: unknown): ExtensionInfo {
+  const parsed = schema.parse(data);
+
+  const result: ExtensionInfo = {
+    name: parsed.name,
+    version: parsed.version,
+    author: parsed.author ?? "<unknown>",
+    description: parsed.description ?? "<missing>",
+    id: parsed.id,
+    namespace: parsed.namespace,
+  };
+
+  return result;
+}
+
+export function infoToState(
+  info: ExtensionInfo,
+  extensionPath: string,
+  catalogEntry?: IAvailableExtension,
+): IExtensionState {
+  const result: IExtensionState = {
+    name: catalogEntry?.name ?? info.name,
+    author: catalogEntry?.author ?? info.author,
+    description: catalogEntry?.description?.short ?? info.description,
+    version: catalogEntry?.version ?? info.version,
+
+    endorsed: "Undecided",
+    remove: false,
+    enabled: true,
+    path: extensionPath,
+
+    infoJsonId: info.id,
+
+    modId: catalogEntry?.modId,
+    fileId: catalogEntry?.fileId,
+    type: catalogEntry?.type,
+  };
+
+  return result;
+}

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -25,6 +25,7 @@ import {
   findDependencyInCatalog,
   findInCatalog,
   findInstalled,
+  findInstalledDependency,
   findUpdatableExtensions,
   getMissingOptionalExtensions,
 } from "./queries";
@@ -119,12 +120,13 @@ async function updateAvailableExtensions(
 async function installDependency(api: IExtensionApi, dependencyId: string): Promise<boolean> {
   const state = api.getState();
   const availableExtensions = state.session.extensions.available;
-  const installedExtensions = state.app.extensions ?? {};
 
-  if (installedExtensions[dependencyId] !== undefined) {
+  const installedDependency = findInstalledDependency(state.app.extensions, dependencyId);
+
+  if (installedDependency !== undefined) {
     // installed, probably failed to load or disabled
-    if (!installedExtensions[dependencyId].enabled) {
-      api.store.dispatch(setExtensionEnabled(dependencyId, true));
+    if (!installedDependency.extension.enabled) {
+      api.store.dispatch(setExtensionEnabled(installedDependency.key, true));
       return true;
     } else {
       api.showErrorNotification(

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -52,22 +52,7 @@ async function checkForUpdates(api: IExtensionApi): Promise<void> {
   const { available } = state.session.extensions;
   const installed = state.app.extensions ?? {};
 
-  const updateable: Array<{ installed?: IExtensionState; available: IAvailableExtension }> =
-    findUpdatableExtensions(installed, available);
-  let forceRestart: boolean = false;
-
-  const { commandLine } = state.session.base;
-  if (commandLine.installExtension !== undefined) {
-    const request = parseInstallCmdLine(commandLine.installExtension);
-    const update = findInCatalog(available, { modId: request.modId });
-
-    if (update !== undefined) {
-      forceRestart = true;
-      updateable.push({
-        available: update,
-      });
-    }
-  }
+  const updateable = findUpdatableExtensions(installed, available);
 
   if (updateable.length === 0) return;
 
@@ -79,10 +64,10 @@ async function checkForUpdates(api: IExtensionApi): Promise<void> {
   });
 
   log("info", "extensions will be updated", {
-    updateable: updateable.map(({ installed, available }) => {
-      const prefix = installed ? `${installed.name} v${installed.version} ` : "";
-      return prefix + `${available.name} v${available.version}`;
-    }),
+    updateable: updateable.map(
+      ({ installed, available }) =>
+        `${installed.name} v${installed.version} ${available.name} v${available.version}`,
+    ),
   });
 
   const promises = updateable.map(({ available }) => downloadAndInstallExtension(api, available));
@@ -92,23 +77,19 @@ async function checkForUpdates(api: IExtensionApi): Promise<void> {
   localState.reloadNecessary = true;
 
   if (success.find((iter) => iter === true)) {
-    if (forceRestart) {
-      relaunch();
-    } else {
-      api.sendNotification({
-        id: "extension-updates",
-        type: "success",
-        message: "Extensions updated, please restart to apply them",
-        actions: [
-          {
-            title: "Restart now",
-            action: () => {
-              relaunch();
-            },
+    api.sendNotification({
+      id: "extension-updates",
+      type: "success",
+      message: "Extensions updated, please restart to apply them",
+      actions: [
+        {
+          title: "Restart now",
+          action: () => {
+            relaunch();
           },
-        ],
-      });
-    }
+        },
+      ],
+    });
   }
 }
 
@@ -264,18 +245,6 @@ function signalRestartNeeded(api: IExtensionApi, gameName?: string): void {
         },
       ],
     });
-  }
-}
-
-function parseInstallCmdLine(argument: string): IExtensionDownloadInfo {
-  const modIdMatch = argument.match(/modId:(\d+)/);
-  if (modIdMatch != null) {
-    return {
-      name: "Commandline Request",
-      modId: parseInt(modIdMatch[1], 10),
-    };
-  } else {
-    throw new Error(`invalid command line argument "${argument}"`);
   }
 }
 

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -314,11 +314,7 @@ function init(context: IExtensionContext) {
       await didFetchAvailableExtensions;
       const success = await downloadAndInstallExtension(context.api, ext);
 
-      if (success) {
-        const gameName =
-          ext.type === "game" || ext.name?.startsWith("Game:") ? ext.name : undefined;
-        signalRestartNeeded(context.api, gameName);
-      }
+      if (success) signalRestartNeeded(context.api);
       return success;
     });
 

--- a/src/renderer/src/extensions/extension_manager/installExtension.test.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.test.ts
@@ -9,7 +9,6 @@ import { DataInvalid } from "../../util/CustomErrors";
 import {
   clearStaleRemovalFlags,
   validateExtension,
-  validateInstall,
   validateTheme,
   validateTranslation,
 } from "./installExtension";
@@ -326,92 +325,6 @@ describe("validate* extension install checks", () => {
         [langDir]: [file("strings.json")],
       });
       await expect(validateTranslation(extPath)).resolves.toBeUndefined();
-    });
-  });
-
-  describe("validateInstall", () => {
-    const extPath = path.join("mock", "install-ext");
-    const baseInfo: Omit<IExtension, "type"> = {
-      name: "some-extension",
-      author: "someone",
-      description: "a description",
-      version: "1.0.0",
-    };
-
-    it("delegates to theme validation when info.type is 'theme'", async () => {
-      const themeDir = path.join(extPath, "default");
-      mockDirTree({
-        [extPath]: [dir("default")],
-        [themeDir]: [file("variables.scss")],
-      });
-      const info: IExtension = { ...baseInfo, type: "theme" };
-      await expect(validateInstall(extPath, info)).resolves.toBe("theme");
-      expect(statMock).not.toHaveBeenCalled();
-    });
-
-    it("propagates theme validation failures when info.type is 'theme'", async () => {
-      mockDirTree({ [extPath]: [] });
-      const info: IExtension = { ...baseInfo, type: "theme" };
-      await expect(validateInstall(extPath, info)).rejects.toThrow(DataInvalid);
-    });
-
-    it("delegates to translation validation when info.type is 'translation'", async () => {
-      const langDir = path.join(extPath, "en");
-      mockDirTree({
-        [extPath]: [dir("en")],
-        [langDir]: [file("strings.json")],
-      });
-      const info: IExtension = { ...baseInfo, type: "translation" };
-      await expect(validateInstall(extPath, info)).resolves.toBe("translation");
-    });
-
-    it("only runs validateExtension (no fallback) when info is defined with another type", async () => {
-      statMock.mockResolvedValue({} as never);
-      const info: IExtension = { ...baseInfo, type: "game" };
-      await expect(validateInstall(extPath, info)).resolves.toBe("game");
-      expect(readdirMock).not.toHaveBeenCalled();
-    });
-
-    it("rejects without falling back to theme/translation when info is defined but validation fails", async () => {
-      statMock.mockRejectedValue(new Error("ENOENT"));
-      const info: IExtension = { ...baseInfo };
-      await expect(validateInstall(extPath, info)).rejects.toThrow("ENOENT");
-      expect(readdirMock).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined type when info is undefined and the extension validates directly", async () => {
-      statMock.mockResolvedValue({} as never);
-      await expect(validateInstall(extPath, undefined)).resolves.toBeUndefined();
-      expect(readdirMock).not.toHaveBeenCalled();
-    });
-
-    it("falls back to theme validation when info is undefined and extension validation fails", async () => {
-      statMock.mockRejectedValue(new Error("ENOENT"));
-      const themeDir = path.join(extPath, "default");
-      mockDirTree({
-        [extPath]: [dir("default")],
-        [themeDir]: [file("style.scss")],
-      });
-      await expect(validateInstall(extPath, undefined)).resolves.toBe("theme");
-    });
-
-    it("falls back to translation validation when info is undefined and extension/theme validation fail", async () => {
-      statMock.mockRejectedValue(new Error("ENOENT"));
-      const langDir = path.join(extPath, "en");
-      mockDirTree({
-        [extPath]: [dir("en")],
-        // no theme stylesheet here, so theme validation fails and translation succeeds
-        [langDir]: [file("strings.json")],
-      });
-      await expect(validateInstall(extPath, undefined)).resolves.toBe("translation");
-    });
-
-    it("throws when info is undefined and none of extension/theme/translation validate", async () => {
-      statMock.mockRejectedValue(new Error("ENOENT"));
-      mockDirTree({ [extPath]: [] });
-      await expect(validateInstall(extPath, undefined)).rejects.toThrow(
-        "Doesn't seem to contain a correctly packaged extension, theme or translation",
-      );
     });
   });
 });

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -1,4 +1,4 @@
-import { stat, rename, rm, writeFile, readdir } from "node:fs/promises";
+import { stat, rename, rm, writeFile, readdir, readFile } from "node:fs/promises";
 import * as path from "node:path";
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
@@ -15,7 +15,7 @@ import type {
   IAvailableExtension,
 } from "../../types/extensions";
 import type { IExtensionApi, IExtensionContext } from "../../types/IExtensionContext";
-import type { IState } from "../../types/IState";
+import type { IExtensionState, IState } from "../../types/IState";
 import { DataInvalid } from "../../util/CustomErrors";
 import { withTrackedActivity } from "../../util/errorHandling";
 import getVortexPath from "../../util/getVortexPath";
@@ -26,9 +26,9 @@ import {
   type ExtensionInstallSource,
 } from "../analytics/mixpanel/extensionInstallAnalytics";
 import { countryExists, languageExists } from "../settings_interface/languagemap";
+import { parseExtensionInfo } from "./extensionInfo";
 import { findDependencyInCatalog, findPreviousVersions, isAlreadyInstalled } from "./queries";
 import _sessionReducer from "./reducers";
-import { readExtensionInfo } from "./util";
 
 class ContextProxyHandler implements ProxyHandler<any> {
   private mDependencies: string[] = [];
@@ -222,49 +222,6 @@ export async function validateExtension(extPath: string): Promise<void> {
   await Promise.all([stat(path.join(extPath, "index.js")), stat(path.join(extPath, "info.json"))]);
 }
 
-export async function validateInstall(extPath: string, info?: IExtension): Promise<ExtensionType> {
-  if (info?.type === "theme") {
-    await validateTheme(extPath);
-    return "theme";
-  }
-
-  if (info?.type === "translation") {
-    await validateTranslation(extPath);
-    return "translation";
-  }
-
-  if (info !== undefined) {
-    await validateExtension(extPath);
-    return info?.type;
-  }
-
-  // if we don't know the type we can only check if _any_ extension type applies
-  try {
-    await validateExtension(extPath);
-    return undefined;
-  } catch {
-    // ignored
-  }
-
-  try {
-    await validateTheme(extPath);
-    return "theme";
-  } catch {
-    // ignored
-  }
-
-  try {
-    await validateTranslation(extPath);
-    return "translation";
-  } catch {
-    // ignored
-  }
-
-  throw new DataInvalid(
-    "Doesn't seem to contain a correctly packaged extension, theme or translation",
-  );
-}
-
 interface InstallAnalytics {
   source: ExtensionInstallSource;
   gameDomain?: string;
@@ -280,7 +237,7 @@ const activeInstalls: Map<string, Promise<void>> = new Map();
 function installExtension(
   api: IExtensionApi,
   archivePath: string,
-  data?: { info?: ExtensionInfo; catalogEntry?: IAvailableExtension; analytics?: InstallAnalytics },
+  data?: { catalogEntry?: IAvailableExtension; analytics?: InstallAnalytics },
 ): Promise<void> {
   const key = path.basename(archivePath).toLowerCase();
   const active = activeInstalls.get(key);
@@ -300,7 +257,7 @@ function installExtension(
 async function installExtensionImpl(
   api: IExtensionApi,
   archivePath: string,
-  data?: { info?: ExtensionInfo; catalogEntry?: IAvailableExtension; analytics?: InstallAnalytics },
+  data?: { catalogEntry?: IAvailableExtension; analytics?: InstallAnalytics },
 ): Promise<void> {
   const extensionsPath = path.join(getVortexPath("userData"), "plugins");
   let destPath: string;
@@ -313,8 +270,8 @@ async function installExtensionImpl(
     "extension.install",
     {
       "extension.archive": path.basename(archivePath),
-      "extension.name": data?.catalogEntry?.name ?? data?.info?.name,
-      "extension.type": data?.catalogEntry?.type ?? data?.info?.type,
+      "extension.name": data?.catalogEntry?.name,
+      "extension.type": data?.catalogEntry?.type,
     },
     async () => {
       try {
@@ -353,27 +310,43 @@ async function installExtensionImpl(
         throw new DataInvalid(`Failed to extract extension archive: ${detail}`);
       }
 
-      const manifestInfo = await Promise.resolve(readExtensionInfo(tempPath, false, data?.info));
+      const infoJsonPath = path.join(tempPath, "info.json");
+      const isJavaScriptExtension = await validateExtension(tempPath)
+        .then(() => true)
+        .catch(() => false);
 
-      const fullInfo = { ...manifestInfo.info };
-      if (fullInfo.type === undefined) {
-        fullInfo.type = await validateInstall(tempPath, data?.info);
+      let extensionInfo: ExtensionInfo | undefined = undefined;
+      let guessedType: ExtensionType | undefined = undefined;
+
+      // NOTE(erri120): themes and translations don't have an info.json file
+      // only JavaScript extensions have one.
+      if (isJavaScriptExtension) {
+        const contents = await readFile(infoJsonPath, { encoding: "utf8" });
+        extensionInfo = parseExtensionInfo(JSON.parse(contents));
+      } else {
+        try {
+          await validateTheme(tempPath);
+          guessedType = "theme";
+        } catch {
+          // ignored
+        }
+
+        try {
+          await validateTranslation(tempPath);
+          guessedType = "translation";
+        } catch {
+          // ignored
+        }
       }
 
-      // update the manifest on disc, in case we had new info from the caller
-      await writeFile(path.join(tempPath, "info.json"), JSON.stringify(fullInfo, undefined, 2));
-
-      const dirName = sanitize(manifestInfo.id);
+      const dirName = sanitize(tempPath);
       destPath = path.join(extensionsPath, dirName);
 
       // Keys whose previous-version state entries were marked for removal during
       // this install. Cleared after the rename succeeds so the next launch's
       // state-flag-driven removal path in ExtensionManager doesn't wipe the
       // just-installed folder (#19527).
-      let removedKeys: string[] = [];
-      if (data?.catalogEntry) {
-        removedKeys = removeOldVersion(api, data?.catalogEntry);
-      }
+      const removedKeys = data?.catalogEntry ? removeOldVersion(api, data?.catalogEntry) : [];
 
       // we don't actually expect the output directory to exist
       await rm(destPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
@@ -381,25 +354,43 @@ async function installExtensionImpl(
 
       clearStaleRemovalFlags(api, removedKeys, destPath);
 
-      const extId = fullInfo.id ?? dirName;
-      api.store.dispatch(addExtension(extId, { ...fullInfo, path: destPath }));
+      const state: IExtensionState = {
+        name: data?.catalogEntry?.name ?? extensionInfo?.name ?? path.basename(destPath),
+        author: data?.catalogEntry?.author ?? extensionInfo?.author ?? "<unknown>",
+        description:
+          data?.catalogEntry?.description?.short ?? extensionInfo?.description ?? "<missing>",
+        version: data?.catalogEntry?.version ?? extensionInfo?.version ?? "0.0.1",
+
+        endorsed: "Undecided",
+        remove: false,
+        enabled: true,
+        path: destPath,
+
+        infoJsonId: extensionInfo?.id,
+
+        modId: data?.catalogEntry?.modId,
+        fileId: data?.catalogEntry?.fileId,
+        type: data?.catalogEntry?.type ?? guessedType,
+      };
+
+      api.store.dispatch(addExtension(state));
 
       emitExtensionInstalled(
         api,
-        { ...fullInfo, type: fullInfo.type, id: manifestInfo.id },
+        { ...state },
         {
           source: data?.analytics.source,
           isUpdate: removedKeys.length > 0,
-          gameDomain: data?.analytics.gameDomain,
-          gameName: data?.analytics.gameName,
+          gameDomain: data?.analytics?.gameDomain,
+          gameName: data?.analytics?.gameName,
         },
       );
 
-      if (fullInfo.type === "theme" || fullInfo.type === "translation") return;
+      if (state.type === "theme" || state.type === "translation") return;
 
       // don't install dependencies for extensions that are already loaded because
       // doing so could cause an exception
-      if (api.getLoadedExtensions().find((ext) => ext.name === manifestInfo.id) === undefined) {
+      if (api.getLoadedExtensions().find((ext) => ext.path === destPath) === undefined) {
         await installExtensionDependencies(api, destPath);
       }
     },

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -339,7 +339,7 @@ async function installExtensionImpl(
         }
       }
 
-      const dirName = sanitize(tempPath);
+      const dirName = sanitize(extensionInfo?.id ?? path.basename(archivePath));
       destPath = path.join(extensionsPath, dirName);
 
       // Keys whose previous-version state entries were marked for removal during

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -27,7 +27,12 @@ import {
 } from "../analytics/mixpanel/extensionInstallAnalytics";
 import { countryExists, languageExists } from "../settings_interface/languagemap";
 import { parseExtensionInfo } from "./extensionInfo";
-import { findDependencyInCatalog, findPreviousVersions, isAlreadyInstalled } from "./queries";
+import {
+  findDependencyInCatalog,
+  findPreviousVersions,
+  isAlreadyInstalled,
+  findInstalledDependency,
+} from "./queries";
 import _sessionReducer from "./reducers";
 
 class ContextProxyHandler implements ProxyHandler<any> {
@@ -79,16 +84,13 @@ async function installExtensionDependencies(api: IExtensionApi, extPath: string)
     initFunc(context);
 
     const state = api.getState();
-    const { available } = state.session.extensions;
-    const extState = state.app.extensions ?? {};
-
     const promises = handler.dependencies.map(async (dependencyId) => {
-      if (extState[dependencyId]) return;
+      if (findInstalledDependency(state.app.extensions, dependencyId) !== undefined) return;
 
-      const toInstall = findDependencyInCatalog(available, dependencyId);
+      const toInstall = findDependencyInCatalog(state.session.extensions.available, dependencyId);
       if (!toInstall) return;
 
-      if (isAlreadyInstalled(extState, toInstall)) return;
+      if (isAlreadyInstalled(state.app.extensions, toInstall)) return;
       await api.emitAndAwait<"install-extension">("install-extension", toInstall);
     });
 

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -326,18 +326,22 @@ async function installExtensionImpl(
         const contents = await readFile(infoJsonPath, { encoding: "utf8" });
         extensionInfo = parseExtensionInfo(JSON.parse(contents));
       } else {
-        try {
-          await validateTheme(tempPath);
+        const isTheme = await validateTheme(tempPath)
+          .then(() => true)
+          .catch(() => false);
+        if (isTheme) {
           guessedType = "theme";
-        } catch {
-          // ignored
-        }
-
-        try {
-          await validateTranslation(tempPath);
-          guessedType = "translation";
-        } catch {
-          // ignored
+        } else {
+          const isTranslation = await validateTranslation(tempPath)
+            .then(() => true)
+            .catch(() => false);
+          if (isTranslation) {
+            guessedType = "translation";
+          } else {
+            throw new DataInvalid(
+              "Doesn't seem to contain a correctly packaged extension, theme or translation",
+            );
+          }
         }
       }
 

--- a/src/renderer/src/extensions/extension_manager/queries.test.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.test.ts
@@ -42,6 +42,8 @@ function makeAvailableExtension(overrides: Partial<IAvailableExtension> = {}): I
     endorsements: 0,
     timestamp: 0,
     tags: [],
+    modId: 0,
+    fileId: 0,
     ...overrides,
   };
 }

--- a/src/renderer/src/extensions/extension_manager/queries.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.ts
@@ -34,6 +34,20 @@ export function matchesQuery(
   return query.fileId !== undefined ? entry.fileId === query.fileId : true;
 }
 
+/** Find a dependency extension by its declared identifier among the installed extensions. */
+export function findInstalledDependency(
+  installedExtensions: Record<string, IExtensionState>,
+  dependencyId: string,
+): { key: string; extension: IExtensionState } | undefined {
+  const result = Object.entries(installedExtensions).find(
+    ([_, entry]) => entry.infoJsonId === dependencyId || entry.name === dependencyId,
+  );
+  if (result === undefined) return undefined;
+
+  const [key, extension] = result;
+  return { key, extension };
+}
+
 /** Find a dependency extension by its declared identifier in the catalog. */
 export function findDependencyInCatalog(
   catalog: IAvailableExtension[],

--- a/src/renderer/src/extensions/extension_manager/queries.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.ts
@@ -1,12 +1,17 @@
+import * as path from "node:path";
+
 import * as semver from "semver";
 
 import type { IAvailableExtension, IRegisteredExtension } from "@/types/extensions";
 import type { IExtensionOptional, IExtensionState } from "@/types/IState";
 
+type CatalogQuery = { modId: number; fileId?: number };
+type InstalledQuery = { modId: number; fileId?: number } | { path: string };
+
 /** Find an extension in the available catalog. */
 export function findInCatalog(
   catalog: IAvailableExtension[],
-  query: { modId: number; fileId?: number },
+  query: CatalogQuery,
 ): IAvailableExtension | undefined {
   return catalog.find((catalogEntry) => matchesQuery(query, catalogEntry));
 }
@@ -14,11 +19,16 @@ export function findInCatalog(
 /** Find an installed extension. */
 export function findInstalled(
   installedExtensions: Record<string, IExtensionState>,
-  query: { modId: number; fileId?: number },
+  query: InstalledQuery,
 ): { key: string; extension: IExtensionState } | undefined {
-  const result = Object.entries(installedExtensions).find(([_, extension]) =>
-    matchesQuery(query, extension),
-  );
+  const result = Object.entries(installedExtensions).find(([_, extension]) => {
+    if ("path" in query)
+      return (
+        path.normalize(extension.path).toLowerCase() === path.normalize(query.path).toLowerCase()
+      );
+    return matchesQuery(query, extension);
+  });
+
   if (result === undefined) return undefined;
 
   const [key, extension] = result;

--- a/src/renderer/src/extensions/extension_manager/util.test.ts
+++ b/src/renderer/src/extensions/extension_manager/util.test.ts
@@ -15,6 +15,8 @@ function makeExtension(overrides: Partial<IAvailableExtension> = {}): IAvailable
     endorsements: 0,
     timestamp: 0,
     tags: [],
+    modId: 0,
+    fileId: 0,
     ...overrides,
   };
 }
@@ -26,24 +28,28 @@ describe("filterInstallableExtensions", () => {
   });
 
   it("drops extensions missing modId", () => {
-    const extensions = [makeExtension({ fileId: 2 })];
+    const extensions = [makeExtension({ modId: undefined, fileId: 2 })];
     expect(filterInstallableExtensions(extensions)).toEqual([]);
   });
 
   it("drops extensions missing fileId", () => {
-    const extensions = [makeExtension({ modId: 1 })];
+    const extensions = [makeExtension({ modId: 1, fileId: undefined })];
     expect(filterInstallableExtensions(extensions)).toEqual([]);
   });
 
   it("drops legacy GitHub-hosted entries lacking both modId and fileId", () => {
-    const extensions = [makeExtension({})];
+    const extensions = [makeExtension({ modId: undefined, fileId: undefined })];
     expect(filterInstallableExtensions(extensions)).toEqual([]);
   });
 
   it("keeps only the qualifying entries out of a mixed list", () => {
     const nexusExt = makeExtension({ name: "Nexus Extension", modId: 1, fileId: 2 });
-    const githubExt = makeExtension({ name: "GitHub Extension" });
-    const partialExt = makeExtension({ name: "Partial Extension", modId: 3 });
+    const githubExt = makeExtension({
+      name: "GitHub Extension",
+      modId: undefined,
+      fileId: undefined,
+    });
+    const partialExt = makeExtension({ name: "Partial Extension", modId: 3, fileId: undefined });
 
     expect(filterInstallableExtensions([nexusExt, githubExt, partialExt])).toEqual([nexusExt]);
   });

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -356,17 +356,6 @@ async function downloadFromNexus(
   api: IExtensionApi,
   ext: IExtensionDownloadInfo,
 ): Promise<string[]> {
-  // TODO: remove this check, download info should always carry fileId and modId at this point
-  if (ext.fileId === undefined && ext.modId !== undefined) {
-    const state = api.getState();
-    const available = findInCatalog(state.session.extensions.available, { modId: ext.modId });
-    if (available !== undefined) {
-      ext.fileId = available.fileId;
-    } else {
-      throw new Error("unavailable nexus extension");
-    }
-  }
-
   log("debug", "download from nexus", archiveFileName(ext));
   return await api.emitAndAwait<"nexus-download">(
     "nexus-download",

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -23,6 +23,7 @@ import { INVALID_FILENAME_RE } from "../../util/util";
 import { setDownloadModInfo } from "../download_management/actions/state";
 import { downloadPathForGame } from "../download_management/selectors";
 import { SITE_ID } from "../gamemode_management/constants";
+import { parseExtensionInfo } from "./extensionInfo";
 import installExtension from "./installExtension";
 import { findInCatalog } from "./queries";
 
@@ -78,40 +79,6 @@ function getAllDirectories(searchPath: string): PromiseBB<string[]> {
     .catch({ code: "ENOENT" }, () => []);
 }
 
-function applyExtensionInfo(
-  id: string,
-  bundled: boolean,
-  archiveInfo: Partial<IExtension>,
-  manifestInfo: Partial<IExtension>,
-): IExtension {
-  const res = {
-    name: manifestInfo.name || archiveInfo.name || id,
-    author: manifestInfo.author || archiveInfo.author || "Unknown",
-    version: manifestInfo.version || archiveInfo.version || "0.0.0",
-    description: manifestInfo.description || archiveInfo.description || "Missing",
-  } satisfies IExtension;
-
-  // add optional settings if we have them
-  const add = <T>(key: string, primary: T, secondary: T) => {
-    if (primary !== undefined) {
-      res[key] = primary;
-    } else if (secondary !== undefined) {
-      res[key] = secondary;
-    }
-  };
-
-  add("id", archiveInfo.id, manifestInfo.id);
-  add("type", manifestInfo.type, archiveInfo.type);
-  add("path", archiveInfo.path, undefined);
-  add("bundled", bundled, undefined);
-  // modId/fileId are identity data assigned by the Nexus Mods manifest, not
-  // something an extension author controls via their own info.json.
-  add("modId", manifestInfo.modId, archiveInfo.modId);
-  add("fileId", manifestInfo.fileId, archiveInfo.fileId);
-
-  return res;
-}
-
 export function selectorMatch(ext: IAvailableExtension, selector: ISelector): boolean {
   if (selector === undefined) {
     return false;
@@ -126,27 +93,29 @@ export function sanitize(input: string): string {
 export function readExtensionInfo(
   extensionPath: string,
   bundled: boolean,
-  manifestInfo: Partial<IExtension> = {},
 ): PromiseBB<{ id: string; info: IExtension }> {
   const finalPath = extensionPath.replace(/\.installing$/, "");
 
   return fs
     .readFileAsync(path.join(extensionPath, "info.json"), { encoding: "utf-8" })
-    .then((info: string) => {
-      const data = JSON.parse(info) as unknown as Partial<IExtension>;
-      data.path = finalPath;
-      const id = data.id || path.basename(finalPath);
-      return {
-        id,
-        info: applyExtensionInfo(id, bundled, data, manifestInfo),
-      };
+    .then((contents: string) => {
+      const data: unknown = JSON.parse(contents);
+      const info = parseExtensionInfo(data);
+      const id = info.id || path.basename(finalPath);
+      info.bundled = bundled;
+      return { id, info };
     })
     .catch(() => {
       const id = path.basename(finalPath);
-      return {
+      const info: IExtension = {
         id,
-        info: applyExtensionInfo(id, bundled, {}, manifestInfo),
+        bundled,
+        name: "<missing>",
+        author: "<missing>",
+        description: "<missing>",
+        version: "<missing>",
       };
+      return { id, info };
     });
 }
 
@@ -290,29 +259,17 @@ export async function downloadAndInstallExtension(
       fetchAvailableExtensions(false),
     );
 
-    const extDetail = findInCatalog(availableExtensions, { modId: ext.modId });
-
-    const info: IExtension | undefined =
-      extDetail !== undefined
-        ? {
-            ..._.pick(extDetail, ["id", "name", "author", "version", "type"]),
-            bundled: false,
-            description: extDetail.description.short,
-            modId: ext.modId,
-            fileId: extDetail.fileId,
-          }
-        : undefined;
+    const catalogEntry = findInCatalog(availableExtensions, { modId: ext.modId });
 
     const state = api.getState();
     const downloadPath = downloadPathForGame(state, SITE_ID);
 
     await installExtension(api, path.join(downloadPath, download.localPath), {
-      info,
-      catalogEntry: extDetail,
+      catalogEntry,
       analytics: {
         source: "nexusmods",
-        gameDomain: extDetail?.gameId,
-        gameName: extDetail?.gameName,
+        gameDomain: catalogEntry?.gameId,
+        gameName: catalogEntry?.gameName,
       },
     });
 

--- a/src/renderer/src/reducers/app.ts
+++ b/src/renderer/src/reducers/app.ts
@@ -1,3 +1,5 @@
+import shortid from "shortid";
+
 import * as actions from "../actions/app";
 import type { IApp } from "../types/IState";
 import { actionsToReducerSpec } from "./builder";
@@ -19,24 +21,14 @@ export const appReducer = actionsToReducerSpec(
     setStateVersion: (state, payload) => ({ ...state, version: payload }),
     setApplicationVersion: (state, payload) => ({ ...state, appVersion: payload }),
     addExtension: (state, payload) => {
-      const { extensionId, info } = payload;
-      const existing = state.extensions[extensionId];
+      const { extension } = payload;
+      const id = shortid();
+
       return {
         ...state,
         extensions: {
           ...state.extensions,
-          [extensionId]: {
-            ...existing,
-            name: info.name,
-            version: info.version,
-            author: info.author,
-            description: info.description,
-            path: info.path,
-            modId: info.modId,
-            fileId: info.fileId,
-            type: info.type,
-            bundled: info.bundled,
-          },
+          [id]: extension,
         },
       };
     },

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -64,15 +64,18 @@ export type IExtensionWithState = IExtensionState & {
 
 export interface IExtensionDownloadInfo {
   name: string;
-  modId?: number;
-  fileId?: number;
+  modId: number;
+  fileId: number;
   type?: ExtensionType;
 }
 
 /**
  * information about an extension available on the central extension list
  */
-export interface IAvailableExtension extends IExtensionDownloadInfo {
+export interface IAvailableExtension {
+  name: string;
+  modId: number;
+  fileId: number;
   description: {
     short: string;
     long: string;

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -66,7 +66,6 @@ export interface IExtensionDownloadInfo {
   name: string;
   modId: number;
   fileId: number;
-  type?: ExtensionType;
 }
 
 /**

--- a/src/shared/src/types/cli.ts
+++ b/src/shared/src/types/cli.ts
@@ -2,7 +2,6 @@ export interface IParameters {
   download?: string;
   install?: string;
   installArchive?: string;
-  installExtension?: string;
   report?: string;
   restore?: string;
   startMinimized?: boolean;


### PR DESCRIPTION
Part of LAZ-690.

This PR has potential breaking changes:

- `state.app.extensions` object is now keyed on generated short-ids meaning any previous by-name or by-bullshit lookup will fail. The previous PR #23926 and this PR should've changed all lookups to proper queries.
- the `info.json` file is no-longer the source of truth and Vortex stops updating it on disk