### PR TITLE
fix: fall back to the out-of-process FOMOD installer when the native addon can't load

### DIFF
--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -20,7 +20,7 @@
     ],
     "publisherName": ["Black Tree Gaming Limited", "Black Tree Gaming Ltd"],
     "signingHashAlgorithms": ["sha256"],
-    "signExts": [".node"],
+    "signExts": [".node", ".dll"],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
     "timeStampServer": "http://timestamp.comodoca.com"
   },

--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -20,6 +20,7 @@
     ],
     "publisherName": ["Black Tree Gaming Limited", "Black Tree Gaming Ltd"],
     "signingHashAlgorithms": ["sha256"],
+    "signExts": [".node"],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
     "timeStampServer": "http://timestamp.comodoca.com"
   },

--- a/src/renderer/src/extensions/installer_fomod_ipc/index.ts
+++ b/src/renderer/src/extensions/installer_fomod_ipc/index.ts
@@ -20,6 +20,30 @@ const main = (context: IExtensionContext): boolean => {
     osSupportsAppContainer,
   }));
 
+  const installOutOfProcess = toBluebird(
+    async (
+      files: string[],
+      destinationPath: string,
+      gameId: string,
+      _progressDelegate: unknown,
+      choices?: unknown,
+      unattended?: boolean,
+      archivePath?: string,
+      details?: IInstallationDetails,
+    ) => {
+      return await install(
+        context.api,
+        files,
+        destinationPath,
+        gameId,
+        choices,
+        unattended,
+        archivePath,
+        details,
+      );
+    },
+  );
+
   context.registerInstaller(
     /*id:*/ `fomod`,
     /*priority:*/ 20,
@@ -30,32 +54,30 @@ const main = (context: IExtensionContext): boolean => {
         _archivePath?: string,
         details?: ITestSupportedDetails,
       ) => {
-        return await testSupported(context.api, files, gameId, details);
+        return await testSupported(context.api, files, gameId, details, "scripted");
       },
     ),
-    /*install:*/ toBluebird(
+    /*install:*/ installOutOfProcess,
+  );
+
+  // Stand-in for the native installer's own basic handler, and registered at
+  // its priority so that the installers between the two (dinput at 50,
+  // script-extender at 50, ...) keep winning over a generic basic install.
+  // Inert while the native addon loads - see the ipc tester.
+  context.registerInstaller(
+    /*id:*/ `fomod`,
+    /*priority:*/ 100,
+    /*testSupported:*/ toBluebird(
       async (
         files: string[],
-        destinationPath: string,
         gameId: string,
-        _progressDelegate: unknown,
-        choices?: unknown,
-        unattended?: boolean,
-        archivePath?: string,
-        details?: IInstallationDetails,
+        _archivePath?: string,
+        details?: ITestSupportedDetails,
       ) => {
-        return await install(
-          context.api,
-          files,
-          destinationPath,
-          gameId,
-          choices,
-          unattended,
-          archivePath,
-          details,
-        );
+        return await testSupported(context.api, files, gameId, details, "basic");
       },
     ),
+    /*install:*/ installOutOfProcess,
   );
 
   return true;

--- a/src/renderer/src/extensions/installer_fomod_ipc/tester.ts
+++ b/src/renderer/src/extensions/installer_fomod_ipc/tester.ts
@@ -1,8 +1,52 @@
+import { getErrorMessageOrDefault } from "@vortex/shared";
+
 import type { IExtensionApi, ISupportedResult } from "../../types/api";
 import { log } from "../../util/log";
+import {
+  isNativeInstallerAvailable,
+  notifyNativeInstallerUnavailable,
+} from "../installer_fomod_shared/utils/nativeAvailability";
 import type { ITestSupportedDetails } from "../mod_management/types/TestSupported";
+import type { TesterMode } from "./utils/allowedTypes";
+import { allowedTypesFor } from "./utils/allowedTypes";
 import { createConnectionStrategies } from "./utils/connectionStrategy";
 import { VortexIPCConnection } from "./utils/VortexIPCConnection";
