### PR TITLE
supersede legacy extension entries at scan time (LAZ-690)

### DIFF
--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 
 import { isPromiseLike, VCREDIST_URL } from "@vortex/shared";
 import { getErrorCode, getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
+import type { DiffOperation } from "@vortex/shared/ipc";
 import type { PreloadWindow } from "@vortex/shared/preload";
 import PromiseBB from "bluebird";
 import type { OpenDialogOptions, SaveDialogOptions } from "electron";
@@ -39,7 +40,7 @@ import { suppressNotification } from "./actions/notificationSettings";
 import { setExtensionLoadFailures } from "./actions/session";
 import { setOptionalExtensions } from "./extensions/extension_manager/actions";
 import { parseExtensionInfo } from "./extensions/extension_manager/extensionInfo";
-import { findInstalled } from "./extensions/extension_manager/queries";
+import { extensionStateFromScan, findInstalled } from "./extensions/extension_manager/queries";
 import type { IModReference, IModRepoId } from "./extensions/mod_management/types/IMod";
 import { IPCDownloadAdapter } from "./IPCDownloadAdapter";
 import { log } from "./logging";
@@ -847,12 +848,16 @@ class ExtensionManager {
         .readdirSync(getVortexPath("temp"))
         .filter((name) => name.startsWith("__disable_"));
 
-      const extensionsPath = path.join(getVortexPath("userData"), "plugins");
-
       disableExtensions.forEach((ext) => {
         const extensionName = ext.substring(10);
-        const extensionPath = path.join(extensionsPath, extensionName);
-        const existingExtension = findInstalled(this.mExtensionState, { path: extensionPath });
+        // the marker carries only a folder name, which can be in either location
+        let existingExtension: ReturnType<typeof findInstalled>;
+        for (const { path: extensionsPath } of ExtensionManager.getExtensionPaths()) {
+          existingExtension = findInstalled(this.mExtensionState, {
+            path: path.join(extensionsPath, extensionName),
+          });
+          if (existingExtension !== undefined) break;
+        }
 
         if (existingExtension === undefined) {
           log("info", "skipping disable file for unknown extension", { extensionName });
@@ -915,11 +920,7 @@ class ExtensionManager {
     log("info", "outdated extensions", { numOutdated: this.mOutdated.length });
     const extensionsPath = path.join(getVortexPath("userData"), "plugins");
     if (this.mOutdated.length > 0) {
-      const removeOps: Array<{
-        type: "set";
-        path: string[];
-        value: unknown;
-      }> = [];
+      const removeOps: DiffOperation[] = [];
       this.mOutdated.forEach((ext) => {
         log("info", "extension older than bundled version, will be removed", {
           name: ext,
@@ -960,17 +961,21 @@ class ExtensionManager {
           });
         }
       });
-      try {
-        window.api?.persist?.sendDiff?.("app", removeOps);
-      } catch (err) {
-        log("warn", "failed to persist outdated-extension remove flags", {
-          error: getErrorMessageOrDefault(err),
-        });
-      }
+      this.persistAppDiff(removeOps, "failed to persist outdated-extension remove flags");
       return;
     }
 
     this.initExtensions();
+  }
+
+  /** Write app-hive operations directly, for repairs whose dispatch does not reach disk. */
+  private persistAppDiff(operations: DiffOperation[], failureMessage: string) {
+    if (operations.length === 0) return;
+    try {
+      window.api?.persist?.sendDiff?.("app", operations);
+    } catch (err) {
+      log("warn", failureMessage, { error: getErrorMessageOrDefault(err) });
+    }
   }
 
   public get hasOutdatedExtensions() {
@@ -2944,6 +2949,24 @@ class ExtensionManager {
           );
 
           if (loadedExtension === undefined) return prev;
+
+          // an entry keyed by extension name carries no path to match this
+          // folder by; replace it, keeping the state it records
+          const recorded = this.mExtensionState[loadedExtension.name];
+          if (recorded !== undefined && recorded.path === undefined) {
+            // unless a complete entry or an earlier scan already covers the folder
+            const claimed =
+              installedExtension !== undefined ||
+              this.mPendingAdds.some((add) => add.name === loadedExtension.name);
+            if (!claimed) {
+              this.mPendingAdds.push(extensionStateFromScan(loadedExtension, recorded));
+            }
+            if (recorded.enabled === false || recorded.remove) {
+              log("debug", "extension disabled", { name: loadedExtension.name });
+              return prev;
+            }
+          }
+
           loadedExtensions.add(loadedExtension.name);
 
           const loadTime = Date.now() - before;
@@ -3083,6 +3106,16 @@ class ExtensionManager {
       dynamicallyLoaded,
     );
 
+    // forgetExtension reaches the store but not disk; main drains its persist
+    // queue during shutdown
+    this.persistAppDiff(
+      this.mPendingRemoves.map((extensionId) => ({
+        type: "remove" as const,
+        path: ["extensions", extensionId],
+      })),
+      "failed to persist removal of extension entries",
+    );
+
     return staticExts.concat(userExts).concat(bundledExts);
   }
 
@@ -3096,11 +3129,22 @@ class ExtensionManager {
     const result: IRegisteredExtension[] = [];
     const loadedFromState = new Set<string>();
     for (const [extId, state] of Object.entries(this.mExtensionState)) {
-      if (state.remove || state.enabled === false) continue;
-      if (state.path === undefined || !fs.existsSync(state.path)) {
+      if (state.remove) continue;
+      // no lookup matches a path-less entry; a scan replaces it, or it goes
+      if (state.path === undefined) {
         this.mPendingRemoves.push(extId);
         continue;
       }
+      // ahead of the skips below, so a gone folder is cleaned up either way
+      if (!fs.existsSync(state.path)) {
+        this.mPendingRemoves.push(extId);
+        continue;
+      }
+      if (state.enabled === false) continue;
+      // a bundled extension loads from the bundled scan; its entry only records
+      // whether it is enabled
+      if (state.bundled) continue;
+
       const ext = this.loadDynamicExtension(state.path, alreadyLoaded, false);
       if (ext !== undefined) {
         result.push(ext);
@@ -3115,24 +3159,17 @@ class ExtensionManager {
       loadedExtensions,
       alreadyLoaded,
     );
-    for (const ext of scanned) {
-      if (!loadedFromState.has(ext.name)) {
-        const state: IExtensionState = {
-          name: ext.name,
-          author: ext.info?.author ?? "<unknown>",
-          description: ext.info?.description ?? "<missing>",
-          version: ext.info?.version ?? "0.0.1",
-          infoJsonId: ext.info?.id,
-          path: ext.path,
-          enabled: true,
-          endorsed: "Undecided",
-          remove: false,
-        };
 
-        this.mPendingAdds.push(state);
-        result.push(ext);
-        loadedExtensions.add(ext.name);
+    for (const ext of scanned) {
+      if (loadedFromState.has(ext.name)) continue;
+
+      // a replaced entry already has its own queued; this one is new
+      if (this.mExtensionState[ext.name] === undefined) {
+        this.mPendingAdds.push(extensionStateFromScan(ext));
       }
+
+      result.push(ext);
+      loadedExtensions.add(ext.name);
     }
 
     return result;

--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
+  addExtension,
   removeExtension,
   setDialogVisible,
   setExtensionEnabled,
@@ -36,6 +37,7 @@ import { PageScroll } from "@/views/components/Page/PageScroll";
 import { SITE_ID } from "../gamemode_management/constants";
 import { useDisplayOptionsAction } from "./hooks/useDisplayOptionsAction.hook";
 import installExtension from "./installExtension";
+import { extensionStateFromScan, findInstalled } from "./queries";
 import getTableAttributes from "./tableAttributes";
 
 export interface IExtensionManagerProps {
@@ -48,7 +50,8 @@ export interface IExtensionManagerProps {
   pageId?: string;
 }
 
-type IExtensionStates = { [extId: string]: IExtensionState };
+/** Keyed by extension id. */
+type IExtensionStates = Record<string, IExtensionState>;
 
 const EMPTY_EXTENSIONS: IExtensionStates = {};
 
@@ -81,17 +84,32 @@ export const ExtensionManager = ({
   // The config as the page found it; a change from here means Vortex needs a restart.
   const [oldExtensions] = useState(extensions);
 
-  // Held in a ref so the columns and row actions stay stable across renders while
-  // their callbacks still see the current extensions.
-  const extensionsRef = useRef(extensions);
-  extensionsRef.current = extensions;
+  // refs, so the columns and row actions below stay stable across renders.
+  // Every rendered row, bundled ones included, so every row has an id here
+  const extensionsRef = useRef<Record<string, IExtensionWithState>>({});
+  // the persisted entries alone, to tell the two apart
+  const persistedRef = useRef(extensions);
+  persistedRef.current = extensions;
 
   const setEnabled = useCallback(
     (extName: string, enabled: boolean) => {
       const current = extensionsRef.current;
       const extId = Object.keys(current).find((iter) => current[iter].name === extName);
+      if (extId === undefined) {
+        log("warn", "toggling unknown extension", { extName, enabled });
+        return;
+      }
+
       log("info", "user toggling extension manually", { extId, enabled });
-      dispatch(setExtensionEnabled(extId, enabled));
+
+      if (persistedRef.current[extId] !== undefined) {
+        dispatch(setExtensionEnabled(extId, enabled));
+        return;
+      }
+
+      // a bundled extension has no entry until its enabled state needs recording
+      const { loadFailures: _loadFailures, ...entry } = current[extId];
+      dispatch(addExtension({ ...entry, enabled }));
     },
     [dispatch],
   );
@@ -146,27 +164,20 @@ export const ExtensionManager = ({
     () =>
       (api?.getLoadedExtensions?.() ?? [])
         .filter((ext) => ext.dynamic && ext.info?.bundled)
+        // one with an entry of its own is already a row
+        .filter((ext) => findInstalled(extensions, { path: ext.path }) === undefined)
         .reduce<IExtensionStates>((prev, ext) => {
-          prev[ext.name] = {
-            enabled: true,
-            version: ext.info?.version ?? "",
-            remove: false,
-            endorsed: "Undecided",
-            name: ext.info?.name ?? ext.name,
-            author: ext.info?.author ?? "Unknown",
-            description: ext.info?.description ?? "",
-            path: ext.path,
-            bundled: true,
-          };
+          // built like a persisted entry, since toggling the row persists it
+          prev[ext.name] = { ...extensionStateFromScan(ext), name: ext.info?.name ?? ext.name };
           return prev;
         }, {}),
-    [api],
+    [api, extensions],
   );
 
   const extensionsWithState = useMemo(() => {
     const allExtensions = showBundled ? { ...extensions, ...bundled } : extensions;
 
-    return Object.keys(allExtensions).reduce<{ [id: string]: IExtensionWithState }>((prev, id) => {
+    return Object.keys(allExtensions).reduce<Record<string, IExtensionWithState>>((prev, id) => {
       const state = allExtensions[id];
 
       if ((!showBundled && state.bundled) || state.remove) {
@@ -181,6 +192,8 @@ export const ExtensionManager = ({
       return prev;
     }, {});
   }, [bundled, extensions, loadFailures, showBundled]);
+
+  extensionsRef.current = extensionsWithState;
 
   const dropExtension = useCallback(
     (type: DropType, extPaths: string[]) => {

--- a/src/renderer/src/extensions/extension_manager/queries.test.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { ExtensionInfo, IAvailableExtension, IRegisteredExtension } from "@/types/extensions";
-import type { IExtensionOptional, IExtensionState } from "@/types/IState";
+import type { IExtensionOptional } from "@/types/IState";
 
+import { makeExtensionState, makeLegacyExtensionState } from "../../test-utils/builders";
 import {
+  extensionStateFromScan,
   findDependencyInCatalog,
   findInCatalog,
   findInstalled,
@@ -13,21 +15,6 @@ import {
   isAlreadyInstalled,
   matchesQuery,
 } from "./queries";
-
-/** Helper to create a test extension state */
-function makeExtensionState(overrides: Partial<IExtensionState> = {}): IExtensionState {
-  return {
-    enabled: true,
-    remove: false,
-    name: "Test Extension",
-    description: "A test extension",
-    author: "Test Author",
-    version: "1.0.0",
-    path: "/path/to/extension",
-    endorsed: "Undecided",
-    ...overrides,
-  };
-}
 
 /** Helper to create a test available extension */
 function makeAvailableExtension(overrides: Partial<IAvailableExtension> = {}): IAvailableExtension {
@@ -139,6 +126,98 @@ describe("findInstalled", () => {
   it("returns undefined for empty installed extensions", () => {
     const result = findInstalled({}, { modId: 123 });
     expect(result).toBeUndefined();
+  });
+});
+
+describe("findInstalled by path", () => {
+  it("finds an installed extension by exact path", () => {
+    const ext = makeExtensionState({ path: "/plugins/real-ext" });
+    const installed = { abc123: ext };
+    const result = findInstalled(installed, { path: "/plugins/real-ext" });
+    expect(result).toEqual({ key: "abc123", extension: ext });
+  });
+
+  it("matches paths case-insensitively", () => {
+    const ext = makeExtensionState({ path: "/Plugins/Real-Ext" });
+    const installed = { abc123: ext };
+    const result = findInstalled(installed, { path: "/plugins/real-ext" });
+    expect(result).toEqual({ key: "abc123", extension: ext });
+  });
+
+  it("does not match entries installed under a queried parent directory", () => {
+    const ext = makeExtensionState({ path: "/plugins/real-ext" });
+    const installed = { abc123: ext };
+    const result = findInstalled(installed, { path: "/plugins" });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips entries without a path", () => {
+    // the path-less entry precedes the match, so the query steps over it
+    const target = makeExtensionState({ path: "/plugins/real-ext" });
+    const installed = { "legacy-ext": makeLegacyExtensionState(), abc123: target };
+    expect(findInstalled(installed, { path: "/plugins/real-ext" })).toEqual({
+      key: "abc123",
+      extension: target,
+    });
+  });
+
+  it("returns undefined when only entries without a path exist", () => {
+    const installed = { "legacy-ext": makeLegacyExtensionState() };
+    expect(findInstalled(installed, { path: "/plugins/real-ext" })).toBeUndefined();
+  });
+});
+
+describe("extensionStateFromScan", () => {
+  const scanned = makeRegisteredExtension({
+    name: "fnv-sanity-checks",
+    path: "/plugins/fnv-sanity-checks",
+    info: makeExtensionInfo({ id: "fnv-sanity-checks", author: "Senjay", version: "1.2.0" }),
+  });
+
+  it("builds a complete entry for a newly scanned extension", () => {
+    expect(extensionStateFromScan(scanned)).toEqual({
+      name: "fnv-sanity-checks",
+      author: "Senjay",
+      description: "Test description",
+      version: "1.2.0",
+      infoJsonId: "fnv-sanity-checks",
+      path: "/plugins/fnv-sanity-checks",
+      bundled: undefined,
+      enabled: true,
+      endorsed: "Undecided",
+      remove: false,
+    });
+  });
+
+  it("keeps the state a superseded entry recorded", () => {
+    const recorded = makeLegacyExtensionState({ version: "1.1.6", endorsed: "Endorsed" });
+    expect(extensionStateFromScan(scanned, recorded)).toMatchObject({
+      enabled: false,
+      version: "1.1.6",
+      endorsed: "Endorsed",
+      path: "/plugins/fnv-sanity-checks",
+    });
+  });
+
+  it("falls back to the extension's own values for what it recorded nothing of", () => {
+    expect(extensionStateFromScan(scanned, makeLegacyExtensionState())).toMatchObject({
+      version: "1.2.0",
+      endorsed: "Undecided",
+    });
+  });
+
+  it("keeps a pending removal, so the next startup retries the delete", () => {
+    const recorded = makeLegacyExtensionState({ remove: true });
+    expect(extensionStateFromScan(scanned, recorded).remove).toBe(true);
+  });
+
+  it("marks a bundled extension bundled", () => {
+    const bundled = makeRegisteredExtension({
+      name: "fnis-integration",
+      path: "/vortex/bundledPlugins/fnis-integration",
+      info: makeExtensionInfo({ bundled: true }),
+    });
+    expect(extensionStateFromScan(bundled).bundled).toBe(true);
   });
 });
 

--- a/src/renderer/src/extensions/extension_manager/queries.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.ts
@@ -21,12 +21,14 @@ export function findInstalled(
   installedExtensions: Record<string, IExtensionState>,
   query: InstalledQuery,
 ): { key: string; extension: IExtensionState } | undefined {
+  const queryPath = "path" in query ? path.normalize(query.path).toLowerCase() : undefined;
+
   const result = Object.entries(installedExtensions).find(([_, extension]) => {
-    if ("path" in query)
+    if (queryPath !== undefined)
       return (
-        path.normalize(extension.path).toLowerCase() === path.normalize(query.path).toLowerCase()
+        extension.path !== undefined && path.normalize(extension.path).toLowerCase() === queryPath
       );
-    return matchesQuery(query, extension);
+    return matchesQuery(query as CatalogQuery, extension);
   });
 
   if (result === undefined) return undefined;
@@ -42,6 +44,29 @@ export function matchesQuery(
 ): boolean {
   if (entry.modId !== query.modId) return false;
   return query.fileId !== undefined ? entry.fileId === query.fileId : true;
+}
+
+/**
+ * Build the entry for a scanned extension. `recorded` is an entry for the same
+ * extension that this one replaces - the path-less shape releases up to v2.4.x
+ * persist - and what it records wins over the extension's own values.
+ */
+export function extensionStateFromScan(
+  ext: IRegisteredExtension,
+  recorded?: IExtensionState,
+): IExtensionState {
+  return {
+    name: ext.name,
+    author: ext.info?.author ?? "<unknown>",
+    description: ext.info?.description ?? "<missing>",
+    version: recorded?.version ?? ext.info?.version ?? "0.0.1",
+    infoJsonId: ext.info?.id,
+    path: ext.path,
+    bundled: ext.info?.bundled,
+    enabled: recorded?.enabled ?? true,
+    endorsed: recorded?.endorsed ?? "Undecided",
+    remove: recorded?.remove ?? false,
+  };
 }
 
 /** Find a dependency extension by its declared identifier among the installed extensions. */

--- a/src/renderer/src/reducers/app.test.ts
+++ b/src/renderer/src/reducers/app.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import * as actions from "../actions/app";
+import { makeExtensionState, makeLegacyExtensionState } from "../test-utils/builders";
+import { appReducer } from "./app";
+
+describe("app reducer extension field writes", () => {
+  const base = { ...appReducer.defaults, extensions: { abc123: makeExtensionState() } };
+  const apply = (action: { getType: () => string }, payload: unknown) =>
+    appReducer.reducers[action.getType()](base, payload);
+
+  it("applies setExtensionEnabled to an existing entry", () => {
+    const result = apply(actions.setExtensionEnabled, { extensionId: "abc123", enabled: false });
+    expect(result.extensions.abc123.enabled).toBe(false);
+  });
+
+  // a write through a key naming no entry must not mint a partial one
+  it.each([
+    [
+      "setExtensionEnabled",
+      actions.setExtensionEnabled,
+      { extensionId: "missing", enabled: false },
+    ],
+    ["setExtensionVersion", actions.setExtensionVersion, { extensionId: "missing", version: "2" }],
+    [
+      "setExtensionEndorsed",
+      actions.setExtensionEndorsed,
+      { extensionId: "missing", endorsed: "Endorsed" },
+    ],
+    ["removeExtension", actions.removeExtension, "missing"],
+  ])("ignores %s for an unknown key", (_name, action, payload) => {
+    expect(apply(action, payload).extensions).toEqual(base.extensions);
+  });
+});
+
+describe("app reducer forgetExtension", () => {
+  const base = {
+    ...appReducer.defaults,
+    extensions: { "legacy-ext": makeLegacyExtensionState(), abc123: makeExtensionState() },
+  };
+
+  it("drops the entry a scan superseded, leaving the rest", () => {
+    const result = appReducer.reducers[actions.forgetExtension.getType()](base, "legacy-ext");
+    expect(Object.keys(result.extensions)).toEqual(["abc123"]);
+  });
+});

--- a/src/renderer/src/reducers/app.ts
+++ b/src/renderer/src/reducers/app.ts
@@ -1,7 +1,7 @@
 import shortid from "shortid";
 
 import * as actions from "../actions/app";
-import type { IApp } from "../types/IState";
+import type { IApp, IExtensionState } from "../types/IState";
 import { actionsToReducerSpec } from "./builder";
 
 const defaultState: IApp = {
@@ -13,6 +13,23 @@ const defaultState: IApp = {
   migrations: [],
   installType: "regular",
 };
+
+// entries are created only by addExtension, so a write through a key naming
+// none must not mint a partial entry holding just that field
+function updateExtension(
+  state: IApp,
+  extensionId: string,
+  changes: Partial<IExtensionState>,
+): IApp {
+  if (state.extensions[extensionId] === undefined) return state;
+  return {
+    ...state,
+    extensions: {
+      ...state.extensions,
+      [extensionId]: { ...state.extensions[extensionId], ...changes },
+    },
+  };
+}
 
 export const appReducer = actionsToReducerSpec(
   defaultState,
@@ -32,43 +49,13 @@ export const appReducer = actionsToReducerSpec(
         },
       };
     },
-    setExtensionEnabled: (state, payload) => ({
-      ...state,
-      extensions: {
-        ...state.extensions,
-        [payload.extensionId]: {
-          ...state.extensions[payload.extensionId],
-          enabled: payload.enabled,
-        },
-      },
-    }),
-    setExtensionVersion: (state, payload) => ({
-      ...state,
-      extensions: {
-        ...state.extensions,
-        [payload.extensionId]: {
-          ...state.extensions[payload.extensionId],
-          version: payload.version,
-        },
-      },
-    }),
-    setExtensionEndorsed: (state, payload) => ({
-      ...state,
-      extensions: {
-        ...state.extensions,
-        [payload.extensionId]: {
-          ...state.extensions[payload.extensionId],
-          endorsed: payload.endorsed,
-        },
-      },
-    }),
-    removeExtension: (state, payload) => ({
-      ...state,
-      extensions: {
-        ...state.extensions,
-        [payload]: { ...state.extensions[payload], remove: true },
-      },
-    }),
+    setExtensionEnabled: (state, payload) =>
+      updateExtension(state, payload.extensionId, { enabled: payload.enabled }),
+    setExtensionVersion: (state, payload) =>
+      updateExtension(state, payload.extensionId, { version: payload.version }),
+    setExtensionEndorsed: (state, payload) =>
+      updateExtension(state, payload.extensionId, { endorsed: payload.endorsed }),
+    removeExtension: (state, payload) => updateExtension(state, payload, { remove: true }),
     forgetExtension: (state, payload) => {
       const { [payload]: _, ...extensions } = state.extensions;
       return { ...state, extensions };

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -73,7 +73,7 @@ import {
   HealthCheckSeverity,
   HealthCheckTrigger,
 } from "../types/IHealthCheck";
-import type { IState } from "../types/IState";
+import type { IExtensionState, IState } from "../types/IState";
 import local from "../util/local";
 import type { IStarterInfo } from "../util/StarterInfo";
 import type {
@@ -986,6 +986,28 @@ export function makeDownloadAdapterHarness(
     resume,
     getStates,
   };
+}
+
+/** A complete installed-extension entry, as `addExtension` writes it. */
+export function makeExtensionState(overrides: Partial<IExtensionState> = {}): IExtensionState {
+  return {
+    enabled: true,
+    remove: false,
+    name: "Test Extension",
+    description: "A test extension",
+    author: "Test Author",
+    version: "1.0.0",
+    path: "/path/to/extension",
+    endorsed: "Undecided",
+    ...overrides,
+  };
+}
+
+/** An entry holding only the fields a write touched - no path, no name. */
+export function makeLegacyExtensionState(
+  overrides: Partial<IExtensionState> = {},
+): IExtensionState {
+  return { enabled: false, ...overrides } as IExtensionState;
 }
 
 let loEntrySeq = 0;


### PR DESCRIPTION
Extension entries are looked up by path, so one persisted without a path matches nothing and startup dies in `path.normalize(undefined)` before the UI shows.

There are two ways to end up with one. Old state: up to v2.4.x an entry was just `{ enabled, version, remove, endorsed }` keyed by extension name, with no path field at all. That is what #23870 is showing, 11 disabled rows with no name or author. And the current build: toggling a bundled extension looks its id up in `app.extensions`, which has no bundled entries, so it writes `"undefined": { enabled: false }` and the next start won't boot.

Now when a scan loads the extension an entry names, it replaces that entry with a complete one and keeps what it recorded (enabled, version, endorsed, remove). Anything no scan matches is dropped. Removals are written to disk directly, since a dispatch this early only reaches the store. The reducers also ignore writes for a key that names no entry, so nothing can mint a partial one again, and the extensions page resolves row actions against the rows it renders, so bundled rows finally have an id: Remove stays hidden for them and toggling one persists.

Checked each of these by staging the state and restarting:

- legacy entry: one complete entry, version/enabled/endorsed kept, disable honoured on that same start
- orphan: dropped, and stays dropped
- folder removed by an update: entry cleaned up even when it says bundled or disabled
- entry flagged for removal: flag survives, and the next start deletes the folder for real
- bundled toggle: persists, `extension disabled` on the next start

closes #23870
part of LAZ-690