### PR TITLE
Al/hc skip collection mods

### DIFF
--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.test.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.test.ts
@@ -11,14 +11,18 @@ vi.mock("@/extensions/nexus_integration/util/UIDs", () => ({
   VORTEX_MOD_UID: "9856949944321",
   makeModUID: vi.fn((repoInfo: { gameId: string; modId: string }) =>
     // "site" + modId "1" is the one case the check cares about; everything else just
-    // needs to be distinct from it.
-    repoInfo.gameId === "site" && repoInfo.modId === "1" ? "9856949944321" : "other-uid",
+    // needs to be distinct per (gameId, modId) pair.
+    repoInfo.gameId === "site" && repoInfo.modId === "1"
+      ? "9856949944321"
+      : `${repoInfo.gameId}-${repoInfo.modId}`,
   ),
 }));
 
+import type { IMod } from "@/extensions/mod_management/types/IMod";
 import { numericGameIdToDomainName } from "@/extensions/nexus_integration/util";
+import type { IProfile } from "@/extensions/profile_management/types/IProfile";
 
-import { resolveRequirementTarget } from "./modRequirementsCheck";
+import { partitionNexusMods, resolveRequirementTarget } from "./modRequirementsCheck";
 
 const mockDomainName = vi.mocked(numericGameIdToDomainName);
 
@@ -45,5 +49,91 @@ describe("resolveRequirementTarget", () => {
     const target = resolveRequirementTarget({ modId: "1", gameId: "1704" }, "skyrimse");
     expect(target).not.toBeNull();
     expect(target?.domainName).toBe("skyrimse");
+  });
+});
+
+describe("partitionNexusMods", () => {
+  /** A minimal enabled Nexus mod with the given Nexus modId and (optional) referenceTag. */
+  function nexusMod(id: string, modId: number, referenceTag?: string): IMod {
+    return {
+      id,
+      attributes: { modId, source: "nexus", downloadGame: "skyrimse", referenceTag },
+    } as unknown as IMod;
+  }
+
+  /** A collection mod carrying the given dependency rules (each with a reference tag). */
+  function collectionMod(id: string, rules: Array<{ type: string; tag: string }>): IMod {
+    return {
+      id,
+      type: "collection",
+      rules: rules.map((r) => ({ type: r.type, reference: { tag: r.tag } })),
+    } as unknown as IMod;
+  }
+
+  /** A profile where every given mod id is enabled. */
+  function profileWith(...modIds: string[]): IProfile {
+    return {
+      modState: Object.fromEntries(modIds.map((id) => [id, { enabled: true }])),
+    } as unknown as IProfile;
+  }
+
+  it("excludes a required collection dependency from self-check but keeps it installed", () => {
+    const collection = collectionMod("collection", [{ type: "requires", tag: "tag-req" }]);
+    const dep = nexusMod("mod-1", 100, "tag-req");
+    const mods = { collection, "mod-1": dep };
+    const { checkedModsByUid, installedModUids } = partitionNexusMods(
+      [collection, dep],
+      mods,
+      profileWith("collection", "mod-1"),
+      "skyrimse",
+    );
+
+    expect(installedModUids.has("skyrimse-100")).toBe(true);
+    expect(checkedModsByUid.has("skyrimse-100")).toBe(false);
+  });
+
+  it("excludes an optional/recommended collection dependency the same way", () => {
+    const collection = collectionMod("collection", [{ type: "recommends", tag: "tag-rec" }]);
+    const dep = nexusMod("mod-2", 200, "tag-rec");
+    const mods = { collection, "mod-2": dep };
+    const { checkedModsByUid, installedModUids } = partitionNexusMods(
+      [collection, dep],
+      mods,
+      profileWith("collection", "mod-2"),
+      "skyrimse",
+    );
+
+    expect(installedModUids.has("skyrimse-200")).toBe(true);
+    expect(checkedModsByUid.has("skyrimse-200")).toBe(false);
+  });
+
+  it("keeps a manually installed mod in both sets", () => {
+    const manual = nexusMod("mod-3", 300);
+    const { checkedModsByUid, installedModUids } = partitionNexusMods(
+      [manual],
+      { "mod-3": manual },
+      profileWith("mod-3"),
+      "skyrimse",
+    );
+
+    expect(installedModUids.has("skyrimse-300")).toBe(true);
+    expect(checkedModsByUid.has("skyrimse-300")).toBe(true);
+  });
+
+  it("a collection-managed mod still counts as installed for another mod's requirement", () => {
+    const collection = collectionMod("collection", [{ type: "requires", tag: "tag-req" }]);
+    const dep = nexusMod("mod-1", 100, "tag-req");
+    const other = nexusMod("mod-4", 400);
+    const mods = { collection, "mod-1": dep, "mod-4": other };
+    const { installedModUids } = partitionNexusMods(
+      [collection, dep, other],
+      mods,
+      profileWith("collection", "mod-1", "mod-4"),
+      "skyrimse",
+    );
+
+    // If "mod-4" declared a Nexus requirement on modId 100, this is the set the check
+    // consults to decide it's satisfied.
+    expect(installedModUids.has("skyrimse-100")).toBe(true);
   });
 });

