### PR TITLE
Correct behaviour of some buttons in Health Check

### DIFF
--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -78,6 +78,7 @@
       "missing_for": "Missing required mod for: <modLink>{{modName}}</modLink>",
       "missing_for_plural": "Missing required mods for: <modLink>{{modName}}</modLink>",
       "install_via_mod_page": "Install via mod page",
+      "view_mod_page": "View mod page",
       "install_one_click": "1-click install",
       "downloading": "Downloading...",
       "installing": "Installing...",

--- a/locales/en/health_check.json
+++ b/locales/en/health_check.json
@@ -136,7 +136,7 @@
       "buttons": {
         "primary": "Unlock 1-click installs",
         "secondary": {
-          "single": "Go to mod page (free)",
+          "single": "Install via mod page (free)",
           "all": "Return and open mod pages"
         }
       }

--- a/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/ListingRow.tsx
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 import {
   downloadFileRequirement,
   installDownloadedFile,
-  openModPage,
+  openFilePage,
   switchActiveVersions,
 } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import {
@@ -219,10 +219,10 @@ export const ListingRow = ({ api, entry, isHidden, onOpen, onToggleHide }: IList
         onDownload={() => {
           setShowPremium(false);
 
-          // Free-user fallback: a single candidate opens its mod page; otherwise
-          // open the detail so each requirement's mod page is reachable.
+          // Free-user fallback: a single candidate opens its file page directly;
+          // otherwise open the detail so each requirement's mod page is reachable.
           if (candidates.length === 1) {
-            openModPage(api, candidates[0]);
+            openFilePage(api, candidates[0]);
           } else {
             onOpen();
           }

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -59,7 +59,14 @@ export const CandidateCard = ({
 
   const handleModPage = () => {
     ctx.onOpenModPage(candidate, resolution);
-    openModPage(ctx.api, candidate);
+
+    // Free users would still need to find and download the file themselves from the mod
+    // page, so send them straight to it; premium users are just browsing.
+    if (ctx.showPremiumAd) {
+      openFilePage(ctx.api, candidate);
+    } else {
+      openModPage(ctx.api, candidate);
+    }
   };
 
   return (
@@ -73,7 +80,9 @@ export const CandidateCard = ({
               leftIconPath={mdiOpenInNew}
               onClick={handleModPage}
             >
-              {t("detail::item::install_via_mod_page")}
+              {ctx.showPremiumAd
+                ? t("detail::item::install_via_mod_page")
+                : t("detail::item::view_mod_page")}
             </Button>
 
             <Button

--- a/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
+++ b/src/renderer/src/extensions/health_check/components/file_requirement/cards/CandidateCard.tsx
@@ -1,5 +1,5 @@
 import { mdiMonitorArrowDownVariant, mdiOpenInNew } from "@mdi/js";
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -8,13 +8,18 @@ import {
   type IFileActionContext,
   type IResolutionContext,
 } from "@/extensions/health_check/utils/fileRequirements/cardHelpers";
-import { openModPage } from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
+import {
+  openFilePage,
+  openModPage,
+} from "@/extensions/health_check/utils/fileRequirements/fileRequirementActions";
 import type { IInstalledFile } from "@/extensions/health_check/utils/fileRequirements/installedFiles";
 import type { IFileRequirementCandidate } from "@/extensions/health_check/utils/fileRequirements/mapRequirementsReport";
+import { decodeUID } from "@/extensions/nexus_integration/util/UIDs";
 import { Button } from "@/ui/components/button/Button";
 import { PremiumBadge } from "@/ui/components/premium_badge/PremiumBadge";
 
 import { useInstallButton } from "../../../hooks/useInstallButton";
+import { PremiumModal } from "../../premium_modal/PremiumModal";
 import { FileRequirement } from "../FileRequirement";
 
 /** A download/enable card for one candidate (used by download + OR cards). */
@@ -33,16 +38,22 @@ export const CandidateCard = ({
   isOr?: boolean;
 }) => {
   const { t } = useTranslation(["health_check", "common"]);
+  const [showPremium, setShowPremium] = useState(false);
 
-  const { isLoading, onClick } = useInstallButton(
-    () => ctx.requestDownload(candidate, enabledFile),
-    ctx.showPremiumAd,
+  const { isLoading, onClick } = useInstallButton(() =>
+    ctx.requestDownload(candidate, enabledFile),
   );
 
   const loading = isLoading || !!ctx.isDownloadingAll;
 
   const handleInstall = () => {
     ctx.onInstall(candidate, resolution);
+
+    if (ctx.showPremiumAd) {
+      setShowPremium(true);
+      return;
+    }
+
     onClick();
   };
 
@@ -52,34 +63,50 @@ export const CandidateCard = ({
   };
 
   return (
-    <FileRequirement
-      actions={
-        <>
-          <Button
-            appearance="subdued"
-            brand="neutral"
-            leftIconPath={mdiOpenInNew}
-            onClick={handleModPage}
-          >
-            {t("detail::item::install_via_mod_page")}
-          </Button>
+    <>
+      <FileRequirement
+        actions={
+          <>
+            <Button
+              appearance="subdued"
+              brand="neutral"
+              leftIconPath={mdiOpenInNew}
+              onClick={handleModPage}
+            >
+              {t("detail::item::install_via_mod_page")}
+            </Button>
 
-          <Button
-            appearance={ctx.installButtonAppearance ?? "strong"}
-            brand="neutral"
-            isLoading={loading}
-            leftIconPath={mdiMonitorArrowDownVariant}
-            rightIcon={ctx.showPremiumAd ? <PremiumBadge /> : undefined}
-            size="sm"
-            onClick={handleInstall}
-          >
-            {loading ? t("detail::item::downloading") : t("detail::item::install_one_click")}
-          </Button>
-        </>
-      }
-      file={candidateToFileData(candidate)}
-      isOr={isOr}
-      {...fileWebLinks(ctx.api, candidate)}
-    />
+            <Button
+              appearance={ctx.installButtonAppearance ?? "strong"}
+              brand="neutral"
+              isLoading={loading}
+              leftIconPath={mdiMonitorArrowDownVariant}
+              rightIcon={ctx.showPremiumAd ? <PremiumBadge /> : undefined}
+              size="sm"
+              onClick={handleInstall}
+            >
+              {loading ? t("detail::item::downloading") : t("detail::item::install_one_click")}
+            </Button>
+          </>
+        }
+        file={candidateToFileData(candidate)}
+        isOr={isOr}
+        {...fileWebLinks(ctx.api, candidate)}
+      />
+
+      <PremiumModal
+        api={ctx.api}
+        isOpen={showPremium}
+        modCount={1}
+        modId={decodeUID(candidate.modUID)?.id ?? 0}
+        trigger="single_install"
+        onClose={() => setShowPremium(false)}
+        onDownload={() => {
+          setShowPremium(false);
+          openFilePage(ctx.api, candidate);
+        }}
+        onPremiumUnlocked={onClick}
+      />
+    </>
   );
 };


### PR DESCRIPTION
Closes LAZ-975
- Show premium upsell on `1-click-install` button for free users
- Link to specific file from inside modal
- Link to specific file for free users using the `Install via mod page` button on the health check card. 

We would like this to be part of 2.7 beta