### PR TITLE
fix: sign bundled dlls, unique temp dir per file

### DIFF
--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -19,7 +19,7 @@
       }
     ],
     "publisherName": ["Black Tree Gaming Limited", "Black Tree Gaming Ltd"],
-    "signExts": [".dll", ".node"],
+    "signExts": [".dll"],
     "signingHashAlgorithms": ["sha256"],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
     "timeStampServer": "http://timestamp.comodoca.com"

--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -19,6 +19,7 @@
       }
     ],
     "publisherName": ["Black Tree Gaming Limited", "Black Tree Gaming Ltd"],
+    "signExts": [".dll"],
     "signingHashAlgorithms": ["sha256"],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
     "timeStampServer": "http://timestamp.comodoca.com"

--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -19,7 +19,7 @@
       }
     ],
     "publisherName": ["Black Tree Gaming Limited", "Black Tree Gaming Ltd"],
-    "signExts": [".dll"],
+    "signExts": [".dll", ".node"],
     "signingHashAlgorithms": ["sha256"],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
     "timeStampServer": "http://timestamp.comodoca.com"

--- a/src/main/sign.cjs
+++ b/src/main/sign.cjs
@@ -13,6 +13,24 @@ const CODE_SIGN_TOOL_DIR = path.join(PROJECT_ROOT, "CodeSignTool");
 // Make sure these are lowercase
 const ignoreFileList = ["arctool.exe", "vc_redist.x64.exe", "windowsdesktop-runtime-win-x64.exe"];
 
+// Only PE binaries can carry an Authenticode signature. The packaged tree also
+// carries linux/darwin/android prebuilds of some native modules (leveldown,
+// xxhash-addon), which are ELF/Mach-O and would fail the signing call.
+function isPortableExecutable(filePath) {
+    let fd;
+    try {
+        fd = fs.openSync(filePath, "r");
+        const magic = Buffer.alloc(2);
+        return fs.readSync(fd, magic, 0, 2, 0) === 2 && magic.toString("latin1") === "MZ";
+    } catch (err) {
+        return false;
+    } finally {
+        if (fd !== undefined) {
+            fs.closeSync(fd);
+        }
+    }
+}
+
 if (!fs.existsSync(TEMP_DIR)) {
     fs.mkdirSync(TEMP_DIR, { recursive: true });
 }
@@ -26,6 +44,11 @@ async function sign(configuration) {
 
     if (ignoreFileList.includes(path.basename(configuration.path.toLowerCase()))) {
         console.log(`Ignoring ${configuration.path} as the file is in the ignore list`);
+        return;
+    }
+
+    if (!isPortableExecutable(configuration.path)) {
+        console.log(`Ignoring ${configuration.path} as it is not a PE binary`);
         return;
     }
 

--- a/src/main/sign.cjs
+++ b/src/main/sign.cjs
@@ -1,6 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 const childProcess = require("child_process");
+const crypto = require("crypto");
 require("dotenv").config();
 
 const TEMP_DIR = path.join(__dirname, "temp");
@@ -32,19 +33,33 @@ async function sign(configuration) {
         console.log(`Signing ${configuration.path}`);
 
         const { base, dir } = path.parse(configuration.path);
-        const tempFile = path.join(TEMP_DIR, base);
 
         // CodeSignTool can't sign in place without verifying the overwrite with a
         // y/m interaction so we are creating a new file in a temp directory and
         // then replacing the original file with the signed file.
 
-        const setDir = `cd "${CODE_SIGN_TOOL_DIR}"`;
-        const signFile = `CodeSignTool sign -input_file_path="${configuration.path}" -output_dir_path="${TEMP_DIR}" -credential_id="${ES_CREDENTIAL_ID}" -username="${ES_USERNAME}" -password="${ES_PASSWORD}" -totp_secret="${ES_TOTP_SECRET}"`;
-        const moveFile = `move "${tempFile}" "${dir}"`;
+        // The output directory is derived from the full source path rather than
+        // shared, because basenames are not unique across the packaged tree
+        // (e.g. several copies of AccessControl.dll and watcher.node). A shared
+        // directory would let concurrent signings overwrite each other's output.
+        const outDir = path.join(
+            TEMP_DIR,
+            crypto.createHash("sha1").update(configuration.path).digest("hex").slice(0, 12),
+        );
+        fs.mkdirSync(outDir, { recursive: true });
+        const tempFile = path.join(outDir, base);
 
-        childProcess.execSync(`${setDir} && ${signFile} && ${moveFile}`, {
-            stdio: "inherit",
-        });
+        try {
+            const setDir = `cd "${CODE_SIGN_TOOL_DIR}"`;
+            const signFile = `CodeSignTool sign -input_file_path="${configuration.path}" -output_dir_path="${outDir}" -credential_id="${ES_CREDENTIAL_ID}" -username="${ES_USERNAME}" -password="${ES_PASSWORD}" -totp_secret="${ES_TOTP_SECRET}"`;
+            const moveFile = `move /Y "${tempFile}" "${dir}"`;
+
+            childProcess.execSync(`${setDir} && ${signFile} && ${moveFile}`, {
+                stdio: "inherit",
+            });
+        } finally {
+            fs.rmSync(outDir, { recursive: true, force: true });
+        }
     } else {
         console.warn(`sign.js - Can't sign file ${configuration.path}, missing value for:
         ${ES_USERNAME ? "" : "ES_USERNAME"}


### PR DESCRIPTION
electron-builder's `shouldSignFile` only hands `.exe` to the custom signer unless `signExts` is set, so every dll in a packaged build ships unsigned. That's 28 in 2.5.0, ours included (`FomodInstaller.Interface`, `ModInstallerIPC`, `XmlScript`, `CSharpScript`). `signExts: [".dll"]` routes them through `sign.cjs`.

`sign.cjs` signed everything into one temp dir keyed on basename. Fine for the 11 `.exe` files we sign today since those names are unique, but the nsis plugins ship three copies of `AccessControl.dll`, so widening the filter puts colliding names through one temp slot. Now keyed on a hash of the full path and cleaned up after. Also `move /Y` so a leftover target can't sit waiting on an overwrite prompt.

Confirmed working in CI (run 32152373865, green). 46 files signed, 35 dll and 11 exe, no failures. Every one got its own temp dir, which matters for the 5 files sharing 2 names: three copies of `AccessControl.dll` and two of `Newtonsoft.Json.dll`.

```
Signing ...\nsis\plugins\x86-unicode\AccessControl.dll
Code signed successfully: ...\temp\beda073027b0\AccessControl.dll
Signing ...\nsis\plugins\x86-ansi\AccessControl.dll
Code signed successfully: ...\temp\6020bfcadff3\AccessControl.dll
Signing ...\nsis\plugins\amd64-unicode\AccessControl.dll
Code signed successfully: ...\temp\7060aca1d7de\AccessControl.dll
```

I tried `.node` as well and CodeSignTool rejects it: `Unsupported file format for signing - node`, on a win32-x64 prebuild that's a valid PE file. So it's the extension it objects to, not the contents, and eSigner's supported-types list was right to leave it off. Backed out in 3bf11f25b, so the 22 `.node` files stay unsigned as they are on master today. If we want them later the options are signing as `.dll` and renaming back (Authenticode lives in the PE cert table, so the signature survives the rename) or moving to eSigner CKA.

The PE check in `sign.cjs` stays. Nothing non-PE ships as `.dll` today, but it costs one file read and turns a future one into a skip instead of a failed release build.

Costs 8.1min for the 46 files, about 10s each with no parallelism. Previously 11 files in roughly 3min, so call it 5min added.