--- a/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/modRequirementsCheck.ts
@@ -8,6 +8,10 @@ import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import { getGame } from "@/extensions/gamemode_management/util/getGame";
 import { getModFilesWithCache } from "@/extensions/health_check/utils/modRequirements/modFiles";
 import { chunked, resolveCached } from "@/extensions/health_check/utils/shared/batchCache";
+import {
+  collectionManagedTags,
+  isCollectionManaged,
+} from "@/extensions/health_check/utils/shared/collectionManaged";
 import { getModDetails } from "@/extensions/health_check/utils/shared/modDetails";
 import type { IMod } from "@/extensions/mod_management/types/IMod";
 import renderModName from "@/extensions/mod_management/util/modName";
@@ -16,6 +20,7 @@ import { nexusGamesProm, numericGameIdToDomainName } from "@/extensions/nexus_in
 import { nexusGameId } from "@/extensions/nexus_integration/util/convertGameId";
 import { makeModUID, VORTEX_MOD_UID } from "@/extensions/nexus_integration/util/UIDs";
 import { activeProfile } from "@/extensions/profile_management/selectors";
+import type { IProfile } from "@/extensions/profile_management/types/IProfile";
 import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import {
@@ -184,6 +189,47 @@ function resolveModUID(mod: IMod, gameId: string): string | undefined {
 }
 
 /**
+ * Splits the profile's enabled Nexus mods into `checkedModsByUid` (mods to check against
+ * their own Nexus-declared requirements) and `installedModUids` (mods that count as
+ * installed when checking whether some other mod's requirement is satisfied).
+ * Collection-managed mods are excluded from the former but included in the latter.
+ */
+export function partitionNexusMods(
+  enabledMods: IMod[],
+  mods: { [modId: string]: IMod },
+  profile: IProfile,
+  gameId: string,
+): { checkedModsByUid: Map<string, IMod>; installedModUids: Set<string> } {
+  const nexusMods = enabledMods.filter(
+    (mod) =>
+      mod.type !== "collection" && mod.attributes?.modId && mod.attributes?.source === "nexus",
+  );
+
+  const collectionTags = collectionManagedTags(mods, profile);
+
+  const uidByModId = new Map<string, string>();
+  const installedModUids = new Set<string>();
+  for (const mod of nexusMods) {
+    const uid = resolveModUID(mod, gameId);
+    if (uid) {
+      uidByModId.set(mod.id, uid);
+      installedModUids.add(uid);
+    }
+  }
+
+  const checkedModsByUid = new Map<string, IMod>();
+  for (const mod of nexusMods) {
+    if (isCollectionManaged(mod, collectionTags)) continue;
+    const uid = uidByModId.get(mod.id);
+    if (uid) {
+      checkedModsByUid.set(uid, mod);
+    }
+  }
+
+  return { checkedModsByUid, installedModUids };
+}
+
+/**
  * Check Nexus mod requirements
  * Fetches requirements from Nexus API and checks if they are satisfied
  */
@@ -214,15 +260,20 @@ export async function checkModRequirements(
       );
     }
 