+
+const unsupported = (): ISupportedResult => ({ supported: false, requiredFiles: [] });
+
+/** Ask the out-of-process installer whether it handles these files. */
+const probeSupport = async (
+  api: IExtensionApi,
+  files: string[],
+  gameId: string,
+  allowedTypes: string[],
+): Promise<ISupportedResult> => {
+  let connection: VortexIPCConnection | null = null;
+
+  try {
+    connection = new VortexIPCConnection(api, createConnectionStrategies(), 10000);
+    await connection.initialize();
+
+    const result = await connection.testSupported(files, allowedTypes);
+    log("debug", "FOMOD testSupported result", {
+      supported: result.supported,
+      requiredFiles: result.requiredFiles,
+      allowedTypes,
+      gameId,
+    });
+    return result;
+  } catch (err: unknown) {
+    log("error", "FOMOD testSupported failed", {
+      errorName: err instanceof Error ? err.name : "Error",
+      error: getErrorMessageOrDefault(err),
+      allowedTypes,
+      gameId,
+    });
+    return unsupported();
+  } finally {
+    await connection?.dispose();
+  }
+};
 
 /**
  * Test if files are supported by the FOMOD installer
@@ -12,52 +56,20 @@ export const testSupported = async (
   files: string[],
   gameId: string,
   details?: ITestSupportedDetails,
+  mode: TesterMode = "scripted",
 ): Promise<ISupportedResult> => {
-  if (!["oblivion", "fallout3", "falloutnv"].includes(gameId)) {
-    return {
-      supported: false,
-      requiredFiles: [],
-    };
+  const nativeAvailable = await isNativeInstallerAvailable();
+  if (!nativeAvailable) {
+    // Raised from here rather than only from the native tester: once this
+    // extension starts claiming basic installs it wins the priority-100 tie
+    // (it registers first), so the native tester never runs to raise it.
+    notifyNativeInstallerUnavailable(api);
   }
 
-  if (details && details.hasCSScripts === false) {
-    return {
-      supported: false,
-      requiredFiles: [],
-    };
+  const allowedTypes = allowedTypesFor(gameId, details, mode, nativeAvailable);
+  if (allowedTypes.length === 0) {
+    return unsupported();
   }
 
-  let connection: VortexIPCConnection | null = null;
-
-  try {
-    const strategies = createConnectionStrategies();
-    connection = new VortexIPCConnection(api, strategies, 10000);
-    await connection.initialize();
-
-    const result = await connection.testSupported(files, ["CSharpScript"]);
-
-    log("debug", "FOMOD testSupported result", {
-      supported: result.supported,
-      requiredFiles: result.requiredFiles,
-      gameId,
-    });
-
-    return result;
-  } catch (err: any) {
-    const errorName = err.name || "Error";
-    log("error", "FOMOD testSupported failed", {
-      errorName,
-      error: err.message,
-      gameId,
-    });
-
-    return {
-      supported: false,
-      requiredFiles: [],
-    };
-  } finally {
-    if (connection) {
-      await connection.dispose();
-    }
-  }
+  return probeSupport(api, files, gameId, allowedTypes);
 };

--- a/src/renderer/src/extensions/installer_fomod_ipc/tester.ts
+++ b/src/renderer/src/extensions/installer_fomod_ipc/tester.ts
@@ -59,16 +59,21 @@ export const testSupported = async (
   mode: TesterMode = "scripted",
 ): Promise<ISupportedResult> => {
   const nativeAvailable = await isNativeInstallerAvailable();
-  if (!nativeAvailable) {
-    // Raised from here rather than only from the native tester: once this
-    // extension starts claiming basic installs it wins the priority-100 tie
-    // (it registers first), so the native tester never runs to raise it.
-    notifyNativeInstallerUnavailable(api);
-  }
-
   const allowedTypes = allowedTypesFor(gameId, details, mode, nativeAvailable);
   if (allowedTypes.length === 0) {
     return unsupported();
+  }
+
+  if (!nativeAvailable) {
+    // Raised from here as well as from the native tester: the native scripted
+    // tester short-circuits on `hasXmlConfigXML === false` before it ever tries
+    // to load the addon, and once this extension claims basic installs it wins
+    // the priority-100 tie (it registers first), so for a plain archive neither
+    // native registration gets far enough to raise the warning.
+    //
+    // Deliberately after the early return, so we only warn once we are actually
+    // standing in for the missing addon on this archive.
+    notifyNativeInstallerUnavailable(api);
   }
 
   return probeSupport(api, files, gameId, allowedTypes);

--- a/src/renderer/src/extensions/installer_fomod_ipc/utils/allowedTypes.test.ts
+++ b/src/renderer/src/extensions/installer_fomod_ipc/utils/allowedTypes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { allowedTypesFor } from "./allowedTypes";
+
+describe("fomod ipc allowedTypesFor", () => {
+  describe("while the native addon loads", () => {
+    const native = true;
+
+    it("claims C# for the games that ship C# fomods", () => {
+      expect(allowedTypesFor("fallout3", undefined, "scripted", native)).toEqual(["CSharpScript"]);
+    });
+
+    it("claims nothing for other games, leaving them to the native installer", () => {
+      expect(allowedTypesFor("fallout4", undefined, "scripted", native)).toEqual([]);
+    });
+
+    it("claims nothing when the archive is known to have no C# script", () => {
+      expect(allowedTypesFor("fallout3", { hasCSScripts: false }, "scripted", native)).toEqual([]);
+    });
+
+    it("stays out of basic installs entirely", () => {
+      expect(allowedTypesFor("fallout4", undefined, "basic", native)).toEqual([]);
+    });
+  });
+
+  describe("when the native addon is unavailable", () => {
+    // Without this the mod reaches mod_management's verbatim-copy `fallback`
+    // installer, which applies neither stop patterns nor pluginPath - that is
+    // what nests a Bethesda archive's `Data` inside the game's own `Data`.
+    const native = false;
+
+    it("takes over XmlScript for a game the native installer used to own", () => {
+      expect(allowedTypesFor("fallout4", undefined, "scripted", native)).toEqual(["XmlScript"]);
+    });
+
+    it("takes over basic installs", () => {
+      expect(allowedTypesFor("fallout4", undefined, "basic", native)).toEqual(["Basic"]);
+    });
+
+    it("still claims both types on a C# game", () => {
+      expect(allowedTypesFor("oblivion", undefined, "scripted", native)).toEqual([
+        "CSharpScript",
+        "XmlScript",
+      ]);
+    });
+
+    it("respects the archive scan that ruled out an XmlScript config", () => {
+      expect(allowedTypesFor("fallout4", { hasXmlConfigXML: false }, "scripted", native)).toEqual(
+        [],
+      );
+    });
+  });
+});

--- a/src/renderer/src/extensions/installer_fomod_ipc/utils/allowedTypes.ts
+++ b/src/renderer/src/extensions/installer_fomod_ipc/utils/allowedTypes.ts
@@ -1,0 +1,49 @@
+import type { ITestSupportedDetails } from "../../mod_management/types/TestSupported";
+
+/**
+ * Which registration is asking. `scripted` is the priority-20 installer,
+ * `basic` the priority-100 one that only exists to stand in for the native
+ * installer's own basic handler.
+ */
+export type TesterMode = "scripted" | "basic";
+
+// Games whose fomods routinely carry C# scripts. Those go out of process even
+// when the native addon is healthy, because it doesn't run C# scripts.
+const CSHARP_GAMES = ["oblivion", "fallout3", "falloutnv"];
+
+/**
+ * Decide which fomod script types the out-of-process installer claims for an
+ * archive.
+ *
+ * Normally that is C# only. When the native addon can't be loaded, this
+ * extension also claims the types the native installer would have handled -
+ * otherwise every mod walks down the priority list to mod_management's
+ * `fallback` installer, which copies archives verbatim and therefore applies
+ * neither the game's stop patterns nor its pluginPath. `ModInstallerIPC.exe` is
+ * a separate signed executable, so it typically still runs in the environments
+ * that reject the unsigned `.node` addon.
+ *
+ * Kept free of the IPC plumbing so it stays unit-testable: importing the
+ * transport pulls in `@nexusmods/fomod-installer-ipc`, which resolves
+ * `vortex-api` only inside a running Vortex.
+ */
+export const allowedTypesFor = (
+  gameId: string,
+  details: ITestSupportedDetails | undefined,
+  mode: TesterMode,
+  nativeAvailable: boolean,
+): string[] => {
+  if (mode === "basic") {
+    // Never compete with the native basic installer, only replace it.
+    return nativeAvailable ? [] : ["Basic"];
+  }
+
+  const types: string[] = [];
+  if (CSHARP_GAMES.includes(gameId) && details?.hasCSScripts !== false) {
+    types.push("CSharpScript");
+  }
+  if (!nativeAvailable && details?.hasXmlConfigXML !== false) {
+    types.push("XmlScript");
+  }
+  return types;
+};

