### PR TITLE
Collection install fixes when flip-flopping between different collections (LAZ-972)

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -10,7 +10,6 @@ import { Dropdown as Dropdown_2 } from 'react-bootstrap';
 import { DropdownButton as DropdownButton_2 } from 'react-bootstrap';
 import { EndorsedStatus } from '@nexusmods/nexus-api';
 import { FC } from 'react';
-import { HTMLAttributes } from 'react';
 import { i18n } from 'i18next';
 import I18next from 'i18next';
 import { ICollection } from '@nexusmods/nexus-api';
@@ -377,26 +376,16 @@ export type FileSystemErrorData = Partial<OsErrorData> & {
     path: string;
 };
 
-// @public (undocumented)
-const Fixed: (props: React$2.HTMLAttributes<HTMLDivElement>) => React$2.JSX.Element;
-
-// Warning: (ae-forgotten-export) The symbol "IFlexProps" needs to be exported by the entry point api.d.ts
-//
-// @public (undocumented)
-const Flex: (props: IFlexProps & React$2.HTMLAttributes<HTMLDivElement>) => React$2.JSX.Element;
-
 // Warning: (ae-forgotten-export) The symbol "IProps$7" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
 export class FlexLayout extends React$2.PureComponent<IProps$7, {}> {
-    // Warning: (ae-forgotten-export) The symbol "Fixed" needs to be exported by the entry point api.d.ts
+    // (undocumented)
+    static Fixed: (props: React$2.HTMLAttributes<HTMLDivElement>) => React$2.JSX.Element;
+    // Warning: (ae-forgotten-export) The symbol "IFlexProps" needs to be exported by the entry point api.d.ts
     //
     // (undocumented)
-    static Fixed: typeof Fixed;
-    // Warning: (ae-forgotten-export) The symbol "Flex" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    static Flex: typeof Flex;
+    static Flex: (props: IFlexProps & React$2.HTMLAttributes<HTMLDivElement>) => React$2.JSX.Element;
     // (undocumented)
     render(): JSX.Element;
 }