-    const enabledMods = getEnabledMods(api, gameId).filter(
-      (mod: IMod) =>
-        mod.type !== "collection" &&
-        !mod.attributes?.installedAsDependency &&
-        mod.attributes?.modId &&
-        mod.attributes?.source === "nexus",
+    const mods = state.persistent.mods[gameId] ?? {};
+
+    // makeModUID needs the nexus games list to map a game domain to its numeric id;
+    // ensure it is loaded before building any UIDs (GH#22466).
+    await nexusGamesProm();
+
+    const { checkedModsByUid, installedModUids } = partitionNexusMods(
+      getEnabledMods(api, gameId),
+      mods,
+      profile,
+      gameId,
     );
 
-    if (enabledMods.length === 0) {
+    if (installedModUids.size === 0) {
       return createResult(startTime, "passed", HealthCheckSeverity.Info, "No Nexus mods installed");
     }
 
@@ -234,23 +285,6 @@ export async function checkModRequirements(
       modRequirements: {},
       errors: [],
     };
-
-    // makeModUID needs the nexus games list to map a game domain to its numeric id;
-    // ensure it is loaded before building any UIDs (GH#22466).
-    await nexusGamesProm();
-
-    // Everything downstream is keyed by mod UID. Installed mods that resolve to the
-    // same UID share a single entry.
-    const modsByUid = new Map<string, IMod>();
-    for (const mod of enabledMods) {
-      const uid = resolveModUID(mod, gameId);
-      if (uid) {
-        modsByUid.set(uid, mod);
-      }
-    }
-
-    // A required mod counts as already installed when its UID matches an enabled mod's.
-    const installedModUids = new Set(modsByUid.keys());
 
     const nexusGetModRequirements = api.ext.nexusGetModRequirements as
       | ((uids: string[]) => Promise<{ [uid: string]: Partial<IModRequirements> }>)
@@ -265,7 +299,7 @@ export async function checkModRequirements(
 
     try {
       const resolved = await resolveCached(
-        [...modsByUid.keys()],
+        [...checkedModsByUid.keys()],
         modRequirementsCache,
         async (missingUids): Promise<Map<string, Partial<IModRequirements>>> => {
           if (!nexusGetModRequirements) {
@@ -296,7 +330,7 @@ export async function checkModRequirements(
     // second pass then reads both from cache instead of awaiting one mod at a time.
     // Keyed by the required mod's UID so cross-game mods sharing a numeric id stay distinct.
     const requiredTargets = new Map<string, { gameId: string; modId: number }>();
-    for (const [requiringUid, mod] of modsByUid) {
+    for (const [requiringUid, mod] of checkedModsByUid) {
       const sourceGameId = mod.attributes?.downloadGame;
       if (!sourceGameId) {
         continue;
@@ -348,7 +382,7 @@ export async function checkModRequirements(
     }
 
     // Second pass: process requirements and check for missing dependencies
-    for (const [uid, mod] of modsByUid) {
+    for (const [uid, mod] of checkedModsByUid) {
       const modId = mod.attributes?.modId;
       if (!modId) continue;
       const gameId = mod.attributes.downloadGame;

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/extensions/nexus_integration/util", () => ({
+  nexusGamesProm: vi.fn(() => Promise.resolve([])),
+}));
 
 import type { IDownload } from "@/extensions/download_management/types/IDownload";
 import type { IModDetails } from "@/extensions/health_check/types";
+import type { IMod } from "@/extensions/mod_management/types/IMod";
 import { makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 
 import {
+  gatherInstalledFiles,
   makeDownloadedFileHydrator,
   makeInstalledFileHydrator,
   type IDownloadedFileRef,
@@ -213,5 +219,71 @@ describe("makeInstalledFileHydrator", () => {
     expect(hydrateInstalled(true)?.adultContent).toBe(true);
     expect(hydrateInstalled(false)?.adultContent).toBe(false);
     expect(hydrateInstalled()?.adultContent).toBe(false);
+  });
+});
+
+describe("gatherInstalledFiles", () => {
+  /** A minimal installed, non-collection Nexus mod with the given fileId/referenceTag. */
+  function nexusMod(fileId: number, referenceTag?: string): IMod {
+    return {
+      id: `mod-${fileId}`,
+      state: "installed",
+      attributes: { source: "nexus", fileId, downloadGame: "1704", referenceTag },
+    } as unknown as IMod;
+  }
+
+  /** A collection mod carrying the given dependency rules (each with a reference tag). */
+  function collectionMod(id: string, rules: Array<{ type: string; tag: string }>): IMod {
+    return {
+      id,
+      type: "collection",
+      state: "installed",
+      rules: rules.map((r) => ({ type: r.type, reference: { tag: r.tag } })),
+    } as unknown as IMod;
+  }
+
+  function apiWithMods(mods: { [modId: string]: IMod }): IExtensionApi {
+    const modState = Object.fromEntries(Object.keys(mods).map((id) => [id, { enabled: true }]));
+    return {
+      getState: () => ({
+        settings: { profiles: { activeProfileId: "p1" } },
+        persistent: {
+          profiles: { p1: { id: "p1", gameId: "skyrimse", modState } },
+          mods: { skyrimse: mods },
+        },
+      }),
+    } as unknown as IExtensionApi;
+  }
+
+  test("exempts files pulled in as required collection dependencies", async () => {
+    const api = apiWithMods({
+      collection: collectionMod("collection", [{ type: "requires", tag: "tag-req" }]),
+      "mod-1": nexusMod(1, "tag-req"),
+    });
+    const refs = await gatherInstalledFiles(api);
+    expect(refs.find((r) => r.modId === "mod-1")?.emitRequirements).toBe(false);
+  });
+
+  test("exempts files pulled in as optional/recommended collection dependencies", () => {
+    // Regression: collectionManagedTags used to only look at "requires" rules, so
+    // optional ("recommends") collection members were treated as manually installed
+    // and could trip the file-requirements health check.
+    return gatherInstalledFiles(
+      apiWithMods({
+        collection: collectionMod("collection", [{ type: "recommends", tag: "tag-rec" }]),
+        "mod-2": nexusMod(2, "tag-rec"),
+      }),
+    ).then((refs) => {
+      expect(refs.find((r) => r.modId === "mod-2")?.emitRequirements).toBe(false);
+    });
+  });
+
+  test("does not exempt a manually installed mod with no matching collection tag", async () => {
+    const api = apiWithMods({
+      collection: collectionMod("collection", [{ type: "requires", tag: "tag-req" }]),
+      "mod-3": nexusMod(3, undefined),
+    });
+    const refs = await gatherInstalledFiles(api);
+    expect(refs.find((r) => r.modId === "mod-3")?.emitRequirements).toBe(true);
   });
 });

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.test.ts
@@ -265,9 +265,6 @@ describe("gatherInstalledFiles", () => {
   });
 
   test("exempts files pulled in as optional/recommended collection dependencies", () => {
-    // Regression: collectionManagedTags used to only look at "requires" rules, so
-    // optional ("recommends") collection members were treated as manually installed
-    // and could trip the file-requirements health check.
     return gatherInstalledFiles(
       apiWithMods({
         collection: collectionMod("collection", [{ type: "recommends", tag: "tag-rec" }]),

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -1,6 +1,7 @@
 import type { IDownload } from "@/extensions/download_management/types/IDownload";
 import type { IModDetails } from "@/extensions/health_check/types";
 import type { IMod } from "@/extensions/mod_management/types/IMod";
+import { isDependencyRule } from "@/extensions/mod_management/util/testModReference";
 import { nexusGamesProm } from "@/extensions/nexus_integration/util";
 import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import { activeProfile } from "@/extensions/profile_management/selectors";
@@ -96,7 +97,8 @@ export interface IInstalledFileRef {
 
 /**
  * Reference tags of mods pulled in by a collection installed on the active
- * profile; files carrying one satisfy requirements but don't emit their own.
+ * profile (both required and optional/recommended entries); files carrying
+ * one satisfy requirements but don't emit their own.
  * Edit `countsForProfile` to change which collections count.
  */
 function collectionManagedTags(mods: { [modId: string]: IMod }, profile: IProfile): Set<string> {
@@ -108,7 +110,7 @@ function collectionManagedTags(mods: { [modId: string]: IMod }, profile: IProfil
       continue;
     }
     for (const rule of mod.rules ?? []) {
-      if (rule.type === "requires" && rule.reference?.tag != null) {
+      if (isDependencyRule(rule) && rule.reference?.tag != null) {
         tags.add(rule.reference.tag);
       }
     }

--- a/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
+++ b/src/renderer/src/extensions/health_check/utils/fileRequirements/installedFiles.ts
@@ -1,16 +1,15 @@
 import type { IDownload } from "@/extensions/download_management/types/IDownload";
 import type { IModDetails } from "@/extensions/health_check/types";
 import type { IMod } from "@/extensions/mod_management/types/IMod";
-import { isDependencyRule } from "@/extensions/mod_management/util/testModReference";
 import { nexusGamesProm } from "@/extensions/nexus_integration/util";
 import { makeFileUID, makeModUID } from "@/extensions/nexus_integration/util/UIDs";
 import { activeProfile } from "@/extensions/profile_management/selectors";
-import type { IProfile } from "@/extensions/profile_management/types/IProfile";
 import { log } from "@/logging";
 import type { IExtensionApi } from "@/types/IExtensionContext";
 import { getSafe } from "@/util/storeHelper";
 
 import renderModName from "../../../mod_management/util/modName";
+import { collectionManagedTags, isCollectionManaged } from "../shared/collectionManaged";
 
 /**
  * A file the user already has installed (a Vortex mod)
@@ -96,29 +95,6 @@ export interface IInstalledFileRef {
 }
 
 /**
- * Reference tags of mods pulled in by a collection installed on the active
- * profile (both required and optional/recommended entries); files carrying
- * one satisfy requirements but don't emit their own.
- * Edit `countsForProfile` to change which collections count.
- */
-function collectionManagedTags(mods: { [modId: string]: IMod }, profile: IProfile): Set<string> {
-  const countsForProfile = (collection: IMod): boolean => profile.modState?.[collection.id] != null;
-
-  const tags = new Set<string>();
-  for (const mod of Object.values(mods)) {
-    if (mod.type !== "collection" || !countsForProfile(mod)) {
-      continue;
-    }
-    for (const rule of mod.rules ?? []) {
-      if (isDependencyRule(rule) && rule.reference?.tag != null) {
-        tags.add(rule.reference.tag);
-      }
-    }
-  }
-  return tags;
-}
-
-/**
  * Resolve a Nexus file UID for a mod, or return undefined if not possible.
  * Shared by both gather functions below.
  */
@@ -170,9 +146,7 @@ export async function gatherInstalledFiles(api: IExtensionApi): Promise<IInstall
       fileUID,
       modId: mod.id,
       enabled: getSafe(profile.modState, [mod.id, "enabled"], false),
-      emitRequirements: !(
-        attributes.referenceTag != null && collectionTags.has(attributes.referenceTag)
-      ),
+      emitRequirements: !isCollectionManaged(mod, collectionTags),
     });
   }
 

--- a/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.ts
@@ -1,0 +1,36 @@
+import type { IMod } from "@/extensions/mod_management/types/IMod";
+import { isDependencyRule } from "@/extensions/mod_management/util/testModReference";
+import type { IProfile } from "@/extensions/profile_management/types/IProfile";
+
+/**
+ * Reference tags of mods pulled in by a collection installed on the active profile,
+ * via either a required or optional/recommended rule. A mod carrying one of these
+ * tags is collection-managed: it satisfies other mods' requirements but should not
+ * have its own emitted (the collection already vetted it).
+ * Edit `countsForProfile` to change which collections count.
+ */
+export function collectionManagedTags(
+  mods: { [modId: string]: IMod },
+  profile: IProfile,
+): Set<string> {
+  const countsForProfile = (collection: IMod): boolean => profile.modState?.[collection.id] != null;
+
+  const tags = new Set<string>();
+  for (const mod of Object.values(mods)) {
+    if (mod.type !== "collection" || !countsForProfile(mod)) {
+      continue;
+    }
+    for (const rule of mod.rules ?? []) {
+      if (isDependencyRule(rule) && rule.reference?.tag != null) {
+        tags.add(rule.reference.tag);
+      }
+    }
+  }
+  return tags;
+}
+
+/** Whether a mod's own referenceTag matches one of the given collection-managed tags. */
+export function isCollectionManaged(mod: IMod, collectionTags: Set<string>): boolean {
+  const referenceTag = (mod.attributes as { referenceTag?: string } | undefined)?.referenceTag;
+  return referenceTag != null && collectionTags.has(referenceTag);
+}


### PR DESCRIPTION
The function that was collecting the files was skipping mods that were required by the collection, without filtering out mods that were recommended by the collection.

Switched the check to `isDependencyRule(rule)` which checks both required and recommended.
This check still does cover manually installed mods that are part of the collection.
For that fix we need bigger changes.

Fixes the Mod to mod Requirements health check not correctly distinguishing the mods that need to be checked for missing requirements (skip collections), and the mods that are available to satisfy the requirements (include collections).