--- a/src/renderer/src/extensions/installer_fomod_native/index.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/index.ts
@@ -22,7 +22,7 @@ const main = (context: IExtensionContext): boolean => {
         _archivePath: string,
         details?: ITestSupportedDetails,
       ) => {
-        return await testSupported(files, details, false);
+        return await testSupported(context.api, files, details, false);
       },
     ),
     /*install:*/ toBluebird(
@@ -59,7 +59,7 @@ const main = (context: IExtensionContext): boolean => {
         _archivePath: string,
         details?: ITestSupportedDetails,
       ) => {
-        return await testSupported(files, details, true);
+        return await testSupported(context.api, files, details, true);
       },
     ),
     /*install:*/ toBluebird(

--- a/src/renderer/src/extensions/installer_fomod_native/installer.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/installer.ts
@@ -35,10 +35,12 @@ export const install = async (
   const invokeInstall = async (validate: boolean) => {
     // When override instructions file is present, use only the universal stop patterns and null pluginPath
     // to prevent any automatic path manipulation (both FindPathPrefix and pluginPath stripping)
-    const stopPatterns = details.hasInstructionsOverrideFile
+    // `details` is null when simulating an install during a collection session
+    // (see InstallManager.simulateInstall), so this has to stay optional.
+    const stopPatterns = details?.hasInstructionsOverrideFile
       ? uniPatterns
       : getStopPatterns(gameId, getGame(gameId));
-    const pluginPath = details.hasInstructionsOverrideFile ? null : getPluginPath(gameId);
+    const pluginPath = details?.hasInstructionsOverrideFile ? null : getPluginPath(gameId);
 
     // Skip Redux dialog-state dispatches when we have a preset and are running
     // unattended (collection install). The C# fomod still calls uiUpdateState

--- a/src/renderer/src/extensions/installer_fomod_native/tester.test.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/tester.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { IExtensionApi } from "../../types/api";
 import { testSupported } from "./tester";
 
 describe("fomod native testSupported (APP-483)", () => {
@@ -10,21 +11,25 @@ describe("fomod native testSupported (APP-483)", () => {
   // re-assert them.
   const xmlScriptFiles = ["fomod/", "fomod/ModuleConfig.xml", "textures/example.dds"];
 
+  // Only consulted to warn the user when the addon can't be loaded, which is
+  // the failure these tests are asserting against.
+  const api = {} as IExtensionApi;
+
   it("supports an interactive XmlScript fomod so the installer dialog is shown", async () => {
     // Load guard: if the addon fails to load, this reports unsupported and fails.
-    const result = await testSupported(xmlScriptFiles, { hasXmlConfigXML: true }, false);
+    const result = await testSupported(api, xmlScriptFiles, { hasXmlConfigXML: true }, false);
 
     expect(result.supported).toBe(true);
   });
 
   it("short-circuits to unsupported when details report no XmlScript config", async () => {
-    const result = await testSupported(xmlScriptFiles, { hasXmlConfigXML: false }, false);
+    const result = await testSupported(api, xmlScriptFiles, { hasXmlConfigXML: false }, false);
 
     expect(result).toEqual({ supported: false, requiredFiles: [] });
   });
 
   it("routes to the Basic handler when isBasic is set", async () => {
-    const result = await testSupported(["data/a.esp"], undefined, true);
+    const result = await testSupported(api, ["data/a.esp"], undefined, true);
 
     expect(result.supported).toBe(true);
   });

--- a/src/renderer/src/extensions/installer_fomod_native/tester.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/tester.ts
@@ -1,3 +1,5 @@
+import type { IExtensionApi } from "../../types/api";
+import { notifyNativeInstallerUnavailable } from "../installer_fomod_shared/utils/nativeAvailability";
 import type {
   ISupportedResult,
   ITestSupportedDetails,
@@ -10,6 +12,7 @@ let testerInstance: VortexModTester | null = null;
  * Test if files are supported by the FOMOD installer
  */
 export const testSupported = async (
+  api: IExtensionApi,
   files: string[],
   details: ITestSupportedDetails | undefined,
   isBasic: boolean,
@@ -23,9 +26,14 @@ export const testSupported = async (
 
   if (testerInstance === null) {
     testerInstance = await VortexModTester.create();
-    if (testerInstance === null) return Promise.resolve({ supported: false, requiredFiles: [] });
+    if (testerInstance === null) {
+      // The addon can't be loaded in this process. Say so, because the
+      // alternative is a silent walk down to the verbatim-copy `fallback`
+      // installer that quietly mis-installs every mod.
+      notifyNativeInstallerUnavailable(api);
+      return { supported: false, requiredFiles: [] };
+    }
   }
 
-  const result = testerInstance.testSupport(files, isBasic ? ["Basic"] : ["XmlScript"]);
-  return Promise.resolve(result);
+  return testerInstance.testSupport(files, isBasic ? ["Basic"] : ["XmlScript"]);
 };

--- a/src/renderer/src/extensions/installer_fomod_native/utils/VortexModTester.ts
+++ b/src/renderer/src/extensions/installer_fomod_native/utils/VortexModTester.ts
@@ -3,17 +3,17 @@ import type * as fomodT from "@nexusmods/fomod-installer-native";
 import { log } from "@/logging";
 import type { ISupportedResult } from "@/types/api";
 
+import { loadNativeInstaller } from "../../installer_fomod_shared/utils/nativeAvailability";
+
 export class VortexModTester {
   readonly #fomod: typeof fomodT;
 
   static async create(): Promise<VortexModTester | null> {
-    try {
-      const nativeModule = await import("@nexusmods/fomod-installer-native");
-      return new VortexModTester(nativeModule);
-    } catch (err) {
-      log("error", "Failed to load native FOMOD module", err);
-      return null;
-    }
+    // The load is probed (and its failure logged) once per session by
+    // loadNativeInstaller, which the IPC installer also consults to decide
+    // whether it needs to stand in for us.
+    const nativeModule = await loadNativeInstaller();
+    return nativeModule !== undefined ? new VortexModTester(nativeModule) : null;
   }
 
   private constructor(fomod: typeof fomodT) {

--- a/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.test.ts
+++ b/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.test.ts
@@ -40,6 +40,17 @@ describe("notifyNativeInstallerUnavailable", () => {
     expect(api.sendNotification).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the warning pending when the caller has no notification surface", async () => {
+    const { notifyNativeInstallerUnavailable } = await import("./nativeAvailability.js");
+    const withoutSurface = {} as IExtensionApi;
+    const api = makeApi();
+
+    notifyNativeInstallerUnavailable(withoutSurface);
+    notifyNativeInstallerUnavailable(api);
+
+    expect(api.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
   it("explains the cause through the notification action", async () => {
     const { notifyNativeInstallerUnavailable } = await import("./nativeAvailability.js");
     const api = makeApi();

--- a/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.test.ts
+++ b/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+
+// The warning is the only thing standing between a blocked addon and a silent
+// run of mis-installed mods, so pin that it fires, that it fires once, and that
+// its dialog is reachable.
+describe("notifyNativeInstallerUnavailable", () => {
+  const makeApi = () =>
+    ({
+      sendNotification: vi.fn(),
+      showDialog: vi.fn(),
+    }) as unknown as IExtensionApi;
+
+  // Module-level `notified` latch: each test needs a fresh module instance.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("raises a warning notification", async () => {
+    const { notifyNativeInstallerUnavailable } = await import("./nativeAvailability.js");
+    const api = makeApi();
+
+    notifyNativeInstallerUnavailable(api);
+
+    expect(api.sendNotification).toHaveBeenCalledTimes(1);
+    const notification = vi.mocked(api.sendNotification).mock.calls[0]![0];
+    expect(notification.type).toBe("warning");
+    expect(notification.id).toBe("fomod-native-unavailable");
+  });
+
+  it("only notifies once per session, however many installs are attempted", async () => {
+    const { notifyNativeInstallerUnavailable } = await import("./nativeAvailability.js");
+    const api = makeApi();
+
+    notifyNativeInstallerUnavailable(api);
+    notifyNativeInstallerUnavailable(api);
+    notifyNativeInstallerUnavailable(api);
+
+    expect(api.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains the cause through the notification action", async () => {
+    const { notifyNativeInstallerUnavailable } = await import("./nativeAvailability.js");
+    const api = makeApi();
+
+    notifyNativeInstallerUnavailable(api);
+
+    const notification = vi.mocked(api.sendNotification).mock.calls[0]![0];
+    notification.actions![0]!.action(() => undefined);
+
+    expect(api.showDialog).toHaveBeenCalledTimes(1);
+    const [type, title, content] = vi.mocked(api.showDialog).mock.calls[0]!;
+    expect(type).toBe("info");
+    expect(title).toBe("FOMOD installer unavailable");
+    expect(content.text).toContain("modinstaller.node");
+  });
+});
+
+describe("isNativeInstallerAvailable", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("reports the addon as unavailable when it cannot be loaded", async () => {
+    vi.doMock("@nexusmods/fomod-installer-native", () => {
+      throw new Error("An Application Control policy has blocked this file.");
+    });
+
+    const { isNativeInstallerAvailable } = await import("./nativeAvailability.js");
+
+    await expect(isNativeInstallerAvailable()).resolves.toBe(false);
+  });
+
+  it("probes only once and reuses the answer", async () => {
+    const factory = vi.fn(() => {
+      throw new Error("blocked");
+    });
+    vi.doMock("@nexusmods/fomod-installer-native", factory);
+
+    const { isNativeInstallerAvailable } = await import("./nativeAvailability.js");
+
+    await isNativeInstallerAvailable();
+    await isNativeInstallerAvailable();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.ts
+++ b/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.ts
@@ -1,0 +1,83 @@
+import type * as fomodT from "@nexusmods/fomod-installer-native";
+
+import type { IExtensionApi } from "../../../types/IExtensionContext";
+import { log } from "../../../util/log";
+
+const NOTIFICATION_ID = "fomod-native-unavailable";
+
+let probe: Promise<typeof fomodT | undefined> | undefined;
+let notified = false;
+
+/**
+ * Load the native FOMOD addon (`modinstaller.node`), resolving to `undefined`
+ * when it can't be loaded in this process.
+ *
+ * The probe runs once and the result is cached for the session: a failure here
+ * is environmental - an unsigned binary rejected by an application control
+ * policy (Windows Smart App Control / WDAC), a missing native rebuild - so
+ * retrying per install would only pay the cost again for the same answer.
+ */
+export function loadNativeInstaller(): Promise<typeof fomodT | undefined> {
+  if (probe === undefined) {
+    // The addon's published types resolve to `any` here, so the assignment can
+    // only be as safe as this module's own signature makes it.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    probe = import("@nexusmods/fomod-installer-native").catch((err) => {
+      log("error", "Failed to load native FOMOD module", err);
+      return undefined;
+    });
+  }
+  return probe;
+}
+
+export async function isNativeInstallerAvailable(): Promise<boolean> {
+  return (await loadNativeInstaller()) !== undefined;
+}
+
+// Dialog.tsx translates each line of dialog text, so these stay plain strings.
+function showUnavailableDialog(api: IExtensionApi): void {
+  api.showDialog?.(
+    "info",
+    "FOMOD installer unavailable",
+    {
+      text:
+        "Vortex could not load its built-in FOMOD installer (modinstaller.node). " +
+        "This is normally caused by an application control policy blocking the file - " +
+        "on Windows 11 that is most often Smart App Control.\n\n" +
+        "Vortex will fall back to the out-of-process installer where possible. If that " +
+        "one is unavailable too, mods get installed exactly as they are packaged, " +
+        "without the per-game path corrections. For Bethesda games that means an " +
+        'archive wrapping its content in a "Data" folder ends up nested inside the ' +
+        "game's own \"Data\" folder, and the game won't load the mod.\n\n" +
+        "If mods are landing in the wrong folders, reinstall them once the installer " +
+        "is working again.",
+    },
+    [{ label: "Close" }],
+  );
+}
+
+/**
+ * Warn the user, once per session, that the native FOMOD installer is gone.
+ *
+ * Without this the degradation is invisible: both native installers report
+ * "unsupported", every mod walks down the priority list to mod_management's
+ * `fallback` installer, and that one copies archives verbatim - no stop
+ * patterns, no pluginPath stripping. A Bethesda archive that wraps its content
+ * in `Data` then stages one level too deep and deploys to `<game>/Data/Data`,
+ * where nothing loads it. The install still reports success, so the only clue
+ * is a single log line.
+ */
+export function notifyNativeInstallerUnavailable(api: IExtensionApi): void {
+  if (notified) {
+    return;
+  }
+  notified = true;
+
+  api.sendNotification?.({
+    id: NOTIFICATION_ID,
+    type: "warning",
+    title: "FOMOD installer unavailable",
+    message: "Vortex is falling back to a different installer",
+    actions: [{ title: "More", action: () => showUnavailableDialog(api) }],
+  });
+}

--- a/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.ts
+++ b/src/renderer/src/extensions/installer_fomod_shared/utils/nativeAvailability.ts
@@ -68,12 +68,16 @@ function showUnavailableDialog(api: IExtensionApi): void {
  * is a single log line.
  */
 export function notifyNativeInstallerUnavailable(api: IExtensionApi): void {
-  if (notified) {
+  // Only latch once the warning has actually gone out: the first caller may be
+  // holding an api without a notification surface (the native tester runs
+  // before the ipc one), and latching on that call would swallow the warning
+  // for the rest of the session.
+  if (notified || api.sendNotification === undefined) {
     return;
   }
   notified = true;
 
-  api.sendNotification?.({
+  api.sendNotification({
     id: NOTIFICATION_ID,
     type: "warning",
     title: "FOMOD installer unavailable",


### PR DESCRIPTION
## The problem

When `modinstaller.node` cannot be loaded, Vortex silently installs **every** mod
through the verbatim-copy `fallback` installer. For Bethesda games this nests the
archive's `Data` folder inside the game's own `Data`, so nothing loads — and the
install still reports success.

This was found on a real 2.5.0 install (Fallout 4). The only trace in the log is a
single line:

```
[ERRO] Failed to load native FOMOD module
"An Application Control policy has blocked this file.
 \\?\C:\Program Files\Vortex\resources\app.asar.unpacked\node_modules\
 @nexusmods\fomod-installer-native\build\Release\modinstaller.node"
```

The Windows CodeIntegrity log attributes the block to policy
`{0283ac0f-fff1-49ae-ada1-8a933130cad6}` — Smart App Control — with reason
"did not meet the Enterprise signing level requirements".

Every mod installed after that used `fallback`:

```
[DEBG] invoking installer {"installer":"fallback","enforced":false}
```

which left staging folders like `Achievements Mods Enabler/Data/F4SE/Plugins/...`
and deployed them to `Fallout 4/Data/Data/F4SE/Plugins/...`. F4SE looks in
`Data/F4SE/Plugins`, so the plugin never loaded. Mod Configuration Menu was in the
same state, and FallUI - HUD had its raw archive dumped into `Data` (`fomod/`
included) because the scripted installer never ran.

## Root cause

Two independent things:

**1. The addon ships unsigned.** In a 2.5.0 install, `Vortex.exe` is `Valid`
(Black Tree Gaming, via SSL.com) but every `.node` is `NotSigned`. That is
electron-builder's default — `app-builder-lib/out/winPackager.js`:

```js
shouldSignFile(file) {
  const shouldSignDll = this.platformSpecificBuildOptions.signDlls === true && file.endsWith(".dll");
  const shouldSignExplicit = !!this.platformSpecificBuildOptions.signExts?.some(ext => file.endsWith(ext));
  return shouldSignDll || shouldSignExplicit || file.endsWith(".exe");
}
```

Only `.exe` is signed, so the `sign.cjs` hook never sees the addon. Most `.node`
files get by on ISG reputation; `modinstaller.node` is new and rare, so it has
none.

**2. The failure degrades silently.** `VortexModTester.create()` returns `null`,
so both native registrations (priority 10 and 100) report `supported: false`,
`getInstaller` walks to the end of the list, and `fallback` (priority 1000)
copies every entry with `destination: source` — no stop patterns, no
`pluginPath` stripping. Nothing surfaces to the user.

## Changes

**Sign the addon and its native dependency** — `"signExts": [".node", ".dll"]`
routes them through the sign hook that already exists.

`.dll` is required, not incidental. `modinstaller.node` is a 570 KB N-API shim
that links against `ModInstaller.Native.dll` (11 MB) sitting next to it, and in a
2.5.0 install both are unsigned:

```
NotSigned  build\Release\ModInstaller.Native.dll
NotSigned  build\Release\modinstaller.node
```

Signing only the `.node` would just move the block one step later — the log
stops at the `.node` because the load never gets as far as the DLL.

Worth a deliberate decision: `signExts` matches on extension alone, so this also
re-signs Electron's own `ffmpeg.dll`/`libGLESv2.dll`/etc. and the
`fomod-installer-ipc` assemblies. That costs build time (one CodeSignTool call
each) and replaces signatures on third-party DLLs that already carry one, so
`sign.cjs`'s `ignoreFileList` may want extending — it already exists because
esigner flagged some redist files. Happy to narrow this if you prefer.

**Stand in for the addon when it is unavailable** — `installer_fomod_ipc` now
also claims the script types the native installer would have handled, plus a
second registration at priority 100 for basic installs. Both are inert while the
addon loads, and the priority is deliberately 100 so `dinput` and
`script-extender` (50) still win over a generic basic install.

This is a mitigation, not a guarantee. `ModInstallerIPC.exe` is `Valid` in the
same install where the addon is blocked, and the IPC path worked on the machine
this was found on — but its dependencies are not signed either:

```
Valid       ModInstallerIPC.exe, Newtonsoft.Json.dll, Microsoft.CodeAnalysis*.dll
NotSigned   Utils.dll, XmlScript.dll, FomodInstaller.Interface.dll,
            ModInstallerIPC.dll, CSharpScript.dll, Scripting.dll, Antlr*.dll
```

#21742 is exactly that failure — `Utils.dll` blocked by an application control
policy — so on some machines the fallback will be blocked too. It still helps
where only the addon lacks reputation, and where it doesn't, the new notification
at least tells the user instead of leaving them with silently broken installs.

**Say something** — a one-per-session warning notification with a dialog
explaining the likely cause, instead of one log line.

A shared, memoised probe (`installer_fomod_shared/utils/nativeAvailability.ts`)
is the single place that decides whether the addon is usable.

Also included: `simulateInstall` passes `details: null` during a collection
session, which `installer_fomod_native/installer.ts` dereferenced
unconditionally.

## Verification

The native installer's own output on the affected archive, with the real
fallout4 stop patterns and `pluginPath`:

```
copy  Data\F4SE\Plugins\AchievementsModsEnablerLoader.dll  ->  F4SE\Plugins\AchievementsModsEnablerLoader.dll
copy  Data\Plugins\Sumwunn\AchievementsModsEnabler.dll     ->  Plugins\Sumwunn\AchievementsModsEnabler.dll
```

Reinstalling the three affected mods with a build carrying this change produced
correct staging (`F4SE/`, `Plugins/`, `Interface/`, `MCM/`, `Scripts/` — no
wrapper), the FOMOD dialog appeared for FallUI - HUD, and the game loaded the
mods.

New tests cover the routing table (`allowedTypes.test.ts`) and the warning
behaviour, including the once-per-session latch
(`nativeAvailability.test.ts`).

Full `pnpm run build` (152 projects), `pnpm test`, `pnpm lint` and
`pnpm format:check` pass.

**What I could not verify:** the `signExts` change end-to-end — that needs the
SSL.com credentials, so a signed build has to confirm it. What is confirmed is
that the installed electron-builder consumes the option and that only `.exe` is
signed today. Everything else was validated on a single Windows 11 machine with
Smart App Control enabled.

## Prior reports

Nobody appears to have reported this symptom — which fits, since it produces no
error: the user sees "my mods don't work", not a crash. But the underlying cause
has been reported twice and closed without a fix:

- #21742 — application control policy blocks `fomod-installer-ipc/dist/Utils.dll`
  (Vortex 1.16.7, Fallout: New Vegas)
- #17010 — the same policy blocks a `.node` shipped by a game extension

## Open questions

**Backport?** Per `docs/branching-and-release-strategy.md`, this affects both
master and the shipped 2.5.0. With `release/v2.6` already cut, `release/v2.5` is
in maintenance, where the doc limits backports to critical fixes and asks to
check first. Silently mis-installing every mod is not a crash or data loss, but
it is not cosmetic either — happy to add a `pick:` label if the team wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