@@ -1252,6 +1241,8 @@ interface ICommonModAttributes {
     pictureUrl?: string;
     // (undocumented)
     referenceTag?: string;
+    // (undocumented)
+    referenceTags?: string[];
     // (undocumented)
     scriptExtender?: boolean;
     // (undocumented)
@@ -2890,6 +2881,8 @@ interface IModInfo$2 {
     // (undocumented)
     referenceTag?: string;
     // (undocumented)
+    referenceTags?: string[];
+    // (undocumented)
     revisionNumber?: number;
     // (undocumented)
     source?: string;
@@ -4107,9 +4100,6 @@ interface IState {
             optional: {
                 [extId: string]: IExtensionOptional[];
             };
-            installed: {
-                [extId: string]: IExtension;
-            };
             updateTime: number;
         };
     };
@@ -4692,7 +4682,7 @@ export const MainPage: typeof MainPageInner & {
 };
 
 // @public (undocumented)
-const MainPageBody: React$1.ForwardRefExoticComponent<HTMLAttributes<HTMLDivElement> & React$1.RefAttributes<HTMLDivElement>>;
+const MainPageBody: React$1.ForwardRefExoticComponent<React$1.HTMLAttributes<HTMLDivElement> & React$1.RefAttributes<HTMLDivElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "IProps" needs to be exported by the entry point api.d.ts
 //
@@ -4949,7 +4939,7 @@ type SanityCheck = (state: any, action: Redux.Action) => string | false;
 
 // @public (undocumented)
 export namespace selectors {
-    export { activatorForGame, activeDownloads, activeGameId, activeProfile, activeProfileId, apiKey, currentActivator, currentGame, currentGameDiscovery, discovered, discoveryByGame, downloadPath, downloadPathForGame, downloadsForActiveGame, downloadsForGame, enabledModCountForProfile, gameById, gameName, gameProfiles, getCollectionActiveSession, getCollectionActiveSessionMod, getCollectionActiveSessionMods, getCollectionCompletedMods, getCollectionCurrentPhase, getCollectionInstallProgress, getCollectionLastActiveSessionId, getCollectionLastCompletedSession, getCollectionModByReference, getCollectionModsByPhase, getCollectionModsByStatus, getCollectionModsForPhase, getCollectionModsInProgress, getCollectionOptionalMods, getCollectionPendingMods, getCollectionPhaseProgress, getCollectionRequiredMods, getCollectionSessionById, getCollectionSessionHistory, getCollectionSessionMods, getCollectionStatusBreakdown, getCollectionTotalPhases, getDownloadByIds, getFailedOptionalMods, getFailedRequiredMods, getMod, getModInstallPath, hasCollectionActiveSession, installPath, installPathForGame, isActiveSessionStalled, isAnalyticsEnabled, isCollectionInstalling, isCollectionModPresent, isCollectionPhaseComplete, isLoggedIn, isPremium, isTelemetryEnabled, knownGames, lastActiveProfileForGame, lastActiveProfiles, mainPage, modPathsForGame, modsForActiveGame, modsForGame, needToDeploy, needToDeployForGame, nextProfileId, nexusIdsFromDownloadId, notifications, profileById, profiles, queueClearingDownloads, secondaryPage, shouldShowPremiumAd, userInfo };
+    export { activatorForGame, activeDownloads, activeGameId, activeProfile, activeProfileId, apiKey, currentActivator, currentGame, currentGameDiscovery, discovered, discoveryByGame, downloadPath, downloadPathForGame, downloadsForActiveGame, downloadsForGame, enabledModCountForProfile, gameById, gameName, gameProfiles, getCollectionActiveSession, getCollectionActiveSessionMod, getCollectionActiveSessionMods, getCollectionCompletedMods, getCollectionCurrentPhase, getCollectionInstallProgress, getCollectionLastActiveSessionId, getCollectionLastCompletedSession, getCollectionModByReference, getCollectionModsByPhase, getCollectionModsByStatus, getCollectionModsForPhase, getCollectionModsInProgress, getCollectionOptionalMods, getCollectionPendingMods, getCollectionPhaseProgress, getCollectionRequiredMods, getCollectionSessionById, getCollectionSessionHistory, getCollectionSessionMods, getCollectionStatusBreakdown, getCollectionTotalPhases, getDownloadByIds, getFailedOptionalMods, getFailedRequiredMods, getMod, getModInstallPath, hasCollectionActiveSession, installPath, installPathForGame, isActiveSessionStalled, isAnalyticsEnabled, isCollectionInstalling, isCollectionModPresent, isCollectionPhaseComplete, isCollectionPhaseSettledSuccessfully, isLoggedIn, isPremium, isTelemetryEnabled, knownGames, lastActiveProfileForGame, lastActiveProfiles, mainPage, modPathsForGame, modsForActiveGame, modsForGame, needToDeploy, needToDeployForGame, nextProfileId, nexusIdsFromDownloadId, notifications, profileById, profiles, queueClearingDownloads, secondaryPage, shouldShowPremiumAd, userInfo };
 }
 
 // Warning: (ae-forgotten-export) The symbol "IProps$3" needs to be exported by the entry point api.d.ts
@@ -5275,53 +5265,53 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 
 // Warnings were encountered during analysis:
 //
-// lib/api.d.ts:294:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:953:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1140:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1459:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1679:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1727:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1884:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1886:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2197:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2202:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2205:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2208:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2223:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2260:5 - (ae-forgotten-export) The symbol "IExtensionState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2283:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2286:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2304:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2369:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2431:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2463:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2495:5 - (ae-forgotten-export) The symbol "ISession" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2496:5 - (ae-forgotten-export) The symbol "ICollectionInstallState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2497:5 - (ae-forgotten-export) The symbol "ISessionGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2498:5 - (ae-forgotten-export) The symbol "IDiscoveryState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2499:5 - (ae-forgotten-export) The symbol "INotificationState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2500:5 - (ae-forgotten-export) The symbol "IBrowserState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2501:5 - (ae-forgotten-export) The symbol "IHistoryState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2502:5 - (ae-forgotten-export) The symbol "IOverlaysState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2503:5 - (ae-forgotten-export) The symbol "IHealthCheckSessionState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2507:9 - (ae-forgotten-export) The symbol "IExtensionOptional" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2518:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2520:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2521:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2522:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2524:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2526:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2535:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2536:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2537:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2553:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2597:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3771:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:295:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:954:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1141:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1460:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1681:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1729:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1886:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1888:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2199:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2204:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2207:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2210:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2225:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2262:5 - (ae-forgotten-export) The symbol "IExtensionState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2285:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2288:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2306:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2371:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2433:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2465:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2497:5 - (ae-forgotten-export) The symbol "ISession" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2498:5 - (ae-forgotten-export) The symbol "ICollectionInstallState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2499:5 - (ae-forgotten-export) The symbol "ISessionGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2500:5 - (ae-forgotten-export) The symbol "IDiscoveryState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2501:5 - (ae-forgotten-export) The symbol "INotificationState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2502:5 - (ae-forgotten-export) The symbol "IBrowserState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2503:5 - (ae-forgotten-export) The symbol "IHistoryState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2504:5 - (ae-forgotten-export) The symbol "IOverlaysState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2505:5 - (ae-forgotten-export) The symbol "IHealthCheckSessionState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2509:9 - (ae-forgotten-export) The symbol "IExtensionOptional" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2517:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2519:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2520:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2521:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2523:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2525:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2534:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2535:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2536:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2552:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2596:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3770:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:4160:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:4428:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:4853:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8800:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8801:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8805:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8806:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/renderer/src/extensions/collections/index.ts
+++ b/src/renderer/src/extensions/collections/index.ts
@@ -565,7 +565,9 @@ function genAttributeExtractor(api: IExtensionApi) {
     const revisionId = modInfo.download?.modInfo?.nexus?.ids?.revisionId;
     const collectionSlug = modInfo.download?.modInfo?.nexus?.ids?.collectionSlug;
     const revisionNumber = modInfo.download?.modInfo?.nexus?.ids?.revisionNumber;
-    const referenceTag = modInfo.download?.modInfo?.referenceTag;
+    // the rule being installed names the tag for this collection's copy; the download may have been
+    // fetched by another collection and carry its tag first
+    const referenceTag = modInfo.modReference?.tag ?? modInfo.download?.modInfo?.referenceTag;
 
     const result: { [key: string]: any } = {
       collectionId,

--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -161,7 +161,9 @@ describe("buildCollectionItemRows", () => {
 
   it("resolves a tagged rule's download by identity when no tag matches", () => {
     // the archive was fetched for another collection and never stamped with this rule's tag
-    const rule = requiresRule({ reference: { tag: "ours", fileMD5: "hash-xyz" } });
+    const rule = requiresRule({
+      reference: { tag: "ours", fileMD5: "hash-xyz", gameId: "skyrimse" },
+    });
     const rows = buildCollectionItemRows({
       rules: [rule],
       mods: {},

--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -159,6 +159,31 @@ describe("buildCollectionItemRows", () => {
     expect(rows[modRuleId(theirs)].status).toBe("downloaded");
   });
 
+  it("resolves a mod reused by a second collection through any of its reference tags", () => {
+    // the mod was installed by another collection first, so the legacy referenceTag holds that
+    // collection's tag and ours only appears in the referenceTags array; the tag index must hit,
+    // not fall through to the hash backup, which can land on a different variant of the same file
+    const rule = requiresRule({ reference: { tag: "ours", fileMD5: "hash-shared" } });
+    const rows = buildCollectionItemRows({
+      rules: [rule],
+      mods: {
+        variant: installedMod("variant", { referenceTag: "unrelated", fileMD5: "hash-shared" }),
+        shared: installedMod("shared", {
+          referenceTag: "theirs",
+          referenceTags: ["theirs", "ours"],
+          fileMD5: "hash-shared",
+        }),
+      },
+      downloads: {},
+      modState: {},
+      sessionMods: {},
+    });
+    const row = rows[modRuleId(rule)];
+
+    expect(row.id).toBe("shared");
+    expect(row.status).toBe("installed");
+  });
+
   it("falls back to fileMD5 when a tagged rule's installed mod carries a different tag", () => {
     // a member whose referenceTag drifted, or that was matched by hash rather than tag, is still
     // recognised by content hash - so it is not wrongly shown as not-installed

--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -135,6 +135,53 @@ describe("buildCollectionItemRows", () => {
     expect(row.status).toBe("installed");
   });
 
+  it("resolves each collection's rule against a download shared between them", () => {
+    // one archive satisfies rules in several collections, so it carries a tag per rule
+    const ours = requiresRule({ reference: { tag: "ours" } });
+    const theirs = requiresRule({ reference: { tag: "theirs", description: "Theirs" } });
+    const rows = buildCollectionItemRows({
+      rules: [ours, theirs],
+      mods: {},
+      downloads: {
+        shared: makeDownload({
+          id: "shared",
+          state: "finished",
+          size: 200,
+          received: 200,
+          modInfo: { referenceTag: "theirs", referenceTags: ["theirs", "ours"] },
+        }),
+      },
+      modState: {},
+      sessionMods: {},
+    });
+
+    expect(rows[modRuleId(ours)].status).toBe("downloaded");
+    expect(rows[modRuleId(theirs)].status).toBe("downloaded");
+  });
+
+  it("resolves a tagged rule's download by identity when no tag matches", () => {
+    // the archive was fetched for another collection and never stamped with this rule's tag
+    const rule = requiresRule({ reference: { tag: "ours", fileMD5: "hash-xyz" } });
+    const rows = buildCollectionItemRows({
+      rules: [rule],
+      mods: {},
+      downloads: {
+        shared: makeDownload({
+          id: "shared",
+          state: "finished",
+          size: 200,
+          received: 200,
+          fileMD5: "hash-xyz",
+          modInfo: { referenceTag: "theirs" },
+        }),
+      },
+      modState: {},
+      sessionMods: {},
+    });
+
+    expect(rows[modRuleId(rule)].status).toBe("downloaded");
+  });
+
   it("falls back to fileMD5 when a tagged rule's installed mod carries a different tag", () => {
     // a member whose referenceTag drifted, or that was matched by hash rather than tag, is still
     // recognised by content hash - so it is not wrongly shown as not-installed

--- a/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.test.ts
@@ -159,31 +159,6 @@ describe("buildCollectionItemRows", () => {
     expect(rows[modRuleId(theirs)].status).toBe("downloaded");
   });
 
-  it("resolves a tagged rule's download by identity when no tag matches", () => {
-    // the archive was fetched for another collection and never stamped with this rule's tag
-    const rule = requiresRule({
-      reference: { tag: "ours", fileMD5: "hash-xyz", gameId: "skyrimse" },
-    });
-    const rows = buildCollectionItemRows({
-      rules: [rule],
-      mods: {},
-      downloads: {
-        shared: makeDownload({
-          id: "shared",
-          state: "finished",
-          size: 200,
-          received: 200,
-          fileMD5: "hash-xyz",
-          modInfo: { referenceTag: "theirs" },
-        }),
-      },
-      modState: {},
-      sessionMods: {},
-    });
-
-    expect(rows[modRuleId(rule)].status).toBe("downloaded");
-  });
-
   it("falls back to fileMD5 when a tagged rule's installed mod carries a different tag", () => {
     // a member whose referenceTag drifted, or that was matched by hash rather than tag, is still
     // recognised by content hash - so it is not wrongly shown as not-installed

--- a/src/renderer/src/extensions/collections/installSession/itemRows.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.ts
@@ -10,10 +10,7 @@ import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findDownloadByRef } from "../../mod_management/util/dependencies";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import { renderModReference } from "../../mod_management/util/modName";
-import {
-  downloadReferenceTags,
-  isDependencyRule,
-} from "../../mod_management/util/testModReference";
+import { isDependencyRule } from "../../mod_management/util/testModReference";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 
 /**
@@ -115,11 +112,10 @@ function persistentRow(
   }
 
   // downloads carry a tag per rule they satisfy, so the tag index resolves the archive for every
-  // collection referencing it. An archive fetched before this collection referenced it carries no
-  // tag of ours, so fall back to the identity scan rather than reporting the member as pending.
+  // collection referencing it; only a tagless rule needs the scan.
   const dlId =
     tag !== undefined
-      ? (indexes.downloadIdByTag.get(tag) ?? findDownloadByRef(rule.reference, downloads))
+      ? indexes.downloadIdByTag.get(tag)
       : findDownloadByRef(rule.reference, downloads);
   const download = dlId !== undefined ? downloads[dlId] : undefined;
   const data = download !== undefined ? rowFromDownload(dlId, download, rule) : stubRow(rule);
@@ -198,7 +194,11 @@ export function buildCollectionItemRows(
     }
   }
   for (const [dlId, download] of Object.entries(downloads)) {
-    for (const tag of downloadReferenceTags(download)) {
+    const { referenceTag, referenceTags } = download.modInfo ?? {};
+    if (typeof referenceTag === "string" && !indexes.downloadIdByTag.has(referenceTag)) {
+      indexes.downloadIdByTag.set(referenceTag, dlId);
+    }
+    for (const tag of referenceTags ?? []) {
       if (!indexes.downloadIdByTag.has(tag)) {
         indexes.downloadIdByTag.set(tag, dlId);
       }

--- a/src/renderer/src/extensions/collections/installSession/itemRows.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.ts
@@ -10,7 +10,7 @@ import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findDownloadByRef } from "../../mod_management/util/dependencies";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import { renderModReference } from "../../mod_management/util/modName";
-import { isDependencyRule } from "../../mod_management/util/testModReference";
+import { isDependencyRule, modReferenceTags } from "../../mod_management/util/testModReference";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 
 /**
@@ -70,10 +70,10 @@ function rowFromDownload(dlId: string, download: IDownload, rule: IModRule): Ite
 // its installed mod / download without the findModByRef/findDownloadByRef per-rule scan that
 // dominated render time on large collections.
 interface RowIndexes {
-  // installed mod by referenceTag, and (backup) by content hash
+  // installed mod by each reference tag it satisfies, and (backup) by content hash
   modByTag: Map<string, IMod>;
   modByMd5: Map<string, IMod>;
-  // download id by referenceTag
+  // download id by each reference tag the archive satisfies
   downloadIdByTag: Map<string, string>;
 }
 
@@ -176,17 +176,18 @@ export function buildCollectionItemRows(
 
   // Built once so each rule resolves its mod/download in O(1) instead of scanning every mod/download
   // (those per-rule scans dominated render time on large collections). Installed mods are keyed by
-  // referenceTag and by content hash (fileMD5); downloads by referenceTag. First entry wins on the
-  // (rare) duplicate, matching findModByRef's first-match.
+  // every reference tag they satisfy and by content hash (fileMD5); downloads by every reference
+  // tag. First entry wins on the (rare) duplicate, matching findModByRef's first-match.
   const indexes: RowIndexes = {
     modByTag: new Map<string, IMod>(),
     modByMd5: new Map<string, IMod>(),
     downloadIdByTag: new Map<string, string>(),
   };
   for (const mod of Object.values(mods)) {
-    const tag = mod.attributes?.referenceTag;
-    if (typeof tag === "string" && !indexes.modByTag.has(tag)) {
-      indexes.modByTag.set(tag, mod);
+    for (const tag of modReferenceTags(mod)) {
+      if (!indexes.modByTag.has(tag)) {
+        indexes.modByTag.set(tag, mod);
+      }
     }
     const md5 = mod.attributes?.fileMD5;
     if (typeof md5 === "string" && !indexes.modByMd5.has(md5)) {

--- a/src/renderer/src/extensions/collections/installSession/itemRows.ts
+++ b/src/renderer/src/extensions/collections/installSession/itemRows.ts
@@ -10,7 +10,10 @@ import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findDownloadByRef } from "../../mod_management/util/dependencies";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import { renderModReference } from "../../mod_management/util/modName";
-import { isDependencyRule } from "../../mod_management/util/testModReference";
+import {
+  downloadReferenceTags,
+  isDependencyRule,
+} from "../../mod_management/util/testModReference";
 import type { IProfileMod } from "../../profile_management/types/IProfile";
 
 /**
@@ -111,11 +114,12 @@ function persistentRow(
     };
   }
 
-  // downloads are stamped with the rule's referenceTag at download time (and reconciled on a
-  // mismatch), so the tag is authoritative; only a tagless rule needs the scan.
+  // downloads carry a tag per rule they satisfy, so the tag index resolves the archive for every
+  // collection referencing it. An archive fetched before this collection referenced it carries no
+  // tag of ours, so fall back to the identity scan rather than reporting the member as pending.
   const dlId =
     tag !== undefined
-      ? indexes.downloadIdByTag.get(tag)
+      ? (indexes.downloadIdByTag.get(tag) ?? findDownloadByRef(rule.reference, downloads))
       : findDownloadByRef(rule.reference, downloads);
   const download = dlId !== undefined ? downloads[dlId] : undefined;
   const data = download !== undefined ? rowFromDownload(dlId, download, rule) : stubRow(rule);
@@ -194,9 +198,10 @@ export function buildCollectionItemRows(
     }
   }
   for (const [dlId, download] of Object.entries(downloads)) {
-    const tag = download.modInfo?.referenceTag;
-    if (typeof tag === "string" && !indexes.downloadIdByTag.has(tag)) {
-      indexes.downloadIdByTag.set(tag, dlId);
+    for (const tag of downloadReferenceTags(download)) {
+      if (!indexes.downloadIdByTag.has(tag)) {
+        indexes.downloadIdByTag.set(tag, dlId);
+      }
     }
   }
 

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -724,3 +724,66 @@ describe("InstallDriver journey: re-attribution of an already-installed member",
     expect(h.driver.isInstallComplete(false)).toBe(false);
   });
 });
+
+describe("InstallDriver collection membership tags", () => {
+  // A member mod can belong to more than one collection: identity (here the file hash) is what
+  // attributes it, and each collection's tag is recorded so it stays recognisable as their member.
+  const sharedRule = makeRule({
+    type: "requires",
+    reference: makeReference({ tag: "ours", fileMD5: "shared-hash" }),
+  });
+  const sharedFixture = makeCollectionFixture({ id: "col-shared", rule: sharedRule });
+  const sharedMod = makeMod({
+    id: "m-shared",
+    attributes: {
+      referenceTag: "theirs",
+      referenceTags: ["theirs"],
+      fileMD5: "shared-hash",
+    },
+  });
+
+  test("records the installing rule's tag on a member whose mod carries another's", async ({
+    startCollection,
+  }) => {
+    const h = await startCollection(sharedFixture);
+    h.setState((draft) => {
+      draft.persistent.mods[GAME_ID][sharedMod.id] = sharedMod;
+    });
+
+    h.emit("did-install-mod", GAME_ID, sharedFixture.download.id, sharedMod.id);
+
+    await vi.waitFor(() => {
+      expect(
+        h.getState().persistent.mods[GAME_ID][sharedMod.id].attributes?.referenceTags,
+      ).toContain("ours");
+    });
+    // the other collection's tag is kept, so its own rules still match this mod
+    expect(h.getState().persistent.mods[GAME_ID][sharedMod.id].attributes?.referenceTags).toContain(
+      "theirs",
+    );
+  });
+
+  // A member already present when the collection is added is never queued and emits no install
+  // event, so the tag has to be recorded while the install session is built.
+  test("records the rule's tag on a member that was already installed at start", async ({
+    makeDriver,
+  }) => {
+    const h = makeDriver({
+      mods: {
+        [GAME_ID]: {
+          [sharedFixture.collection.id]: sharedFixture.collection,
+          [sharedMod.id]: sharedMod,
+        },
+      },
+      downloads: { [sharedFixture.download.id]: sharedFixture.download },
+      profiles: { [profile.id]: profile },
+    });
+
+    await h.driver.start(profile, sharedFixture.collection);
+
+    const attributes = h.getState().persistent.mods[GAME_ID][sharedMod.id].attributes;
+    expect(attributes?.referenceTags).toContain("ours");
+    // the user may have installed it themselves, so it is not marked as pulled in by a collection
+    expect(attributes?.installedAsDependency).toBeUndefined();
+  });
+});

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -786,4 +786,34 @@ describe("InstallDriver collection membership tags", () => {
     // the user may have installed it themselves, so it is not marked as pulled in by a collection
     expect(attributes?.installedAsDependency).toBeUndefined();
   });
+
+  // Two members can resolve to the same installed mod (same file, pinned twice), so the tags are
+  // recorded per mod rather than per member - one write per member would only keep the last tag.
+  test("records both rules' tags when two members resolve to the same installed mod", async ({
+    makeDriver,
+  }) => {
+    const firstRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "ours-first", fileMD5: "shared-hash" }),
+    });
+    const secondRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "ours-second", fileMD5: "shared-hash" }),
+    });
+    const fixture = buildCollectionFixture("col-twice", [firstRule, secondRule]);
+    const h = makeDriver({
+      mods: {
+        [GAME_ID]: { [fixture.collection.id]: fixture.collection, [sharedMod.id]: sharedMod },
+      },
+      downloads: { [fixture.download.id]: fixture.download },
+      profiles: { [profile.id]: profile },
+    });
+
+    await h.driver.start(profile, fixture.collection);
+
+    const tags = h.getState().persistent.mods[GAME_ID][sharedMod.id].attributes?.referenceTags;
+    expect(tags).toContain("ours-first");
+    expect(tags).toContain("ours-second");
+    expect(tags).toContain("theirs");
+  });
 });

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -951,11 +951,10 @@ class InstallDriver {
     // the session's per-rule mod info, keyed by rule id, reconstructed from reality
     const sessionModInfo = reconstructSessionMods({ rules: required, mods, downloads });
 
-    // Members already present at start (installed by the user, or left by another collection) are
-    // never queued and emit no install event, so this is where they get this collection's tag.
-    // Deliberately not marked installedAsDependency: the user may have installed them themselves.
-    // Collected per mod first - several members can resolve to one mod, and that mod's tags are
-    // written as a whole array.
+    // Members already present at start are never queued and emit no install event, so this is
+    // where they get this collection's tag. Deliberately not marked installedAsDependency: the
+    // user may have installed them themselves. Collected per mod because several members can
+    // resolve to one mod, whose tags are written as a whole array.
     const startTagsByMod = new Map<string, string[]>(); // modId -> tags of the rules it satisfies
     for (const info of Object.values(sessionModInfo)) {
       if (info.status !== "installed" || info.modId === undefined) {

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -40,7 +40,6 @@ import testModReference, {
   isDependencyRule,
   isOptionalRule,
   isRequiredRule,
-  modReferenceTags,
   ruleInstallSpec,
   testRefByIdentifiers,
 } from "../../mod_management/util/testModReference";
@@ -203,9 +202,17 @@ class InstallDriver {
       // is what keeps attribution from being O(members) per event (the 2000-4000 mod freeze).
       // a member mod carries a tag per collection that pulled it in, so any of them can name the
       // rule this install belongs to
-      const taggedDependent = modReferenceTags(mod)
-        .map((tag) => this.mDependentByTag.get(tag))
-        .find((dependent) => dependent !== undefined);
+      const attrs = mod?.attributes;
+      let taggedDependent =
+        attrs?.referenceTag !== undefined
+          ? this.mDependentByTag.get(attrs.referenceTag)
+          : undefined;
+      for (const tag of attrs?.referenceTags ?? []) {
+        if (taggedDependent !== undefined) {
+          break;
+        }
+        taggedDependent = this.mDependentByTag.get(tag);
+      }
 
       // fallback for a mod with no (matching) referenceTag: match by reference / identifiers. The
       // identifiers are independent of the rule, so build them once rather than per member.

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -35,7 +35,7 @@ import { installPathForGame } from "../../mod_management/selectors";
 import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import renderModName from "../../mod_management/util/modName";
-import { appendModReferenceTagActions } from "../../mod_management/util/modReferenceTags";
+import { appendModReferenceTagsActions } from "../../mod_management/util/modReferenceTags";
 import testModReference, {
   isDependencyRule,
   isOptionalRule,
@@ -267,7 +267,7 @@ class InstallDriver {
           setModAttribute(gameId, modId, "fileList", installSpec.fileList),
           // record this collection's tag for the member, keeping any tag another collection
           // stamped, so each collection recognises the mod as one of its own
-          ...appendModReferenceTagActions(gameId, modId, mod, dependent.reference.tag),
+          ...appendModReferenceTagsActions(gameId, modId, mod, [dependent.reference.tag]),
         ]);
 
         if (dependent.type === "requires") {
@@ -954,17 +954,28 @@ class InstallDriver {
     // Members already present at start (installed by the user, or left by another collection) are
     // never queued and emit no install event, so this is where they get this collection's tag.
     // Deliberately not marked installedAsDependency: the user may have installed them themselves.
+    // Collected per mod first - several members can resolve to one mod, and that mod's tags are
+    // written as a whole array.
+    const startTagsByMod = new Map<string, string[]>(); // modId -> tags of the rules it satisfies
+    for (const info of Object.values(sessionModInfo)) {
+      if (info.status !== "installed" || info.modId === undefined) {
+        continue;
+      }
+      const tag = info.rule.reference.tag;
+      if (tag === undefined) {
+        continue;
+      }
+      const tags = startTagsByMod.get(info.modId);
+      if (tags === undefined) {
+        startTagsByMod.set(info.modId, [tag]);
+      } else if (!tags.includes(tag)) {
+        tags.push(tag);
+      }
+    }
     batchDispatch(
       this.mApi.store,
-      Object.values(sessionModInfo).flatMap((info) =>
-        info.status === "installed" && info.modId !== undefined
-          ? appendModReferenceTagActions(
-              this.mGameId,
-              info.modId,
-              mods[info.modId],
-              info.rule.reference.tag,
-            )
-          : [],
+      Array.from(startTagsByMod).flatMap(([modId, tags]) =>
+        appendModReferenceTagsActions(this.mGameId, modId, mods[modId], tags),
       ),
     );
 

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -35,10 +35,12 @@ import { installPathForGame } from "../../mod_management/selectors";
 import type { IMod, IModRule } from "../../mod_management/types/IMod";
 import { findModByRef } from "../../mod_management/util/findModByRef";
 import renderModName from "../../mod_management/util/modName";
+import { appendModReferenceTagActions } from "../../mod_management/util/modReferenceTags";
 import testModReference, {
   isDependencyRule,
   isOptionalRule,
   isRequiredRule,
+  modReferenceTags,
   ruleInstallSpec,
   testRefByIdentifiers,
 } from "../../mod_management/util/testModReference";
@@ -199,10 +201,11 @@ class InstallDriver {
       // installed collection member is stamped with its rule's referenceTag, and testModReference
       // treats an identical tag as authoritative, so a tag hit is a definitive O(1) match - this
       // is what keeps attribution from being O(members) per event (the 2000-4000 mod freeze).
-      const taggedDependent =
-        mod?.attributes?.referenceTag !== undefined
-          ? this.mDependentByTag.get(mod.attributes.referenceTag)
-          : undefined;
+      // a member mod carries a tag per collection that pulled it in, so any of them can name the
+      // rule this install belongs to
+      const taggedDependent = modReferenceTags(mod)
+        .map((tag) => this.mDependentByTag.get(tag))
+        .find((dependent) => dependent !== undefined);
 
       // fallback for a mod with no (matching) referenceTag: match by reference / identifiers. The
       // identifiers are independent of the rule, so build them once rather than per member.
@@ -255,6 +258,9 @@ class InstallDriver {
           setModAttribute(gameId, modId, "installerChoices", installSpec.installerChoices),
           setModAttribute(gameId, modId, "patches", installSpec.patches),
           setModAttribute(gameId, modId, "fileList", installSpec.fileList),
+          // record this collection's tag for the member, keeping any tag another collection
+          // stamped, so each collection recognises the mod as one of its own
+          ...appendModReferenceTagActions(gameId, modId, mod, dependent.reference.tag),
         ]);
 
         if (dependent.type === "requires") {
@@ -937,6 +943,23 @@ class InstallDriver {
 
     // the session's per-rule mod info, keyed by rule id, reconstructed from reality
     const sessionModInfo = reconstructSessionMods({ rules: required, mods, downloads });
+
+    // Members already present at start (installed by the user, or left by another collection) are
+    // never queued and emit no install event, so this is where they get this collection's tag.
+    // Deliberately not marked installedAsDependency: the user may have installed them themselves.
+    batchDispatch(
+      this.mApi.store,
+      Object.values(sessionModInfo).flatMap((info) =>
+        info.status === "installed" && info.modId !== undefined
+          ? appendModReferenceTagActions(
+              this.mGameId,
+              info.modId,
+              mods[info.modId],
+              info.rule.reference.tag,
+            )
+          : [],
+      ),
+    );
 
     // Dispatch start session action (omitting computed properties)
     this.mApi.store.dispatch(

--- a/src/renderer/src/extensions/download_management/types/IDownload.ts
+++ b/src/renderer/src/extensions/download_management/types/IDownload.ts
@@ -85,6 +85,9 @@ export interface IModInfo {
     [key: string]: any;
   };
   referenceTag?: string;
+  // every collection-rule tag this archive satisfies; append-only superset of referenceTag, which
+  // holds the first tag stamped and is what older Vortex versions read
+  referenceTags?: string[];
   revisionNumber?: number;
   source?: string;
   // Allow additional properties

--- a/src/renderer/src/extensions/download_management/util/referenceTags.test.ts
+++ b/src/renderer/src/extensions/download_management/util/referenceTags.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Appending a collection-rule tag to a download's tag set. One archive can satisfy rules in
+ * several collections, so the set only ever grows: the legacy single field keeps the first tag
+ * (older Vortex versions read only that one) and every tag lands in the array.
+ */
+import { describe, expect, it } from "vitest";
+
+import { makeDownload } from "../../../test-utils/builders";
+import { downloadReferenceTags } from "../../mod_management/util/testModReference";
+import { appendReferenceTagActions } from "./referenceTags";
+
+const applied = (download: ReturnType<typeof makeDownload>, tag: string) => {
+  const actions = appendReferenceTagActions("dl-1", download, tag);
+  // the reducer writes each action's value at modInfo.<key>
+  const modInfo = { ...download.modInfo };
+  for (const action of actions) {
+    modInfo[action.payload.key] = action.payload.value;
+  }
+  return { actions, modInfo };
+};
+
+describe("appendReferenceTagActions", () => {
+  it("records the tag in the array and as the first tag", () => {
+    const { modInfo } = applied(makeDownload({ modInfo: {} }), "tag-a");
+
+    expect(modInfo.referenceTag).toBe("tag-a");
+    expect(modInfo.referenceTags).toEqual(["tag-a"]);
+  });
+
+  it("keeps the first tag when a second collection's tag is added", () => {
+    const { modInfo } = applied(
+      makeDownload({ modInfo: { referenceTag: "tag-a", referenceTags: ["tag-a"] } }),
+      "tag-b",
+    );
+
+    expect(modInfo.referenceTag).toBe("tag-a");
+    expect(modInfo.referenceTags).toEqual(["tag-a", "tag-b"]);
+  });
+
+  it("adopts a download that carries only the legacy single tag", () => {
+    const { modInfo } = applied(makeDownload({ modInfo: { referenceTag: "legacy" } }), "tag-b");
+
+    expect(modInfo.referenceTag).toBe("legacy");
+    expect(modInfo.referenceTags).toEqual(["legacy", "tag-b"]);
+  });
+
+  it("produces no actions for a tag the download already carries", () => {
+    const legacyOnly = makeDownload({ modInfo: { referenceTag: "tag-a" } });
+    expect(appendReferenceTagActions("dl-1", legacyOnly, "tag-a")).toEqual([]);
+
+    const inArray = makeDownload({ modInfo: { referenceTags: ["tag-a", "tag-b"] } });
+    expect(appendReferenceTagActions("dl-1", inArray, "tag-b")).toEqual([]);
+  });
+});
+
+describe("downloadReferenceTags", () => {
+  it("reads the legacy tag and the array as one deduped set", () => {
+    expect(
+      downloadReferenceTags(
+        makeDownload({ modInfo: { referenceTag: "tag-a", referenceTags: ["tag-a", "tag-b"] } }),
+      ),
+    ).toEqual(["tag-a", "tag-b"]);
+  });
+
+  it("reads a download that carries only the legacy tag", () => {
+    expect(downloadReferenceTags(makeDownload({ modInfo: { referenceTag: "only" } }))).toEqual([
+      "only",
+    ]);
+  });
+
+  it("reads an untagged or missing download as carrying no tags", () => {
+    expect(downloadReferenceTags(makeDownload({ modInfo: {} }))).toEqual([]);
+    expect(downloadReferenceTags(undefined)).toEqual([]);
+  });
+});

--- a/src/renderer/src/extensions/download_management/util/referenceTags.test.ts
+++ b/src/renderer/src/extensions/download_management/util/referenceTags.test.ts
@@ -6,17 +6,22 @@
 import { describe, expect, it } from "vitest";
 
 import { makeDownload } from "../../../test-utils/builders";
+import type { IDownload } from "../../download_management/types/IDownload";
 import { downloadReferenceTags } from "../../mod_management/util/testModReference";
+import { stateReducer } from "../reducers/state";
 import { appendReferenceTagActions } from "./referenceTags";
 
-const applied = (download: ReturnType<typeof makeDownload>, tag: string) => {
+// run the produced actions through the real download reducer, so what is asserted is the modInfo a
+// download ends up with rather than the shape of the actions
+const applied = (download: IDownload, tag: string) => {
   const actions = appendReferenceTagActions("dl-1", download, tag);
-  // the reducer writes each action's value at modInfo.<key>
-  const modInfo = { ...download.modInfo };
+  // keyed by download id, as the download slice is
+  let files: Record<string, IDownload> = { "dl-1": download };
   for (const action of actions) {
-    modInfo[action.payload.key] = action.payload.value;
+    const reduce = stateReducer.reducers[action.type];
+    files = reduce({ files }, (action as unknown as { payload: unknown }).payload).files;
   }
-  return { actions, modInfo };
+  return { actions, modInfo: files["dl-1"].modInfo };
 };
 
 describe("appendReferenceTagActions", () => {

--- a/src/renderer/src/extensions/download_management/util/referenceTags.ts
+++ b/src/renderer/src/extensions/download_management/util/referenceTags.ts
@@ -1,0 +1,35 @@
+/**
+ * Recording collection-rule tags on a download. One archive can satisfy rules in several
+ * collections, so the tag set is append-only: `modInfo.referenceTag` keeps the first tag stamped
+ * (older Vortex versions read only that field) and `modInfo.referenceTags` carries all of them.
+ *
+ * The read side lives with the rest of the identity matching (testModReference).
+ */
+import type { Action } from "redux";
+
+import { downloadReferenceTags } from "../../mod_management/util/testModReference";
+import { setDownloadModInfo } from "../actions/state";
+import type { IDownload } from "../types/IDownload";
+
+/**
+ * Actions recording `tag` on the download's tag set. Writes the whole unioned array in one action
+ * (the reducer sets a dotted path, so a merge would combine arrays by index), and sets the legacy
+ * single field only when the archive carries no tag yet. Empty when the tag is already recorded.
+ */
+export function appendReferenceTagActions(
+  downloadId: string,
+  download: IDownload,
+  tag: string,
+): Action[] {
+  const tags = downloadReferenceTags(download);
+  if (tags.includes(tag)) {
+    return [];
+  }
+  const actions: Action[] = [
+    setDownloadModInfo(downloadId, "referenceTags", [...tags, tag]),
+  ] as Action[];
+  if (download.modInfo?.referenceTag === undefined) {
+    actions.push(setDownloadModInfo(downloadId, "referenceTag", tag) as Action);
+  }
+  return actions;
+}

--- a/src/renderer/src/extensions/download_management/util/referenceTags.ts
+++ b/src/renderer/src/extensions/download_management/util/referenceTags.ts
@@ -18,7 +18,7 @@ import type { IDownload } from "../types/IDownload";
  */
 export function appendReferenceTagActions(
   downloadId: string,
-  download: IDownload,
+  download: IDownload | undefined,
   tag: string,
 ): Action[] {
   const tags = downloadReferenceTags(download);
@@ -28,7 +28,7 @@ export function appendReferenceTagActions(
   const actions: Action[] = [
     setDownloadModInfo(downloadId, "referenceTags", [...tags, tag]),
   ] as Action[];
-  if (download.modInfo?.referenceTag === undefined) {
+  if (download?.modInfo?.referenceTag === undefined) {
     actions.push(setDownloadModInfo(downloadId, "referenceTag", tag) as Action);
   }
   return actions;

--- a/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.test.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Deciding whether an installed mod belongs to a collection, which is what lets a health check
+ * leave a collection's members to the collection.
+ */
+import { describe, expect, it } from "vitest";
+
+import { MOD_TYPE } from "@/extensions/collections/constants";
+import type { IModRule } from "@/extensions/mod_management/types/IMod";
+import { makeMod, makeProfile, makeReference, makeRule } from "@/test-utils/builders";
+
+import { collectionManagedTags, isCollectionManaged } from "./collectionManaged";
+
+const PROFILE = "prof-1";
+
+const collectionMod = (id: string, tags: string[], type: IModRule["type"] = "requires") =>
+  makeMod({
+    id,
+    type: MOD_TYPE,
+    rules: tags.map((tag) => makeRule({ type, reference: makeReference({ tag }) })),
+  });
+
+// a profile that has every named collection installed
+const profileWith = (...collectionIds: string[]) =>
+  makeProfile({
+    id: PROFILE,
+    modState: Object.fromEntries(
+      collectionIds.map((id) => [id, { enabled: true, enabledTime: 0 }]),
+    ),
+  });
+
+describe("isCollectionManaged", () => {
+  it("claims a mod carrying an installed collection's rule tag", () => {
+    const mods = { "col-a": collectionMod("col-a", ["tag-a"]) };
+    const tags = collectionManagedTags(mods, profileWith("col-a"));
+
+    expect(isCollectionManaged(makeMod({ attributes: { referenceTag: "tag-a" } }), tags)).toBe(
+      true,
+    );
+  });
+
+  // a mod can belong to several collections, each recording its own tag, so the claim holds
+  // through any of them - including after the collection that installed it first is removed
+  it("claims a mod through any of the tags it carries", () => {
+    const mods = { "col-b": collectionMod("col-b", ["tag-b"]) };
+    const tags = collectionManagedTags(mods, profileWith("col-b"));
+    const shared = makeMod({
+      attributes: { referenceTag: "tag-a", referenceTags: ["tag-a", "tag-b"] },
+    });
+
+    expect(isCollectionManaged(shared, tags)).toBe(true);
+  });
+
+  it("does not claim a mod that carries no collection's tag", () => {
+    const mods = { "col-a": collectionMod("col-a", ["tag-a"]) };
+    const tags = collectionManagedTags(mods, profileWith("col-a"));
+
+    expect(isCollectionManaged(makeMod({ attributes: { referenceTag: "own" } }), tags)).toBe(false);
+    expect(isCollectionManaged(makeMod({ attributes: {} }), tags)).toBe(false);
+  });
+
+  it("claims a member the user opted into rather than one required", () => {
+    const mods = { "col-o": collectionMod("col-o", ["tag-opt"], "recommends") };
+    const tags = collectionManagedTags(mods, profileWith("col-o"));
+
+    expect(isCollectionManaged(makeMod({ attributes: { referenceTag: "tag-opt" } }), tags)).toBe(
+      true,
+    );
+  });
+});
+
+describe("collectionManagedTags", () => {
+  it("reads only collections the profile has installed", () => {
+    const mods = {
+      "col-a": collectionMod("col-a", ["tag-a"]),
+      "col-b": collectionMod("col-b", ["tag-b"]),
+    };
+
+    expect(Array.from(collectionManagedTags(mods, profileWith("col-a")))).toEqual(["tag-a"]);
+  });
+
+  it("reads no tags from a mod that is not a collection", () => {
+    const mods = {
+      "not-a-collection": makeMod({
+        id: "not-a-collection",
+        rules: [makeRule({ type: "requires", reference: makeReference({ tag: "tag-x" }) })],
+      }),
+    };
+
+    expect(collectionManagedTags(mods, profileWith("not-a-collection")).size).toBe(0);
+  });
+});

--- a/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/collectionManaged.ts
@@ -1,5 +1,8 @@
 import type { IMod } from "@/extensions/mod_management/types/IMod";
-import { isDependencyRule } from "@/extensions/mod_management/util/testModReference";
+import {
+  isDependencyRule,
+  modReferenceTags,
+} from "@/extensions/mod_management/util/testModReference";
 import type { IProfile } from "@/extensions/profile_management/types/IProfile";
 
 /**
@@ -29,8 +32,11 @@ export function collectionManagedTags(
   return tags;
 }
 
-/** Whether a mod's own referenceTag matches one of the given collection-managed tags. */
+/**
+ * Whether any tag the mod carries is one of the given collection-managed tags. A mod can belong
+ * to several collections, each recording its own tag, so all of them count - reading only the
+ * first-stamped `referenceTag` would drop the mod from every collection but that one.
+ */
 export function isCollectionManaged(mod: IMod, collectionTags: Set<string>): boolean {
-  const referenceTag = (mod.attributes as { referenceTag?: string } | undefined)?.referenceTag;
-  return referenceTag != null && collectionTags.has(referenceTag);
+  return modReferenceTags(mod).some((tag) => collectionTags.has(tag));
 }

--- a/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.optionalPhaseGate.test.ts
@@ -20,13 +20,13 @@ import {
   makeReference,
   makeRule,
   makeSession,
+  managerInternals as internals,
 } from "../../test-utils/builders";
 import type { IDriverHarnessState, IInstallManagerHarness } from "../../test-utils/harnessTypes";
 import { test as imTest } from "../../test-utils/installManagerTest";
 import { generateCollectionSessionId, modRuleId } from "../../util/collectionInstallSession";
 import { getCollectionInstallProgress } from "../../util/collectionInstallSessionSelectors";
 import { MOD_TYPE } from "../collections/constants";
-import type InstallManager from "./InstallManager";
 import { OPTIONAL_PHASE } from "./util/rulePhase";
 
 vi.mock("../../util/log", () => {
@@ -37,49 +37,6 @@ vi.mock("../../util/log", () => {
 const GAME = "skyrimse";
 const PROFILE = "prof-1";
 const COLLECTION = "col-1";
-
-// the private InstallManager internals these tests drive directly
-interface IManagerInternals {
-  reQueueDownloadedMods: (
-    api: unknown,
-    sourceModId: string,
-    allMods: unknown[],
-    currentPhase: number,
-  ) => void;
-  checkCollectionPhaseStatus: (
-    api: unknown,
-    sourceModId: string,
-    phase: number,
-  ) => { phaseComplete: boolean; needsRequeue: boolean; allMods: unknown[] };
-  driveSelectedOptionals: (api: unknown, sourceModId: string) => void;
-  admitSettledOptionalPhase: (sourceModId: string, api: unknown) => void;
-  pollAllPhasesComplete: (api: unknown, sourceModId: string) => Promise<void>;
-  withInstructions: (
-    api: unknown,
-    sourceName: string,
-    title: string,
-    id: string,
-    instructions: string,
-    recommendations: boolean,
-    cb: () => PromiseLike<unknown>,
-  ) => Promise<unknown>;
-  mPendingInstalls: Map<string, unknown>;
-  startQueuedInstallation: (
-    api: unknown,
-    dep: unknown,
-    downloadId: string,
-    gameId: string,
-    sourceModId: string,
-    recommended: boolean,
-    phase: number,
-  ) => void;
-  mDependencyInstalls: Record<string, () => void>;
-  maybeAdvancePhase: (sourceModId: string, api: unknown) => void;
-  getTerminalModCount: (api: unknown, sourceModId: string) => number;
-}
-
-const internals = (manager: InstallManager): IManagerInternals =>
-  manager as unknown as IManagerInternals;
 
 const requiredRule = makeRule({
   type: "requires",

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -376,9 +376,7 @@ describe("a resumed dependency install", () => {
       const optionalDeps = [
         { reference: optionalRule.reference, phase: OPTIONAL_PHASE, lookupResults: [], extra: {} },
       ];
-      expect(await frontierAfterRound(h, optionalDeps, true)).toBeGreaterThanOrEqual(
-        OPTIONAL_PHASE,
-      );
+      expect(await frontierAfterRound(h, optionalDeps, true)).toBe(OPTIONAL_PHASE);
     },
   );
 

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -45,6 +45,50 @@ const memberRule = makeRule({
 // a member reference whose tag drifted away from the rule the session is keyed with
 const driftedReference = { ...memberRule.reference, tag: FOREIGN_TAG };
 
+// a second required member, one phase later than memberRule
+const laterRule = makeRule({
+  type: "requires",
+  phase: 1,
+  reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+});
+
+// the dependency list a resumed round gathers for both required members
+const bothPhaseDeps = [
+  { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
+  { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+];
+
+/**
+ * Run one dependency round far enough to read the phase frontier it set, then unwind it - the
+ * round never settles on its own here, since nothing drives the gathered members. Clearing
+ * allowedPhase makes it a re-entry.
+ */
+async function frontierAfterRound(
+  h: IInstallManagerHarness,
+  dependencies: unknown[],
+  recommendations = false,
+): Promise<number | undefined> {
+  const phaseState = h.phaseTracker.get(COLLECTION);
+  if (phaseState !== undefined) {
+    phaseState.allowedPhase = undefined;
+  }
+  const installing = internals(h.manager).doInstallDependencies(
+    h.api,
+    GAME,
+    COLLECTION,
+    dependencies,
+    recommendations,
+    true,
+  );
+  try {
+    return h.phaseTracker.get(COLLECTION)?.allowedPhase;
+  } finally {
+    internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+    delete internals(h.manager).mDependencyInstalls[COLLECTION];
+    await installing.catch(() => undefined);
+  }
+}
+
 /**
  * A collection install where the member's archive is already downloaded under another collection's
  * tag, and that collection's copy of the mod is still installed. The session tracks the member as
@@ -263,18 +307,13 @@ describe("a resumed dependency install", () => {
   // Phase state is rebuilt per round, so the round has to read how far the collection already got
   // from the active session; starting at the lowest gathered phase would redo settled phases.
   imTest("re-enters at the failed required member's phase", async ({ makeInstallManager }) => {
-    const laterRule = makeRule({
-      type: "requires",
-      phase: 1,
-      reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
-    });
-    const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+    const { h } = makeSharedArchiveInstall(makeInstallManager, {
       rules: [memberRule, laterRule],
     });
     // phase 0 has a FAILED required member, which the round re-gathers for retry - so the
     // frontier must start AT phase 0, not past it; phase 1 stays gated until the retry settles
     h.setState((draft) => {
-      const mods = draft.session.collections.activeSession!.mods;
+      const mods = draft.session.collections.activeSession.mods;
       mods[modRuleId(memberRule)].status = "failed";
       mods[modRuleId(laterRule)] = makeModInstallInfo({
         rule: laterRule,
@@ -283,39 +322,15 @@ describe("a resumed dependency install", () => {
         phase: 1,
       });
     });
-    phaseState.allowedPhase = undefined;
 
-    const installing = internals(h.manager).doInstallDependencies(
-      h.api,
-      GAME,
-      COLLECTION,
-      [
-        { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
-        { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
-      ],
-      false,
-      true,
-    );
-
-    try {
-      expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(0);
-    } finally {
-      internals(h.manager).mDependencyInstalls[COLLECTION]?.();
-      delete internals(h.manager).mDependencyInstalls[COLLECTION];
-      await installing.catch(() => undefined);
-    }
+    expect(await frontierAfterRound(h, bothPhaseDeps)).toBe(0);
   });
 
   // The gather re-lists a member whose reference drifted from the mod that satisfies it, so a
   // settled phase can arrive with its member still in the dependency list. The frontier reads the
   // session, not the list, and starts past the phase rather than redoing it.
   imTest("starts past a genuinely complete prefix", async ({ makeInstallManager }) => {
-    const laterRule = makeRule({
-      type: "requires",
-      phase: 1,
-      reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
-    });
-    const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+    const { h } = makeSharedArchiveInstall(makeInstallManager, {
       rules: [memberRule, laterRule],
     });
     h.setState((draft) => {
@@ -329,27 +344,8 @@ describe("a resumed dependency install", () => {
         phase: 1,
       });
     });
-    phaseState.allowedPhase = undefined;
 
-    const installing = internals(h.manager).doInstallDependencies(
-      h.api,
-      GAME,
-      COLLECTION,
-      [
-        { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
-        { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
-      ],
-      false,
-      true,
-    );
-
-    try {
-      expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(1);
-    } finally {
-      internals(h.manager).mDependencyInstalls[COLLECTION]?.();
-      delete internals(h.manager).mDependencyInstalls[COLLECTION];
-      await installing.catch(() => undefined);
-    }
+    expect(await frontierAfterRound(h, bothPhaseDeps)).toBe(1);
   });
 
   // Optionals run in a trailing phase of their own, reached only once every required phase has
@@ -362,7 +358,7 @@ describe("a resumed dependency install", () => {
         ignored: false,
         reference: makeExactRef({ tag: "member-opt", gameId: GAME, fileMD5: "def456" }),
       });
-      const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+      const { h } = makeSharedArchiveInstall(makeInstallManager, {
         rules: [memberRule, optionalRule],
       });
       h.setState((draft) => {
@@ -376,31 +372,13 @@ describe("a resumed dependency install", () => {
           phase: OPTIONAL_PHASE,
         });
       });
-      phaseState.allowedPhase = undefined;
 
-      const installing = internals(h.manager).doInstallDependencies(
-        h.api,
-        GAME,
-        COLLECTION,
-        [
-          {
-            reference: optionalRule.reference,
-            phase: OPTIONAL_PHASE,
-            lookupResults: [],
-            extra: {},
-          },
-        ],
-        true,
-        true,
+      const optionalDeps = [
+        { reference: optionalRule.reference, phase: OPTIONAL_PHASE, lookupResults: [], extra: {} },
+      ];
+      expect(await frontierAfterRound(h, optionalDeps, true)).toBeGreaterThanOrEqual(
+        OPTIONAL_PHASE,
       );
-
-      try {
-        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBeGreaterThanOrEqual(OPTIONAL_PHASE);
-      } finally {
-        internals(h.manager).mDependencyInstalls[COLLECTION]?.();
-        delete internals(h.manager).mDependencyInstalls[COLLECTION];
-        await installing.catch(() => undefined);
-      }
     },
   );
 
@@ -410,12 +388,7 @@ describe("a resumed dependency install", () => {
   imTest(
     "starts at the lowest gathered phase when the only session for the collection is history",
     async ({ makeInstallManager }) => {
-      const laterRule = makeRule({
-        type: "requires",
-        phase: 1,
-        reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
-      });
-      const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+      const { h } = makeSharedArchiveInstall(makeInstallManager, {
         rules: [memberRule, laterRule],
       });
       const sessionId = generateCollectionSessionId(COLLECTION, PROFILE);
@@ -447,27 +420,7 @@ describe("a resumed dependency install", () => {
           },
         });
       });
-      phaseState.allowedPhase = undefined;
-
-      const installing = internals(h.manager).doInstallDependencies(
-        h.api,
-        GAME,
-        COLLECTION,
-        [
-          { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
-          { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
-        ],
-        false,
-        true,
-      );
-
-      try {
-        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(0);
-      } finally {
-        internals(h.manager).mDependencyInstalls[COLLECTION]?.();
-        delete internals(h.manager).mDependencyInstalls[COLLECTION];
-        await installing.catch(() => undefined);
-      }
+      expect(await frontierAfterRound(h, bothPhaseDeps)).toBe(0);
     },
   );
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -271,4 +271,71 @@ describe("a resumed dependency install", () => {
       }
     },
   );
+
+  // Session ids are collectionId_profileId, so an earlier install of the same collection on the
+  // same profile sits in history under the id this round computes. Phase completion is only ever
+  // read from the active session, so a history hit must not drive the phase frontier.
+  imTest(
+    "starts at the lowest gathered phase when the only session for the collection is history",
+    async ({ makeInstallManager }) => {
+      const laterRule = makeRule({
+        type: "requires",
+        phase: 1,
+        reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+      });
+      const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+        rules: [memberRule, laterRule],
+      });
+      const sessionId = generateCollectionSessionId(COLLECTION, PROFILE);
+      h.setState((draft) => {
+        draft.session.collections = makeInstallState({
+          lastActiveSessionId: sessionId,
+          sessionHistory: {
+            [sessionId]: makeSession({
+              sessionId,
+              collectionId: COLLECTION,
+              profileId: PROFILE,
+              gameId: GAME,
+              mods: {
+                [modRuleId(memberRule)]: makeModInstallInfo({
+                  rule: memberRule,
+                  type: "requires",
+                  status: "installed",
+                  phase: 0,
+                }),
+                [modRuleId(laterRule)]: makeModInstallInfo({
+                  rule: laterRule,
+                  type: "requires",
+                  status: "installed",
+                  phase: 1,
+                }),
+              },
+              totalRequired: 2,
+            }),
+          },
+        });
+      });
+      phaseState.allowedPhase = undefined;
+
+      const installing = internals(h.manager).doInstallDependencies(
+        h.api,
+        GAME,
+        COLLECTION,
+        [
+          { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
+          { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+        ],
+        false,
+        true,
+      );
+
+      try {
+        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(0);
+      } finally {
+        internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+        delete internals(h.manager).mDependencyInstalls[COLLECTION];
+        await installing.catch(() => undefined);
+      }
+    },
+  );
 });

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -1,11 +1,10 @@
 /**
  * Collection members whose archive is already on disk from a DIFFERENT collection: the download
  * carries that collection's referenceTag, so the member is identified by file hash / repo rather
- * than by tag, and the install engine retags the dependency to match the download.
+ * than by tag.
  *
- * The install session is keyed by each member's rule identity, so these tests pin that a member
- * still settles - without a terminal status the completion poll requeues it every tick and the
- * install never finishes.
+ * The session is keyed by each member's rule identity. Without a terminal status the completion
+ * poll requeues the member every tick and the install never finishes.
  */
 import { describe, expect, vi } from "vitest";
 
@@ -42,8 +41,8 @@ const memberRule = makeRule({
   reference: makeExactRef({ tag: "member-orig", gameId: GAME, md5Hint: "abc123" }),
 });
 
-// the reference the engine hands the installer once it has adopted the download's tag
-const adoptedReference = { ...memberRule.reference, tag: FOREIGN_TAG };
+// a member reference whose tag drifted away from the rule the session is keyed with
+const driftedReference = { ...memberRule.reference, tag: FOREIGN_TAG };
 
 /**
  * A collection install where the member's archive is already downloaded under another collection's
@@ -127,16 +126,16 @@ const memberStatus = (h: IInstallManagerHarness) =>
   h.getState().session.collections.activeSession?.mods[modRuleId(memberRule)];
 
 describe("a collection member satisfied by another collection's download", () => {
-  // The installer receives the dependency after its reference was retagged to match the download,
-  // so the "installed" write no longer carries the identity the session was keyed with.
+  // A member whose reference identity drifted from its rule cannot be matched back to the session
+  // by identity, so the "installed" write has to be addressed by the member's own key.
   imTest("settles as installed when its mod is reused", async ({ makeInstallManager }) => {
     const { h } = makeSharedArchiveInstall(makeInstallManager);
 
     internals(h.manager).startQueuedInstallation(
       h.api,
-      // as gathered: the member's session key alongside the reference the engine retagged
+      // as gathered: the member's session key alongside a drifted reference
       {
-        reference: adoptedReference,
+        reference: driftedReference,
         sessionRuleId: modRuleId(memberRule),
         phase: 0,
         extra: {},

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -173,6 +173,56 @@ describe("a collection member satisfied by another collection's download", () =>
   });
 });
 
+describe("resolving a member's already-present download", () => {
+  // The archive satisfies this collection's rule too, so it records this rule's tag alongside the
+  // one it already carries. The rule itself is left alone: the session is keyed from it.
+  imTest("records this collection's tag on the download", async ({ makeInstallManager }) => {
+    const { h } = makeSharedArchiveInstall(makeInstallManager);
+
+    const installing = internals(h.manager).doInstallDependencies(
+      h.api,
+      GAME,
+      COLLECTION,
+      [
+        {
+          reference: memberRule.reference,
+          sessionRuleId: modRuleId(memberRule),
+          download: SHARED_DOWNLOAD,
+          phase: 0,
+          lookupResults: [],
+          extra: {},
+        },
+      ],
+      false,
+      true,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        const tags =
+          h.getState().persistent.downloads.files[SHARED_DOWNLOAD].modInfo?.referenceTags;
+        expect(tags).toContain(memberRule.reference.tag);
+      });
+      // the first collection's tag is kept, so its rules still resolve this archive
+      const modInfo = h.getState().persistent.downloads.files[SHARED_DOWNLOAD].modInfo;
+      expect(modInfo?.referenceTags).toContain(FOREIGN_TAG);
+      expect(modInfo?.referenceTag).toBe(FOREIGN_TAG);
+      // the collection's own rules are untouched
+      const ruleActions = h.dispatched.filter(
+        (action) => action.type.includes("MOD_RULE") || action.type.includes("ModRule"),
+      );
+      expect(ruleActions).toEqual([]);
+      expect(h.getState().persistent.mods[GAME][COLLECTION].rules?.[0]?.reference.tag).toBe(
+        memberRule.reference.tag,
+      );
+    } finally {
+      internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+      delete internals(h.manager).mDependencyInstalls[COLLECTION];
+      await installing.catch(() => undefined);
+    }
+  });
+});
+
 describe("a resumed dependency install", () => {
   // Phase state is rebuilt per round, so the round has to read how far the collection already got
   // from the active session; starting at the lowest gathered phase would redo settled phases.

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -262,26 +262,118 @@ describe("resolving a member's already-present download", () => {
 describe("a resumed dependency install", () => {
   // Phase state is rebuilt per round, so the round has to read how far the collection already got
   // from the active session; starting at the lowest gathered phase would redo settled phases.
-  imTest(
-    "starts at the first incomplete phase of the active session",
-    async ({ makeInstallManager }) => {
-      const laterRule = makeRule({
+  imTest("re-enters at the failed required member's phase", async ({ makeInstallManager }) => {
+    const laterRule = makeRule({
+      type: "requires",
+      phase: 1,
+      reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+    });
+    const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+      rules: [memberRule, laterRule],
+    });
+    // phase 0 has a FAILED required member, which the round re-gathers for retry - so the
+    // frontier must start AT phase 0, not past it; phase 1 stays gated until the retry settles
+    h.setState((draft) => {
+      const mods = draft.session.collections.activeSession!.mods;
+      mods[modRuleId(memberRule)].status = "failed";
+      mods[modRuleId(laterRule)] = makeModInstallInfo({
+        rule: laterRule,
         type: "requires",
+        status: "pending",
         phase: 1,
-        reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+      });
+    });
+    phaseState.allowedPhase = undefined;
+
+    const installing = internals(h.manager).doInstallDependencies(
+      h.api,
+      GAME,
+      COLLECTION,
+      [
+        { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
+        { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+      ],
+      false,
+      true,
+    );
+
+    try {
+      expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(0);
+    } finally {
+      internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+      delete internals(h.manager).mDependencyInstalls[COLLECTION];
+      await installing.catch(() => undefined);
+    }
+  });
+
+  // The gather re-lists a member whose reference drifted from the mod that satisfies it, so a
+  // settled phase can arrive with its member still in the dependency list. The frontier reads the
+  // session, not the list, and starts past the phase rather than redoing it.
+  imTest("starts past a genuinely complete prefix", async ({ makeInstallManager }) => {
+    const laterRule = makeRule({
+      type: "requires",
+      phase: 1,
+      reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+    });
+    const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+      rules: [memberRule, laterRule],
+    });
+    h.setState((draft) => {
+      const mods = draft.session.collections.activeSession.mods;
+      mods[modRuleId(memberRule)].status = "installed";
+      mods[modRuleId(memberRule)].modId = SHARED_MOD;
+      mods[modRuleId(laterRule)] = makeModInstallInfo({
+        rule: laterRule,
+        type: "requires",
+        status: "pending",
+        phase: 1,
+      });
+    });
+    phaseState.allowedPhase = undefined;
+
+    const installing = internals(h.manager).doInstallDependencies(
+      h.api,
+      GAME,
+      COLLECTION,
+      [
+        { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
+        { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+      ],
+      false,
+      true,
+    );
+
+    try {
+      expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(1);
+    } finally {
+      internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+      delete internals(h.manager).mDependencyInstalls[COLLECTION];
+      await installing.catch(() => undefined);
+    }
+  });
+
+  // Optionals run in a trailing phase of their own, reached only once every required phase has
+  // settled - the round that installs them gathers nothing else.
+  imTest(
+    "reaches the optional phase when the required prefix is complete",
+    async ({ makeInstallManager }) => {
+      const optionalRule = makeRule({
+        type: "recommends",
+        ignored: false,
+        reference: makeExactRef({ tag: "member-opt", gameId: GAME, fileMD5: "def456" }),
       });
       const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
-        rules: [memberRule, laterRule],
+        rules: [memberRule, optionalRule],
       });
-      // phase 0 settled terminally (failed counts as terminal), phase 1 still outstanding
       h.setState((draft) => {
-        const mods = draft.session.collections.activeSession!.mods;
-        mods[modRuleId(memberRule)].status = "failed";
-        mods[modRuleId(laterRule)] = makeModInstallInfo({
-          rule: laterRule,
-          type: "requires",
+        const mods = draft.session.collections.activeSession.mods;
+        mods[modRuleId(memberRule)].status = "installed";
+        mods[modRuleId(memberRule)].modId = SHARED_MOD;
+        mods[modRuleId(optionalRule)] = makeModInstallInfo({
+          rule: optionalRule,
+          type: "recommends",
           status: "pending",
-          phase: 1,
+          phase: OPTIONAL_PHASE,
         });
       });
       phaseState.allowedPhase = undefined;
@@ -291,15 +383,19 @@ describe("a resumed dependency install", () => {
         GAME,
         COLLECTION,
         [
-          { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
-          { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+          {
+            reference: optionalRule.reference,
+            phase: OPTIONAL_PHASE,
+            lookupResults: [],
+            extra: {},
+          },
         ],
-        false,
+        true,
         true,
       );
 
       try {
-        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(1);
+        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBeGreaterThanOrEqual(OPTIONAL_PHASE);
       } finally {
         internals(h.manager).mDependencyInstalls[COLLECTION]?.();
         delete internals(h.manager).mDependencyInstalls[COLLECTION];

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -134,7 +134,13 @@ describe("a collection member satisfied by another collection's download", () =>
 
     internals(h.manager).startQueuedInstallation(
       h.api,
-      { reference: adoptedReference, phase: 0, extra: {} },
+      // as gathered: the member's session key alongside the reference the engine retagged
+      {
+        reference: adoptedReference,
+        sessionRuleId: modRuleId(memberRule),
+        phase: 0,
+        extra: {},
+      },
       SHARED_DOWNLOAD,
       GAME,
       COLLECTION,

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Collection members whose archive is already on disk from a DIFFERENT collection: the download
+ * carries that collection's referenceTag, so the member is identified by file hash / repo rather
+ * than by tag, and the install engine retags the dependency to match the download.
+ *
+ * The install session is keyed by each member's rule identity, so these tests pin that a member
+ * still settles - without a terminal status the completion poll requeues it every tick and the
+ * install never finishes.
+ */
+import { describe, expect, vi } from "vitest";
+
+import {
+  makeDownload,
+  makeExactRef,
+  makeInstallState,
+  makeMod,
+  makeModInstallInfo,
+  makeProfile,
+  makeRule,
+  makeSession,
+  managerInternals as internals,
+} from "../../test-utils/builders";
+import type { IDriverHarnessState, IInstallManagerHarness } from "../../test-utils/harnessTypes";
+import { test as imTest } from "../../test-utils/installManagerTest";
+import { generateCollectionSessionId, modRuleId } from "../../util/collectionInstallSession";
+import { MOD_TYPE } from "../collections/constants";
+
+vi.mock("../../logging", () => ({ log: vi.fn() }));
+
+const GAME = "skyrimse";
+const PROFILE = "prof-1";
+const COLLECTION = "col-1";
+const SHARED_DOWNLOAD = "dl-shared";
+const SHARED_MOD = "m-shared";
+// the tag the collection that downloaded the archive first stamped on it
+const FOREIGN_TAG = "foreign-tag";
+
+// this collection's member: repo-pinned and hash-pinned, so it resolves the shared archive and the
+// installed mod by identity even though neither carries its tag
+const memberRule = makeRule({
+  type: "requires",
+  reference: makeExactRef({ tag: "member-orig", gameId: GAME, md5Hint: "abc123" }),
+});
+
+// the reference the engine hands the installer once it has adopted the download's tag
+const adoptedReference = { ...memberRule.reference, tag: FOREIGN_TAG };
+
+/**
+ * A collection install where the member's archive is already downloaded under another collection's
+ * tag, and that collection's copy of the mod is still installed. The session tracks the member as
+ * "downloaded", which is what the archive being present reconstructs to.
+ */
+function makeSharedArchiveInstall(
+  makeInstallManager: (overrides?: Partial<IDriverHarnessState>) => IInstallManagerHarness,
+  opts: { rules?: (typeof memberRule)[]; mods?: Record<string, ReturnType<typeof makeMod>> } = {},
+) {
+  const rules = opts.rules ?? [memberRule];
+  const h = makeInstallManager({
+    profiles: { [PROFILE]: makeProfile({ id: PROFILE, gameId: GAME }) },
+    mods: {
+      [GAME]: {
+        [COLLECTION]: makeMod({
+          id: COLLECTION,
+          type: MOD_TYPE,
+          rules,
+          attributes: { collectionId: 1 },
+        }),
+        [SHARED_MOD]: makeMod({
+          id: SHARED_MOD,
+          state: "installed",
+          attributes: {
+            referenceTag: FOREIGN_TAG,
+            fileMD5: "abc123",
+            source: "nexus",
+            modId: 100,
+            fileId: 5,
+            installedAsDependency: true,
+          },
+        }),
+        ...opts.mods,
+      },
+    },
+    downloads: {
+      [SHARED_DOWNLOAD]: makeDownload({
+        id: SHARED_DOWNLOAD,
+        state: "finished",
+        game: [GAME],
+        size: 1024,
+        localPath: "shared.7z",
+        fileMD5: "abc123",
+        modInfo: { referenceTag: FOREIGN_TAG, nexus: { ids: { modId: 100, fileId: 5 } } },
+      }),
+    },
+    session: makeInstallState({
+      activeSession: makeSession({
+        sessionId: generateCollectionSessionId(COLLECTION, PROFILE),
+        collectionId: COLLECTION,
+        profileId: PROFILE,
+        gameId: GAME,
+        mods: {
+          [modRuleId(memberRule)]: makeModInstallInfo({
+            rule: memberRule,
+            type: "requires",
+            status: "downloaded",
+            phase: 0,
+          }),
+        },
+        totalRequired: 1,
+        downloadedCount: 1,
+      }),
+    }),
+  });
+
+  h.setState((draft) => {
+    draft.settings.profiles.activeProfileId = PROFILE;
+  });
+
+  const phaseState = h.phaseTracker.ensure(COLLECTION);
+  phaseState.allowedPhase = 0;
+  phaseState.downloadsFinished.add(0);
+  phaseState.deployedPhases.add(0);
+
+  return { h, phaseState };
+}
+
+const memberStatus = (h: IInstallManagerHarness) =>
+  h.getState().session.collections.activeSession?.mods[modRuleId(memberRule)];
+
+describe("a collection member satisfied by another collection's download", () => {
+  // The installer receives the dependency after its reference was retagged to match the download,
+  // so the "installed" write no longer carries the identity the session was keyed with.
+  imTest("settles as installed when its mod is reused", async ({ makeInstallManager }) => {
+    const { h } = makeSharedArchiveInstall(makeInstallManager);
+
+    internals(h.manager).startQueuedInstallation(
+      h.api,
+      { reference: adoptedReference, phase: 0, extra: {} },
+      SHARED_DOWNLOAD,
+      GAME,
+      COLLECTION,
+      false,
+      0,
+    );
+
+    await vi.waitFor(() => {
+      expect(memberStatus(h)?.status).toBe("installed");
+    });
+    expect(memberStatus(h)?.modId).toBe(SHARED_MOD);
+  });
+
+  // The requeue pass is the poll's backstop: it runs every tick for as long as the member is
+  // non-terminal, so it is the last chance to settle a member whose install already happened.
+  imTest("settles as installed in a single requeue pass", async ({ makeInstallManager }) => {
+    const { h } = makeSharedArchiveInstall(makeInstallManager);
+    const installEvents: string[] = [];
+    h.api.events.on("did-install-mod", (_gameId: string, _archiveId: string, modId: string) =>
+      installEvents.push(modId),
+    );
+
+    const mgr = internals(h.manager);
+    const status = mgr.checkCollectionPhaseStatus(h.api, COLLECTION, 0);
+    mgr.reQueueDownloadedMods(h.api, COLLECTION, status.allMods, 0);
+
+    expect(memberStatus(h)?.status).toBe("installed");
+    expect(memberStatus(h)?.modId).toBe(SHARED_MOD);
+    expect(installEvents.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("a resumed dependency install", () => {
+  // Phase state is rebuilt per round, so the round has to read how far the collection already got
+  // from the active session; starting at the lowest gathered phase would redo settled phases.
+  imTest(
+    "starts at the first incomplete phase of the active session",
+    async ({ makeInstallManager }) => {
+      const laterRule = makeRule({
+        type: "requires",
+        phase: 1,
+        reference: makeExactRef({ tag: "member-later", gameId: GAME, fileMD5: "def456" }),
+      });
+      const { h, phaseState } = makeSharedArchiveInstall(makeInstallManager, {
+        rules: [memberRule, laterRule],
+      });
+      // phase 0 settled terminally (failed counts as terminal), phase 1 still outstanding
+      h.setState((draft) => {
+        const mods = draft.session.collections.activeSession!.mods;
+        mods[modRuleId(memberRule)].status = "failed";
+        mods[modRuleId(laterRule)] = makeModInstallInfo({
+          rule: laterRule,
+          type: "requires",
+          status: "pending",
+          phase: 1,
+        });
+      });
+      phaseState.allowedPhase = undefined;
+
+      const installing = internals(h.manager).doInstallDependencies(
+        h.api,
+        GAME,
+        COLLECTION,
+        [
+          { reference: memberRule.reference, phase: 0, lookupResults: [], extra: {} },
+          { reference: laterRule.reference, phase: 1, lookupResults: [], extra: {} },
+        ],
+        false,
+        true,
+      );
+
+      try {
+        expect(h.phaseTracker.get(COLLECTION)?.allowedPhase).toBe(1);
+      } finally {
+        internals(h.manager).mDependencyInstalls[COLLECTION]?.();
+        delete internals(h.manager).mDependencyInstalls[COLLECTION];
+        await installing.catch(() => undefined);
+      }
+    },
+  );
+});

--- a/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.sharedDownloads.test.ts
@@ -23,6 +23,7 @@ import type { IDriverHarnessState, IInstallManagerHarness } from "../../test-uti
 import { test as imTest } from "../../test-utils/installManagerTest";
 import { generateCollectionSessionId, modRuleId } from "../../util/collectionInstallSession";
 import { MOD_TYPE } from "../collections/constants";
+import { OPTIONAL_PHASE } from "./util/rulePhase";
 
 vi.mock("../../logging", () => ({ log: vi.fn() }));
 
@@ -169,6 +170,42 @@ describe("a collection member satisfied by another collection's download", () =>
     expect(memberStatus(h)?.status).toBe("installed");
     expect(memberStatus(h)?.modId).toBe(SHARED_MOD);
     expect(installEvents.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("a required and an optional member backed by the same file", () => {
+  // same reference identity, so the two session entries differ only in their rule id; the settle
+  // write must land on the entry being requeued, not on whichever entry matches the reference first
+  const optionalRule = makeRule({
+    type: "recommends",
+    reference: memberRule.reference,
+    ignored: false,
+  });
+
+  imTest("settles the requeued optional on its own session entry", ({ makeInstallManager }) => {
+    const { h } = makeSharedArchiveInstall(makeInstallManager, {
+      rules: [memberRule, optionalRule],
+    });
+    h.setState((draft) => {
+      const mods = draft.session.collections.activeSession.mods;
+      // the required member already settled on the shared mod
+      mods[modRuleId(memberRule)].status = "installed";
+      mods[modRuleId(memberRule)].modId = SHARED_MOD;
+      mods[modRuleId(optionalRule)] = makeModInstallInfo({
+        rule: optionalRule,
+        type: "recommends",
+        status: "downloaded",
+        phase: OPTIONAL_PHASE,
+      });
+    });
+
+    const mgr = internals(h.manager);
+    const status = mgr.checkCollectionPhaseStatus(h.api, COLLECTION, OPTIONAL_PHASE);
+    mgr.reQueueDownloadedMods(h.api, COLLECTION, status.allMods, OPTIONAL_PHASE);
+
+    const optional = h.getState().session.collections.activeSession?.mods[modRuleId(optionalRule)];
+    expect(optional?.status).toBe("installed");
+    expect(optional?.modId).toBe(SHARED_MOD);
   });
 });
 

--- a/src/renderer/src/extensions/mod_management/InstallManager.test.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { updateModStatus } from "../../actions/collectionInstallTracking";
+import { log } from "../../logging";
 import {
   makeDownload,
   makeMod,
@@ -10,8 +11,11 @@ import {
 } from "../../test-utils/builders";
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
+import { modRuleId } from "../../util/collectionInstallSession";
 import { resyncCollectionSessionRules } from "../../util/collectionSessionReconstruct";
+import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
 import InstallManager from "./InstallManager";
+import type { IModReference } from "./types/IMod";
 import { lookupFromDownload } from "./util/dependencies";
 import type { InstallPhaseTracker } from "./util/InstallPhaseTracker";
 
@@ -23,6 +27,7 @@ vi.mock("../../util/log", () => {
   const log = vi.fn();
   return { default: log, log };
 });
+vi.mock("../../logging", () => ({ log: vi.fn() }));
 
 // TODO: prefer the shared api/harness fixtures (makeApiHarness and the test.extend fixtures in
 // test-utils) over the hand-built mockApi/mockState in this file; new tests should seed state with
@@ -44,6 +49,12 @@ interface IInstallManagerTestable {
     silent: boolean,
   ): Promise<unknown[]>;
   markPhaseDownloadsFinished(sourceModId: string, phase: number, api: IExtensionApi): void;
+  writeCollectionSession(
+    reference: IModReference,
+    outcome: CollectionInstallOutcome,
+    ruleId?: string,
+    sourceModId?: string,
+  ): void;
   // per-collection phase-gating state now lives on the tracker; tests drive it directly
   mPhaseTracker: InstallPhaseTracker;
 }
@@ -454,6 +465,86 @@ describe("collection download failure handling", () => {
 
     // status leaves "downloading" so the row is no longer mis-bucketed under the Downloading filter
     expect(dispatch).toHaveBeenCalledWith(updateModStatus("col-1_prof1", "rule-1", "failed"));
+  });
+
+  it("keeps an unaddressed write that names no member quiet", () => {
+    // a transitive sub-dependency gathered under a member carries no session key and has no
+    // session entry; its lifecycle writes are expected no-ops, not warnings
+    installManager.writeCollectionSession(
+      { tag: "sub-dependency-tag" },
+      { type: "status", status: "downloading" },
+      undefined,
+      "col-1",
+    );
+
+    expect(vi.mocked(log)).not.toHaveBeenCalledWith(
+      "warn",
+      "collection session write matched no member",
+      expect.anything(),
+    );
+  });
+
+  it("reports an addressed write whose member the session does not track", () => {
+    installManager.writeCollectionSession(
+      { tag: "member-gone-tag" },
+      { type: "status", status: "downloading" },
+      "requires_member-gone-tag",
+      "col-1",
+    );
+
+    expect(vi.mocked(log)).toHaveBeenCalledWith(
+      "warn",
+      "collection session write matched no member",
+      expect.objectContaining({ ruleId: "requires_member-gone-tag" }),
+    );
+  });
+
+  it("settles the failed download's own member when another member shares its file", () => {
+    // two members reference the same logical file pinned to different versions, so their session
+    // keys differ while their reference identity (referenceId) collides on the file name; the
+    // write must be addressed by the matched rule's key, not by first reference match
+    const requiredV1 = makeRule({
+      type: "requires",
+      reference: { logicalFileName: "SharedMod", versionMatch: "1.0.0" },
+    });
+    const optionalV2 = makeRule({
+      type: "recommends",
+      reference: { logicalFileName: "SharedMod", versionMatch: "2.0.0" },
+    });
+    state.session = {
+      collections: {
+        activeSession: makeSession({
+          sessionId: "col-1_prof1",
+          collectionId: "col-1",
+          gameId: "skyrimse",
+          mods: {
+            [modRuleId(requiredV1)]: makeModInstallInfo({
+              rule: requiredV1,
+              type: "requires",
+              status: "installed",
+            }),
+            [modRuleId(optionalV2)]: makeModInstallInfo({
+              rule: optionalV2,
+              type: "recommends",
+              status: "downloading",
+            }),
+          },
+        }),
+      },
+    };
+    // the failed download is the 2.0.0 file, so it matches only the optional member
+    vi.mocked(lookupFromDownload).mockReturnValue({
+      logicalFileName: "SharedMod",
+      version: "2.0.0",
+      fileMD5: "dl-md5",
+      fileName: "member.zip",
+    } as never);
+
+    installManager.handleDownloadFailed(api, "dl-fail");
+
+    expect(dispatch).toHaveBeenCalledWith(
+      updateModStatus("col-1_prof1", modRuleId(optionalV2), "failed"),
+    );
   });
 
   it("settles the member as failed when its download terminally fails in the install phase", async () => {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -93,6 +93,7 @@ import {
   getCollectionSessionById,
   getCollectionStatusBreakdown,
   isCollectionPhaseComplete,
+  isCollectionPhaseSettledSuccessfully,
 } from "../../util/collectionInstallSessionSelectors";
 import { resyncCollectionSessionRules } from "../../util/collectionSessionReconstruct";
 import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
@@ -6684,9 +6685,11 @@ class InstallManager {
         // consecutively-complete phases and stop at the first incomplete one. Taking the highest
         // complete phase anywhere would jump the frontier to the trailing optional phase whenever
         // its members are all ignored (terminal) while a required phase is still pending.
+        // A failed required member breaks the prefix: this round re-gathers it for retry, and that
+        // retry has to run at its own phase, serialized before the phases after it.
         let highestCompletedPhase = -1;
         for (const phase of Array.from(allPhases).sort((a, b) => a - b)) {
-          if (!isCollectionPhaseComplete(api.getState(), phase)) {
+          if (!isCollectionPhaseSettledSuccessfully(api.getState(), phase)) {
             break;
           }
           highestCompletedPhase = phase;

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -843,7 +843,12 @@ class InstallManager {
     // requeued, so without this the member stays on "downloading" while rendering "Download failed"
     // - bucketed under the Downloading filter and missed by the Failed filter. Mirrors how
     // handleDownloadSkipped settles a skipped member, then lets the phase advance past it.
-    this.writeCollectionSession(matchingRule.reference, { type: "status", status: "failed" });
+    this.writeCollectionSession(
+      matchingRule.reference,
+      { type: "status", status: "failed" },
+      modRuleId(matchingRule),
+      collectionId,
+    );
     this.maybeAdvancePhase(collectionId, api);
   }
 
@@ -3324,11 +3329,14 @@ class InstallManager {
           this.mPendingInstalls.delete(installKey);
           this.mActiveInstalls.delete(installKey);
           // the mod exists with the wanted install spec: settle the member on the session's own
-          // rule, or every poll tick selects it again
-          this.writeCollectionSession(mod.rule.reference, {
-            type: "installed",
-            modId: existingMod.id,
-          });
+          // rule, or every poll tick selects it again. mod.rule is the session snapshot, so its
+          // rule id addresses this entry even when another member shares the reference identity.
+          this.writeCollectionSession(
+            mod.rule.reference,
+            { type: "installed", modId: existingMod.id },
+            modRuleId(mod.rule),
+            sourceModId,
+          );
           api.events.emit(
             "did-install-mod",
             gameId,
@@ -7731,8 +7739,9 @@ class InstallManager {
 
   /**
    * Report a lifecycle outcome that named no session member: that member keeps its status and the
-   * completion poll goes on selecting it. Writes outside an install, and writes the planner
-   * declined for a member it did match, are expected and stay quiet.
+   * completion poll goes on selecting it. Writes outside an install, writes the planner declined
+   * for a member it did match, and unaddressed writes (a transitive sub-dependency gathered under
+   * a member carries no session key and is not a member) are expected and stay quiet.
    */
   private warnUnmatchedSessionWrite(
     reference: IModReference,
@@ -7740,6 +7749,9 @@ class InstallManager {
     ruleId?: string,
     sourceModId?: string,
   ): void {
+    if (ruleId === undefined) {
+      return;
+    }
     const session = getCollectionActiveSession(this.mApi.getState());
     if (session === undefined) {
       return;
@@ -7747,7 +7759,7 @@ class InstallManager {
     if (sourceModId !== undefined && sourceModId !== session.collectionId) {
       return;
     }
-    if (ruleId !== undefined && session.mods[ruleId] !== undefined) {
+    if (session.mods[ruleId] !== undefined) {
       return;
     }
     if (matchSessionRuleEntry(session, reference) !== undefined) {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -6696,7 +6696,7 @@ class InstallManager {
         const rules = api.getState().persistent.mods[gameId]?.[sourceModId]?.rules ?? [];
         const nextPhaseAfterCompleted =
           this.mPhaseTracker.phaseSet(sourceModId, rules).find((p) => p > highestCompletedPhase) ??
-          highestCompletedPhase + 1;
+          highestCompletedPhase;
         const effectiveStartPhase = Math.max(lowestPhase, nextPhaseAfterCompleted);
 
         if (

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -3298,6 +3298,13 @@ class InstallManager {
           const installKey = this.generateDependencyInstallKey(sourceModId, downloadId);
           this.mPendingInstalls.delete(installKey);
           this.mActiveInstalls.delete(installKey);
+          // the mod exists with the wanted install spec, so settle the member: keyed on the
+          // session's own rule, which is the identity the member is tracked under. Without this
+          // the member stays non-terminal and every poll tick selects it again.
+          this.writeCollectionSession(mod.rule.reference, {
+            type: "installed",
+            modId: existingMod.id,
+          });
           api.events.emit(
             "did-install-mod",
             gameId,

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -150,6 +150,7 @@ import { resolveCategoryId } from "../category_management/util/retrieveCategoryP
 import { finishDownload } from "../download_management/actions/state";
 import type { IDownload } from "../download_management/types/IDownload";
 import getDownloadGames from "../download_management/util/getDownloadGames";
+import { appendReferenceTagActions } from "../download_management/util/referenceTags";
 import { discoveryByGame } from "../gamemode_management/selectors";
 import type { IModType } from "../gamemode_management/types/IModType";
 import { getGame } from "../gamemode_management/util/getGame";
@@ -199,6 +200,8 @@ import { reconcileOrphanedArchive } from "./util/reconcileOrphanedArchive";
 import { selectRequeueCandidates } from "./util/requeueCandidates";
 import { OPTIONAL_PHASE, rulePhase } from "./util/rulePhase";
 import testModReference, {
+  downloadHasReferenceTag,
+  downloadReferenceTags,
   downloadToModRef,
   idOnlyRef,
   isDependencyRule,
@@ -294,7 +297,7 @@ function findDownloadByReferenceTag(
   return (
     Object.keys(downloads).find(
       (id) =>
-        downloads[id].modInfo?.referenceTag === reference.tag ||
+        downloadHasReferenceTag(downloads[id], reference.tag) ||
         (reference.md5Hint && downloads[id].fileMD5 === reference.md5Hint),
     ) || null
   );
@@ -724,9 +727,9 @@ class InstallManager {
     if (hasPhaseState) {
       const phaseState = this.mPhaseTracker.get(collectionId);
       if (phaseState) {
-        // Add this download to the cache
-        if (download.modInfo?.referenceTag) {
-          phaseState.downloadLookupCache.byTag.set(download.modInfo.referenceTag, downloadId);
+        // Add this download to the cache under every rule tag it satisfies
+        for (const tag of downloadReferenceTags(download)) {
+          phaseState.downloadLookupCache.byTag.set(tag, downloadId);
         }
         if (download.fileMD5) {
           phaseState.downloadLookupCache.byMd5.set(download.fileMD5, downloadId);
@@ -1253,6 +1256,9 @@ class InstallManager {
     const batchContext = getBatchContext(["install-dependencies", "install-recommendations"], "");
     const profileId = batchContext?.get<string>("profileId") ?? activeProfile(state)?.id;
     const currentProfile = profileById(state, profileId) ?? activeProfile(state);
+    // the installing dependency's reference, so attribute extractors can take the tag from the
+    // rule being installed rather than from whichever collection stamped the archive first
+    const installingReference = modReference;
 
     // Use parallel installation concurrency limiter instead of sequential mQueue
     this.mInstallLimit
@@ -1260,7 +1266,7 @@ class InstallManager {
         return new Promise<string>((resolve, reject) => {
           const installationZip = new Zip();
 
-          const fullInfo = { ...info };
+          const fullInfo = { ...info, modReference: installingReference };
           let rules: IRule[] = [];
           let overrides: string[] = [];
           let destinationPath: string;
@@ -5560,8 +5566,15 @@ class InstallManager {
               if (successResult === undefined) {
                 return Promise.reject(results[0].error);
               } else {
-                api.store.dispatch(
-                  setDownloadModInfo(results[0].dlId, "referenceTag", referenceTag),
+                // the resolved download may be one another collection already fetched, so the tag
+                // is added to its set rather than replacing what it carries
+                batchDispatch(
+                  api.store,
+                  appendReferenceTagActions(
+                    results[0].dlId,
+                    api.getState().persistent.downloads.files[results[0].dlId],
+                    referenceTag,
+                  ),
                 );
                 if (parentCollection !== undefined) {
                   // See downloadURL: kept off nexus.ids.collectionId to avoid the
@@ -5705,8 +5718,13 @@ class InstallManager {
               [path.join(stagingPath, sourceMod.installationPath, dep.extra.localPath)],
               (dlIds: string[]) => {
                 if (dlIds.length > 0) {
-                  api.store.dispatch(
-                    setDownloadModInfo(dlIds[0], "referenceTag", dep.reference.tag),
+                  batchDispatch(
+                    api.store,
+                    appendReferenceTagActions(
+                      dlIds[0],
+                      api.getState().persistent.downloads.files[dlIds[0]],
+                      dep.reference.tag,
+                    ),
                   );
                   resolve(dlIds[0]);
                 } else {
@@ -6279,7 +6297,7 @@ class InstallManager {
                 const downloadId = Object.keys(currentDownloads).find(
                   (dlId) =>
                     currentDownloads[dlId].localPath === alreadyDlErr?.fileName ||
-                    currentDownloads[dlId].modInfo?.referenceTag === dep.reference?.tag,
+                    downloadHasReferenceTag(currentDownloads[dlId], dep.reference?.tag),
                 );
 
                 if (downloadId) {
@@ -6306,8 +6324,8 @@ class InstallManager {
                 // and if so, try to resume it through the concurrent queue
                 setTimeout(() => {
                   const currentDownloads = api.getState().persistent.downloads.files;
-                  const downloadId = Object.keys(currentDownloads).find(
-                    (dlId) => currentDownloads[dlId].modInfo?.referenceTag === dep.reference?.tag,
+                  const downloadId = Object.keys(currentDownloads).find((dlId) =>
+                    downloadHasReferenceTag(currentDownloads[dlId], dep.reference?.tag),
                   );
 
                   if (downloadId && currentDownloads[downloadId].state === "paused") {
@@ -6338,8 +6356,8 @@ class InstallManager {
               // Try to resolve the download by referenceTag if possible
               const tag = dep.reference?.tag;
               if (truthy(tag)) {
-                const foundId = Object.keys(currentDownloads).find(
-                  (dlId) => currentDownloads[dlId]?.modInfo?.referenceTag === tag,
+                const foundId = Object.keys(currentDownloads).find((dlId) =>
+                  downloadHasReferenceTag(currentDownloads[dlId], tag),
                 );
                 if (foundId) {
                   log("info", "Resolved missing download id from referenceTag", {
@@ -6522,23 +6540,19 @@ class InstallManager {
 
           if (
             dep.reference.tag !== undefined &&
-            downloads[downloadId].modInfo?.referenceTag !== undefined &&
-            downloads[downloadId].modInfo?.referenceTag !== dep.reference.tag
+            !downloadHasReferenceTag(downloads[downloadId], dep.reference.tag)
           ) {
-            // we can't change the tag on the download because that might break
-            // dependencies on the other mod
-            // instead we update the rule in the collection. This has to happen immediately,
-            // otherwise the installation might have weird issues around the mod
-            // being installed having a different tag than the rule
-            const reference: IModReference = {
-              ...dep.reference,
-              tag: downloads[downloadId].modInfo.referenceTag,
-            };
-            dep.reference =
-              this.updateModRule(api, gameId, sourceModId, dep, reference, recommended)
-                ?.reference ?? reference;
-
-            dep.mod = findModByRef(dep.reference, api.getState().persistent.mods[gameId]);
+            // the archive satisfies this rule too, so record this rule's tag on it alongside any
+            // tag it already carries. The rule and dep.reference are left alone: the install
+            // session is keyed from them, and other collections still resolve the archive by
+            // their own tag.
+            batchDispatch(
+              api.store,
+              appendReferenceTagActions(downloadId, downloads[downloadId], dep.reference.tag),
+            );
+            this.mPhaseTracker
+              .get(sourceModId)
+              ?.downloadLookupCache?.byTag?.set(dep.reference.tag, downloadId);
           } else {
             log("info", "downloaded as dependency", {
               dependency: dep.reference.logicalFileName,
@@ -6995,8 +7009,8 @@ class InstallManager {
       if (cache === undefined) {
         return;
       }
-      if (download.modInfo?.referenceTag !== undefined) {
-        cache.byTag.set(download.modInfo.referenceTag, download.id);
+      for (const tag of downloadReferenceTags(download)) {
+        cache.byTag.set(tag, download.id);
       }
       if (download.fileMD5 !== undefined) {
         cache.byMd5.set(download.fileMD5, download.id);

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -6628,8 +6628,18 @@ class InstallManager {
         .sort((a, b) => a - b);
       const lowestPhase = phaseNumbers[0];
 
-      // Check collection session to determine actual current phase
-      const activeCollectionSession = getCollectionSessionById(api.getState(), sourceModId);
+      // Check collection session to determine actual current phase. Session ids are
+      // collectionId_profileId, resolved the same way the completion poll resolves them.
+      const phaseBatchContext = getBatchContext(
+        ["install-dependencies", "install-recommendations"],
+        "",
+      );
+      const phaseProfileId =
+        phaseBatchContext?.get<string>("profileId") ?? activeProfile(api.getState())?.id;
+      const activeCollectionSession = getCollectionSessionById(
+        api.getState(),
+        generateCollectionSessionId(sourceModId, phaseProfileId),
+      );
 
       if (activeCollectionSession) {
         // Determine the highest completed phase from the collection session

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -2531,6 +2531,7 @@ class InstallManager {
               currentDep.reference,
               { type: "status", status: "installing" },
               currentDep.sessionRuleId,
+              sourceModId,
             );
           }
           const modId =
@@ -2569,6 +2570,7 @@ class InstallManager {
               currentDep.reference,
               { type: "installed", modId },
               currentDep.sessionRuleId,
+              sourceModId,
             );
 
             // Apply any extra attributes
@@ -2712,6 +2714,7 @@ class InstallManager {
                 dep.reference,
                 { type: "status", status: "failed" },
                 dep.sessionRuleId,
+                sourceModId,
               );
               if (recovery.showError) {
                 this.showDependencyError(
@@ -5952,6 +5955,7 @@ class InstallManager {
                 dep.reference,
                 { type: "status", status: "failed" },
                 dep.sessionRuleId,
+                sourceModId,
               );
             // don't cancel the whole process if one dependency fails to install
             if (innerErr instanceof ProcessCanceled) {
@@ -6240,6 +6244,7 @@ class InstallManager {
         dep.reference,
         { type: "status", status: "downloading" },
         dep.sessionRuleId,
+        sourceModId,
       );
       if (dep.reference.tag !== undefined) {
         queuedDownloads.push(dep.reference);
@@ -7707,15 +7712,18 @@ class InstallManager {
    *
    * Pass the dependency's `sessionRuleId` wherever it is in scope: the member is then addressed
    * by the key it is tracked under rather than by an identity the engine may have retagged.
+   * `sourceModId` scopes the unmatched-write warning: the dependency pipeline also runs for mods
+   * other than the session's collection, whose writes are expected no-ops.
    */
   private writeCollectionSession(
     reference: IModReference,
     outcome: CollectionInstallOutcome,
     ruleId?: string,
+    sourceModId?: string,
   ): void {
     const plan = sessionWriteForDependency(this.mApi.getState(), reference, outcome, ruleId);
     if (plan === null) {
-      this.warnUnmatchedSessionWrite(reference, outcome, ruleId);
+      this.warnUnmatchedSessionWrite(reference, outcome, ruleId, sourceModId);
       return;
     }
     const action =
@@ -7734,9 +7742,13 @@ class InstallManager {
     reference: IModReference,
     outcome: CollectionInstallOutcome,
     ruleId?: string,
+    sourceModId?: string,
   ): void {
     const session = getCollectionActiveSession(this.mApi.getState());
     if (session === undefined) {
+      return;
+    }
+    if (sourceModId !== undefined && sourceModId !== session.collectionId) {
       return;
     }
     if (ruleId !== undefined && session.mods[ruleId] !== undefined) {

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -3330,8 +3330,7 @@ class InstallManager {
           this.mPendingInstalls.delete(installKey);
           this.mActiveInstalls.delete(installKey);
           // the mod exists with the wanted install spec: settle the member on the session's own
-          // rule, or every poll tick selects it again. mod.rule is the session snapshot, so its
-          // rule id addresses this entry even when another member shares the reference identity.
+          // rule, or every poll tick selects it again.
           this.writeCollectionSession(
             mod.rule.reference,
             { type: "installed", modId: existingMod.id },
@@ -6681,12 +6680,8 @@ class InstallManager {
           allPhases.add(mod.phase ?? 0);
         });
 
-        // The highest phase whose COMPLETE PREFIX is unbroken - i.e. advance only through
-        // consecutively-complete phases and stop at the first incomplete one. Taking the highest
-        // complete phase anywhere would jump the frontier to the trailing optional phase whenever
-        // its members are all ignored (terminal) while a required phase is still pending.
-        // A failed required member breaks the prefix: this round re-gathers it for retry, and that
-        // retry has to run at its own phase, serialized before the phases after it.
+        // The highest phase whose COMPLETE PREFIX is unbroken.
+        // A failed required member breaks the prefix and its retry runs at its own phase.
         let highestCompletedPhase = -1;
         for (const phase of Array.from(allPhases).sort((a, b) => a - b)) {
           if (!isCollectionPhaseSettledSuccessfully(api.getState(), phase)) {
@@ -7741,10 +7736,7 @@ class InstallManager {
   }
 
   /**
-   * Report a lifecycle outcome that named no session member: that member keeps its status and the
-   * completion poll goes on selecting it. Writes outside an install, writes the planner declined
-   * for a member it did match, and unaddressed writes (a transitive sub-dependency gathered under
-   * a member carries no session key and is not a member) are expected and stay quiet.
+   * Report a lifecycle outcome that named no session member.
    */
   private warnUnmatchedSessionWrite(
     reference: IModReference,

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -742,12 +742,17 @@ class InstallManager {
       lookupResults: [], // Will be populated if needed
       download: downloadId,
       phase: rulePhase(matchingRule),
+      sessionRuleId: modRuleId(matchingRule),
     };
 
     // record that this collection mod's download is available, coupled to the install
     // queueing below so we never mark "downloaded" for a download we then don't install
     // (no-op outside an active collection session)
-    this.writeCollectionSession(dependency.reference, { type: "status", status: "downloaded" });
+    this.writeCollectionSession(
+      dependency.reference,
+      { type: "status", status: "downloaded" },
+      dependency.sessionRuleId,
+    );
 
     // Ensure the phase is marked as having downloads finished
     // This is needed when downloads complete after initial dependency processing
@@ -2514,10 +2519,11 @@ class InstallManager {
           if (existingMod == null) {
             // about to actually install (not reusing an existing mod): mark installing so
             // the collection session reflects the live install phase
-            this.writeCollectionSession(currentDep.reference, {
-              type: "status",
-              status: "installing",
-            });
+            this.writeCollectionSession(
+              currentDep.reference,
+              { type: "status", status: "installing" },
+              currentDep.sessionRuleId,
+            );
           }
           const modId =
             existingMod != null
@@ -2551,7 +2557,11 @@ class InstallManager {
             // record the successful install on the collection session (no-op outside an
             // active collection session). This is the sole writer of the "installed"
             // status, covering both a freshly installed mod and a reused existing one.
-            this.writeCollectionSession(currentDep.reference, { type: "installed", modId });
+            this.writeCollectionSession(
+              currentDep.reference,
+              { type: "installed", modId },
+              currentDep.sessionRuleId,
+            );
 
             // Apply any extra attributes
             this.applyExtraFromRule(api, gameId, modId, {
@@ -2690,7 +2700,11 @@ class InstallManager {
               // Retries exhausted: settle the member as failed (terminal) so the collection can
               // still complete and the member is not re-prompted. writeCollectionSession no-ops
               // over an already-terminal status, so this only settles a genuinely stuck member.
-              this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
+              this.writeCollectionSession(
+                dep.reference,
+                { type: "status", status: "failed" },
+                dep.sessionRuleId,
+              );
               if (recovery.showError) {
                 this.showDependencyError(
                   api,
@@ -3481,7 +3495,7 @@ class InstallManager {
       this.mOptionalDownloadsInFlight.add(key);
       // mark downloading up front so a subsequent poll tick doesn't re-select it before the async
       // gather resolves; the in-flight set is the hard guard, this keeps the session status honest.
-      this.writeCollectionSession(rule.reference, { type: "status", status: "downloading" });
+      this.writeCollectionSession(rule.reference, { type: "status", status: "downloading" }, key);
       gatherDependencies([rule], api, true, undefined, this.addToPhaseStateCache(api))
         .then((deps: IDependency[]): Promise<string | undefined> => {
           const dep = deps[0];
@@ -3524,7 +3538,7 @@ class InstallManager {
           // leave a canceled/torn-down install alone; otherwise settle failed so the member becomes
           // terminal and stops blocking completion.
           if (!(err instanceof UserCanceled) && this.mDependencyInstalls[sourceModId]) {
-            this.writeCollectionSession(rule.reference, { type: "status", status: "failed" });
+            this.writeCollectionSession(rule.reference, { type: "status", status: "failed" }, key);
           }
         });
     }
@@ -3671,9 +3685,13 @@ class InstallManager {
     // the members below fail by watchdog fiat, not by their own attempts: mark the session so
     // the finished dialog presents the install as incomplete rather than complete-with-failures
     api.store.dispatch(markSessionStalled(session.sessionId, true));
-    Object.values(session.mods).forEach((mod) => {
+    Object.entries(session.mods).forEach(([ruleId, mod]) => {
       if (!isTerminalMemberStatus(mod.status) && mod.rule?.reference != null) {
-        this.writeCollectionSession(mod.rule.reference, { type: "status", status: "failed" });
+        this.writeCollectionSession(
+          mod.rule.reference,
+          { type: "status", status: "failed" },
+          ruleId,
+        );
       }
     });
   }
@@ -5905,12 +5923,16 @@ class InstallManager {
               return undefined;
             }
             // A terminal download/install failure settles the member as failed on the collection
-            // session. Keyed on the dependency's own reference, so it does not depend on matching the
-            // (possibly md5-less, tag-drifted) failed download back to a rule - which is how a failed
-            // download would otherwise be left stuck on "downloading". No-ops outside an active
-            // collection session and over an already-terminal status.
+            // session. Addressed by the dependency's own session key, so it does not depend on
+            // matching the failed download back to a rule - which is how a failed download would
+            // otherwise be left stuck on "downloading". No-ops outside an active collection session
+            // and over an already-terminal status.
             const settleMemberFailed = () =>
-              this.writeCollectionSession(dep.reference, { type: "status", status: "failed" });
+              this.writeCollectionSession(
+                dep.reference,
+                { type: "status", status: "failed" },
+                dep.sessionRuleId,
+              );
             // don't cancel the whole process if one dependency fails to install
             if (innerErr instanceof ProcessCanceled) {
               if (
@@ -6194,7 +6216,11 @@ class InstallManager {
       // mark the dependency as downloading on the collection session (no-op outside an
       // active collection session). Bundled mods are imported, not queued here, so they
       // are naturally excluded - matching the old driver's bundled skip.
-      this.writeCollectionSession(dep.reference, { type: "status", status: "downloading" });
+      this.writeCollectionSession(
+        dep.reference,
+        { type: "status", status: "downloading" },
+        dep.sessionRuleId,
+      );
       if (dep.reference.tag !== undefined) {
         queuedDownloads.push(dep.reference);
       }
@@ -7649,15 +7675,19 @@ class InstallManager {
   /**
    * Record a dependency install outcome on the active collection session. This is the
    * direct, in-process write path: the orchestrator already knows which dependency it is
-   * processing, so it matches the rule by reference and dispatches the resulting tracking
-   * action. Additive to the existing api.events.emit calls - it does not replace them.
+   * processing, so it addresses the member and dispatches the resulting tracking action.
+   * Additive to the existing api.events.emit calls - it does not replace them.
    * A no-op when there is no active session, no rule matches, or the write is redundant.
+   *
+   * Pass the dependency's `sessionRuleId` wherever it is in scope: the member is then addressed
+   * by the key it is tracked under rather than by an identity the engine may have retagged.
    */
   private writeCollectionSession(
     reference: IModReference,
     outcome: CollectionInstallOutcome,
+    ruleId?: string,
   ): void {
-    const plan = sessionWriteForDependency(this.mApi.getState(), reference, outcome);
+    const plan = sessionWriteForDependency(this.mApi.getState(), reference, outcome, ruleId);
     if (plan === null) {
       return;
     }

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -84,6 +84,7 @@ import {
   isOutstandingOptionalMember,
   isTerminalMemberStatus,
   modRuleId,
+  referenceId,
 } from "../../util/collectionInstallSession";
 import {
   getCollectionActiveSession,
@@ -96,6 +97,7 @@ import {
 import { resyncCollectionSessionRules } from "../../util/collectionSessionReconstruct";
 import type { CollectionInstallOutcome } from "../../util/collectionSessionWrite";
 import {
+  matchSessionRuleEntry,
   planDependencyErrorRecovery,
   sessionWriteForDependency,
 } from "../../util/collectionSessionWrite";
@@ -7699,6 +7701,7 @@ class InstallManager {
   ): void {
     const plan = sessionWriteForDependency(this.mApi.getState(), reference, outcome, ruleId);
     if (plan === null) {
+      this.warnUnmatchedSessionWrite(reference, outcome, ruleId);
       return;
     }
     const action =
@@ -7706,6 +7709,33 @@ class InstallManager {
         ? markModInstalled(plan.sessionId, plan.ruleId, plan.write.modId)
         : updateModStatus(plan.sessionId, plan.ruleId, plan.write.status);
     this.mApi.store.dispatch(action);
+  }
+
+  /**
+   * Report a lifecycle outcome that named no session member, since the member then keeps whatever
+   * status it had and the completion poll goes on selecting it. Writes outside an install, and
+   * writes the planner declined for a member it did match, are expected and stay quiet.
+   */
+  private warnUnmatchedSessionWrite(
+    reference: IModReference,
+    outcome: CollectionInstallOutcome,
+    ruleId?: string,
+  ): void {
+    const session = getCollectionActiveSession(this.mApi.getState());
+    if (session === undefined) {
+      return;
+    }
+    if (ruleId !== undefined && session.mods[ruleId] !== undefined) {
+      return;
+    }
+    if (matchSessionRuleEntry(session, reference) !== undefined) {
+      return;
+    }
+    log("warn", "collection session write matched no member", {
+      ruleId,
+      referenceId: referenceId(reference),
+      outcome: outcome.type,
+    });
   }
 
   /**

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -1256,8 +1256,8 @@ class InstallManager {
     const batchContext = getBatchContext(["install-dependencies", "install-recommendations"], "");
     const profileId = batchContext?.get<string>("profileId") ?? activeProfile(state)?.id;
     const currentProfile = profileById(state, profileId) ?? activeProfile(state);
-    // the installing dependency's reference, so attribute extractors can take the tag from the
-    // rule being installed rather than from whichever collection stamped the archive first
+    // lets attribute extractors take the tag from the rule being installed rather than from
+    // whichever collection stamped the archive
     const installingReference = modReference;
 
     // Use parallel installation concurrency limiter instead of sequential mQueue
@@ -3323,9 +3323,8 @@ class InstallManager {
           const installKey = this.generateDependencyInstallKey(sourceModId, downloadId);
           this.mPendingInstalls.delete(installKey);
           this.mActiveInstalls.delete(installKey);
-          // the mod exists with the wanted install spec, so settle the member: keyed on the
-          // session's own rule, which is the identity the member is tracked under. Without this
-          // the member stays non-terminal and every poll tick selects it again.
+          // the mod exists with the wanted install spec: settle the member on the session's own
+          // rule, or every poll tick selects it again
           this.writeCollectionSession(mod.rule.reference, {
             type: "installed",
             modId: existingMod.id,
@@ -5945,10 +5944,8 @@ class InstallManager {
               this.dropUnfulfilled(api, dep, gameId, sourceModId, recommended);
               return undefined;
             }
-            // A terminal download/install failure settles the member as failed on the collection
-            // session. Addressed by the dependency's own session key, so it does not depend on
-            // matching the failed download back to a rule - which is how a failed download would
-            // otherwise be left stuck on "downloading". No-ops outside an active collection session
+            // Settle the member as failed, addressed by its own session key so it does not depend
+            // on matching the failed download back to a rule. No-ops outside an active session
             // and over an already-terminal status.
             const settleMemberFailed = () =>
               this.writeCollectionSession(
@@ -6547,10 +6544,9 @@ class InstallManager {
             dep.reference.tag !== undefined &&
             !downloadHasReferenceTag(downloads[downloadId], dep.reference.tag)
           ) {
-            // the archive satisfies this rule too, so record this rule's tag on it alongside any
-            // tag it already carries. The rule and dep.reference are left alone: the install
-            // session is keyed from them, and other collections still resolve the archive by
-            // their own tag.
+            // the archive satisfies this rule too: record this rule's tag alongside the tags it
+            // carries. The rule and dep.reference stay as they are - the session is keyed from
+            // them, and other collections resolve the archive by their own tag.
             batchDispatch(
               api.store,
               appendReferenceTagActions(downloadId, downloads[downloadId], dep.reference.tag),
@@ -6649,17 +6645,16 @@ class InstallManager {
         .sort((a, b) => a - b);
       const lowestPhase = phaseNumbers[0];
 
-      // Check collection session to determine actual current phase. Session ids are
-      // collectionId_profileId, resolved the same way the completion poll resolves them.
+      // Session ids are collectionId_profileId, resolved the same way the completion poll
+      // resolves them.
       const phaseBatchContext = getBatchContext(
         ["install-dependencies", "install-recommendations"],
         "",
       );
       const phaseProfileId =
         phaseBatchContext?.get<string>("profileId") ?? activeProfile(api.getState())?.id;
-      // The ACTIVE session only: phase completion below is read from the active session, and a
-      // finished install of this collection on this profile carries the same id in history, where
-      // every phase would read complete and push the frontier past phases that never ran.
+      // The ACTIVE session only: phase completion below reads it, and a finished install of this
+      // collection carries the same id in history, where every phase reads complete.
       const collectionSession = getCollectionActiveSession(api.getState());
       const activeCollectionSession =
         collectionSession?.sessionId === generateCollectionSessionId(sourceModId, phaseProfileId)
@@ -7708,16 +7703,13 @@ class InstallManager {
   }
 
   /**
-   * Record a dependency install outcome on the active collection session. This is the
-   * direct, in-process write path: the orchestrator already knows which dependency it is
-   * processing, so it addresses the member and dispatches the resulting tracking action.
-   * Additive to the existing api.events.emit calls - it does not replace them.
-   * A no-op when there is no active session, no rule matches, or the write is redundant.
+   * Record a dependency install outcome on the active collection session. A no-op when there is
+   * no active session, no rule matches, or the write is redundant.
    *
-   * Pass the dependency's `sessionRuleId` wherever it is in scope: the member is then addressed
-   * by the key it is tracked under rather than by an identity the engine may have retagged.
-   * `sourceModId` scopes the unmatched-write warning: the dependency pipeline also runs for mods
-   * other than the session's collection, whose writes are expected no-ops.
+   * Pass the dependency's `sessionRuleId` wherever it is in scope, so the member is addressed by
+   * the key it is tracked under rather than by its reference identity. `sourceModId` scopes the
+   * unmatched-write warning: the dependency pipeline also runs for mods outside the session's
+   * collection, whose writes are expected no-ops.
    */
   private writeCollectionSession(
     reference: IModReference,
@@ -7738,9 +7730,9 @@ class InstallManager {
   }
 
   /**
-   * Report a lifecycle outcome that named no session member, since the member then keeps whatever
-   * status it had and the completion poll goes on selecting it. Writes outside an install, and
-   * writes the planner declined for a member it did match, are expected and stay quiet.
+   * Report a lifecycle outcome that named no session member: that member keeps its status and the
+   * completion poll goes on selecting it. Writes outside an install, and writes the planner
+   * declined for a member it did match, are expected and stay quiet.
    */
   private warnUnmatchedSessionWrite(
     reference: IModReference,

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -6657,10 +6657,14 @@ class InstallManager {
       );
       const phaseProfileId =
         phaseBatchContext?.get<string>("profileId") ?? activeProfile(api.getState())?.id;
-      const activeCollectionSession = getCollectionSessionById(
-        api.getState(),
-        generateCollectionSessionId(sourceModId, phaseProfileId),
-      );
+      // The ACTIVE session only: phase completion below is read from the active session, and a
+      // finished install of this collection on this profile carries the same id in history, where
+      // every phase would read complete and push the frontier past phases that never ran.
+      const collectionSession = getCollectionActiveSession(api.getState());
+      const activeCollectionSession =
+        collectionSession?.sessionId === generateCollectionSessionId(sourceModId, phaseProfileId)
+          ? collectionSession
+          : undefined;
 
       if (activeCollectionSession) {
         // Determine the highest completed phase from the collection session

--- a/src/renderer/src/extensions/mod_management/types/IDependency.ts
+++ b/src/renderer/src/extensions/mod_management/types/IDependency.ts
@@ -23,6 +23,7 @@ export interface IDependency extends IModInstallSpec {
   mod?: IMod;
   phase?: number;
   extra?: IModRuleExtra;
+  sessionRuleId?: string;
 }
 
 export interface IDependencyError {

--- a/src/renderer/src/extensions/mod_management/types/IMod.ts
+++ b/src/renderer/src/extensions/mod_management/types/IMod.ts
@@ -89,6 +89,9 @@ export interface ICommonModAttributes {
   installTime?: string | Date;
   installedAsDependency?: boolean;
   referenceTag?: string;
+  // every collection-rule tag this mod satisfies; append-only superset of referenceTag, which
+  // holds the first tag stamped and is what older Vortex versions read
+  referenceTags?: string[];
 
   // Installer and patching
   installerChoices?: IChoiceType;

--- a/src/renderer/src/extensions/mod_management/util/dependencies.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.test.ts
@@ -4,9 +4,7 @@
  * to gatherDependencies/findModByRef; tested here without the InstallManager orchestration.
  *
  * Also covers gatherDependencies' session addressing: the install session tracks the collection's
- * OWN rules, so only a top-level node carries its rule's session key. A transitive sub-dependency
- * is not a member, and an addressed write for it would warn "matched no member" on every lifecycle
- * event.
+ * OWN rules, so only a top-level node carries its rule's session key.
  */
 import { describe, expect, vi } from "vitest";
 
@@ -55,12 +53,12 @@ describe("gatherDependencies", () => {
       extra: { rules: [subRule] },
     });
     const h = makeApi();
-    const api = Object.assign(h.api, {
+    Object.assign(h.api, {
       lookupModReference: vi.fn().mockResolvedValue([]),
       lookupModMeta: vi.fn().mockResolvedValue([]),
     });
 
-    const deps = await gatherDependencies([memberRule], api, false);
+    const deps = await gatherDependencies([memberRule], h.api, false);
 
     const member = deps.find((dep) => dep.reference.tag === "member-tag");
     const sub = deps.find((dep) => dep.reference.tag === "sub-tag");

--- a/src/renderer/src/extensions/mod_management/util/dependencies.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.test.ts
@@ -2,17 +2,24 @@
  * Unit coverage for selectedOptionalRules - the pure filter that decides which optional (recommends)
  * members still need installing when the trailing optional phase runs. Kept in dependencies.ts next
  * to gatherDependencies/findModByRef; tested here without the InstallManager orchestration.
+ *
+ * Also covers gatherDependencies' session addressing: the install session tracks the collection's
+ * OWN rules, so only a top-level node carries its rule's session key. A transitive sub-dependency
+ * is not a member, and an addressed write for it would warn "matched no member" on every lifecycle
+ * event.
  */
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
-import { makeMod, makeRule } from "../../../test-utils/builders";
+import { makeMod, makeReference, makeRule } from "../../../test-utils/builders";
+import { test } from "../../../test-utils/harnessTest";
+import { modRuleId } from "../../../util/collectionInstallSession";
 import type { IMod } from "../types/IMod";
-import { selectedOptionalRules } from "./dependencies";
+import gatherDependencies, { selectedOptionalRules } from "./dependencies";
 
 vi.mock("../../../util/log", () => ({ log: vi.fn() }));
 
 describe("selectedOptionalRules", () => {
-  it("returns only selected (non-ignored) optional members that are not yet installed", () => {
+  test("returns only selected (non-ignored) optional members that are not yet installed", () => {
     const rules = [
       makeRule({ type: "recommends", reference: { tag: "opt-selected" } }),
       makeRule({ type: "recommends", reference: { tag: "opt-skipped" }, ignored: true }),
@@ -28,13 +35,37 @@ describe("selectedOptionalRules", () => {
     expect(result.map((r) => r.reference.tag)).toEqual(["opt-selected"]);
   });
 
-  it("treats an explicit ignored:false as selected", () => {
+  test("treats an explicit ignored:false as selected", () => {
     const rules = [makeRule({ type: "recommends", reference: { tag: "opt" }, ignored: false })];
     expect(selectedOptionalRules(rules, {}).map((r) => r.reference.tag)).toEqual(["opt"]);
   });
 
-  it("tolerates an empty / undefined rule list", () => {
+  test("tolerates an empty / undefined rule list", () => {
     expect(selectedOptionalRules([], {})).toEqual([]);
     expect(selectedOptionalRules(undefined as unknown as [], {})).toEqual([]);
+  });
+});
+
+describe("gatherDependencies", () => {
+  test("keys only the collection's own rules for session writes", async ({ makeApi }) => {
+    const subRule = makeRule({ type: "requires", reference: makeReference({ tag: "sub-tag" }) });
+    const memberRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "member-tag" }),
+      extra: { rules: [subRule] },
+    });
+    const h = makeApi();
+    const api = Object.assign(h.api, {
+      lookupModReference: vi.fn().mockResolvedValue([]),
+      lookupModMeta: vi.fn().mockResolvedValue([]),
+    });
+
+    const deps = await gatherDependencies([memberRule], api, false);
+
+    const member = deps.find((dep) => dep.reference.tag === "member-tag");
+    const sub = deps.find((dep) => dep.reference.tag === "sub-tag");
+    expect(member?.sessionRuleId).toBe(modRuleId(memberRule));
+    expect(sub).toBeDefined();
+    expect(sub?.sessionRuleId).toBeUndefined();
   });
 });

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -355,6 +355,7 @@ async function gatherDependenciesGraph(
   gameMode: string,
   recommendations: boolean,
   addToCache?: (download: IDownload) => void,
+  sessionRuleId?: string,
 ): Promise<IDependencyNode> {
   const state = api.getState();
   const downloads = state.persistent.downloads.files;
@@ -416,7 +417,7 @@ async function gatherDependenciesGraph(
       download: downloadId,
       mod,
       reference: rule.reference,
-      sessionRuleId: modRuleId(rule),
+      sessionRuleId,
       lookupResults: lookupResults.map((iter) =>
         makeLookupResult(iter as ILookupResult, urlFromHint),
       ),
@@ -525,7 +526,16 @@ function gatherDependencies(
     Promise.all(
       requirements.map((rule: IModRule) =>
         Promise.resolve(
-          limit.do(() => gatherDependenciesGraph(rule, api, gameMode, recommendations, addToCache)),
+          limit.do(() =>
+            gatherDependenciesGraph(
+              rule,
+              api,
+              gameMode,
+              recommendations,
+              addToCache,
+              modRuleId(rule),
+            ),
+          ),
         )
           .then((node: IDependencyNode) => {
             onProgress();

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -7,6 +7,7 @@ import * as semver from "semver";
 
 import type { IExtensionApi } from "../../../types/IExtensionContext";
 import type { IDownload } from "../../../types/IState";
+import { modRuleId } from "../../../util/collectionInstallSession";
 import ConcurrencyLimiter from "../../../util/ConcurrencyLimiter";
 import { NotFound, ProcessCanceled, UserCanceled } from "../../../util/CustomErrors";
 import { log } from "../../../util/log";
@@ -413,6 +414,7 @@ async function gatherDependenciesGraph(
       download: downloadId,
       mod,
       reference: rule.reference,
+      sessionRuleId: modRuleId(rule),
       lookupResults: lookupResults.map((iter) =>
         makeLookupResult(iter as ILookupResult, urlFromHint),
       ),

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -20,6 +20,7 @@ import { findModByRef } from "./findModByRef";
 import { isFuzzyVersion } from "./isFuzzyVersion";
 import { rulePhase } from "./rulePhase";
 import testModReference, {
+  downloadReferenceTags,
   isOptionalRule,
   ruleInstallSpec,
   testRefByIdentifiers,
@@ -260,6 +261,7 @@ export function lookupFromDownload(download: IDownload): IModLookupInfo {
     game: download.game,
     source: download.modInfo?.source,
     referenceTag: download.modInfo?.referenceTag,
+    referenceTags: downloadReferenceTags(download),
     modId,
     fileId,
   };

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -261,7 +261,7 @@ export function lookupFromDownload(download: IDownload): IModLookupInfo {
     game: download.game,
     source: download.modInfo?.source,
     referenceTag: download.modInfo?.referenceTag,
-    referenceTags: downloadReferenceTags(download),
+    referenceTags: download.modInfo?.referenceTags,
     modId,
     fileId,
   };

--- a/src/renderer/src/extensions/mod_management/util/dependencies.ts
+++ b/src/renderer/src/extensions/mod_management/util/dependencies.ts
@@ -355,7 +355,6 @@ async function gatherDependenciesGraph(
   gameMode: string,
   recommendations: boolean,
   addToCache?: (download: IDownload) => void,
-  sessionRuleId?: string,
 ): Promise<IDependencyNode> {
   const state = api.getState();
   const downloads = state.persistent.downloads.files;
@@ -417,7 +416,6 @@ async function gatherDependenciesGraph(
       download: downloadId,
       mod,
       reference: rule.reference,
-      sessionRuleId,
       lookupResults: lookupResults.map((iter) =>
         makeLookupResult(iter as ILookupResult, urlFromHint),
       ),
@@ -526,19 +524,15 @@ function gatherDependencies(
     Promise.all(
       requirements.map((rule: IModRule) =>
         Promise.resolve(
-          limit.do(() =>
-            gatherDependenciesGraph(
-              rule,
-              api,
-              gameMode,
-              recommendations,
-              addToCache,
-              modRuleId(rule),
-            ),
-          ),
+          limit.do(() => gatherDependenciesGraph(rule, api, gameMode, recommendations, addToCache)),
         )
           .then((node: IDependencyNode) => {
             onProgress();
+            if (node !== null) {
+              // only these top-level rules are collection members, so only their nodes address a
+              // session entry; the sub-dependencies gathered under them carry no key
+              node.sessionRuleId = modRuleId(rule);
+            }
             return Promise.resolve(node);
           })
           .catch((err) => {

--- a/src/renderer/src/extensions/mod_management/util/modReferenceTags.ts
+++ b/src/renderer/src/extensions/mod_management/util/modReferenceTags.ts
@@ -12,27 +12,33 @@ import type { IMod } from "../types/IMod";
 import { modReferenceTags } from "./testModReference";
 
 /**
- * Actions recording `tag` on the mod's tag set. Sets the legacy single field only when the mod
- * carries no tag yet. Empty when the tag is already recorded or the rule has none.
+ * Actions recording `tags` on the mod's tag set. Sets the legacy single field only when the mod
+ * carries no tag yet. Empty when every tag is already recorded.
+ *
+ * All tags for one mod must go through a single call: the actions carry the whole array, so two
+ * calls built from the same mod would each write only their own addition.
  */
-export function appendModReferenceTagActions(
+export function appendModReferenceTagsActions(
   gameId: string,
   modId: string,
   mod: IMod | undefined,
-  tag: string | undefined,
+  tags: readonly (string | undefined)[],
 ): Action[] {
-  if (tag === undefined) {
-    return [];
+  const recorded = modReferenceTags(mod);
+  const added: string[] = [];
+  for (const tag of tags) {
+    if (tag !== undefined && !recorded.includes(tag) && !added.includes(tag)) {
+      added.push(tag);
+    }
   }
-  const tags = modReferenceTags(mod);
-  if (tags.includes(tag)) {
+  if (added.length === 0) {
     return [];
   }
   const actions: Action[] = [
-    setModAttribute(gameId, modId, "referenceTags", [...tags, tag]) as Action,
+    setModAttribute(gameId, modId, "referenceTags", [...recorded, ...added]) as Action,
   ];
   if (mod?.attributes?.referenceTag === undefined) {
-    actions.push(setModAttribute(gameId, modId, "referenceTag", tag) as Action);
+    actions.push(setModAttribute(gameId, modId, "referenceTag", added[0]) as Action);
   }
   return actions;
 }

--- a/src/renderer/src/extensions/mod_management/util/modReferenceTags.ts
+++ b/src/renderer/src/extensions/mod_management/util/modReferenceTags.ts
@@ -1,0 +1,38 @@
+/**
+ * Recording collection-rule tags on an installed mod. A mod can be a member of more than one
+ * collection, so the tag set is append-only: `attributes.referenceTag` keeps the first tag stamped
+ * (older Vortex versions read only that field) and `attributes.referenceTags` carries all of them.
+ *
+ * The read side lives with the rest of the identity matching (testModReference).
+ */
+import type { Action } from "redux";
+
+import { setModAttribute } from "../actions/mods";
+import type { IMod } from "../types/IMod";
+import { modReferenceTags } from "./testModReference";
+
+/**
+ * Actions recording `tag` on the mod's tag set. Sets the legacy single field only when the mod
+ * carries no tag yet. Empty when the tag is already recorded or the rule has none.
+ */
+export function appendModReferenceTagActions(
+  gameId: string,
+  modId: string,
+  mod: IMod | undefined,
+  tag: string | undefined,
+): Action[] {
+  if (tag === undefined) {
+    return [];
+  }
+  const tags = modReferenceTags(mod);
+  if (tags.includes(tag)) {
+    return [];
+  }
+  const actions: Action[] = [
+    setModAttribute(gameId, modId, "referenceTags", [...tags, tag]) as Action,
+  ];
+  if (mod?.attributes?.referenceTag === undefined) {
+    actions.push(setModAttribute(gameId, modId, "referenceTag", tag) as Action);
+  }
+  return actions;
+}

--- a/src/renderer/src/extensions/mod_management/util/testModReference.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.test.ts
@@ -1111,3 +1111,38 @@ describe("findRuleByRef", () => {
     expect(findRuleByRef(undefined, mod)).toBeUndefined();
   });
 });
+
+describe("multiple reference tags", () => {
+  const taggedMod = (attributes: IModAttributes): IMod => ({
+    id: "mod-multi",
+    state: "installed",
+    type: "",
+    installationPath: "mods/mod-multi",
+    attributes,
+  });
+
+  // one archive can satisfy rules in several collections, so each collection's tag is recorded
+  // alongside the first one rather than replacing it
+  it("matches a reference against any tag the mod carries", () => {
+    const mod = taggedMod({ referenceTag: "other", referenceTags: ["other", "mine"] });
+    expect(testModReference(mod, { tag: "mine" })).toBe(true);
+    expect(testModReference(mod, { tag: "other" })).toBe(true);
+  });
+
+  it("does not match a tag the mod does not carry", () => {
+    const mod = taggedMod({ referenceTag: "other", referenceTags: ["other", "mine"] });
+    expect(testModReference(mod, { tag: "absent" })).toBe(false);
+  });
+
+  // a fuzzy reference drops fileMD5 as a marker, so without a tag hit there is nothing left to
+  // match on and the member would be re-downloaded
+  it("matches a fuzzy hash-only reference through the tag set", () => {
+    const mod = taggedMod({
+      referenceTag: "other",
+      referenceTags: ["other", "mine"],
+      fileMD5: "abc123",
+      version: "1.2.0",
+    });
+    expect(testModReference(mod, { tag: "mine", fileMD5: "abc123", versionMatch: "*" })).toBe(true);
+  });
+});

--- a/src/renderer/src/extensions/mod_management/util/testModReference.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.ts
@@ -34,9 +34,45 @@ export interface IModLookupInfo {
   modId?: string;
   source?: string;
   referenceTag?: string;
+  // every collection-rule tag the mod or archive satisfies; referenceTag holds the first of them
+  referenceTags?: string[];
   installerChoices?: IChoiceType;
   patches?: IModPatches;
   fileList?: IFileListItem[];
+}
+
+/**
+ * Every collection-rule tag a download satisfies: the legacy single field unioned with the tag
+ * array, deduped. Empty when the archive carries no tag.
+ */
+export function downloadReferenceTags(download: IDownload | undefined): string[] {
+  const { referenceTag, referenceTags } = download?.modInfo ?? {};
+  const tags = new Set<string>(Array.isArray(referenceTags) ? referenceTags : []);
+  if (typeof referenceTag === "string") {
+    tags.add(referenceTag);
+  }
+  return Array.from(tags);
+}
+
+/** Whether a download satisfies this collection-rule tag. */
+export function downloadHasReferenceTag(
+  download: IDownload | undefined,
+  tag: string | undefined,
+): boolean {
+  if (tag === undefined) {
+    return false;
+  }
+  return downloadReferenceTags(download).includes(tag);
+}
+
+/** Every collection-rule tag an installed mod satisfies, as its attributes record them. */
+export function modReferenceTags(mod: IMod | undefined): string[] {
+  const attrs = mod?.attributes ?? {};
+  const tags = new Set<string>(Array.isArray(attrs.referenceTags) ? attrs.referenceTags : []);
+  if (typeof attrs.referenceTag === "string") {
+    tags.add(attrs.referenceTag);
+  }
+  return Array.from(tags);
 }
 
 export function modAttributesToLookupInfo(
@@ -62,6 +98,7 @@ export function modAttributesToLookupInfo(
     modId: attrs.modId?.toString(),
     source: attrs.source,
     referenceTag: attrs.referenceTag,
+    referenceTags: attrs.referenceTags,
     installerChoices: attrs.installerChoices,
     patches: attrs.patches,
     fileList: attrs.fileList,
@@ -212,8 +249,17 @@ function hasIdentifyingMarker(
     (ref.fileExpression !== undefined && (mod.fileName ?? mod.name) !== undefined) ||
     (ref.logicalFileName !== undefined && mod.logicalFileName !== undefined) ||
     (ref.repo !== undefined && mod.source !== undefined) ||
-    (allowTag && ref.tag !== undefined && mod.referenceTag !== undefined)
+    (allowTag && ref.tag !== undefined && lookupReferenceTags(mod).length > 0)
   );
+}
+
+/** The tags a lookup carries: the single field unioned with the array, deduped. */
+function lookupReferenceTags(mod: IModLookupInfo): string[] {
+  const tags = new Set<string>(Array.isArray(mod.referenceTags) ? mod.referenceTags : []);
+  if (typeof mod.referenceTag === "string") {
+    tags.add(mod.referenceTag);
+  }
+  return Array.from(tags);
 }
 
 let onRefResolved: (
@@ -258,7 +304,8 @@ function testRef(
   }
 
   if (ref.tag != null) {
-    if (mod.referenceTag === ref.tag) {
+    // an archive shared between collections carries a tag per rule, so any of them is a hit
+    if (lookupReferenceTags(mod).includes(ref.tag)) {
       return true;
     } else {
       // tags differ. if the mod has no stricter attribute we have to refuse here, otherwise

--- a/src/renderer/src/extensions/mod_management/util/testModReference.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.ts
@@ -54,7 +54,7 @@ export function downloadReferenceTags(download: IDownload | undefined): string[]
   return Array.from(tags);
 }
 
-/** Whether a download satisfies this collection-rule tag. */
+/** Whether a download satisfies this collection-rule tag. Runs inside per-download scans. */
 export function downloadHasReferenceTag(
   download: IDownload | undefined,
   tag: string | undefined,
@@ -62,7 +62,8 @@ export function downloadHasReferenceTag(
   if (tag === undefined) {
     return false;
   }
-  return downloadReferenceTags(download).includes(tag);
+  const modInfo = download?.modInfo;
+  return modInfo?.referenceTag === tag || modInfo?.referenceTags?.includes(tag) === true;
 }
 
 /** Every collection-rule tag an installed mod satisfies, as its attributes record them. */

--- a/src/renderer/src/extensions/mod_management/util/testModReference.ts
+++ b/src/renderer/src/extensions/mod_management/util/testModReference.ts
@@ -249,17 +249,10 @@ function hasIdentifyingMarker(
     (ref.fileExpression !== undefined && (mod.fileName ?? mod.name) !== undefined) ||
     (ref.logicalFileName !== undefined && mod.logicalFileName !== undefined) ||
     (ref.repo !== undefined && mod.source !== undefined) ||
-    (allowTag && ref.tag !== undefined && lookupReferenceTags(mod).length > 0)
+    (allowTag &&
+      ref.tag !== undefined &&
+      (mod.referenceTag !== undefined || (mod.referenceTags?.length ?? 0) > 0))
   );
-}
-
-/** The tags a lookup carries: the single field unioned with the array, deduped. */
-function lookupReferenceTags(mod: IModLookupInfo): string[] {
-  const tags = new Set<string>(Array.isArray(mod.referenceTags) ? mod.referenceTags : []);
-  if (typeof mod.referenceTag === "string") {
-    tags.add(mod.referenceTag);
-  }
-  return Array.from(tags);
 }
 
 let onRefResolved: (
@@ -305,7 +298,7 @@ function testRef(
 
   if (ref.tag != null) {
     // an archive shared between collections carries a tag per rule, so any of them is a hit
-    if (lookupReferenceTags(mod).includes(ref.tag)) {
+    if (mod.referenceTag === ref.tag || mod.referenceTags?.includes(ref.tag) === true) {
       return true;
     } else {
       // tags differ. if the mod has no stricter attribute we have to refuse here, otherwise

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -288,6 +288,43 @@ describe("installTracking reducer", () => {
 
       expect(result).toBe(state);
     });
+
+    it("leaves the session untouched when the rule is not tracked", () => {
+      const session = makeSession({
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
+      });
+      const state = makeInstallState({ activeSession: session });
+
+      const result = reduce(state, actions.markModInstalled, {
+        sessionId: "col1_prof1",
+        ruleId: "requires_ghost",
+        modId: "m1",
+      });
+
+      expect(result.activeSession.mods).not.toHaveProperty("requires_ghost");
+      expect(result.activeSession.installedCount).toBe(0);
+    });
+  });
+
+  // A rule id the session does not track identifies no member, so writing it would invent an entry
+  // with no rule and count it towards the totals the completion check and progress bars read.
+  describe("writes for an untracked rule", () => {
+    it("leaves the session untouched on a status update", () => {
+      const session = makeSession({
+        mods: modsByRule([{ ruleId: "rule1", status: "pending", type: "requires" }]),
+      });
+      const state = makeInstallState({ activeSession: session });
+
+      const result = reduce(state, actions.updateModStatus, {
+        sessionId: "col1_prof1",
+        ruleId: "requires_ghost",
+        status: "ignored",
+      });
+
+      expect(result.activeSession.mods).not.toHaveProperty("requires_ghost");
+      expect(result.activeSession.ignoredCount).toBe(0);
+      expect(result.activeSession.downloadedCount).toBe(0);
+    });
   });
 
   describe("finishInstallSession", () => {

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -50,6 +50,50 @@ describe("installTracking reducer", () => {
       expect(result.activeSession.installedCount).toBe(1);
     });
 
+    it("counts members seeded as ignored or failed toward their totals", () => {
+      // a resumed install seeds each member from reality, so members can already be terminal
+      const state = makeInstallState();
+      const payload = {
+        collectionId: "col1",
+        profileId: "prof1",
+        gameId: "skyrimse",
+        totalRequired: 2,
+        totalOptional: 2,
+        mods: {
+          rule1: { status: "installed", type: "requires", rule: {} },
+          rule2: { status: "failed", type: "requires", rule: {} },
+          rule3: { status: "ignored", type: "recommends", rule: {} },
+          rule4: { status: "ignored", type: "recommends", rule: {} },
+        },
+      };
+
+      const result = reduce(state, actions.startInstallSession, payload);
+
+      expect(result.activeSession.ignoredCount).toBe(2);
+      expect(result.activeSession.failedCount).toBe(1);
+    });
+
+    it("keeps the ignored total at zero when a member seeded as ignored is selected", () => {
+      // an optional skipped in an earlier install of the same collection rehydrates as "ignored";
+      // selecting it moves it off that status, which must not take the total below zero
+      const started = reduce(makeInstallState(), actions.startInstallSession, {
+        collectionId: "col1",
+        profileId: "prof1",
+        gameId: "skyrimse",
+        totalRequired: 0,
+        totalOptional: 1,
+        mods: { rule1: { status: "ignored", type: "recommends", rule: {} } },
+      });
+
+      const result = reduce(started, actions.updateModStatus, {
+        sessionId: "col1_prof1",
+        ruleId: "rule1",
+        status: "pending",
+      });
+
+      expect(result.activeSession.ignoredCount).toBe(0);
+    });
+
     it("computes zero counters for an empty mods object", () => {
       const state = makeInstallState();
       const payload = {

--- a/src/renderer/src/reducers/collectionInstallTracking.test.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.test.ts
@@ -350,8 +350,8 @@ describe("installTracking reducer", () => {
     });
   });
 
-  // A rule id the session does not track identifies no member, so writing it would invent an entry
-  // with no rule and count it towards the totals the completion check and progress bars read.
+  // writing an id the session does not track would invent a rule-less entry and count it towards
+  // the totals completion and progress read
   describe("writes for an untracked rule", () => {
     it("leaves the session untouched on a status update", () => {
       const session = makeSession({

--- a/src/renderer/src/reducers/collectionInstallTracking.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.ts
@@ -63,9 +63,8 @@ function adjustCounters(
 }
 
 /**
- * Whether the session tracks this rule id. A write for an id it does not track identifies no
- * member, so applying it would invent an entry with no rule and count it towards the totals the
- * completion check and the progress bars read.
+ * Whether the session tracks this rule id. Applying a write for an id it does not track would
+ * invent a rule-less entry and count it towards the totals completion and progress read.
  */
 function isTrackedRule(session: types.ICollectionInstallSession, ruleId: string): boolean {
   if (session.mods[ruleId] !== undefined) {

--- a/src/renderer/src/reducers/collectionInstallTracking.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.ts
@@ -93,13 +93,17 @@ const collectionInstallReducer = actionsToReducerSpec(defaultState, actions, {
       DOWNLOADED_STATUSES.has(mod.status),
     ).length;
     const installedCount = Object.values(mods).filter((mod) => mod.status === "installed").length;
+    // members seeded terminal (a resumed install, or an optional skipped in an earlier one) count
+    // from the start, otherwise moving one off that status takes its total below zero
+    const failedCount = Object.values(mods).filter((mod) => mod.status === "failed").length;
+    const ignoredCount = Object.values(mods).filter((mod) => mod.status === "ignored").length;
     const session: types.ICollectionInstallSession = {
       ...payload,
       sessionId,
       downloadedCount,
       installedCount,
-      failedCount: 0,
-      ignoredCount: 0,
+      failedCount,
+      ignoredCount,
     };
 
     return { ...state, activeSession: session };

--- a/src/renderer/src/reducers/collectionInstallTracking.ts
+++ b/src/renderer/src/reducers/collectionInstallTracking.ts
@@ -5,6 +5,7 @@ import {
   startInstallSession,
   updateModStatus,
 } from "../actions/collectionInstallTracking";
+import { log } from "../logging";
 import type * as types from "../types/api";
 import { generateCollectionSessionId } from "../util/collectionInstallSession";
 import { actionsToReducerSpec } from "./builder";
@@ -61,6 +62,22 @@ function adjustCounters(
   return { downloadedCount, installedCount, failedCount, ignoredCount };
 }
 
+/**
+ * Whether the session tracks this rule id. A write for an id it does not track identifies no
+ * member, so applying it would invent an entry with no rule and count it towards the totals the
+ * completion check and the progress bars read.
+ */
+function isTrackedRule(session: types.ICollectionInstallSession, ruleId: string): boolean {
+  if (session.mods[ruleId] !== undefined) {
+    return true;
+  }
+  log("warn", "collection session write for an untracked rule", {
+    sessionId: session.sessionId,
+    ruleId,
+  });
+  return false;
+}
+
 const defaultState: types.ICollectionInstallState = {
   activeSession: undefined,
   lastActiveSessionId: undefined,
@@ -92,6 +109,9 @@ const collectionInstallReducer = actionsToReducerSpec(defaultState, actions, {
     if (!state.activeSession || state.activeSession.sessionId !== payload.sessionId) {
       return state;
     }
+    if (!isTrackedRule(state.activeSession, payload.ruleId)) {
+      return state;
+    }
 
     const { mods, ...activeSession } = state.activeSession;
     const oldStatus = mods[payload.ruleId]?.status;
@@ -112,6 +132,9 @@ const collectionInstallReducer = actionsToReducerSpec(defaultState, actions, {
 
   markModInstalled: (state, payload) => {
     if (!state.activeSession || state.activeSession.sessionId !== payload.sessionId) {
+      return state;
+    }
+    if (!isTrackedRule(state.activeSession, payload.ruleId)) {
       return state;
     }
 

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -89,6 +89,7 @@ import type {
   IHealthCheckHarnessOpts,
   IInstallContextHarness,
   IInstallManagerHarness,
+  IManagerInternals,
   IModCheckOpts,
   IModChangeHarness,
   IParkCheckOpts,
@@ -721,6 +722,15 @@ export function makeInstallManagerHarness(
   // instead of casting the manager per test
   const phaseTracker = (manager as unknown as { mPhaseTracker: InstallPhaseTracker }).mPhaseTracker;
   return { manager, phaseTracker, ...base };
+}
+
+/**
+ * Typed handle on the private InstallManager members phase-engine suites drive (the phase walk, the
+ * requeue pass, the completion poll). The single cast site for them, so suites state which member
+ * they drive rather than each casting the manager.
+ */
+export function managerInternals(manager: InstallManager): IManagerInternals {
+  return manager as unknown as IManagerInternals;
 }
 
 /**

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -35,6 +35,7 @@ import type {
   ICollectionModRule,
 } from "../extensions/collections/types/ICollection";
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
+import { stateReducer as downloadStateReducer } from "../extensions/download_management/reducers/state";
 import { downloadPathForGame } from "../extensions/download_management/selectors";
 import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
 import type { ILoadOrderEntry } from "../extensions/file_based_loadorder/types/types";
@@ -458,6 +459,12 @@ const modsReducers = modsReducer.reducers as Record<
   string,
   (state: ModsSlice, payload: unknown) => ModsSlice
 >;
+// the real download reducer, applied to state.persistent.downloads, so writes onto a download's
+// modInfo (the collection-rule tags the install path records) are observable by read-back
+const downloadReducers = downloadStateReducer.reducers as Record<
+  string,
+  (state: IState["persistent"]["downloads"], payload: unknown) => IState["persistent"]["downloads"]
+>;
 
 function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
   const slices: IDriverHarnessState = {
@@ -580,6 +587,10 @@ export function makeApiHarness(overrides: Partial<IDriverHarnessState> = {}): IA
     const modsReducerFn = modsReducers[action.type];
     if (modsReducerFn !== undefined) {
       state.persistent.mods = modsReducerFn(state.persistent.mods, action.payload);
+    }
+    const downloadReducerFn = downloadReducers[action.type];
+    if (downloadReducerFn !== undefined) {
+      state.persistent.downloads = downloadReducerFn(state.persistent.downloads, action.payload);
     }
   };
 

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -134,6 +134,61 @@ export interface IInstallManagerHarness extends IApiHarness {
   phaseTracker: InstallPhaseTracker;
 }
 
+/**
+ * The private InstallManager members phase-engine suites drive directly. Reached through
+ * `managerInternals` (builders.ts), the single typed seam for them, so no suite casts the manager
+ * itself. `api` is `unknown` here because the harness api is structurally narrower than the real
+ * IExtensionApi.
+ */
+export interface IManagerInternals {
+  reQueueDownloadedMods: (
+    api: unknown,
+    sourceModId: string,
+    allMods: unknown[],
+    currentPhase: number,
+  ) => void;
+  checkCollectionPhaseStatus: (
+    api: unknown,
+    sourceModId: string,
+    phase: number,
+  ) => { phaseComplete: boolean; needsRequeue: boolean; allMods: unknown[] };
+  driveSelectedOptionals: (api: unknown, sourceModId: string) => void;
+  admitSettledOptionalPhase: (sourceModId: string, api: unknown) => void;
+  pollAllPhasesComplete: (api: unknown, sourceModId: string) => Promise<void>;
+  doInstallDependencies: (
+    api: unknown,
+    gameId: string,
+    sourceModId: string,
+    dependencies: unknown[],
+    recommended: boolean,
+    silent: boolean,
+  ) => Promise<unknown[]>;
+  withInstructions: (
+    api: unknown,
+    sourceName: string,
+    title: string,
+    id: string,
+    instructions: string,
+    recommendations: boolean,
+    cb: () => PromiseLike<unknown>,
+  ) => Promise<unknown>;
+  startQueuedInstallation: (
+    api: unknown,
+    dep: unknown,
+    downloadId: string,
+    gameId: string,
+    sourceModId: string,
+    recommended: boolean,
+    phase: number,
+  ) => void;
+  maybeAdvancePhase: (sourceModId: string, api: unknown) => void;
+  getTerminalModCount: (api: unknown, sourceModId: string) => number;
+  // queued dependency installs, keyed by `${sourceModId}:${downloadId}`
+  mPendingInstalls: Map<string, unknown>;
+  // the per-collection cancel callback the completion poll checks, keyed by collection mod id
+  mDependencyInstalls: Record<string, () => void>;
+}
+
 /** What a health-check registry test arranges. */
 export interface IHealthCheckHarnessOpts {
   // the game the active profile is on (defaults to skyrimse)

--- a/src/renderer/src/util/collectionInstallSession.ts
+++ b/src/renderer/src/util/collectionInstallSession.ts
@@ -20,6 +20,13 @@ export function isTerminalMemberStatus(status: CollectionModStatus): boolean {
 }
 
 /**
+ * Same as isTerminalMemberStatus but only the "successful" outcomes.
+ */
+export function isSuccessfulMemberStatus(status: CollectionModStatus): boolean {
+  return status === "installed" || status === "ignored";
+}
+
+/**
  * An optional (recommends) member with no decided outcome yet, so it still blocks completion.
  *
  * This is the single definition of "an optional that still needs installing" as judged from the

--- a/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.test.ts
@@ -25,6 +25,8 @@ import {
   getCollectionPhaseProgress,
   getCollectionStatusBreakdown,
   getFailedOptionalMods,
+  isCollectionPhaseComplete,
+  isCollectionPhaseSettledSuccessfully,
 } from "./collectionInstallSessionSelectors";
 
 interface Entry {
@@ -150,6 +152,41 @@ describe("getCollectionInstallProgress optional handling", () => {
       { ruleId: "o1", type: "recommends", status: "installed" },
     ]);
     expect(getCollectionInstallProgress(state)!.isComplete).toBe(false);
+  });
+});
+
+describe("isCollectionPhaseSettledSuccessfully", () => {
+  it("reports a phase whose required members all installed", () => {
+    const state = stateWith([
+      { ruleId: "r1", phase: 0, type: "requires", status: "installed" },
+      { ruleId: "r2", phase: 0, type: "requires", status: "installed" },
+    ]);
+    expect(isCollectionPhaseSettledSuccessfully(state, 0)).toBe(true);
+  });
+
+  it("reports a phase holding a failed required member as not settled", () => {
+    const state = stateWith([
+      { ruleId: "r1", phase: 0, type: "requires", status: "installed" },
+      { ruleId: "r2", phase: 0, type: "requires", status: "failed" },
+    ]);
+
+    expect(isCollectionPhaseSettledSuccessfully(state, 0)).toBe(false);
+    // the divergence the re-entry frontier needs: mid-install advancement counts the same failed
+    // member as terminal, so the walk moves on and the install still completes
+    expect(isCollectionPhaseComplete(state, 0)).toBe(true);
+  });
+
+  it("counts a member the user ignored as settled", () => {
+    const state = stateWith([
+      { ruleId: "r1", phase: 0, type: "requires", status: "installed" },
+      { ruleId: "r2", phase: 0, type: "requires", status: "ignored" },
+    ]);
+    expect(isCollectionPhaseSettledSuccessfully(state, 0)).toBe(true);
+  });
+
+  it("reports a phase of only optional members as settled", () => {
+    const state = stateWith([{ ruleId: "o1", phase: 0, type: "recommends", status: "pending" }]);
+    expect(isCollectionPhaseSettledSuccessfully(state, 0)).toBe(true);
   });
 });
 

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -489,6 +489,25 @@ export const isCollectionPhaseComplete = (state: IState, phase: number): boolean
 };
 
 /**
+ * Check if a phase settled successfully - every required member installed or ignored.
+ * For the re-entry phase frontier only: a `failed` member deliberately does not count, because a
+ * re-entered install re-gathers it for retry and that retry has to run at its own phase,
+ * serialized before later phases. Mid-install advancement reads isCollectionPhaseComplete, where
+ * `failed` is terminal so a broken member never wedges the walk.
+ * @param phase The phase number to check
+ */
+export const isCollectionPhaseSettledSuccessfully = (state: IState, phase: number): boolean => {
+  const phaseMods = getCollectionModsForPhase(state, phase);
+  const requiredPhaseMods = phaseMods.filter(isRequiredRule);
+
+  if (requiredPhaseMods.length === 0) {
+    return true;
+  }
+
+  return requiredPhaseMods.every((mod) => mod.status === "installed" || mod.status === "ignored");
+};
+
+/**
  * Get the current phase being processed
  * @returns The lowest phase number with incomplete mods, or -1 if all complete
  */

--- a/src/renderer/src/util/collectionInstallSessionSelectors.ts
+++ b/src/renderer/src/util/collectionInstallSessionSelectors.ts
@@ -17,7 +17,11 @@ import type {
   CollectionModStatus,
 } from "../types/collections/ICollectionInstallSession";
 import type { IDownload, IMod, IState } from "../types/IState";
-import { isOutstandingOptionalMember, isTerminalMemberStatus } from "./collectionInstallSession";
+import {
+  isOutstandingOptionalMember,
+  isSuccessfulMemberStatus,
+  isTerminalMemberStatus,
+} from "./collectionInstallSession";
 
 /**
  * Selectors for the installTracking reducer
@@ -471,41 +475,34 @@ export const getCollectionCompletedMods = (state: IState): ICollectionModInstall
 };
 
 /**
+ * Whether every required member of a phase satisfies `settled`. Optional members never gate a
+ * phase, and a phase with no required members is settled.
+ */
+const everyRequiredPhaseMod = (
+  state: IState,
+  phase: number,
+  settled: (status: CollectionModStatus) => boolean,
+): boolean =>
+  getCollectionModsForPhase(state, phase)
+    .filter(isRequiredRule)
+    .every((mod) => settled(mod.status));
+
+/**
  * Check if a specific phase is complete
  * @param phase The phase number to check
  * @returns True if all required mods in the phase are completed
  */
-export const isCollectionPhaseComplete = (state: IState, phase: number): boolean => {
-  const phaseMods = getCollectionModsForPhase(state, phase);
-  const requiredPhaseMods = phaseMods.filter(isRequiredRule);
-
-  if (requiredPhaseMods.length === 0) {
-    return true;
-  }
-
-  return requiredPhaseMods.every(
-    (mod) => mod.status === "installed" || mod.status === "failed" || mod.status === "ignored",
-  );
-};
+export const isCollectionPhaseComplete = (state: IState, phase: number): boolean =>
+  everyRequiredPhaseMod(state, phase, isTerminalMemberStatus);
 
 /**
  * Check if a phase settled successfully - every required member installed or ignored.
- * For the re-entry phase frontier only: a `failed` member deliberately does not count, because a
- * re-entered install re-gathers it for retry and that retry has to run at its own phase,
- * serialized before later phases. Mid-install advancement reads isCollectionPhaseComplete, where
- * `failed` is terminal so a broken member never wedges the walk.
+ * On re-entry check that a failed member's retry runs at its own phase,
+ * serialized before later phases. Mid-install advancement reads isCollectionPhaseComplete.
  * @param phase The phase number to check
  */
-export const isCollectionPhaseSettledSuccessfully = (state: IState, phase: number): boolean => {
-  const phaseMods = getCollectionModsForPhase(state, phase);
-  const requiredPhaseMods = phaseMods.filter(isRequiredRule);
-
-  if (requiredPhaseMods.length === 0) {
-    return true;
-  }
-
-  return requiredPhaseMods.every((mod) => mod.status === "installed" || mod.status === "ignored");
-};
+export const isCollectionPhaseSettledSuccessfully = (state: IState, phase: number): boolean =>
+  everyRequiredPhaseMod(state, phase, isSuccessfulMemberStatus);
 
 /**
  * Get the current phase being processed

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -130,7 +130,7 @@ describe("sessionWriteForDependency", () => {
   });
 
   // a dependency carries its member's session key (sessionRuleId), captured while its rule was in
-  // hand, so a write still addresses the member after the engine retags the reference
+  // hand, so a write still addresses the member when its reference identity drifts
   it("resolves the member named by rule id even when the reference identity differs", () => {
     const state = stateWith([{ ruleId: "r1", status: "downloaded" }]);
     expect(

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -127,6 +127,40 @@ describe("sessionWriteForDependency", () => {
     ).toBeNull();
   });
 
+  // a dependency carries its member's session key (sessionRuleId), captured while its rule was in
+  // hand, so a write still addresses the member after the engine retags the reference
+  it("resolves the member named by rule id even when the reference identity differs", () => {
+    const state = stateWith([{ ruleId: "r1", status: "downloaded" }]);
+    expect(
+      sessionWriteForDependency(
+        state,
+        refForTag("retagged"),
+        { type: "installed", modId: "mod-1" },
+        "r1",
+      ),
+    ).toEqual({
+      sessionId: "col1_prof1",
+      ruleId: "r1",
+      write: { kind: "markInstalled", modId: "mod-1" },
+    });
+  });
+
+  it("falls back to reference matching when the rule id is not tracked", () => {
+    const state = stateWith([{ ruleId: "r1", status: "pending" }]);
+    expect(
+      sessionWriteForDependency(
+        state,
+        refForTag("r1"),
+        { type: "status", status: "installing" },
+        "stale-key",
+      ),
+    ).toEqual({
+      sessionId: "col1_prof1",
+      ruleId: "r1",
+      write: { kind: "updateStatus", status: "installing" },
+    });
+  });
+
   it("returns null when the write would override a user-ignored mod", () => {
     const state = stateWith([{ ruleId: "r1", status: "ignored" }]);
     expect(

--- a/src/renderer/src/util/collectionSessionWrite.test.ts
+++ b/src/renderer/src/util/collectionSessionWrite.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import type { IModReference } from "../extensions/mod_management/types/IMod";
 import {
   makeInstallState,
   makeModInstallInfo,
@@ -17,6 +18,7 @@ import type {
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
 import {
+  matchSessionRuleEntry,
   planDependencyErrorRecovery,
   planSessionWrite,
   sessionWriteForDependency,
@@ -166,6 +168,34 @@ describe("sessionWriteForDependency", () => {
     expect(
       sessionWriteForDependency(state, refForTag("r1"), { type: "installed", modId: "mod-1" }),
     ).toBeNull();
+  });
+});
+
+describe("matchSessionRuleEntry", () => {
+  const sessionWith = (refs: Record<string, IModReference>) =>
+    makeSession({
+      mods: Object.fromEntries(
+        Object.entries(refs).map(([ruleId, reference]) => [
+          ruleId,
+          makeModInstallInfo({ rule: makeRule({ reference }) }),
+        ]),
+      ),
+    });
+
+  it("names the member a reference identifies", () => {
+    const session = sessionWith({ r1: { tag: "r1" }, r2: { tag: "r2" } });
+    expect(matchSessionRuleEntry(session, makeReference({ tag: "r2" }))?.[0]).toBe("r2");
+  });
+
+  it("names no member for a reference no member carries", () => {
+    const session = sessionWith({ r1: { tag: "r1" } });
+    expect(matchSessionRuleEntry(session, makeReference({ tag: "other" }))).toBeUndefined();
+  });
+
+  // an id-less reference would otherwise alias onto any other id-less member
+  it("names no member for a reference with no identifying field", () => {
+    const session = sessionWith({ r1: {} });
+    expect(matchSessionRuleEntry(session, {})).toBeUndefined();
   });
 });
 

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -5,7 +5,11 @@
  * is deliberately NOT re-exported through the public api barrels.
  */
 import type { IModReference } from "../extensions/mod_management/types/IMod";
-import type { CollectionModStatus } from "../types/collections/ICollectionInstallSession";
+import type {
+  CollectionModStatus,
+  ICollectionInstallSession,
+  ICollectionModInstallInfo,
+} from "../types/collections/ICollectionInstallSession";
 import type { IState } from "../types/IState";
 import { referenceId } from "./collectionInstallSession";
 import { getCollectionActiveSession } from "./collectionInstallSessionSelectors";
@@ -109,42 +113,57 @@ export interface IResolvedSessionWrite {
 }
 
 /**
- * Resolve how an install lifecycle outcome should be written to the active session,
- * given the reference of the dependency the outcome is about. The orchestrator
- * (InstallManager) always has the dependency in hand, so the rule is matched by
- * reference identity (referenceId, the same identity the session-mods key uses) rather
- * than by lookup. Combines the active-session lookup, rule matching and planSessionWrite
- * into one step so a writer can record progress with a single call. The returned ruleId
- * is the session-mods key.
+ * The session member a reference identifies, as a [ruleId, info] pair, matched on referenceId -
+ * the same identity the session-mods key is built from. Undefined when the reference carries no
+ * identifying field (matching it would alias onto another id-less rule) or no member matches.
+ */
+export function matchSessionRuleEntry(
+  session: ICollectionInstallSession,
+  reference: IModReference,
+): readonly [string, ICollectionModInstallInfo] | undefined {
+  const target = referenceId(reference);
+  if (target === undefined) {
+    return undefined;
+  }
+  return Object.entries(session.mods).find(
+    ([, info]) => referenceId(info.rule.reference) === target,
+  );
+}
+
+/**
+ * Resolve how an install lifecycle outcome should be written to the active session. Combines the
+ * active-session lookup, member matching and planSessionWrite into one step so a writer can record
+ * progress with a single call. The returned ruleId is the session-mods key.
  *
- * Returns null when there is no active session, no rule matches the reference, or the
- * write would be a no-op (e.g. a downgrade from a protected state).
+ * `ruleId` is the member's session key, captured when its rule was in hand (IDependency's
+ * sessionRuleId). Given one, the member is addressed directly, which is what keeps a write landing
+ * when the dependency's reference identity no longer matches the key the member is tracked under.
+ * Without one the member is matched by reference identity.
+ *
+ * Returns null when there is no active session, no member matches, or the write would be a no-op
+ * (e.g. a downgrade from a protected state).
  */
 export function sessionWriteForDependency(
   state: IState,
   reference: IModReference,
   outcome: CollectionInstallOutcome,
+  ruleId?: string,
 ): IResolvedSessionWrite | null {
   const session = getCollectionActiveSession(state);
   if (session === undefined) {
     return null;
   }
-  const target = referenceId(reference);
-  if (target === undefined) {
-    // a reference with no identifying field can't be matched to a specific rule; bail
-    // rather than aliasing onto another id-less rule (undefined === undefined)
-    return null;
-  }
-  const entry = Object.entries(session.mods).find(
-    ([, info]) => referenceId(info.rule.reference) === target,
-  );
+  const entry =
+    ruleId !== undefined && session.mods[ruleId] !== undefined
+      ? ([ruleId, session.mods[ruleId]] as const)
+      : matchSessionRuleEntry(session, reference);
   if (entry === undefined) {
     return null;
   }
-  const [ruleId, info] = entry;
+  const [matchedRuleId, info] = entry;
   const write = planSessionWrite(info.status, outcome);
   if (write.kind === "none") {
     return null;
   }
-  return { sessionId: session.sessionId, ruleId, write };
+  return { sessionId: session.sessionId, ruleId: matchedRuleId, write };
 }

--- a/src/renderer/src/util/collectionSessionWrite.ts
+++ b/src/renderer/src/util/collectionSessionWrite.ts
@@ -131,14 +131,13 @@ export function matchSessionRuleEntry(
 }
 
 /**
- * Resolve how an install lifecycle outcome should be written to the active session. Combines the
- * active-session lookup, member matching and planSessionWrite into one step so a writer can record
- * progress with a single call. The returned ruleId is the session-mods key.
+ * Resolve how an install lifecycle outcome should be written to the active session. The returned
+ * ruleId is the session-mods key.
  *
  * `ruleId` is the member's session key, captured when its rule was in hand (IDependency's
- * sessionRuleId). Given one, the member is addressed directly, which is what keeps a write landing
- * when the dependency's reference identity no longer matches the key the member is tracked under.
- * Without one the member is matched by reference identity.
+ * sessionRuleId); given one the member is addressed directly, so the write lands even when the
+ * dependency's reference identity does not match that key. Without one the member is matched by
+ * reference identity.
  *
  * Returns null when there is no active session, no member matches, or the write would be a no-op
  * (e.g. a downgrade from a protected state).

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -102,6 +102,28 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(durableIgnored(h)).toBe(true);
   });
 
+  // a session can track a member the collection's current rules no longer carry (the rules were
+  // replaced mid-install); the skip settles the session entry without re-adding the old rule
+  test("settles a member whose rule left the collection without re-adding it", ({ makeApi }) => {
+    const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const unrelatedRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-other" }),
+    });
+    const h = makeApi(ruleOverrides(rule, unrelatedRule));
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "mod-a" }),
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+    // the collection's current rules are untouched
+    const rules = h.getState().persistent.mods[GAME_ID][COLLECTION_ID].rules;
+    expect(rules).toHaveLength(1);
+    expect(rules?.[0]?.reference.tag).toBe("mod-other");
+  });
+
   test("does nothing for a reference that is not a member", ({ makeApi }) => {
     const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
     const h = makeApi(ruleOverrides(rule));

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -102,6 +102,45 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(durableIgnored(h)).toBe(true);
   });
 
+  test("settles and durably flags the same member when two members share a file", ({ makeApi }) => {
+    const ruleX = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "tag-x", fileMD5: "shared-md5" }),
+    });
+    const ruleY = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "tag-y", fileMD5: "shared-md5" }),
+    });
+    const h = makeApi({
+      // the live scan meets Y first (md5 hit), the session scan meets X first (tag hit)
+      mods: {
+        [GAME_ID]: { [COLLECTION_ID]: makeMod({ id: COLLECTION_ID, rules: [ruleY, ruleX] }) },
+      },
+      session: makeInstallState({
+        activeSession: makeSession({
+          sessionId: SESSION_ID,
+          collectionId: COLLECTION_ID,
+          gameId: GAME_ID,
+          mods: {
+            [modRuleId(ruleX)]: makeModInstallInfo({ rule: ruleX, status: "pending" }),
+            [modRuleId(ruleY)]: makeModInstallInfo({ rule: ruleY, status: "pending" }),
+          },
+        }),
+      }),
+    });
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "tag-x", fileMD5: "shared-md5" }),
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, ruleX)).toBe("ignored");
+    expect(statusOf(h, ruleY)).toBe("pending");
+    const rules = h.getState().persistent.mods[GAME_ID][COLLECTION_ID].rules ?? [];
+    const flagged = rules.filter((rule) => rule.ignored === true).map((rule) => rule.reference.tag);
+    expect(flagged).toEqual(["tag-x"]);
+  });
+
   // a session can track a member the collection's current rules no longer carry (the rules were
   // replaced mid-install); the skip settles the session entry without re-adding the old rule
   test("settles a member whose rule left the collection without re-adding it", ({ makeApi }) => {

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -77,17 +77,20 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
   });
 
   // the session is keyed by the member's rule as it was when the install started, so a skip
-  // arriving with the retagged reference has to settle that same entry
+  // arriving with the retagged reference (same file, new tag) has to settle that same entry
   test("ignores the member whose live rule was retagged", ({ makeApi }) => {
-    const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const rule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-a", fileMD5: "abc123" }),
+    });
     const liveRule = makeRule({
       type: "requires",
-      reference: makeReference({ tag: "adopted-tag" }),
+      reference: makeReference({ tag: "adopted-tag", fileMD5: "abc123" }),
     });
     const h = makeApi(ruleOverrides(rule, liveRule));
 
     const matched = markCollectionMemberSkipped(h.api, {
-      reference: makeReference({ tag: "adopted-tag" }),
+      reference: makeReference({ tag: "adopted-tag", fileMD5: "abc123" }),
     });
 
     expect(matched).toBe(true);
@@ -95,6 +98,8 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(h.getState().session.collections.activeSession?.mods).not.toHaveProperty(
       modRuleId(liveRule),
     );
+    // the durable flag still lands on the collection's current rule
+    expect(durableIgnored(h)).toBe(true);
   });
 
   test("does nothing for a reference that is not a member", ({ makeApi }) => {

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -27,9 +27,11 @@ const GAME_ID = "skyrimse";
 const COLLECTION_ID = "col-1";
 const SESSION_ID = "sess-1";
 
-// the harness slices for an active session whose collection tracks the single given member rule
-function ruleOverrides(rule: IModRule): Partial<IDriverHarnessState> {
-  const collection = makeMod({ id: COLLECTION_ID, rules: [rule] });
+// the harness slices for an active session whose collection tracks the single given member rule.
+// `liveRule` models the collection carrying a different snapshot of that member than the session
+// was keyed with, which is what retagging a rule mid-install leaves behind.
+function ruleOverrides(rule: IModRule, liveRule: IModRule = rule): Partial<IDriverHarnessState> {
+  const collection = makeMod({ id: COLLECTION_ID, rules: [liveRule] });
   const session = makeSession({
     sessionId: SESSION_ID,
     collectionId: COLLECTION_ID,
@@ -72,6 +74,27 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(matched).toBe(true);
     expect(statusOf(h, rule)).toBe("ignored");
     expect(durableIgnored(h)).toBe(true);
+  });
+
+  // the session is keyed by the member's rule as it was when the install started, so a skip
+  // arriving with the retagged reference has to settle that same entry
+  test("ignores the member whose live rule was retagged", ({ makeApi }) => {
+    const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const liveRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "adopted-tag" }),
+    });
+    const h = makeApi(ruleOverrides(rule, liveRule));
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "adopted-tag" }),
+    });
+
+    expect(matched).toBe(true);
+    expect(statusOf(h, rule)).toBe("ignored");
+    expect(h.getState().session.collections.activeSession?.mods).not.toHaveProperty(
+      modRuleId(liveRule),
+    );
   });
 
   test("does nothing for a reference that is not a member", ({ makeApi }) => {

--- a/src/renderer/src/util/collectionSkip.test.ts
+++ b/src/renderer/src/util/collectionSkip.test.ts
@@ -124,6 +124,29 @@ describe("markCollectionMemberSkipped - automatic skip (mod reference)", () => {
     expect(rules?.[0]?.reference.tag).toBe("mod-other");
   });
 
+  // A rule the collection gained after the install started has no session entry to settle, so
+  // only the durable flag can carry the decision - and the caller is told nothing was settled.
+  test("records the skip durably for a member the session does not track", ({ makeApi }) => {
+    const trackedRule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
+    const addedRule = makeRule({
+      type: "requires",
+      reference: makeReference({ tag: "mod-added" }),
+    });
+    const h = makeApi(ruleOverrides(trackedRule, addedRule));
+
+    const matched = markCollectionMemberSkipped(h.api, {
+      reference: makeReference({ tag: "mod-added" }),
+    });
+
+    expect(matched).toBe(false);
+    expect(durableIgnored(h)).toBe(true);
+    // the member the session does track is left alone, and the untracked rule gains no entry
+    expect(statusOf(h, trackedRule)).toBe("pending");
+    expect(h.getState().session.collections.activeSession?.mods).not.toHaveProperty(
+      modRuleId(addedRule),
+    );
+  });
+
   test("does nothing for a reference that is not a member", ({ makeApi }) => {
     const rule = makeRule({ type: "requires", reference: makeReference({ tag: "mod-a" }) });
     const h = makeApi(ruleOverrides(rule));

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -125,15 +125,17 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   const sessionEntry = Object.entries(session.mods).find(([, info]) =>
     info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
   );
-  const durableRule = rule ?? sessionEntry?.[1].rule;
-  if (durableRule === undefined) {
+  const memberRuleId = sessionEntry?.[0] ?? (rule !== undefined ? modRuleId(rule) : undefined);
+  if (memberRuleId === undefined) {
     log("error", "could not find collection rule for skipped download", { skip });
     return false;
   }
 
   batchDispatch(api.store, [
-    updateModStatus(sessionId, sessionEntry?.[0] ?? modRuleId(durableRule), "ignored"),
-    addModRule(gameId, collectionId, { ...durableRule, ignored: true }),
+    updateModStatus(sessionId, memberRuleId, "ignored"),
+    // the durable flag goes on the collection's CURRENT rule only - re-adding a session
+    // snapshot would resurrect a rule the collection no longer carries
+    ...(rule !== undefined ? [addModRule(gameId, collectionId, { ...rule, ignored: true })] : []),
   ]);
   return true;
 }

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -98,7 +98,7 @@ function matchesSkip(skip: ICollectionSkip, ref: IModReference): boolean {
  * skipped (required) member as "pending" and the collection could never complete. This is an
  * explicit decision to skip, so it intentionally overrides any terminal protection.
  *
- * Returns true if a member was matched and ignored.
+ * Returns true when a session member was settled.
  */
 export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectionSkip): boolean {
   const state = api.getState();
@@ -125,17 +125,25 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   const sessionEntry = Object.entries(session.mods).find(([, info]) =>
     info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
   );
-  const memberRuleId = sessionEntry?.[0] ?? (rule !== undefined ? modRuleId(rule) : undefined);
-  if (memberRuleId === undefined) {
+  // Only a rule the session tracks can be settled. A live rule it never saw (the collection
+  // gained it after the install started) still carries the decision durably.
+  const liveRuleId = rule !== undefined ? modRuleId(rule) : undefined;
+  const memberRuleId =
+    sessionEntry?.[0] ??
+    (liveRuleId !== undefined && session.mods[liveRuleId] !== undefined ? liveRuleId : undefined);
+  if (memberRuleId === undefined && rule === undefined) {
     log("error", "could not find collection rule for skipped download", { skip });
     return false;
   }
+  if (memberRuleId === undefined) {
+    log("warn", "skipped member is not tracked by the install session", { sessionId, skip });
+  }
 
   batchDispatch(api.store, [
-    updateModStatus(sessionId, memberRuleId, "ignored"),
+    ...(memberRuleId !== undefined ? [updateModStatus(sessionId, memberRuleId, "ignored")] : []),
     // the durable flag goes on the collection's CURRENT rule only - re-adding a session
     // snapshot would resurrect a rule the collection no longer carries
     ...(rule !== undefined ? [addModRule(gameId, collectionId, { ...rule, ignored: true })] : []),
   ]);
-  return true;
+  return memberRuleId !== undefined;
 }

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -114,17 +114,19 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   const rules = (state.persistent.mods[gameId]?.[collectionId]?.rules ?? []).filter((rule) =>
     isDependencyRule(rule),
   );
-  // NOTE (LAZ-483 follow-up): find() returns the FIRST matching rule. This relies on collection
-  // members having distinct identities; if two members share the matched identifier (e.g. the
-  // same logicalFileName, or two fuzzy rules on one modId), the wrong member could be ignored.
-  // The previous mDependentMods.find had the same ambiguity, so this is not a new regression -
-  // but disambiguation (which member did the user actually skip?) needs investigation.
-  const rule = rules.find((iter) => matchesSkip(skip, iter.reference));
   // The session is keyed by each member's rule as it was when the install started, so the entry
   // is matched on its own snapshot rather than on the live rule.
   const sessionEntry = Object.entries(session.mods).find(([, info]) =>
     info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
   );
+
+  // This relies on members having distinct identities; if two members share the matched
+  // identifier (e.g. the same logicalFileName, or two fuzzy rules on one modId), the wrong member
+  // could be ignored. Not a regression - this falls back to inability to identify a mod
+  // uniquely due to available data.
+  const rule =
+    rules.find((iter) => modRuleId(iter) === sessionEntry?.[0]) ??
+    rules.find((iter) => matchesSkip(skip, iter.reference));
   // Only a rule the session tracks can be settled. A live rule it never saw (the collection
   // gained it after the install started) still carries the decision durably.
   const liveRuleId = rule !== undefined ? modRuleId(rule) : undefined;

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -116,22 +116,23 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   );
   // The session is keyed by each member's rule as it was when the install started, so the entry
   // is matched on its own snapshot rather than on the live rule.
-  const sessionEntry = Object.entries(session.mods).find(([, info]) =>
-    info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
-  );
+  const [sessionRuleId] =
+    Object.entries(session.mods).find(([, info]) =>
+      info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
+    ) ?? [];
 
-  // This relies on members having distinct identities; if two members share the matched
+  // The fallback scan relies on members having distinct identities; if two share the matched
   // identifier (e.g. the same logicalFileName, or two fuzzy rules on one modId), the wrong member
-  // could be ignored. Not a regression - this falls back to inability to identify a mod
-  // uniquely due to available data.
+  // could be ignored.
   const rule =
-    rules.find((iter) => modRuleId(iter) === sessionEntry?.[0]) ??
-    rules.find((iter) => matchesSkip(skip, iter.reference));
+    (sessionRuleId !== undefined
+      ? rules.find((iter) => modRuleId(iter) === sessionRuleId)
+      : undefined) ?? rules.find((iter) => matchesSkip(skip, iter.reference));
   // Only a rule the session tracks can be settled. A live rule it never saw (the collection
   // gained it after the install started) still carries the decision durably.
   const liveRuleId = rule !== undefined ? modRuleId(rule) : undefined;
   const memberRuleId =
-    sessionEntry?.[0] ??
+    sessionRuleId ??
     (liveRuleId !== undefined && session.mods[liveRuleId] !== undefined ? liveRuleId : undefined);
   if (memberRuleId === undefined && rule === undefined) {
     log("error", "could not find collection rule for skipped download", { skip });

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -120,8 +120,8 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   // The previous mDependentMods.find had the same ambiguity, so this is not a new regression -
   // but disambiguation (which member did the user actually skip?) needs investigation.
   const rule = rules.find((iter) => matchesSkip(skip, iter.reference));
-  // The session is keyed by each member's rule as it was when the install started, so the entry is
-  // matched on its own snapshot rather than derived from the (possibly retagged) live rule.
+  // The session is keyed by each member's rule as it was when the install started, so the entry
+  // is matched on its own snapshot rather than on the live rule.
   const sessionEntry = Object.entries(session.mods).find(([, info]) =>
     info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
   );

--- a/src/renderer/src/util/collectionSkip.ts
+++ b/src/renderer/src/util/collectionSkip.ts
@@ -120,14 +120,20 @@ export function markCollectionMemberSkipped(api: IExtensionApi, skip: ICollectio
   // The previous mDependentMods.find had the same ambiguity, so this is not a new regression -
   // but disambiguation (which member did the user actually skip?) needs investigation.
   const rule = rules.find((iter) => matchesSkip(skip, iter.reference));
-  if (rule === undefined) {
+  // The session is keyed by each member's rule as it was when the install started, so the entry is
+  // matched on its own snapshot rather than derived from the (possibly retagged) live rule.
+  const sessionEntry = Object.entries(session.mods).find(([, info]) =>
+    info.rule?.reference != null ? matchesSkip(skip, info.rule.reference) : false,
+  );
+  const durableRule = rule ?? sessionEntry?.[1].rule;
+  if (durableRule === undefined) {
     log("error", "could not find collection rule for skipped download", { skip });
     return false;
   }
 
   batchDispatch(api.store, [
-    updateModStatus(sessionId, modRuleId(rule), "ignored"),
-    addModRule(gameId, collectionId, { ...rule, ignored: true }),
+    updateModStatus(sessionId, sessionEntry?.[0] ?? modRuleId(durableRule), "ignored"),
+    addModRule(gameId, collectionId, { ...durableRule, ignored: true }),
   ]);
   return true;
 }


### PR DESCRIPTION
Installing a collection whose member archives are already on disk from a *different* collection never completed: every member installed fine, but the session polled forever and after 5 minutes the stall watchdog reported successfully installed mods as failed.

Recommend reading commit by commit.

One archive can satisfy rules in several collections, but `modInfo.referenceTag` is a single slot. When a member's existing download carried another collection's tag, the engine adopted that tag onto the dependency and rewrote the persisted rule. The session is keyed by each member's rule identity, so afterwards no session write could find the member: the installing/installed/failed writes all silently no-opped and the completion poll requeued it every 500ms.

- Downloads and mods carry append-only `referenceTags: string[]`. The legacy `referenceTag` keeps the first tag, so older Vortex versions read these archives unchanged and no migration is needed.
- The adoption path stops mutating the dependency and the rule; it records this rule's tag alongside the tags already on the archive, so both collections resolve it.
- Installed mods take their tag from the installing rule, and a mod reused by a second collection gains that collection's tag too.
- `IDependency` carries its session key, so a lifecycle write lands even if the reference identity drifts.
- A pre-existing counter bug: `startInstallSession` hard-coded `failedCount`/`ignoredCount` to 0 while a session can be seeded with terminal members, so selecting a previously skipped optional drove `ignoredCount` negative and leaked into analytics.
- Phase state initialises from the ACTIVE session only. Ids are `collectionId_profileId`, so a finished install of the same collection matched in history while phase completion read the empty active session and reported every phase complete.
- `isCollectionManaged` reads the whole tag set. This touches cd4aaeedc: it read only the first-stamped `referenceTag`, so a mod shared by two collections stopped being collection-managed once the first was removed and started emitting requirements the collection already vets. Both consumers are fixed by the one change, and the module now has unit tests.

Fixes LAZ-972