### PR TITLE
Download fixes

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -19,7 +19,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | @nexusmods/file-dependency-resolver | link:../../packages/file-dependency-resolver |
 | @nexusmods/fomod-installer-ipc | 0.13.3 |
 | @nexusmods/fomod-installer-native | 0.13.3 |
-| @nexusmods/nexus-api | 1.7.2 |
+| @nexusmods/nexus-api | 1.7.3 |
 | @nosferatu500/react-sortable-tree | 4.4.0 |
 | @nosferatu500/theme-file-explorer | 3.0.21 |
 | @opentelemetry/api | 1.9.1 |

--- a/src/renderer/src/extensions/download_management/index.ts
+++ b/src/renderer/src/extensions/download_management/index.ts
@@ -42,6 +42,7 @@ import { stateReducer } from "./reducers/state";
 import { transactionsReducer } from "./reducers/transactions";
 import type { DownloadState, IDownload } from "./types/IDownload";
 import { ensureDownloadsDirectory } from "./util/downloadDirectory";
+import { isTempDownloadName } from "./util/downloadNames";
 import extendAPI from "./util/extendApi";
 import getDownloadGames from "./util/getDownloadGames";
 import { finalizeDownload } from "./util/postprocessDownload";
@@ -240,7 +241,10 @@ async function removeInvalidDownloads(api: IExtensionApi, gameId?: string) {
       (!downloads[dlId].localPath || downloads[dlId].received === 0 || downloads[dlId].size === 0),
   );
   const invalid = Object.keys(downloads).filter(
-    (dlId) => downloads[dlId].localPath && !path.extname(downloads[dlId].localPath),
+    (dlId) =>
+      ["finished", "failed"].includes(downloads[dlId].state) &&
+      downloads[dlId].localPath &&
+      !path.extname(downloads[dlId].localPath),
   );
   const removeSet = new Set<string>(incomplete.concat(invalid));
 
@@ -283,7 +287,7 @@ function removeInvalidFileExts(api: IExtensionApi, gameId?: string) {
     .then((files: string[]) => {
       return PromiseBB.all(
         files.map((fileName) => {
-          if (!knownArchiveExt(fileName)) {
+          if (!knownArchiveExt(fileName) && !isTempDownloadName(fileName)) {
             return fs.removeAsync(path.join(downloadPath, fileName)).catch(() => null);
           }
         }),
@@ -335,7 +339,11 @@ function updateDownloadPath(api: IExtensionApi, gameId?: string) {
       );
 
       const knownDLs = Object.keys(downloads)
-        .filter((dlId) => getDownloadGames(downloads[dlId])[0] === gameId)
+        .filter(
+          (dlId) =>
+            getDownloadGames(downloads[dlId])[0] === gameId &&
+            !isTempDownloadName(downloads[dlId].localPath),
+        )
         .map((dlId) => normalize(downloads[dlId].localPath || ""));
 
       return refreshDownloads(

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.linkCallback.test.ts
@@ -177,6 +177,21 @@ describe("nxm link callback", () => {
       );
     });
 
+    test("reports a missing download record as a download failure, not a log-in failure", async ({
+      makeNxm,
+    }) => {
+      // no arrangeLink: startDownload resolves to an id that has no record in state
+      const { harness, nxm } = makeNxm();
+
+      nxm.handleLink(MOD_URL, false);
+
+      await vi.waitFor(() =>
+        expect(harness.errorNotifications).toEqual([
+          expect.objectContaining({ title: "Failed to start download", allowReport: false }),
+        ]),
+      );
+    });
+
     test("stays quiet when the user cancels the log in", async ({ makeNxm }) => {
       const { harness, handleLink } = arrangeLink(makeNxm());
       logIn.mockReturnValue(PromiseBB.reject(new UserCanceled()) as never);

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -572,7 +572,14 @@ export class NxmProtocol {
     try {
       await ensureLoggedIn(this.#api);
     } catch (err) {
-      this.#reportLinkError(err);
+      if (err instanceof ProcessCanceled) {
+        this.#api.showErrorNotification("Log-in failed", err, {
+          id: "failed-get-nexus-key",
+          allowReport: false,
+        });
+      } else {
+        this.#reportLinkError(err);
+      }
       return;
     }
 
@@ -636,7 +643,7 @@ export class NxmProtocol {
       return;
     }
     if (err instanceof ProcessCanceled) {
-      this.#api.showErrorNotification("Log-in failed", err, {
+      this.#api.showErrorNotification("Failed to start download", err, {
         id: "failed-get-nexus-key",
         allowReport: false,
       });


### PR DESCRIPTION
1. Exclude vortex temp files (downloads that are still happening) from being removed, thus stopping the download process
2. Fixed incorrect error notification titles

Closes LAZ-799