### PR TITLE
Persist show bundled extension option in redux instead of in-memory

### DIFF
--- a/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
+++ b/src/renderer/src/extensions/extension_manager/ExtensionManager.tsx
@@ -35,6 +35,7 @@ import { PageHeader } from "@/views/components/Page/PageHeader";
 import { PageScroll } from "@/views/components/Page/PageScroll";
 
 import { SITE_ID } from "../gamemode_management/constants";
+import { setShowBundledExtensions } from "./actions";
 import { useDisplayOptionsAction } from "./hooks/useDisplayOptionsAction.hook";
 import installExtension from "./installExtension";
 import { extensionStateFromScan, findInstalled } from "./queries";
@@ -80,7 +81,7 @@ export const ExtensionManager = ({
   const downloads = useSelector((state: IState) => state.persistent.downloads.files);
   const downloadPath = useSelector(selectors.downloadPath);
 
-  const [showBundled, setShowBundled] = useState(false);
+  const showBundled = useSelector((state: IState) => state.session.extensions.showBundled);
   // The config as the page found it; a change from here means Vortex needs a restart.
   const [oldExtensions] = useState(extensions);
 
@@ -248,8 +249,8 @@ export const ExtensionManager = ({
   const displayOptions = useDisplayOptionsAction({
     showBundled,
     t,
-    onReset: () => setShowBundled(false),
-    onToggleBundled: () => setShowBundled((prev) => !prev),
+    onReset: () => dispatch(setShowBundledExtensions(false)),
+    onToggleBundled: () => dispatch(setShowBundledExtensions(!showBundled)),
   });
 
   const toolbarActions: IToolbarAction[] = [

--- a/src/renderer/src/extensions/extension_manager/actions.ts
+++ b/src/renderer/src/extensions/extension_manager/actions.ts
@@ -17,3 +17,8 @@ export const setOptionalExtensions = createAction(
   "SET_OPTIONAL_EXTENSIONS",
   (optional: { [extensionName: string]: IExtensionOptional[] }) => optional,
 );
+
+export const setShowBundledExtensions = createAction(
+  "SET_SHOW_BUNDLED_EXTENSIONS",
+  (show: boolean) => show,
+);

--- a/src/renderer/src/extensions/extension_manager/reducers.ts
+++ b/src/renderer/src/extensions/extension_manager/reducers.ts
@@ -11,6 +11,8 @@ type DefaultState = {
   updateTime: number;
   /** Map containing all recorded optional dependencies of an extension, key is the extension name. */
   optional: Record<string, IExtensionOptional[]>;
+  /** Whether the extensions page lists bundled extensions. Session-only by design. */
+  showBundled: boolean;
 };
 
 declare module "@/types/IState" {
@@ -23,12 +25,14 @@ const defaultState: DefaultState = {
   available: [],
   optional: {},
   updateTime: 0,
+  showBundled: false,
 };
 
 const sessionReducer = actionsToReducerSpec(defaultState, actions, {
   setAvailableExtensions: (state, payload) => ({ ...state, available: payload }),
   setOptionalExtensions: (state, payload) => ({ ...state, optional: payload }),
   setExtensionsUpdate: (state, payload) => ({ ...state, updateTime: payload }),
+  setShowBundledExtensions: (state, payload) => ({ ...state, showBundled: payload }),
 });
 
 export default sessionReducer;


### PR DESCRIPTION
The show bundled extension option will be reset when we go from one page to another and then back, since the option is not persisted in the redux session

Closes LAZ-933