### PR TITLE
source the extension catalog from the v3 extensions endpoint (LAZ-690)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -666,47 +666,20 @@ interface IAttributeState {
 
 // @public
 interface IAvailableExtension {
-    // (undocumented)
     author: string;
     // (undocumented)
-    dependencies?: {
-        [key: string]: any;
-    };
-    // (undocumented)
-    description: {
-        short: string;
-        long: string;
-    };
-    // (undocumented)
-    downloads: number;
-    // (undocumented)
-    endorsements: number;
-    // (undocumented)
     fileId: number;
-    // (undocumented)
-    gameId?: string;
-    // (undocumented)
+    gameDomain?: string;
+    gameId?: number;
     gameName?: string;
-    // (undocumented)
-    hide?: boolean;
-    // (undocumented)
-    id?: string;
-    // (undocumented)
-    image: string;
-    // (undocumented)
+    image?: string;
     language?: string;
     // (undocumented)
     modId: number;
     // (undocumented)
     name: string;
-    // (undocumented)
-    tags: string[];
-    // (undocumented)
     timestamp: number;
-    // (undocumented)
     type?: ExtensionType;
-    // (undocumented)
-    uploader: string;
     // (undocumented)
     version: string;
 }
@@ -3100,6 +3073,7 @@ interface INexusAPIExtension {
     nexusGetCollections?: (gameId: string) => PromiseLike<Partial<ICollection>[] | undefined>;
     // (undocumented)
     nexusGetLatestMods?: (gameId: string) => PromiseLike<any>;
+    nexusGetModEndorsementCounts?: (uids: string[]) => PromiseLike<Record<string, number>>;
     // (undocumented)
     nexusGetModFiles?: (gameId: string, modId: number) => PromiseLike<IFileInfo[]>;
     // (undocumented)
@@ -5109,7 +5083,7 @@ export const Usage: React$2.ComponentClass<IUsageProps>;
 
 // @public (undocumented)
 export namespace util {
-    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, readExtensibleDir, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
+    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
 }
 
 // @public (undocumented)
@@ -5268,37 +5242,37 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 // lib/api.d.ts:1110:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:1265:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:1608:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2392:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3293:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3420:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3717:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3774:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4108:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4533:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5209:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5214:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5217:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5220:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5235:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5278:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5301:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5304:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5322:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5387:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5449:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5481:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5527:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5529:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5530:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5531:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5533:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5535:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5544:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5545:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5546:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5562:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8812:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8813:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2389:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3292:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3419:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3716:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3773:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4107:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4532:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5208:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5213:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5216:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5219:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5234:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5277:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5300:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5303:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5321:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5386:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5448:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5480:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5526:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5528:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5529:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5530:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5532:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5534:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5543:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5544:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5545:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5561:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8808:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8809:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/extensions/extension-dashlet/src/ExtensionsDashlet.tsx
+++ b/extensions/extension-dashlet/src/ExtensionsDashlet.tsx
@@ -114,7 +114,6 @@ class ExtensionsDashlet extends ComponentEx<IProps, IExtensionsDashletState> {
             {ext.name}
           </a>
         </h4>
-        <p className="extension-summary">{ext.description.short}</p>
         <div className="extension-extra">
           <div>
             <Icon name="author" /> {t("By {{author}}", { replace: { author: ext.author } })}
@@ -183,7 +182,7 @@ class ExtensionsDashlet extends ComponentEx<IProps, IExtensionsDashletState> {
     const now = Date.now();
 
     return (
-      ext.uploader !== user &&
+      ext.author !== user &&
       (dlId === undefined || now - downloads[dlId].fileTime > ENDORSEMENT_DELAY) &&
       util.getSafe(extensionState, [extId, "endorsed"], "Undecided") === "Undecided"
     );

--- a/extensions/theme-switcher/src/index.ts
+++ b/extensions/theme-switcher/src/index.ts
@@ -6,7 +6,7 @@ import Bluebird from "bluebird";
 import * as ops from "./operations";
 import settingsReducer from "./reducers";
 import SettingsTheme from "./SettingsTheme";
-import { getAvailableFonts, themesPath } from "./util";
+import { getAvailableFonts, listThemeDirs } from "./util";
 
 function applyTheme(api: types.IExtensionApi, theme: string, initial: boolean) {
   if (!initial) {
@@ -20,28 +20,26 @@ function applyTheme(api: types.IExtensionApi, theme: string, initial: boolean) {
     return;
   }
 
-  return util
-    .readExtensibleDir("theme", path.join(__dirname, "themes"), themesPath())
-    .then((themes) => {
-      const selected = themes.find((iter) => path.basename(iter) === theme);
-      if (selected === undefined) {
-        return Promise.resolve();
-      }
+  return listThemeDirs().then((themes) => {
+    const selected = themes.find((iter) => path.basename(iter) === theme);
+    if (selected === undefined) {
+      return Promise.resolve();
+    }
 
-      return fs
-        .statAsync(path.join(selected, "variables.scss"))
-        .then(() => api.setStylesheet("variables", path.join(selected, "variables")))
-        .catch(() => api.setStylesheet("variables", undefined))
-        .then(() => fs.statAsync(path.join(selected, "details.scss")))
-        .then(() => api.setStylesheet("details", path.join(selected, "details")))
-        .catch(() => api.setStylesheet("details", undefined))
-        .then(() => fs.statAsync(path.join(selected, "fonts.scss")))
-        .then(() => api.setStylesheet("fonts", path.join(selected, "fonts")))
-        .catch(() => api.setStylesheet("fonts", undefined))
-        .then(() => fs.statAsync(path.join(selected, "style.scss")))
-        .then(() => api.setStylesheet("style", path.join(selected, "style")))
-        .catch(() => api.setStylesheet("style", undefined));
-    });
+    return fs
+      .statAsync(path.join(selected, "variables.scss"))
+      .then(() => api.setStylesheet("variables", path.join(selected, "variables")))
+      .catch(() => api.setStylesheet("variables", undefined))
+      .then(() => fs.statAsync(path.join(selected, "details.scss")))
+      .then(() => api.setStylesheet("details", path.join(selected, "details")))
+      .catch(() => api.setStylesheet("details", undefined))
+      .then(() => fs.statAsync(path.join(selected, "fonts.scss")))
+      .then(() => api.setStylesheet("fonts", path.join(selected, "fonts")))
+      .catch(() => api.setStylesheet("fonts", undefined))
+      .then(() => fs.statAsync(path.join(selected, "style.scss")))
+      .then(() => api.setStylesheet("style", path.join(selected, "style")))
+      .catch(() => api.setStylesheet("style", undefined));
+  });
 }
 
 function editStyle(api: types.IExtensionApi, themeName: string): Bluebird<void> {

--- a/extensions/theme-switcher/src/operations.ts
+++ b/extensions/theme-switcher/src/operations.ts
@@ -4,15 +4,13 @@ import { fs, log, types, util } from "@nexusmods/vortex-api";
 import Bluebird from "bluebird";
 
 import * as actions from "./actions";
-import { themesPath } from "./util";
+import { listThemeDirs, themesPath } from "./util";
 
 let themes: string[] = [];
 
-export function readThemes() {
-  const bundledPath = path.join(__dirname, "themes");
-  return util.readExtensibleDir("theme", bundledPath, themesPath()).tap((extThemes) => {
-    themes = extThemes;
-  });
+export async function readThemes(): Promise<string[]> {
+  themes = await listThemeDirs();
+  return themes;
 }
 
 export function themeName(location: string): string {

--- a/extensions/theme-switcher/src/util.ts
+++ b/extensions/theme-switcher/src/util.ts
@@ -1,9 +1,29 @@
+import { readdir } from "node:fs/promises";
 import * as path from "path";
 
 import { util } from "@nexusmods/vortex-api";
 
 export function themesPath(): string {
   return path.join(util.getVortexPath("userData"), "themes");
+}
+
+/** List all theme directories: bundled themes plus the user's themes folder. */
+export async function listThemeDirs(): Promise<string[]> {
+  const baseDirs = [path.join(__dirname, "themes"), themesPath()];
+  const lists = await Promise.all(
+    baseDirs.map(async (baseDir) => {
+      try {
+        const entries = await readdir(baseDir, { withFileTypes: true });
+        return entries
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => path.join(baseDir, entry.name));
+      } catch {
+        // an unreadable base dir contributes no themes
+        return [];
+      }
+    }),
+  );
+  return lists.flat();
 }
 
 interface IFont {

--- a/packages/nexus-api-v3/src/client.ts
+++ b/packages/nexus-api-v3/src/client.ts
@@ -169,6 +169,21 @@ export function createNexusV3Client(options: NexusV3ClientOptions) {
       return Array.from(data.data.versions);
     },
 
+    /** Fetch Vortex extensions, themes, and translations, split into three lists. */
+    async getVortexExtensions(): Promise<{
+      extensions: components["schemas"]["VortexExtension"][];
+      themes: components["schemas"]["VortexAsset"][];
+      translations: components["schemas"]["VortexAsset"][];
+    }> {
+      const { data, error, response } = await client.GET("/vortex/extensions");
+      if (error) throw toV3Error(error, response);
+      return {
+        extensions: Array.from(data.data.extensions),
+        themes: Array.from(data.data.themes),
+        translations: Array.from(data.data.translations),
+      };
+    },
+
     /**
      * Resolve mod-level display details (name, summary, status, thumbnail, adult
      * flag) for a set of composite mod UIDs. Up to 2000 `modIds` per call;

--- a/src/renderer/src/ExtensionManager.ts
+++ b/src/renderer/src/ExtensionManager.ts
@@ -41,6 +41,7 @@ import { setExtensionLoadFailures } from "./actions/session";
 import { setOptionalExtensions } from "./extensions/extension_manager/actions";
 import { parseExtensionInfo } from "./extensions/extension_manager/extensionInfo";
 import { extensionStateFromScan, findInstalled } from "./extensions/extension_manager/queries";
+import _sessionReducer from "./extensions/extension_manager/reducers";
 import type { IModReference, IModRepoId } from "./extensions/mod_management/types/IMod";
 import { IPCDownloadAdapter } from "./IPCDownloadAdapter";
 import { log } from "./logging";

--- a/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
+++ b/src/renderer/src/extensions/extension_manager/BrowseExtensions.tsx
@@ -1,6 +1,8 @@
+import { getErrorMessageOrDefault } from "@vortex/shared";
 import * as React from "react";
 import { Button, FormControl, ListGroup, ListGroupItem, ModalHeader } from "react-bootstrap";
-import * as semver from "semver";
+
+import { log } from "@/logging";
 
 import bbcode from "../../controls/bbcode";
 import { ComponentEx, connect, translate } from "../../controls/ComponentEx";
@@ -13,11 +15,10 @@ import { IconButton } from "../../controls/TooltipControls";
 import ZoomableImage from "../../controls/ZoomableImage";
 import type { IAvailableExtension, ISelector } from "../../types/extensions";
 import type { IExtensionState, IState } from "../../types/IState";
-import { getApplication } from "../../util/application";
 import opn from "../../util/opn";
-import { largeNumToString } from "../../util/util";
+import { SITE_ID } from "../gamemode_management/constants";
 import { NEXUS_BASE_URL } from "../nexus_integration/constants";
-import { findInCatalog } from "./queries";
+import { findInCatalog, findInstalled } from "./queries";
 import { downloadAndInstallExtension, selectorMatch } from "./util";
 
 const NEXUS_MODS_URL: string = `${NEXUS_BASE_URL}/site/mods/`;
@@ -33,14 +34,21 @@ export interface IBrowseExtensionsProps {
   onRefreshExtensions: () => void;
 }
 
-type SortOrder = "name" | "endorsements" | "downloads" | "recent";
+type SortOrder = "name" | "recent";
+
+/** Description texts fetched on selection; the extensions endpoint carries none. */
+interface IModDescription {
+  summary?: string;
+  description?: string;
+}
 
 interface IBrowseExtensionsState {
-  error: Error;
   selected?: ISelector;
   installing: string[];
   searchTerm: string;
   sort: SortOrder;
+  // keyed by mod ID
+  descriptions: Record<number, IModDescription>;
 }
 
 function makeSelectorId(ext: IAvailableExtension): string {
@@ -56,18 +64,6 @@ interface IConnectedProps {
 
 type IProps = IBrowseExtensionsProps & IConnectedProps;
 
-const version = (() => {
-  let result: string;
-
-  return () => {
-    if (result === undefined) {
-      result = getApplication().version;
-    }
-
-    return result;
-  };
-})();
-
 function nop() {
   // nop
 }
@@ -78,11 +74,11 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
     super(props);
 
     this.initState({
-      error: undefined,
       selected: undefined,
       installing: [],
       searchTerm: "",
       sort: "name",
+      descriptions: {},
     });
 
     this.mModalRef = React.createRef();
@@ -96,6 +92,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
       this.nextState.selected = {
         modId: nextProps.localState.preselectModId,
       };
+      this.fetchDescription(nextProps.localState.preselectModId);
     }
   }
 
@@ -137,12 +134,6 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
                       <FormControl componentClass="select" onChange={this.changeSort} value={sort}>
                         <option key={"name"} value={"name"}>
                           {t("Name")}
-                        </option>
-                        <option key={"endorsements"} value={"endorsements"}>
-                          {t("Endorsements")}
-                        </option>
-                        <option key="downloads" value="downloads">
-                          {t("Downloads")}
                         </option>
                         <option key="recent" value="recent">
                           {t("Last update")}
@@ -196,9 +187,6 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
 
   private filterSearch = (test: IAvailableExtension) => {
     const { searchTerm } = this.state;
-    if (test.hide) {
-      return false;
-    }
 
     if (!searchTerm) {
       return true;
@@ -207,62 +195,37 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
     const searchTermNorm = searchTerm.toUpperCase();
 
     return (
-      test.name?.toUpperCase?.().indexOf?.(searchTermNorm) !== -1 ||
-      test.author?.toUpperCase?.().indexOf?.(searchTermNorm) !== -1 ||
-      test.description?.short?.toUpperCase?.().indexOf?.(searchTermNorm) !== -1 ||
-      test.description?.long?.toUpperCase?.().indexOf?.(searchTermNorm) !== -1
+      test.name.toUpperCase().includes(searchTermNorm) ||
+      test.author.toUpperCase().includes(searchTermNorm)
     );
   };
 
-  private extensionSort = (lhs: IAvailableExtension, rhs: IAvailableExtension): number => {
-    switch (this.state.sort) {
-      case "downloads":
-        return (rhs.downloads || 0) - (lhs.downloads || 0);
-      case "endorsements":
-        return (rhs.endorsements || 0) - (lhs.endorsements || 0);
-      case "recent":
-        return (rhs.timestamp || 0) - (lhs.timestamp || 0);
-      default:
-        return lhs.name.localeCompare(rhs.name);
-    }
-  };
-
-  private isCompatible(ext: IAvailableExtension): boolean {
-    if (
-      ext.dependencies === undefined ||
-      ext.dependencies["vortex"] === undefined ||
-      process.env.NODE_ENV === "development"
-    ) {
-      return true;
-    }
-
-    return semver.satisfies(version(), ext.dependencies["vortex"], {
-      includePrerelease: true,
-    });
-  }
+  private extensionSort = (lhs: IAvailableExtension, rhs: IAvailableExtension): number =>
+    this.state.sort === "recent"
+      ? (rhs.timestamp || 0) - (lhs.timestamp || 0)
+      : lhs.name.localeCompare(rhs.name);
 
   private isInstalled(ext: IAvailableExtension): boolean {
-    const { extensions } = this.props;
+    return findInstalled(this.props.extensions, { modId: ext.modId }) !== undefined;
+  }
 
-    return (
-      Object.keys(extensions)
-        // looking at modid for mods hosted on nexus and the id for games in vortex-games.
-        // In the past we used the name for games from the repo but that meant that the games
-        // couldn't be renamed without causing issues for this list, not sure why that was
-        // done in the first place.
-        .find((key) => {
-          const iter = extensions[key];
-          return (
-            (ext.modId !== undefined && iter.modId === ext.modId) ||
-            (ext.id !== undefined && key === ext.id)
-          );
-        }) !== undefined
+  private renderAction(ext: IAvailableExtension): React.JSX.Element {
+    const { t } = this.props;
+    const { installing } = this.state;
+
+    return installing.indexOf(ext.name) !== -1 ? (
+      <Spinner />
+    ) : this.isInstalled(ext) ? (
+      <div>{t("Installed")}</div>
+    ) : (
+      <a className="extension-subscribe" data-modid={ext.modId} onClick={this.install}>
+        {t("Install")}
+      </a>
     );
   }
 
-  private renderListEntry = (ext: IAvailableExtension, idx: number) => {
-    const { t } = this.props;
-    const { installing, selected } = this.state;
+  private renderListEntry = (ext: IAvailableExtension) => {
+    const { selected } = this.state;
 
     const classes = ["extension-item"];
 
@@ -270,52 +233,23 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
       classes.push("selected");
     }
 
-    const installed = this.isInstalled(ext);
-    const incompatible = !this.isCompatible(ext);
-
-    const action =
-      installing.indexOf(ext.name) !== -1 ? (
-        <Spinner />
-      ) : installed ? (
-        <div>{t("Installed")}</div>
-      ) : incompatible ? (
-        <div>{t("Incompatible")}</div>
-      ) : (
-        <a className="extension-subscribe" data-modid={ext.modId} onClick={this.install}>
-          {t("Install")}
-        </a>
-      );
-
     return (
       <ListGroupItem
         className={classes.join(" ")}
         key={makeSelectorId(ext)}
         data-modid={ext.modId}
         onClick={this.select}
-        disabled={installed || incompatible}
+        disabled={this.isInstalled(ext)}
       >
         <div className="extension-header">
           <div className="extension-title">
             <span className="extension-name">{ext.name}</span>
             <span className="extension-version">{ext.version}</span>
           </div>
-          <div className="extension-stats">
-            {ext.downloads !== undefined ? (
-              <div className="extension-downloads">
-                <Icon name="download" /> {largeNumToString(ext.downloads)}
-              </div>
-            ) : null}
-            {ext.endorsements !== undefined ? (
-              <div className="extension-endorsements">
-                <Icon name="endorse-yes" /> {largeNumToString(ext.endorsements)}
-              </div>
-            ) : null}
-          </div>
         </div>
-        <div className="extension-description">{ext.description.short}</div>
         <div className="extension-footer">
           <div className="extension-author">{ext.author}</div>
-          {action}
+          {this.renderAction(ext)}
         </div>
       </ListGroupItem>
     );
@@ -323,12 +257,9 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
 
   private renderDescription = (ext: IAvailableExtension) => {
     const { t } = this.props;
-    const { installing } = this.state;
     if (ext === undefined) {
       return null;
     }
-
-    const installed = this.isInstalled(ext);
 
     const openInBrowser = (
       <a className="extension-browse" data-modid={ext.modId} onClick={this.openPage}>
@@ -337,18 +268,7 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
       </a>
     );
 
-    const action =
-      installing.indexOf(ext.name) !== -1 ? (
-        <Spinner />
-      ) : installed ? (
-        <div>{t("Installed")}</div>
-      ) : !this.isCompatible(ext) ? (
-        <div>{t("Incompatible")}</div>
-      ) : (
-        <a className="extension-subscribe" data-modid={ext.modId} onClick={this.install}>
-          {t("Install")}
-        </a>
-      );
+    const details = this.state.descriptions[ext.modId];
 
     return (
       <FlexLayout type="column">
@@ -367,28 +287,20 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
                     {t("by")} {ext.author}
                   </span>
                 </div>
-                <div className="description-short">{ext.description.short}</div>
-                <div className="description-stats">
-                  {ext.downloads !== undefined ? (
-                    <div className="extension-downloads">
-                      <Icon name="download" /> {ext.downloads}
-                    </div>
-                  ) : null}
-                  {ext.endorsements !== undefined ? (
-                    <div className="extension-endorsements">
-                      <Icon name="endorse-yes" /> {ext.endorsements}
-                    </div>
-                  ) : null}
-                </div>
+                {details?.summary !== undefined ? (
+                  <div className="description-short">{details.summary}</div>
+                ) : null}
                 <div className="description-actions">
-                  {action} {openInBrowser}
+                  {this.renderAction(ext)} {openInBrowser}
                 </div>
               </FlexLayout>
             </FlexLayout.Flex>
           </FlexLayout>
         </FlexLayout.Fixed>
         <FlexLayout.Flex>
-          <div className="description-text">{bbcode(ext.description.long)}</div>
+          <div className="description-text">
+            {details === undefined ? <Spinner /> : bbcode(details.description ?? "")}
+          </div>
         </FlexLayout.Flex>
       </FlexLayout>
     );
@@ -421,6 +333,27 @@ class BrowseExtensions extends ComponentEx<IProps, IBrowseExtensionsState> {
     const modIdStr = evt.currentTarget.getAttribute("data-modid");
     const modId = modIdStr !== null ? parseInt(modIdStr, 10) : undefined;
     this.nextState.selected = { modId };
+    this.fetchDescription(modId);
+  };
+
+  private fetchDescription = (modId: number | undefined) => {
+    if (modId === undefined || this.nextState.descriptions[modId] !== undefined) return;
+
+    void (async () => {
+      try {
+        const info = await this.context.api.ext.nexusGetModInfo?.(SITE_ID, modId);
+        this.nextState.descriptions[modId] = {
+          summary: info?.summary,
+          description: info?.description,
+        };
+      } catch (err) {
+        log("warn", "failed to fetch extension description", {
+          modId,
+          error: getErrorMessageOrDefault(err),
+        });
+        this.nextState.descriptions[modId] = {};
+      }
+    })();
   };
 
   private openPage = (evt: React.MouseEvent<any>) => {

--- a/src/renderer/src/extensions/extension_manager/availableExtensions.test.ts
+++ b/src/renderer/src/extensions/extension_manager/availableExtensions.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { makeAvailableExtension } from "../../test-utils/builders";
+import type { VortexAsset, VortexData, VortexExtension } from "./availableExtensions";
+import {
+  dedupeGameExtensions,
+  mapAvailableExtensions,
+  parseTranslationLocale,
+} from "./availableExtensions";
+
+function makeAsset(overrides: Partial<VortexAsset> = {}): VortexAsset {
+  return {
+    name: "Test Extension",
+    version: "1.2.0",
+    author_name: "Uploader",
+    author_user_id: "54321",
+    uploaded_at: "2023-11-14T22:13:20Z",
+    mod_id: "123",
+    file_id: "456",
+    image_url: "https://example.invalid/image.jpg",
+    ...overrides,
+  };
+}
+
+function makeWireExtension(overrides: Partial<VortexExtension> = {}): VortexExtension {
+  return { ...makeAsset(), type: "other", ...overrides };
+}
+
+function makeData(overrides: Partial<VortexData> = {}): VortexData {
+  return { extensions: [], themes: [], translations: [], ...overrides };
+}
+
+describe("mapAvailableExtensions", () => {
+  it("maps a game extension, converting ids and the upload time", () => {
+    const data = makeData({
+      extensions: [makeWireExtension({ type: "game", game_id: "7" })],
+    });
+
+    expect(mapAvailableExtensions(data)).toEqual([
+      {
+        name: "Test Extension",
+        modId: 123,
+        fileId: 456,
+        author: "Uploader",
+        version: "1.2.0",
+        timestamp: Date.parse("2023-11-14T22:13:20Z"),
+        image: "https://example.invalid/image.jpg",
+        type: "game",
+        gameId: 7,
+        language: undefined,
+      },
+    ]);
+  });
+
+  it("maps an 'other' extension to no type", () => {
+    const data = makeData({ extensions: [makeWireExtension()] });
+    expect(mapAvailableExtensions(data)[0].type).toBeUndefined();
+  });
+
+  it("maps themes and translations to their extension types", () => {
+    const data = makeData({
+      themes: [makeAsset({ name: "Some Theme" })],
+      translations: [makeAsset({ name: "German Translation" })],
+    });
+
+    const [theme, translation] = mapAvailableExtensions(data);
+    expect(theme.type).toBe("theme");
+    expect(translation.type).toBe("translation");
+    expect(translation.language).toBe("de");
+  });
+
+  it("drops entries whose ids do not parse", () => {
+    const data = makeData({
+      extensions: [makeWireExtension({ mod_id: "not-a-number" }), makeWireExtension()],
+    });
+    expect(mapAvailableExtensions(data)).toHaveLength(1);
+  });
+
+  it("drops entries with blank ids", () => {
+    const data = makeData({
+      extensions: [makeWireExtension({ mod_id: "" }), makeWireExtension({ file_id: " " })],
+    });
+    expect(mapAvailableExtensions(data)).toHaveLength(0);
+  });
+
+  it("maps a blank game_id to no gameId", () => {
+    const data = makeData({ extensions: [makeWireExtension({ type: "game", game_id: "" })] });
+    expect(mapAvailableExtensions(data)[0].gameId).toBeUndefined();
+  });
+
+  it("maps a null image to undefined", () => {
+    const data = makeData({ extensions: [makeWireExtension({ image_url: null })] });
+    expect(mapAvailableExtensions(data)[0].image).toBeUndefined();
+  });
+
+  it("maps an unparseable upload time to 0", () => {
+    const data = makeData({ extensions: [makeWireExtension({ uploaded_at: "garbage" })] });
+    expect(mapAvailableExtensions(data)[0].timestamp).toBe(0);
+  });
+});
+
+describe("dedupeGameExtensions", () => {
+  const contender = (modId: number, gameId: number, timestamp = 0) =>
+    makeAvailableExtension({ name: `ext-${modId}`, modId, type: "game", gameId, timestamp });
+
+  it("keeps the most endorsed extension of a contested game", () => {
+    const broken = contender(1361, 1955);
+    const curated = contender(1547, 1955);
+
+    const result = dedupeGameExtensions([broken, curated], { 1361: 2, 1547: 43 });
+    expect(result).toEqual([curated]);
+  });
+
+  it("breaks endorsement ties by newest upload", () => {
+    const older = contender(1, 7, 1000);
+    const newer = contender(2, 7, 2000);
+
+    expect(dedupeGameExtensions([newer, older], {})).toEqual([newer]);
+  });
+
+  it("treats a missing endorsement count as zero", () => {
+    const unknown = contender(1, 7, 2000);
+    const endorsed = contender(2, 7, 1000);
+
+    expect(dedupeGameExtensions([unknown, endorsed], { 2: 1 })).toEqual([endorsed]);
+  });
+
+  it("keeps uncontested games and preserves order", () => {
+    const solo = contender(1, 7);
+    const winner = contender(2, 8);
+    const loser = contender(3, 8);
+    const anotherSolo = contender(4, 9);
+
+    const result = dedupeGameExtensions([solo, winner, loser, anotherSolo], { 2: 5 });
+    expect(result).toEqual([solo, winner, anotherSolo]);
+  });
+
+  it("passes through non-game entries and game extensions without a game ID", () => {
+    const theme = makeAvailableExtension({ name: "theme", modId: 5, type: "theme" });
+    const translation = makeAvailableExtension({
+      name: "translation",
+      modId: 6,
+      type: "translation",
+    });
+    const unresolved = makeAvailableExtension({ name: "unresolved", modId: 7, type: "game" });
+
+    const result = dedupeGameExtensions([theme, translation, unresolved], {});
+    expect(result).toEqual([theme, translation, unresolved]);
+  });
+});
+
+describe("parseTranslationLocale", () => {
+  it("prefers an explicit locale code, normalizing its case", () => {
+    expect(parseTranslationLocale("Vortex Translation (pt-BR)")).toBe("pt-BR");
+    expect(parseTranslationLocale("Vortex Translation (DE)")).toBe("de");
+  });
+
+  it("matches an English language name", () => {
+    expect(parseTranslationLocale("Polish Translation for Vortex")).toBe("pl");
+  });
+
+  it("matches any name of a multi-name entry", () => {
+    // languagemap lists es as "Spanish; Castilian"
+    expect(parseTranslationLocale("Spanish Translation")).toBe("es");
+    expect(parseTranslationLocale("Castilian Translation")).toBe("es");
+  });
+
+  it("matches multi-word language names", () => {
+    // languagemap lists gd as "Scottish Gaelic; Gaelic"
+    expect(parseTranslationLocale("Scottish Gaelic Translation")).toBe("gd");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(parseTranslationLocale("Vortex Community Pack")).toBeUndefined();
+  });
+});

--- a/src/renderer/src/extensions/extension_manager/availableExtensions.ts
+++ b/src/renderer/src/extensions/extension_manager/availableExtensions.ts
@@ -1,0 +1,158 @@
+import type { components } from "@vortex/nexus-api-v3";
+
+import { log } from "@/logging";
+
+import type { IAvailableExtension } from "../../types/extensions";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import { createVortexNexusV3Client } from "../nexus_integration/nexusV3Client";
+import { languageCodeByEnglishName } from "../settings_interface/languagemap";
+
+/**
+ * Boundary to GET /v3/vortex/extensions: everything past this module works
+ * with IAvailableExtension, the wire types stay in here.
+ */
+export type VortexAsset = components["schemas"]["VortexAsset"];
+export type VortexExtension = components["schemas"]["VortexExtension"];
+export type VortexData = components["schemas"]["VortexData"];
+
+/**
+ * Derive a locale code from a translation's mod name. The endpoint carries no
+ * locale field, so match an explicit code like "(pt-BR)" or an English
+ * language name like "German".
+ */
+export function parseTranslationLocale(name: string): string | undefined {
+  const explicit = /\(([a-z]{2})(?:-([a-z]{2}))?\)/i.exec(name);
+  if (explicit !== null) {
+    const [, language, country] = explicit;
+    return country !== undefined
+      ? `${language.toLowerCase()}-${country.toUpperCase()}`
+      : language.toLowerCase();
+  }
+
+  const words = name
+    .toLowerCase()
+    .split(/[^\p{L}]+/u)
+    .filter((word) => word.length > 0);
+
+  // longest window first so multi-word names win over their parts; 3 covers
+  // the longest languagemap entry ("Old Church Slavonic")
+  for (let size = 3; size >= 1; size--) {
+    for (let start = 0; start + size <= words.length; start++) {
+      const code = languageCodeByEnglishName(words.slice(start, start + size).join(" "));
+      if (code !== undefined) return code;
+    }
+  }
+  return undefined;
+}
+
+/** Parse to a finite number, or undefined; blank strings are not numbers. */
+function finite(value: string | null | undefined): number | undefined {
+  if (value == null || value.trim().length === 0) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toAvailableExtension(
+  asset: VortexAsset,
+  extras: Pick<IAvailableExtension, "type" | "gameId" | "language">,
+): IAvailableExtension | undefined {
+  const modId = finite(asset.mod_id);
+  const fileId = finite(asset.file_id);
+  if (modId === undefined || fileId === undefined) return undefined;
+
+  const timestamp = Date.parse(asset.uploaded_at);
+
+  return {
+    name: asset.name,
+    modId,
+    fileId,
+    author: asset.author_name,
+    version: asset.version,
+    timestamp: Number.isFinite(timestamp) ? timestamp : 0,
+    image: asset.image_url ?? undefined,
+    ...extras,
+  };
+}
+
+/** Map the wire response to the internal model, dropping unusable entries. */
+export function mapAvailableExtensions(data: VortexData): IAvailableExtension[] {
+  const mapped = [
+    ...data.extensions.map((ext) =>
+      toAvailableExtension(ext, {
+        type: ext.type === "game" ? "game" : undefined,
+        gameId: finite(ext.game_id),
+      }),
+    ),
+    ...data.themes.map((theme) => toAvailableExtension(theme, { type: "theme" })),
+    ...data.translations.map((translation) =>
+      toAvailableExtension(translation, {
+        type: "translation",
+        language: parseTranslationLocale(translation.name),
+      }),
+    ),
+  ];
+
+  const result = mapped.filter((entry): entry is IAvailableExtension => entry !== undefined);
+  const dropped = mapped.length - result.length;
+  if (dropped > 0) {
+    log("debug", "dropped extension entries with unusable ids", { dropped });
+  }
+  return result;
+}
+
+/** Group game extensions by the game they claim; other entries are not included. */
+export function groupGameExtensionsByGameId(
+  extensions: IAvailableExtension[],
+): Map<number, IAvailableExtension[]> {
+  // keyed by numeric Nexus Mods game ID
+  const groups = new Map<number, IAvailableExtension[]>();
+  for (const ext of extensions) {
+    if (ext.type !== "game" || ext.gameId === undefined) continue;
+    const group = groups.get(ext.gameId);
+    if (group === undefined) {
+      groups.set(ext.gameId, [ext]);
+    } else {
+      group.push(ext);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Keep one game extension per game: nothing stops several extensions for the
+ * same game from being listed, so the most endorsed wins and the newest upload
+ * breaks ties. Everything else passes through unchanged.
+ */
+export function dedupeGameExtensions(
+  extensions: IAvailableExtension[],
+  // keyed by mod ID
+  endorsementsByModId: Record<number, number>,
+): IAvailableExtension[] {
+  const beats = (challenger: IAvailableExtension, champion: IAvailableExtension): boolean => {
+    const challengerVotes = endorsementsByModId[challenger.modId] ?? 0;
+    const championVotes = endorsementsByModId[champion.modId] ?? 0;
+    if (challengerVotes !== championVotes) return challengerVotes > championVotes;
+    return challenger.timestamp > champion.timestamp;
+  };
+
+  const winners = new Set<IAvailableExtension>();
+  for (const group of groupGameExtensionsByGameId(extensions).values()) {
+    winners.add(group.reduce((champion, ext) => (beats(ext, champion) ? ext : champion)));
+  }
+
+  const result = extensions.filter(
+    (ext) => ext.type !== "game" || ext.gameId === undefined || winners.has(ext),
+  );
+  const dropped = extensions.length - result.length;
+  if (dropped > 0) {
+    log("info", "dropped extensions for games claimed more than once", { dropped });
+  }
+  return result;
+}
+
+/** Fetch and map the extension list. */
+export async function fetchExtensionList(api: IExtensionApi): Promise<IAvailableExtension[]> {
+  log("info", "downloading extension list");
+  const data = await createVortexNexusV3Client(api).getVortexExtensions();
+  return mapAvailableExtensions(data);
+}

--- a/src/renderer/src/extensions/extension_manager/index.ts
+++ b/src/renderer/src/extensions/extension_manager/index.ts
@@ -104,8 +104,8 @@ async function updateAvailableExtensions(
   }
 
   try {
-    const { time, extensions } = await Promise.resolve(fetchAvailableExtensions(true, force));
-    api.store.dispatch(setExtensionsUpdate(time.getTime()));
+    const extensions = await fetchAvailableExtensions(api, force);
+    api.store.dispatch(setExtensionsUpdate(Date.now()));
     api.store.dispatch(setAvailableExtensions(extensions));
     await checkForUpdates(api);
   } catch (err) {

--- a/src/renderer/src/extensions/extension_manager/installExtension.ts
+++ b/src/renderer/src/extensions/extension_manager/installExtension.ts
@@ -363,8 +363,7 @@ async function installExtensionImpl(
       const state: IExtensionState = {
         name: data?.catalogEntry?.name ?? extensionInfo?.name ?? path.basename(destPath),
         author: data?.catalogEntry?.author ?? extensionInfo?.author ?? "<unknown>",
-        description:
-          data?.catalogEntry?.description?.short ?? extensionInfo?.description ?? "<missing>",
+        description: extensionInfo?.description ?? "<missing>",
         version: data?.catalogEntry?.version ?? extensionInfo?.version ?? "0.0.1",
 
         endorsed: "Undecided",

--- a/src/renderer/src/extensions/extension_manager/queries.test.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import type { ExtensionInfo, IAvailableExtension, IRegisteredExtension } from "@/types/extensions";
+import type { ExtensionInfo, IRegisteredExtension } from "@/types/extensions";
 import type { IExtensionOptional } from "@/types/IState";
 
-import { makeExtensionState, makeLegacyExtensionState } from "../../test-utils/builders";
+import {
+  makeAvailableExtension,
+  makeExtensionState,
+  makeLegacyExtensionState,
+} from "../../test-utils/builders";
 import {
   extensionStateFromScan,
   findDependencyInCatalog,
@@ -15,25 +19,6 @@ import {
   isAlreadyInstalled,
   matchesQuery,
 } from "./queries";
-
-/** Helper to create a test available extension */
-function makeAvailableExtension(overrides: Partial<IAvailableExtension> = {}): IAvailableExtension {
-  return {
-    name: "Test Extension",
-    description: { short: "short", long: "long" },
-    image: "image.png",
-    author: "Test Author",
-    uploader: "uploader",
-    version: "1.0.0",
-    downloads: 0,
-    endorsements: 0,
-    timestamp: 0,
-    tags: [],
-    modId: 0,
-    fileId: 0,
-    ...overrides,
-  };
-}
 
 /** Helper to create extension info */
 function makeExtensionInfo(overrides: Partial<ExtensionInfo> = {}): ExtensionInfo {
@@ -258,13 +243,6 @@ describe("matchesQuery", () => {
 });
 
 describe("findDependencyInCatalog", () => {
-  it("finds a dependency by id", () => {
-    const ext = makeAvailableExtension({ id: "test-extension" });
-    const catalog = [ext];
-    const result = findDependencyInCatalog(catalog, "test-extension");
-    expect(result).toEqual(ext);
-  });
-
   it("finds a dependency by name", () => {
     const ext = makeAvailableExtension({ name: "Test Extension" });
     const catalog = [ext];
@@ -272,17 +250,9 @@ describe("findDependencyInCatalog", () => {
     expect(result).toEqual(ext);
   });
 
-  it("prefers id match over name match", () => {
-    const ext1 = makeAvailableExtension({ id: "test-id", name: "Other Name" });
-    const ext2 = makeAvailableExtension({ id: "other-id", name: "Test Name" });
-    const catalog = [ext1, ext2];
-    const result = findDependencyInCatalog(catalog, "test-id");
-    expect(result).toEqual(ext1);
-  });
-
   it("returns undefined when no match is found", () => {
-    const catalog = [makeAvailableExtension({ id: "other-id" })];
-    const result = findDependencyInCatalog(catalog, "test-id");
+    const catalog = [makeAvailableExtension({ name: "Other Name" })];
+    const result = findDependencyInCatalog(catalog, "Test Name");
     expect(result).toBeUndefined();
   });
 

--- a/src/renderer/src/extensions/extension_manager/queries.ts
+++ b/src/renderer/src/extensions/extension_manager/queries.ts
@@ -83,14 +83,12 @@ export function findInstalledDependency(
   return { key, extension };
 }
 
-/** Find a dependency extension by its declared identifier in the catalog. */
+/** Find a dependency extension by its declared identifier (the extension name) in the catalog. */
 export function findDependencyInCatalog(
   catalog: IAvailableExtension[],
   dependencyId: string,
 ): IAvailableExtension | undefined {
-  return catalog.find(
-    (catalogEntry) => catalogEntry.id === dependencyId || catalogEntry.name === dependencyId,
-  );
+  return catalog.find((catalogEntry) => catalogEntry.name === dependencyId);
 }
 
 /** Checks whether an extension from the catalog is already installed. */

--- a/src/renderer/src/extensions/extension_manager/util.test.ts
+++ b/src/renderer/src/extensions/extension_manager/util.test.ts
@@ -1,66 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import type { IAvailableExtension } from "../../types/extensions";
-import { filterInstallableExtensions, selectorMatch } from "./util";
+import { makeApiHarness, makeAvailableExtension, makeDownload } from "../../test-utils/builders";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import { fetchExtensionList } from "./availableExtensions";
+import installExtension from "./installExtension";
+import { downloadAndInstallExtension, selectorMatch } from "./util";
 
-function makeExtension(overrides: Partial<IAvailableExtension> = {}): IAvailableExtension {
-  return {
-    name: "Some Extension",
-    description: { short: "short", long: "long" },
-    image: "image.png",
-    author: "someone",
-    uploader: "someone",
-    version: "1.0.0",
-    downloads: 0,
-    endorsements: 0,
-    timestamp: 0,
-    tags: [],
-    modId: 0,
-    fileId: 0,
-    ...overrides,
-  };
-}
+vi.mock("./availableExtensions", () => ({
+  fetchExtensionList: vi.fn(),
+  dedupeGameExtensions: (extensions: unknown) => extensions,
+  groupGameExtensionsByGameId: () => new Map(),
+}));
 
-describe("filterInstallableExtensions", () => {
-  it("keeps extensions with both modId and fileId", () => {
-    const extensions = [makeExtension({ modId: 1, fileId: 2 })];
-    expect(filterInstallableExtensions(extensions)).toEqual(extensions);
-  });
+vi.mock("./installExtension", () => ({ default: vi.fn() }));
 
-  it("drops extensions missing modId", () => {
-    const extensions = [makeExtension({ modId: undefined, fileId: 2 })];
-    expect(filterInstallableExtensions(extensions)).toEqual([]);
-  });
+vi.mock("../nexus_integration/util", () => ({
+  nexusGames: () => [],
+  nexusGamesProm: async () => [],
+}));
 
-  it("drops extensions missing fileId", () => {
-    const extensions = [makeExtension({ modId: 1, fileId: undefined })];
-    expect(filterInstallableExtensions(extensions)).toEqual([]);
-  });
-
-  it("drops legacy GitHub-hosted entries lacking both modId and fileId", () => {
-    const extensions = [makeExtension({ modId: undefined, fileId: undefined })];
-    expect(filterInstallableExtensions(extensions)).toEqual([]);
-  });
-
-  it("keeps only the qualifying entries out of a mixed list", () => {
-    const nexusExt = makeExtension({ name: "Nexus Extension", modId: 1, fileId: 2 });
-    const githubExt = makeExtension({
-      name: "GitHub Extension",
-      modId: undefined,
-      fileId: undefined,
-    });
-    const partialExt = makeExtension({ name: "Partial Extension", modId: 3, fileId: undefined });
-
-    expect(filterInstallableExtensions([nexusExt, githubExt, partialExt])).toEqual([nexusExt]);
-  });
-
-  it("returns an empty array unchanged", () => {
-    expect(filterInstallableExtensions([])).toEqual([]);
-  });
-});
+vi.mock("../download_management/selectors", () => ({
+  downloadPathForGame: () => "C:/downloads/site",
+}));
 
 describe("selectorMatch", () => {
-  const ext = makeExtension({ modId: 42, fileId: 7 });
+  const ext = makeAvailableExtension({ modId: 42, fileId: 7 });
 
   it("matches on modId", () => {
     expect(selectorMatch(ext, { modId: 42 })).toBe(true);
@@ -72,5 +36,31 @@ describe("selectorMatch", () => {
 
   it("returns false when the selector is undefined", () => {
     expect(selectorMatch(ext, undefined)).toBe(false);
+  });
+});
+
+describe("downloadAndInstallExtension", () => {
+  it("installs a downloaded archive even when the catalog fetch fails", async () => {
+    vi.mocked(fetchExtensionList).mockRejectedValueOnce(new Error("endpoint unavailable"));
+
+    const harness = makeApiHarness({
+      downloads: { "dl-1": makeDownload({ id: "dl-1", localPath: "some-extension.7z" }) },
+    });
+    harness.api.emitAndAwait = vi.fn(async () => [
+      "dl-1",
+    ]) as unknown as IExtensionApi["emitAndAwait"];
+
+    const result = await downloadAndInstallExtension(harness.api, {
+      name: "Some Extension",
+      modId: 42,
+      fileId: 7,
+    });
+
+    expect(result).toBe(true);
+    expect(vi.mocked(installExtension)).toHaveBeenCalledWith(
+      harness.api,
+      expect.stringContaining("some-extension.7z"),
+      expect.objectContaining({ catalogEntry: undefined }),
+    );
   });
 });

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -1,83 +1,32 @@
 import * as path from "node:path";
 
-import PromiseBB from "bluebird";
-import * as _ from "lodash";
+import type { IGameListEntry } from "@nexusmods/nexus-api";
+import { getErrorMessageOrDefault } from "@vortex/shared";
 
 import { log } from "@/logging";
 
 import type {
-  ExtensionType,
   IAvailableExtension,
-  IExtension,
   IExtensionDownloadInfo,
-  IExtensionManifest,
   ISelector,
 } from "../../types/extensions";
 import type { IExtensionApi } from "../../types/IExtensionContext";
-import { DataInvalid, ProcessCanceled, UserCanceled } from "../../util/CustomErrors";
-import * as fs from "../../util/fs";
-import { writeFileAtomic } from "../../util/fsAtomic";
-import getVortexPath from "../../util/getVortexPath";
-import { jsonRequest } from "../../util/network";
+import { ProcessCanceled, UserCanceled } from "../../util/CustomErrors";
 import { INVALID_FILENAME_RE } from "../../util/util";
 import { setDownloadModInfo } from "../download_management/actions/state";
 import { downloadPathForGame } from "../download_management/selectors";
 import { SITE_ID } from "../gamemode_management/constants";
-import { parseExtensionInfo } from "./extensionInfo";
+import { nexusGamesProm } from "../nexus_integration/util";
+import { decodeUID, makeModUID } from "../nexus_integration/util/UIDs";
+import {
+  dedupeGameExtensions,
+  fetchExtensionList,
+  groupGameExtensionsByGameId,
+} from "./availableExtensions";
 import installExtension from "./installExtension";
 import { findInCatalog } from "./queries";
 
-const caches: {
-  __availableExtensions?: PromiseBB<{
-    time: Date;
-    extensions: IAvailableExtension[];
-  }>;
-  __installedExtensions?: PromiseBB<{ [extId: string]: IExtension }>;
-} = {};
-
-// don't fetch more than once per hour
-const UPDATE_FREQUENCY = 60 * 60 * 1000;
-
-function githubRawUrl(repo: string, branch: string, repoPath: string) {
-  return `https://raw.githubusercontent.com/${repo}/${branch}/${repoPath}`;
-}
-
-//const EXTENSION_FORMAT = '1_8';
-const EXTENSION_FILENAME = `extensions-manifest.json`;
-const EXTENSION_PATH = "out/";
-const EXTENSION_URL = githubRawUrl(
-  "Nexus-Mods/Vortex-Backend",
-  "main",
-  EXTENSION_PATH + EXTENSION_FILENAME,
-);
-
-function getAllDirectories(searchPath: string): PromiseBB<string[]> {
-  return fs
-    .readdirAsync(searchPath)
-    .filter((fileName: string) => {
-      if (path.extname(fileName) === ".installing") {
-        // ignore directories during installation
-        return PromiseBB.resolve(false);
-      }
-      return fs
-        .statAsync(path.join(searchPath, fileName))
-        .then((stat) => stat.isDirectory())
-        .catch((err) => {
-          if (err.code !== "ENOENT") {
-            log("error", "failed to stat file/directory", {
-              searchPath,
-              fileName,
-              error: err.message,
-            });
-          }
-          // the stat may fail if the directory has been removed/renamed between reading the dir
-          // and the stat. Specifically this can happen while installing an extension for the
-          // temporary ".installing" directory
-          return PromiseBB.resolve(false);
-        });
-    })
-    .catch({ code: "ENOENT" }, () => []);
-}
+let availableExtensionsCache: Promise<IAvailableExtension[]> | undefined;
 
 export function selectorMatch(ext: IAvailableExtension, selector: ISelector): boolean {
   if (selector === undefined) {
@@ -90,150 +39,82 @@ export function sanitize(input: string): string {
   return input.replace(INVALID_FILENAME_RE, "_");
 }
 
-export function readExtensionInfo(
-  extensionPath: string,
-  bundled: boolean,
-): PromiseBB<{ id: string; info: IExtension }> {
-  const finalPath = extensionPath.replace(/\.installing$/, "");
-
-  return fs
-    .readFileAsync(path.join(extensionPath, "info.json"), { encoding: "utf-8" })
-    .then((contents: string) => {
-      const data: unknown = JSON.parse(contents);
-      const info = parseExtensionInfo(data);
-      const id = info.id || path.basename(finalPath);
-      info.bundled = bundled;
-      return { id, info };
-    })
-    .catch(() => {
-      const id = path.basename(finalPath);
-      const info: IExtension = {
-        id,
-        bundled,
-        name: "<missing>",
-        author: "<missing>",
-        description: "<missing>",
-        version: "<missing>",
-      };
-      return { id, info };
-    });
-}
-
-function readExtensionDir(
-  pluginPath: string,
-  bundled: boolean,
-): PromiseBB<Array<{ id: string; info: IExtension }>> {
-  return getAllDirectories(pluginPath)
-    .map((extPath: string) => path.join(pluginPath, extPath))
-    .map((fullPath: string) => readExtensionInfo(fullPath, bundled));
-}
-
-export function readExtensions(force: boolean): PromiseBB<{ [extId: string]: IExtension }> {
-  if (caches.__installedExtensions === undefined || force) {
-    caches.__installedExtensions = doReadExtensions();
-  }
-  return caches.__installedExtensions;
-}
-
-function doReadExtensions(): PromiseBB<{ [extId: string]: IExtension }> {
-  const bundledPath = getVortexPath("bundledPlugins");
-  const extensionsPath = path.join(getVortexPath("userData"), "plugins");
-
-  return PromiseBB.all([
-    readExtensionDir(bundledPath, true),
-    readExtensionDir(extensionsPath, false),
-  ])
-    .then((extLists) => [].concat(...extLists))
-    .reduce((prev, value: { id: string; info: IExtension }) => {
-      prev[value.id] = value.info;
-      return prev;
-    }, {});
-}
-
+/**
+ * Fetch the extension list, memoized so concurrent callers share one request.
+ * `force` refetches; a failed fetch clears the memo so the next call retries.
+ */
 export function fetchAvailableExtensions(
-  forceCache: boolean,
-  forceDownload: boolean = false,
-): PromiseBB<{ time: Date; extensions: IAvailableExtension[] }> {
-  if (caches.__availableExtensions === undefined || forceCache || forceDownload) {
-    caches.__availableExtensions = doFetchAvailableExtensions(forceDownload);
-  }
-  return caches.__availableExtensions;
-}
-
-function downloadExtensionList(cachePath: string): PromiseBB<IAvailableExtension[]> {
-  log("info", "downloading extension list", { url: EXTENSION_URL });
-  return PromiseBB.resolve(jsonRequest<IExtensionManifest>(EXTENSION_URL))
-    .then((manifest) => {
-      log("debug", "extension list received");
-      return manifest.extensions.filter((ext) => ext.name !== undefined);
-    })
-    .tap((extensions) => writeFileAtomic(cachePath, JSON.stringify({ extensions }, undefined, 2)))
-    .tapCatch((err) => log("error", "failed to download extension list", err));
-}
-
-function doFetchAvailableExtensions(
-  forceDownload: boolean,
-): PromiseBB<{ time: Date; extensions: IAvailableExtension[] }> {
-  const cachePath = path.join(getVortexPath("temp"), EXTENSION_FILENAME);
-  let time = new Date();
-
-  const checkCache = forceDownload
-    ? PromiseBB.resolve(true)
-    : fs.statAsync(cachePath).then((stat) => {
-        if (Date.now() - stat.mtimeMs > UPDATE_FREQUENCY) {
-          return true;
-        } else {
-          time = stat.mtime;
-          return false;
-        }
-      });
-
-  return checkCache
-    .then((needsDownload) => {
-      if (needsDownload) {
-        log("info", "extension list outdated, will update");
-      } else {
-        log("info", "extension list up-to-date");
+  api: IExtensionApi,
+  force: boolean = false,
+): Promise<IAvailableExtension[]> {
+  if (availableExtensionsCache === undefined || force) {
+    const fetching = doFetchAvailableExtensions(api);
+    fetching.catch(() => {
+      if (availableExtensionsCache === fetching) {
+        availableExtensionsCache = undefined;
       }
-      return needsDownload
-        ? downloadExtensionList(cachePath)
-        : fs.readFileAsync(cachePath, { encoding: "utf8" }).then((data) => {
-            try {
-              return JSON.parse(data).extensions;
-            } catch (err) {
-              return PromiseBB.reject(
-                new DataInvalid("Extension cache invalid, please try again later"),
-              );
-            }
-          });
-    })
-    .catch({ code: "ENOENT" }, () => {
-      log("info", "extension list missing, will update");
-      return downloadExtensionList(cachePath);
-    })
-    .catch((err) => {
-      log("error", "failed to fetch list of extensions", err);
-      return PromiseBB.resolve([]);
-    })
-    .filter((ext: IAvailableExtension) => ext.description !== undefined)
-    .then((extensions: IAvailableExtension[]) => filterInstallableExtensions(extensions))
-    .then((extensions) => ({ time, extensions }));
+    });
+    availableExtensionsCache = fetching;
+  }
+  return availableExtensionsCache;
+}
+
+/** Fill in gameDomain/gameName from the local Nexus games list. */
+function resolveGameInfo(
+  extensions: IAvailableExtension[],
+  games: IGameListEntry[],
+): IAvailableExtension[] {
+  // keyed by numeric Nexus Mods game ID
+  const gameById = new Map<number, IGameListEntry>(games.map((game) => [game.id, game]));
+
+  return extensions.map((ext) => {
+    const game = ext.gameId !== undefined ? gameById.get(ext.gameId) : undefined;
+    return game === undefined ? ext : { ...ext, gameDomain: game.domain_name, gameName: game.name };
+  });
 }
 
 /**
- * Only extensions with both a modId and a fileId can be installed/updated: identity is
- * keyed on modId, with fileId identifying the specific version. Entries missing either
- * (e.g. legacy GitHub-hosted extensions) are dropped from the manifest client-side.
+ * Resolve endorsement counts for the games claimed by more than one extension,
+ * so dedupeGameExtensions keeps the most endorsed claimant.
  */
-export function filterInstallableExtensions(
+async function resolveContestedEndorsements(
+  api: IExtensionApi,
   extensions: IAvailableExtension[],
-): IAvailableExtension[] {
-  const filtered = extensions.filter((ext) => ext.modId !== undefined && ext.fileId !== undefined);
-  const dropped = extensions.length - filtered.length;
-  if (dropped > 0) {
-    log("debug", "dropped extensions without modId/fileId", { dropped });
+): Promise<Record<number, number>> {
+  const contested = [...groupGameExtensionsByGameId(extensions).values()]
+    .filter((group) => group.length > 1)
+    .flat();
+  if (contested.length === 0) return {};
+
+  const uids = contested
+    .map((ext) =>
+      makeModUID({ gameId: SITE_ID, modId: String(ext.modId), fileId: String(ext.fileId) }),
+    )
+    .filter((uid) => uid !== undefined);
+
+  // keyed by mod ID
+  const endorsements: Record<number, number> = {};
+  try {
+    const byUid = (await api.ext.nexusGetModEndorsementCounts?.(uids)) ?? {};
+    for (const [uid, count] of Object.entries(byUid)) {
+      const decoded = decodeUID(uid);
+      if (decoded !== undefined) endorsements[decoded.id] = count;
+    }
+  } catch (err) {
+    // dedupe falls back to the newest upload
+    log("warn", "failed to fetch endorsement counts for duplicate game extensions", {
+      error: getErrorMessageOrDefault(err),
+      contested: contested.length,
+    });
   }
-  return filtered;
+  return endorsements;
+}
+
+async function doFetchAvailableExtensions(api: IExtensionApi): Promise<IAvailableExtension[]> {
+  const [fetched, games] = await Promise.all([fetchExtensionList(api), nexusGamesProm()]);
+  const extensions = resolveGameInfo(fetched, games);
+  const endorsements = await resolveContestedEndorsements(api, extensions);
+  return dedupeGameExtensions(extensions, endorsements);
 }
 
 export async function downloadAndInstallExtension(
@@ -254,10 +135,14 @@ export async function downloadAndInstallExtension(
     const download = api.getState().persistent.downloads.files[downloadId];
 
     api.store.dispatch(setDownloadModInfo(downloadId, "internal", true));
-    // TODO: native Promise
-    const { extensions: availableExtensions } = await Promise.resolve(
-      fetchAvailableExtensions(false),
-    );
+
+    // the catalog only provides metadata here; install the download without it
+    let availableExtensions: IAvailableExtension[] = [];
+    try {
+      availableExtensions = await fetchAvailableExtensions(api);
+    } catch (err) {
+      log("warn", "failed to fetch extension list", { error: getErrorMessageOrDefault(err) });
+    }
 
     const catalogEntry = findInCatalog(availableExtensions, { modId: ext.modId });
 
@@ -268,7 +153,7 @@ export async function downloadAndInstallExtension(
       catalogEntry,
       analytics: {
         source: "nexusmods",
-        gameDomain: catalogEntry?.gameId,
+        gameDomain: catalogEntry?.gameDomain,
         gameName: catalogEntry?.gameName,
       },
     });
@@ -322,30 +207,4 @@ async function downloadFromNexus(
     archiveFileName(ext),
     false,
   );
-}
-
-export function readExtensibleDir(extType: ExtensionType, bundledPath: string, customPath: string) {
-  const readBaseDir = (baseName: string): PromiseBB<string[]> => {
-    return fs
-      .readdirAsync(baseName)
-      .filter((name: string) =>
-        fs.statAsync(path.join(baseName, name)).then((stats) => stats.isDirectory()),
-      )
-      .map((name: string) => path.join(baseName, name))
-      .catch({ code: "ENOENT" }, () => []);
-  };
-
-  return readExtensions(false)
-    .then((extensions) => {
-      const extDirs = Object.keys(extensions)
-        .filter((extId) => extensions[extId].type === extType)
-        .map((extId) => extensions[extId].path);
-
-      return PromiseBB.join(
-        readBaseDir(bundledPath),
-        ...extDirs.map((extPath) => readBaseDir(extPath)),
-        readBaseDir(customPath),
-      );
-    })
-    .then((lists) => [].concat(...lists));
 }

--- a/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
+++ b/src/renderer/src/extensions/gamemode_management/views/GamePicker.tsx
@@ -244,7 +244,7 @@ const GamePicker = ({
   supportedGameList.push(
     ...extensionsUninstalled
       .map((ext) => ({
-        id: ext.gameId || ext.name,
+        id: ext.gameDomain || ext.name,
         name: ext.gameName || ext.name,
         extensionPath: undefined,
         imageURL: ext.image,

--- a/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
+++ b/src/renderer/src/extensions/nexus_integration/eventHandlers.ts
@@ -951,6 +951,32 @@ export function onGetModRequirements(
   };
 }
 
+/**
+ * Fetches endorsement counts for the given mod UIDs in one batched query.
+ * The result is keyed by UID; mods the query cannot resolve are omitted.
+ */
+export function onGetModEndorsementCounts(
+  nexus: Nexus,
+): (uids: string[]) => Bluebird<Record<string, number>> {
+  return (uids: string[]) => {
+    if (uids.length === 0) {
+      return Bluebird.resolve({});
+    }
+
+    return Bluebird.resolve(nexus.modsByUid({ uid: true, endorsements: true }, uids)).then(
+      (mods) => {
+        const result: Record<string, number> = {};
+        for (const mod of mods) {
+          if (mod.uid !== undefined && mod.endorsements !== undefined) {
+            result[mod.uid] = mod.endorsements;
+          }
+        }
+        return result;
+      },
+    );
+  };
+}
+
 export function onGetUserKeyData(
   api: IExtensionApi,
 ): (...args: any[]) => Promise<IValidateKeyDataV2> {

--- a/src/renderer/src/extensions/nexus_integration/index.tsx
+++ b/src/renderer/src/extensions/nexus_integration/index.tsx
@@ -935,6 +935,7 @@ function extendAPI(api: IExtensionApi, nexus: NexusT): INexusAPIExtension {
     nexusModFileContents: eh.onModFileContents(api, nexus),
     nexusGetModInfo: eh.onGetModInfo(api, nexus),
     nexusGetModRequirements: eh.onGetModRequirements(nexus),
+    nexusGetModEndorsementCounts: eh.onGetModEndorsementCounts(nexus),
     nexusGetPreferences: eh.onGetPreferences(api, nexus),
     nexusGetUserKeyData: eh.onGetUserKeyData(api),
   };

--- a/src/renderer/src/extensions/nexus_integration/types/INexusAPIExtension.ts
+++ b/src/renderer/src/extensions/nexus_integration/types/INexusAPIExtension.ts
@@ -109,6 +109,9 @@ export interface INexusAPIExtension {
     uids: string[],
   ) => PromiseLike<{ [uid: string]: Partial<IModRequirements> }>;
 
+  /** Endorsement counts for the given mod UIDs, keyed by UID. */
+  nexusGetModEndorsementCounts?: (uids: string[]) => PromiseLike<Record<string, number>>;
+
   // Retrieves user data which is persistently stored in Vortex's state.
   nexusGetUserKeyData?: () => PromiseLike<IValidateKeyDataV2>;
 }

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -567,7 +567,7 @@ function manageGameUndiscovered(api: IExtensionApi, gameId: string): PromiseBB<v
       extension = stubDownloadInfo;
     } else {
       extension = state.session.extensions.available.find(
-        (ext) => ext?.gameId === gameId || ext.name === gameId,
+        (ext) => ext?.gameDomain === gameId || ext.name === gameId,
       );
     }
     if (extension === undefined) {
@@ -602,7 +602,7 @@ function manageGameUndiscovered(api: IExtensionApi, gameId: string): PromiseBB<v
                 .then(() => api.emitAndAwait("install-extension", extension))
                 .then((results: boolean[]) => {
                   if (results.includes(true)) {
-                    relaunch(["--game", gameId]);
+                    relaunch(["--game", extension.name]);
                   }
                 })
                 .finally(() => {

--- a/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
+++ b/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
@@ -1,5 +1,7 @@
+import { readdir } from "node:fs/promises";
 import * as path from "path";
 
+import { getErrorCode } from "@vortex/shared";
 import type { IParameters } from "@vortex/shared/cli";
 import PromiseBB from "bluebird";
 import * as React from "react";
@@ -25,7 +27,6 @@ import getVortexPath from "../../util/getVortexPath";
 import { log } from "../../util/log";
 import { getPreloadApi } from "../../util/preloadAccess";
 import { truthy } from "../../util/util";
-import { readExtensibleDir } from "../extension_manager/util";
 import getTextModManagement from "../mod_management/texts";
 import getTextProfiles from "../profile_management/texts";
 import {
@@ -552,48 +553,59 @@ function isValidLanguageCode(langId: string) {
   }
 }
 
-function readLocales(extensions: IAvailableExtension[]): PromiseBB<ILanguage[]> {
+/** List the subdirectories of a base directory; a missing base yields none. */
+async function listSubdirectories(basePath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(basePath, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(basePath, entry.name));
+  } catch (err) {
+    if (getErrorCode(err) === "ENOENT") return [];
+    throw err;
+  }
+}
+
+async function readLocales(extensions: IAvailableExtension[]): Promise<ILanguage[]> {
   const bundledLanguages = getVortexPath("locales");
   const userLanguages = path.normalize(path.join(getVortexPath("userData"), "locales"));
 
   const translationExts = extensions.filter((ext) => ext.type === "translation");
 
-  let local: string[] = [];
+  try {
+    const files = (
+      await Promise.all([bundledLanguages, userLanguages].map(listSubdirectories))
+    ).flat();
+    const local = files.map((file) => path.basename(file));
 
-  return PromiseBB.join(
-    readExtensibleDir("translation", bundledLanguages, userLanguages)
-      .map((file: string) => path.basename(file))
-      .tap((files) => (local = files)),
-    translationExts.map((ext) => ext.language),
-  )
-    .then((fileLists) => Array.from(new Set([].concat(...fileLists))))
-    .filter((langId: string) => isValidLanguageCode(langId))
-    .then((files) => {
-      // files contains just the unique languages being supported, but there
-      // may be multiple extensions providing the same language
-      const loc = new Set(local);
-      const locales = files.map((key: string) => {
-        let language;
-        let country;
+    // the unique languages being supported; there may be multiple extensions
+    // providing the same language
+    const keys = Array.from(
+      new Set([...local, ...translationExts.map((ext) => ext.language)]),
+    ).filter((langId): langId is string => langId !== undefined && isValidLanguageCode(langId));
 
-        const [languageKey, countryKey] = key.split("-");
-        language = nativeLanguageName(languageKey);
-        if (countryKey !== undefined) {
-          country = nativeCountryName(countryKey);
-        }
+    const loc = new Set(local);
+    // keyed by locale code
+    const extsByLanguage = new Map<string, IAvailableExtension[]>();
+    for (const ext of translationExts) {
+      if (ext.language === undefined) continue;
+      extsByLanguage.set(ext.language, [...(extsByLanguage.get(ext.language) ?? []), ext]);
+    }
 
-        const ext: Array<Partial<IAvailableExtension>> = loc.has(key)
-          ? []
-          : translationExts.filter((iter) => iter.language === key);
-        return { key, language, country, ext };
-      });
+    return keys.map((key) => {
+      const [languageKey, countryKey] = key.split("-");
+      const language = nativeLanguageName(languageKey);
+      const country = countryKey !== undefined ? nativeCountryName(countryKey) : undefined;
 
-      return locales;
-    })
-    .catch((err) => {
-      log("warn", "failed to read locales", err);
-      return [];
+      const ext: Array<Partial<IAvailableExtension>> = loc.has(key)
+        ? []
+        : (extsByLanguage.get(key) ?? []);
+      return { key, language, country, ext };
     });
+  } catch (err) {
+    log("warn", "failed to read locales", err);
+    return [];
+  }
 }
 
 function SettingsInterface(props: IBaseProps) {

--- a/src/renderer/src/extensions/settings_interface/languagemap.ts
+++ b/src/renderer/src/extensions/settings_interface/languagemap.ts
@@ -1745,6 +1745,25 @@ export function countryExists(code: string): boolean {
   return code !== undefined && countryMap[code] !== undefined;
 }
 
+// keyed by lower-cased English language name; multi-name entries
+// (e.g. "Spanish; Castilian") yield one key per name
+const codeByEnglishName: Map<string, string> = (() => {
+  const result = new Map<string, string>();
+  for (const [code, entry] of Object.entries(languageMap)) {
+    for (const english of entry.name.split(/[;,]/)) {
+      const norm = english.trim().toLowerCase();
+      if (norm.length > 0 && !result.has(norm)) {
+        result.set(norm, code);
+      }
+    }
+  }
+  return result;
+})();
+
+export function languageCodeByEnglishName(name: string): string | undefined {
+  return codeByEnglishName.get(name.toLowerCase());
+}
+
 export function nativeLanguageName(code: string): string {
   const language = languageMap[code];
   if (language === undefined) {

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -75,6 +75,7 @@ import type {
   ICollectionInstallState,
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
+import type { IAvailableExtension } from "../types/extensions";
 import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../types/IDialog";
 import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IGame } from "../types/IGame";
@@ -1151,6 +1152,22 @@ export function makeLegacyExtensionState(
   overrides: Partial<IExtensionState> = {},
 ): IExtensionState {
   return { enabled: false, ...overrides } as IExtensionState;
+}
+
+/** A catalog entry as the extensions endpoint mapping produces it. */
+export function makeAvailableExtension(
+  overrides: Partial<IAvailableExtension> = {},
+): IAvailableExtension {
+  return {
+    name: "Test Extension",
+    modId: 0,
+    fileId: 0,
+    author: "Test Author",
+    version: "1.0.0",
+    timestamp: 0,
+    image: "image.png",
+    ...overrides,
+  };
 }
 
 let loEntrySeq = 0;

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -69,36 +69,30 @@ export interface IExtensionDownloadInfo {
 }
 
 /**
- * information about an extension available on the central extension list
+ * Extension available from the Nexus Mods extensions endpoint. Internal model;
+ * the wire format is private to extension_manager/availableExtensions.ts.
  */
 export interface IAvailableExtension {
   name: string;
   modId: number;
   fileId: number;
-  description: {
-    short: string;
-    long: string;
-  };
-  id?: string;
-  type?: ExtensionType;
-  language?: string;
-  gameName?: string;
-  gameId?: string;
-  image: string;
+  /** username of the uploader */
   author: string;
-  uploader: string;
   version: string;
-  downloads: number;
-  endorsements: number;
+  /** upload time of the current file, epoch milliseconds */
   timestamp: number;
-  tags: string[];
-  dependencies?: { [key: string]: any };
-  hide?: boolean;
-}
-
-export interface IExtensionManifest {
-  last_updated: number;
-  extensions: IAvailableExtension[];
+  /** mod page image, or the game artwork for game extensions */
+  image?: string;
+  /** undefined for extensions that don't target a game (tools, site extensions) */
+  type?: ExtensionType;
+  /** numeric Nexus Mods game ID, game extensions only */
+  gameId?: number;
+  /** game domain name, resolved from the local Nexus games list */
+  gameDomain?: string;
+  /** game display name, resolved from the local Nexus games list */
+  gameName?: string;
+  /** locale code, translations only, derived from the mod name */
+  language?: string;
 }
 
 export interface ISelector {

--- a/src/renderer/src/util/api.ts
+++ b/src/renderer/src/util/api.ts
@@ -21,7 +21,6 @@ import {
   resolveCategoryName,
   resolveCategoryPath,
 } from "../extensions/category_management/util/retrieveCategoryPath";
-import { readExtensibleDir } from "../extensions/extension_manager/util";
 import getDriveList from "../extensions/gamemode_management/util/getDriveList";
 import { getGame, getGames } from "../extensions/gamemode_management/util/getGame";
 import { getModType } from "../extensions/gamemode_management/util/modTypeExtensions";
@@ -277,7 +276,6 @@ export {
   pad,
   ProcessCanceled,
   ReduxProp,
-  readExtensibleDir,
   relativeTime,
   removeMods,
   renderModName,


### PR DESCRIPTION
The catalog comes from GET /v3/vortex/extensions through the typed @vortex/nexus-api-v3 client, fetched at startup and on manual refresh. IAvailableExtension is a local model mapped at one wire boundary; game domain/name resolve from the local Nexus games list, and a game claimed by more than one extension keeps the most endorsed claimant.

- browse dialog drops download/endorsement counts and fetches descriptions per selection via mod info
- translation locales derive from the mod name until the endpoint carries a locale field
- catalog dependency lookup matches by extension name
- readExtensibleDir and the info.json disk scan are removed; theme and locale listings read their base directories directly
- extension_manager/util.ts uses native promises

closes LAZ-690