### PR TITLE
fix: install .net sdk in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      # @tools/dotnetprobe:build shells out to `dotnet publish` and fails the
+      # whole nx build graph if the SDK isn't present.
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+
       - name: Install volta, Node.js and Yarn
         uses: volta-cli/action@v5
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,9 +39,13 @@ jobs:
           python-version: "3.11"
 
       # @tools/dotnetprobe:build shells out to `dotnet publish` and fails the
-      # whole nx build graph if the SDK isn't present.
+      # whole nx build graph if the SDK isn't present. DOTNET_INSTALL_DIR is
+      # set because the default /usr/share/dotnet isn't writable on our
+      # self-hosted runners (they don't run as root).
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: "9.0.x"
 


### PR DESCRIPTION
## Summary
- `@tools/dotnetprobe:build` shells out to `dotnet publish` and, since `c4cb592a9`, exits non-zero (instead of failing silently) when the SDK is missing — which takes down the whole nx build graph for e2e runs.
- `e2e.yml` never installed a .NET SDK on its runners (unlike `signing-test.yml`), so every e2e run currently fails before any tests execute, e.g. https://github.com/Nexus-Mods/Vortex/actions/runs/31704058055/job/94460027490
- Adds a `Setup .NET SDK` step (`actions/setup-dotnet@v5`, `9.0.x` to match `dotnetprobe.csproj`'s `net9.0` target and `signing-test.yml`).

## Test plan
- [ ] Re-run the e2e workflow on a PR and confirm the `@tools/dotnetprobe:build` step now succeeds and tests execute