### PR TITLE
feat: add profile-managed Bethesda game versions

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -441,6 +441,9 @@ type GameInfoQuery = (game: any) => PromiseLike<{
     [key: string]: IGameDetail;
 }>;
 
+// @public (undocumented)
+type GameVersionJobPhase = "planning" | "patching" | "committing";
+
 // Warning: (ae-forgotten-export) The symbol "IGame" needs to be exported by the entry point api.d.ts
 // Warning: (ae-forgotten-export) The symbol "IDiscoveryResult" needs to be exported by the entry point api.d.ts
 //
@@ -666,20 +669,47 @@ interface IAttributeState {
 
 // @public
 interface IAvailableExtension {
+    // (undocumented)
     author: string;
     // (undocumented)
+    dependencies?: {
+        [key: string]: any;
+    };
+    // (undocumented)
+    description: {
+        short: string;
+        long: string;
+    };
+    // (undocumented)
+    downloads: number;
+    // (undocumented)
+    endorsements: number;
+    // (undocumented)
     fileId: number;
-    gameDomain?: string;
-    gameId?: number;
+    // (undocumented)
+    gameId?: string;
+    // (undocumented)
     gameName?: string;
-    image?: string;
+    // (undocumented)
+    hide?: boolean;
+    // (undocumented)
+    id?: string;
+    // (undocumented)
+    image: string;
+    // (undocumented)
     language?: string;
     // (undocumented)
     modId: number;
     // (undocumented)
     name: string;
+    // (undocumented)
+    tags: string[];
+    // (undocumented)
     timestamp: number;
+    // (undocumented)
     type?: ExtensionType;
+    // (undocumented)
+    uploader: string;
     // (undocumented)
     version: string;
 }
@@ -1905,6 +1935,8 @@ interface IExtensionContext {
     // Warning: (ae-forgotten-export) The symbol "GameVersionProviderFunc" needs to be exported by the entry point api.d.ts
     // Warning: (ae-forgotten-export) The symbol "IGameVersionProviderOptions" needs to be exported by the entry point api.d.ts
     registerGameVersionProvider?: (id: string, priority: number, supported: GameVersionProviderTest, getVersion: GameVersionProviderFunc, options?: IGameVersionProviderOptions) => void;
+    // Warning: (ae-forgotten-export) The symbol "IGameVersionTransitionProvider" needs to be exported by the entry point api.d.ts
+    registerGameVersionTransitionProvider?: (provider: IGameVersionTransitionProvider) => void;
     // Warning: (ae-forgotten-export) The symbol "IHealthCheck" needs to be exported by the entry point api.d.ts
     // Warning: (ae-forgotten-export) The symbol "IModHealthCheck" needs to be exported by the entry point api.d.ts
     registerHealthCheck: (healthCheck: IHealthCheck | IModHealthCheck) => void;
@@ -1940,6 +1972,9 @@ interface IExtensionContext {
     registerPreview?: (priority: number, handler: (files: IPreviewFile[], allowPick: boolean) => default_2<IPreviewFile>) => void;
     registerProfileFeature?: (featureId: string, type: string, icon: string, label: string, description: string, supported: () => boolean) => void;
     registerProfileFile?: (gameId: string, filePath: string | (() => PromiseLike<string[]>)) => void;
+    // Warning: (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
+    // Warning: (ae-forgotten-export) The symbol "IProfileFeatureChoice" needs to be exported by the entry point api.d.ts
+    registerProfileSelectFeature?: (featureId: string, icon: string, label: string, description: string, supported: () => boolean, choices: (profile: IProfile) => IProfileFeatureChoice[] | PromiseLike<IProfileFeatureChoice[]>, formatValue?: (value: unknown) => string) => void;
     // Warning: (ae-forgotten-export) The symbol "IReducerSpec" needs to be exported by the entry point api.d.ts
     registerReducer: (path: string[], spec: IReducerSpec) => void;
     // Warning: (ae-forgotten-export) The symbol "RegisterSettings" needs to be exported by the entry point api.d.ts
@@ -2292,7 +2327,57 @@ interface IGameStoreEntry {
 }
 
 // @public (undocumented)
+interface IGameVersionJob {
+    // (undocumented)
+    gameId: string;
+    // Warning: (ae-forgotten-export) The symbol "GameVersionJobPhase" needs to be exported by the entry point api.d.ts
+    //
+    // (undocumented)
+    phase: GameVersionJobPhase;
+    // (undocumented)
+    progress: number;
+    // (undocumented)
+    targetVersion: string;
+}
+
+// @public (undocumented)
 interface IGameVersionProviderOptions {}
+
+// @public (undocumented)
+interface IGameVersionSessionState {
+    // Warning: (ae-forgotten-export) The symbol "IGameVersionJob" needs to be exported by the entry point api.d.ts
+    //
+    // (undocumented)
+    jobs: Record<string, IGameVersionJob>;
+}
+
+// @public (undocumented)
+interface IGameVersionTransitionCatalogSource {
+    // (undocumented)
+    trustedKeys: Record<string, string>;
+    // (undocumented)
+    url: string;
+}
+
+// @public (undocumented)
+interface IGameVersionTransitionProvider {
+    // Warning: (ae-forgotten-export) The symbol "IGameVersionTransitionCatalogSource" needs to be exported by the entry point api.d.ts
+    //
+    // (undocumented)
+    catalog: IGameVersionTransitionCatalogSource;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    launchMode: "direct";
+    // (undocumented)
+    priority: number;
+    // (undocumented)
+    supportedGames: string[];
+    // (undocumented)
+    supportedPlatforms: NodeJS.Platform[];
+    // (undocumented)
+    supportedStores: string[];
+}
 
 // @public (undocumented)
 interface IHealthCheck {
@@ -3073,7 +3158,6 @@ interface INexusAPIExtension {
     nexusGetCollections?: (gameId: string) => PromiseLike<Partial<ICollection>[] | undefined>;
     // (undocumented)
     nexusGetLatestMods?: (gameId: string) => PromiseLike<any>;
-    nexusGetModEndorsementCounts?: (uids: string[]) => PromiseLike<Record<string, number>>;
     // (undocumented)
     nexusGetModFiles?: (gameId: string, modId: number) => PromiseLike<IFileInfo[]>;
     // (undocumented)
@@ -3403,6 +3487,14 @@ interface IProfile {
     name: string;
     // (undocumented)
     pendingRemove?: boolean;
+}
+
+// @public (undocumented)
+interface IProfileFeatureChoice {
+    // (undocumented)
+    label: string;
+    // (undocumented)
+    value: string;
 }
 
 // @public (undocumented)
@@ -3786,6 +3878,10 @@ interface ISessionState {
     //
     // (undocumented)
     gameMode: ISessionGameMode;
+    // Warning: (ae-forgotten-export) The symbol "IGameVersionSessionState" needs to be exported by the entry point api.d.ts
+    //
+    // (undocumented)
+    gameVersioning: IGameVersionSessionState;
     // Warning: (ae-forgotten-export) The symbol "IHealthCheckSessionState" needs to be exported by the entry point api.d.ts
     //
     // (undocumented)
@@ -5061,7 +5157,7 @@ export const TriStateCheckbox: any;
 
 // @public (undocumented)
 export namespace types {
-    export { ActionFunc, ApiEventArgs, ApiEventMap, ApiEventName, ApiEventResult, ApiEvents, ArchiveHandlerCreator, AttributeExtractor, AttributeRenderer, CheckFunction, CollectionModStatus, Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, DirectoryCleaningMode, ExtensionInfo, ExtensionLoadFailureDependency, ExtensionLoadFailureException, LoadOrder as FBLOLoadOrder, LockedState as FBLOLockState, GameEntryNotFound, GameInfoQuery, GameLaunchType, GameStoreNotFound, HealthCheckCategory, HealthCheckFixFunction, HealthCheckFunction, HealthCheckSeverity, HealthCheckTrigger, IActionDefinition, IActionOptions, IApiFuncOptions, IApp, IArchiveHandler, IArchiveOptions, IAttachment, IAttributeState, IAvailableExtension, IBrowserState, ICheckbox, IChoiceType, ICollectionInstallSession, ICollectionInstallState, ICollectionModInstallInfo, ICollectionsPersistentState, IComponentContext, IConditionResult, IControlBase, ICustomExecutionInfo, ICustomProps, IDashletOptions, IDashletSettings, IDeployOptions, IDeployedFile, IDeploymentManifest, IDeploymentMethod, IDialog, IDialogAction, IDialogContent, IDialogResult, IDimensions, IDiscoveredTool, IDiscoveryPhase, IDiscoveryResult, IDiscoveryState, IDownload, IEditChoice, IEnableOptions, IErrorOptions, IExecInfo, IExtension, IExtensionApi, IExtensionApiExtension, IExtensionContext, IExtensionLoadFailure, IExtensionOptional, IExtensionState$1 as IExtensionState, ILoadOrderGameInfo as IFBLOGameInfo, IInvalidResult as IFBLOInvalidResult, IItemRendererProps as IFBLOItemRendererProps, ILoadOrderEntry$1 as IFBLOLoadOrderEntry, IValidationResult as IFBLOValidationResult, IFileChange, IFileFilter, IFileListItem, IFilterProps, IGame, IGameDetail, IGameInfoEntry, IGameModeSettings, IGameStore, IGameStoreEntry, IGameStored, IHealthCheck, IHealthCheckEntry, IHealthCheckResult, IHistoryEvent, IHistoryStack, IInput, IInstallResult, IInstallationDetails, IInstallerInstall, IInstallerMatch, IInstallerSpec, IInstruction, ILegacyTestAdapter, ILink, ILoadOrderDisplayItem, ILoadOrderEntry$1 as ILoadOrderEntry, ILoadOrderGameInfo, ILookupDetails, ILookupResult, IMainPageOptions, IMembership, IMergeFilter, IMod, IModCheckContext, IModHealthCheck, IModInfo$1 as IModInfo, IModInstallSpec, IModLookupInfo, IModPatches, IModReference, IModRepoId, IModRule, IModRuleExtra, IModSourceOptions, IModTable, IModType, IModTypeOptions, IModifiers, INotification, INotificationAction, INotificationState, IOpenOptions, IOverlay, IOverlayOptions, IOverlaysState, IPersistor, IPosition, IPreviewFile, IProfile, IProfileMod, IProgress, IProgressProfile, IProgressProfileDeploying, IProgressWithProfile, IQuery, IQueryArgEntry, IReducerSpec, IReference$1 as IReference, IReferenceIdentifiers, IRegisterProtocol, IRegisterRepositoryLookup, IRegisteredExtension, IRemoveModOptions, IRowState, IRunOptions, IRunParameters, IRunningTool, ISaveOptions, ISession, ISessionGameMode, ISessionState, ISettings, ISettingsAutomation, ISettingsDownloads, ISettingsGameMode, ISettingsInterface, ISettingsMods, ISettingsNotification, ISettingsProfiles, ISettingsUpdate, ISettingsWorkarounds, IStarterInfo, IState, IStateDownloads, IStateGameMode, IStatePaths, IStateTransactions, IStateVerifier, IStoreQuery, ISupportedResult, ITableAttribute, ITableFilter, ITableState, ITableStates, ITestResult, ITestSupportedDetails, IToDoButton, ITool, IToolStored, IUIBlocker, IUnavailableReason, IUser, IValidateKeyData, IValidationResult, IVerifierRepairContext, IWindow, InstallFunc, InstallPathMode, InstallerMatchMode, InstallerSpecInstallFunc, InstructionType, LoadOrder, MergeFunc, MergeTest, NotificationDismiss, NotificationType, PayloadT, PerModCheckFunction, PersistingType, PersistorKey, Placement, ProblemSeverity, ProgressDelegate, PropsCallback, PropsCallbackTyped, RegisterAction, RegisterBanner, RegisterControlWrapper, RegisterDashlet, RegisterDialog, RegisterFooter, RegisterMainPage, RegisterOverlay, RegisterSettings, RegisterToDo, Revertability, SortDirection, SortType, StateChangeCallback, TFunction$1 as TFunction, TestSupported, ThunkStore, ToDoType, ToolParameterCB, UPDATE_CHANNELS, UpdateChannel, UpdateType, ValidationState, VerifierDrop, VerifierDropParent, addReducer, isModHealthCheck };
+    export { ActionFunc, ApiEventArgs, ApiEventMap, ApiEventName, ApiEventResult, ApiEvents, ArchiveHandlerCreator, AttributeExtractor, AttributeRenderer, CheckFunction, CollectionModStatus, Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, DirectoryCleaningMode, ExtensionInfo, ExtensionLoadFailureDependency, ExtensionLoadFailureException, LoadOrder as FBLOLoadOrder, LockedState as FBLOLockState, GameEntryNotFound, GameInfoQuery, GameLaunchType, GameStoreNotFound, HealthCheckCategory, HealthCheckFixFunction, HealthCheckFunction, HealthCheckSeverity, HealthCheckTrigger, IActionDefinition, IActionOptions, IApiFuncOptions, IApp, IArchiveHandler, IArchiveOptions, IAttachment, IAttributeState, IAvailableExtension, IBrowserState, ICheckbox, IChoiceType, ICollectionInstallSession, ICollectionInstallState, ICollectionModInstallInfo, ICollectionsPersistentState, IComponentContext, IConditionResult, IControlBase, ICustomExecutionInfo, ICustomProps, IDashletOptions, IDashletSettings, IDeployOptions, IDeployedFile, IDeploymentManifest, IDeploymentMethod, IDialog, IDialogAction, IDialogContent, IDialogResult, IDimensions, IDiscoveredTool, IDiscoveryPhase, IDiscoveryResult, IDiscoveryState, IDownload, IEditChoice, IEnableOptions, IErrorOptions, IExecInfo, IExtension, IExtensionApi, IExtensionApiExtension, IExtensionContext, IExtensionLoadFailure, IExtensionOptional, IExtensionState$1 as IExtensionState, ILoadOrderGameInfo as IFBLOGameInfo, IInvalidResult as IFBLOInvalidResult, IItemRendererProps as IFBLOItemRendererProps, ILoadOrderEntry$1 as IFBLOLoadOrderEntry, IValidationResult as IFBLOValidationResult, IFileChange, IFileFilter, IFileListItem, IFilterProps, IGame, IGameDetail, IGameInfoEntry, IGameModeSettings, IGameStore, IGameStoreEntry, IGameStored, IGameVersionCatalog, IGameVersionTransitionProvider, IHealthCheck, IHealthCheckEntry, IHealthCheckResult, IHistoryEvent, IHistoryStack, IInput, IInstallResult, IInstallationDetails, IInstallerInstall, IInstallerMatch, IInstallerSpec, IInstruction, ILegacyTestAdapter, ILink, ILoadOrderDisplayItem, ILoadOrderEntry$1 as ILoadOrderEntry, ILoadOrderGameInfo, ILookupDetails, ILookupResult, IMainPageOptions, IMembership, IMergeFilter, IMod, IModCheckContext, IModHealthCheck, IModInfo$1 as IModInfo, IModInstallSpec, IModLookupInfo, IModPatches, IModReference, IModRepoId, IModRule, IModRuleExtra, IModSourceOptions, IModTable, IModType, IModTypeOptions, IModifiers, INotification, INotificationAction, INotificationState, IOpenOptions, IOverlay, IOverlayOptions, IOverlaysState, IPersistor, IPosition, IPreviewFile, IProfile, IProfileMod, IProgress, IProgressProfile, IProgressProfileDeploying, IProgressWithProfile, IQuery, IQueryArgEntry, IReducerSpec, IReference$1 as IReference, IReferenceIdentifiers, IRegisterProtocol, IRegisterRepositoryLookup, IRegisteredExtension, IRemoveModOptions, IRowState, IRunOptions, IRunParameters, IRunningTool, ISaveOptions, ISession, ISessionGameMode, ISessionState, ISettings, ISettingsAutomation, ISettingsDownloads, ISettingsGameMode, ISettingsInterface, ISettingsMods, ISettingsNotification, ISettingsProfiles, ISettingsUpdate, ISettingsWorkarounds, IStarterInfo, IState, IStateDownloads, IStateGameMode, IStatePaths, IStateTransactions, IStateVerifier, IStoreQuery, ISupportedResult, ITableAttribute, ITableFilter, ITableState, ITableStates, ITestResult, ITestSupportedDetails, IToDoButton, ITool, IToolStored, IUIBlocker, IUnavailableReason, IUser, IValidateKeyData, IValidationResult, IVerifierRepairContext, IWindow, InstallFunc, InstallPathMode, InstallerMatchMode, InstallerSpecInstallFunc, InstructionType, LoadOrder, MergeFunc, MergeTest, NotificationDismiss, NotificationType, PayloadT, PerModCheckFunction, PersistingType, PersistorKey, Placement, ProblemSeverity, ProgressDelegate, PropsCallback, PropsCallbackTyped, RegisterAction, RegisterBanner, RegisterControlWrapper, RegisterDashlet, RegisterDialog, RegisterFooter, RegisterMainPage, RegisterOverlay, RegisterSettings, RegisterToDo, Revertability, SortDirection, SortType, StateChangeCallback, TFunction$1 as TFunction, TestSupported, ThunkStore, ToDoType, ToolParameterCB, UPDATE_CHANNELS, UpdateChannel, UpdateType, ValidationState, VerifierDrop, VerifierDropParent, addReducer, isModHealthCheck };
 }
 
 // @public (undocumented)
@@ -5083,7 +5179,7 @@ export const Usage: React$2.ComponentClass<IUsageProps>;
 
 // @public (undocumented)
 export namespace util {
-    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
+    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, readExtensibleDir, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
 }
 
 // @public (undocumented)
@@ -5240,39 +5336,38 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 // lib/api.d.ts:166:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:735:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:1110:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1265:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1608:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2389:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3292:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3419:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3716:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3773:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4107:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4532:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5208:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5213:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5216:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5219:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5234:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5277:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5300:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5303:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5321:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5386:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5448:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5480:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5526:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5528:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5529:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5530:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5532:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5534:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5543:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5544:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5545:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5561:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8808:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8809:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1277:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1620:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2470:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2807:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3397:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3524:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3858:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4192:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4617:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5297:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5302:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5305:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5308:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5323:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5366:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5389:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5392:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5410:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5475:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5537:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5569:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5618:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5619:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5620:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5622:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5624:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5633:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5634:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5635:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5651:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8901:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8902:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -669,47 +669,20 @@ interface IAttributeState {
 
 // @public
 interface IAvailableExtension {
-    // (undocumented)
     author: string;
     // (undocumented)
-    dependencies?: {
-        [key: string]: any;
-    };
-    // (undocumented)
-    description: {
-        short: string;
-        long: string;
-    };
-    // (undocumented)
-    downloads: number;
-    // (undocumented)
-    endorsements: number;
-    // (undocumented)
     fileId: number;
-    // (undocumented)
-    gameId?: string;
-    // (undocumented)
+    gameDomain?: string;
+    gameId?: number;
     gameName?: string;
-    // (undocumented)
-    hide?: boolean;
-    // (undocumented)
-    id?: string;
-    // (undocumented)
-    image: string;
-    // (undocumented)
+    image?: string;
     language?: string;
     // (undocumented)
     modId: number;
     // (undocumented)
     name: string;
-    // (undocumented)
-    tags: string[];
-    // (undocumented)
     timestamp: number;
-    // (undocumented)
     type?: ExtensionType;
-    // (undocumented)
-    uploader: string;
     // (undocumented)
     version: string;
 }
@@ -3158,6 +3131,7 @@ interface INexusAPIExtension {
     nexusGetCollections?: (gameId: string) => PromiseLike<Partial<ICollection>[] | undefined>;
     // (undocumented)
     nexusGetLatestMods?: (gameId: string) => PromiseLike<any>;
+    nexusGetModEndorsementCounts?: (uids: string[]) => PromiseLike<Record<string, number>>;
     // (undocumented)
     nexusGetModFiles?: (gameId: string, modId: number) => PromiseLike<IFileInfo[]>;
     // (undocumented)
@@ -3854,6 +3828,8 @@ interface ISessionGameMode {
     //
     // (undocumented)
     known: IGameStored[];
+    // (undocumented)
+    showHidden: boolean;
 }
 
 // @public (undocumented)
@@ -5179,7 +5155,7 @@ export const Usage: React$2.ComponentClass<IUsageProps>;
 
 // @public (undocumented)
 export namespace util {
-    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, readExtensibleDir, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
+    export { Archive, ArgumentInvalid, Campaign, CollectionInstallOutcomeProps, CollectionsDownloadCancelledEvent, CollectionsDownloadClickedEvent, CollectionsDownloadCompletedEvent, CollectionsDownloadFailedEvent, CollectionsDraftUpdateUploadedEvent, CollectionsDraftUploadedEvent, CollectionsDraftedEvent, CollectionsInstallationCancelledEvent, CollectionsInstallationCompletedEvent, CollectionsInstallationFailedEvent, CollectionsInstallationStartedEvent, ConcurrencyLimiter, Content, CycleError, DataInvalid, Debouncer, GameNotFound, instance$2 as GameStoreHelper, IErrorRendered, IPrettifiedError, IRequestOptions, ISteamEntry, LazyComponent, Method, MissingInterpreter, ModChangeReason, Normalize, NotFound, NotSupportedError, Overlayable, ProcessCanceled, ReduxProp, Section, SetupError, SevenZip, StarterInfo, TextGroup, UserCanceled, addUniqueSafe, batchDispatch, preProcess as bbcodePreProcess, bbcodeToHTML, renderBBCode as bbcodeToReact, buildCopyInstructions, bytesToString, calcDuration, calculateFolderSize, changeOrNop, checksum, coerceToSemver, compileStopPatterns, convertGameIdReverse, copyFileAtomic, copyRecursive, currentGame$1 as currentGame, deBOM, declareInstallers, deepMerge, delay, deleteOrNop, deriveModInstallName as deriveInstallName, instance$1 as epicGamesLauncher, extractExeIcon, fileMD5, findCommonRootDir, findDownloadByRef, findModByRef, findRuleByRef, generateCollectionSessionId, getActivator, getApplication, getCurrentActivator, getCurrentLanguage, getDriveList, getGame, getGames, getManifest, getModSource, getModSources, getModType, getNormalizeFunc, getReduxLog, getSafe, getSafeCI, getText, getVisibleWindow, getVortexPath, _default$14 as github, installIconSet, isChildPath, isFilenameValid, isFuzzyVersion, isPathValid, jsonRequest, lazyRequire, local, lookupFromDownload, makeInstallerFromSpec, makeModReference, makeNormalizingDict, makeOverlayableDictionary, makeQueue, makeReactive, makeRemoteCall, makeUnique, makeUniqueByKey, merge, modRuleId, mutateSafe, nexusGameId, nexusModsURL, normalizeStoreQuery, objDiff, onceCB, open as opn, pad, prettifyNodeErrorMessage, pushSafe, rawRequest, rehydrate, relativeTime, removeMods, removeValue, removeValueIf, renderError, modName as renderModName, renderModReference, request, resolveCategoryName, resolveCategoryPath, ruleInstallSpec, rulePhase, runElevated, runThreaded, sanitizeCSSId, sanitizeFilename, semverCoerce, setDefaultArray, setOrNop, setSafe, setdefault, showActivity, showError, showInfo, showSuccess, sortMods, instance as steam, terminate, testModReference, testRefByIdentifiers, toBlue, toPromise, unique, upload, userFriendlyTime, walk, withContext as withErrorContext, withTrackedActivity, writeFileAtomic };
 }
 
 // @public (undocumented)
@@ -5338,23 +5314,23 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 // lib/api.d.ts:1110:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:1277:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:1620:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2470:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2807:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3397:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3524:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3858:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4192:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4617:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5297:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5302:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5305:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5308:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5323:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5366:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5389:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5392:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5410:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5475:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2467:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2806:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3396:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3523:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3857:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4191:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4616:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5296:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5301:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5304:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5307:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5322:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5365:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5388:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5391:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5409:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5474:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:5537:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:5569:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:5618:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
@@ -5366,8 +5342,8 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 // lib/api.d.ts:5634:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:5635:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:5651:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8901:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8902:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8898:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8899:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/extensions/gameversion-hash/src/hashMapper.ts
+++ b/extensions/gameversion-hash/src/hashMapper.ts
@@ -36,14 +36,14 @@ export class HashMapper {
   }
 
   public async generateCacheKey(filePaths: string[]) {
-    const key: number[] = [];
+    const key: string[] = [];
     for (const filePath of filePaths) {
-      const mtime = (await fs.statAsync(filePath)).mtimeMs;
-      key.push(mtime);
+      const stat = await fs.statAsync(filePath);
+      key.push(`${filePath.toLowerCase()}\0${stat.size}\0${stat.mtimeMs}`);
     }
-    key.sort((lhs, rhs) => lhs - rhs);
+    key.sort();
     const hash = crypto.createHash("md5");
-    const buf = hash.update(key.map((k) => k.toString()).join("")).digest();
+    const buf = hash.update(key.join("\n")).digest();
     return buf.toString("hex");
   }
 

--- a/extensions/gameversion-hash/src/index.ts
+++ b/extensions/gameversion-hash/src/index.ts
@@ -12,42 +12,72 @@ import {
   IHashingDetails,
 } from "./types/types";
 
-type GameHashCache = { [gameId: string]: string };
+interface IGameHashCacheEntry {
+  version: string;
+  fingerprint: string;
+}
+
+type GameHashCache = { [gameAndPath: string]: IGameHashCacheEntry };
 const CACHE: GameHashCache = {};
+
+function gameCacheKey(game: types.IGame, discovery: types.IDiscoveryResult): string {
+  return `${game.id}\0${path.resolve(discovery.path).toLowerCase()}`;
+}
 
 async function insertCacheEntry(
   hashMapper: HashMapper,
   game: types.IGame,
   discovery: types.IDiscoveryResult,
+  filePaths: string[],
+  fingerprint: string,
 ): Promise<void> {
-  if (!isGameValid(game, discovery)) {
-    return;
-  }
-  const details: IHashingDetails = game.details;
-  const hashPath = details?.hashDirPath
-    ? path.isAbsolute(details.hashDirPath)
-      ? details.hashDirPath
-      : path.join(discovery.path, details.hashDirPath)
-    : undefined;
-  const files = details?.hashFiles
-    ? details.hashFiles
-    : hashPath
-      ? (await fs.readdirAsync(hashPath))
-          .map((file) => path.join(hashPath, file))
-          .filter(async (filePath) => (await queryPath(filePath)).isFile)
-      : [];
-  if (files.length > 0) {
-    const filePaths = files.map((file) =>
-      path.isAbsolute(file) ? file : path.join(discovery.path, file),
-    );
+  if (filePaths.length > 0) {
     const cacheKey = await hashMapper.generateCacheKey(filePaths);
     const cacheValue = hashMapper.getCacheValue(cacheKey);
     const hash = cacheValue ? cacheValue : await generateHash(filePaths);
     if (!cacheValue) {
       hashMapper.insertToCache(cacheKey, hash);
     }
-    CACHE[game.id] = await hashMapper.getUserFacingVersion(hash, game.id);
+    CACHE[gameCacheKey(game, discovery)] = {
+      version: await hashMapper.getUserFacingVersion(hash, game.id),
+      fingerprint,
+    };
   }
+}
+
+async function hashingFiles(
+  game: types.IGame,
+  discovery: types.IDiscoveryResult,
+): Promise<string[]> {
+  const details: IHashingDetails = game.details;
+  if (details?.hashFiles !== undefined) {
+    return details.hashFiles
+      .map((file) => (path.isAbsolute(file) ? file : path.join(discovery.path, file)))
+      .sort();
+  }
+  if (details?.hashDirPath === undefined) {
+    return [];
+  }
+  const hashPath = path.isAbsolute(details.hashDirPath)
+    ? details.hashDirPath
+    : path.join(discovery.path, details.hashDirPath);
+  const result: string[] = [];
+  for (const file of await fs.readdirAsync(hashPath)) {
+    const filePath = path.join(hashPath, file);
+    if ((await queryPath(filePath)).isFile) {
+      result.push(filePath);
+    }
+  }
+  return result.sort();
+}
+
+async function fileFingerprint(filePaths: string[]): Promise<string> {
+  const entries: string[] = [];
+  for (const filePath of filePaths) {
+    const stat = await fs.statAsync(filePath);
+    entries.push(`${path.resolve(filePath).toLowerCase()}\0${stat.size}\0${stat.mtimeMs}`);
+  }
+  return entries.join("\n");
 }
 
 async function generateHash(filePaths: string[]): Promise<string> {
@@ -86,9 +116,13 @@ async function testViability(
   const details: IHashingDetails = game.details;
   if (details?.hashDirPath) {
     if (!path.isAbsolute(details.hashDirPath)) {
-      details.hashDirPath = path.join(discovery.path, details.hashDirPath);
+      const hashDirPath = path.join(discovery.path, details.hashDirPath);
+      const pathInfo = await queryPath(hashDirPath);
+      if (pathInfo.exists && !pathInfo.isFile) {
+        return true;
+      }
+      return false;
     }
-
     const pathInfo = await queryPath(details.hashDirPath);
     if (pathInfo.exists && !pathInfo.isFile) {
       return true;
@@ -124,10 +158,13 @@ async function getHashVersion(
   game: types.IGame,
   discovery: types.IDiscoveryResult,
 ): Promise<string> {
-  if (CACHE[game.id] === undefined) {
-    await insertCacheEntry(hashMapper, game, discovery);
+  const cacheKey = gameCacheKey(game, discovery);
+  const files = await hashingFiles(game, discovery);
+  const fingerprint = await fileFingerprint(files);
+  if (CACHE[cacheKey]?.fingerprint !== fingerprint) {
+    await insertCacheEntry(hashMapper, game, discovery, files, fingerprint);
   }
-  return CACHE[game.id];
+  return CACHE[cacheKey]?.version;
 }
 
 async function getHashDetails(

--- a/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.test.ts
@@ -182,6 +182,32 @@ describe("InstallDriver session lifecycle", () => {
   });
 });
 
+describe("InstallDriver game version selection", () => {
+  test("passes the managed-copy selection from the install dialog to preparation", async ({
+    makeDriver,
+  }) => {
+    const h = makeDriver({
+      mods: { [GAME_ID]: { [defaultFixture.collection.id]: defaultFixture.collection } },
+      downloads: { [defaultFixture.download.id]: defaultFixture.download },
+      profiles: { [profile.id]: profile },
+    });
+    await h.driver.query(profile, defaultFixture.collection);
+    (h.driver as any).mRevisionInfo = {
+      gameVersions: [{ reference: "1.5.97" }],
+    };
+    const ensureGameVersion = vi.fn().mockResolvedValue("prepared");
+    h.api.ext.ensureGameVersion = ensureGameVersion;
+
+    h.driver.setGameVersionSelection("managed");
+    await (h.driver as any).startImpl();
+
+    expect(ensureGameVersion).toHaveBeenCalledWith(GAME_ID, ["1.5.97"], "prepare");
+    expect(h.dialogCalls).not.toContainEqual(
+      expect.objectContaining({ title: "Prepare compatible game version" }),
+    );
+  });
+});
+
 describe("InstallDriver optional default-skip", () => {
   const reqRule = makeRule({ type: "requires", reference: makeReference({ tag: "req-a" }) });
   const optRule = makeRule({ type: "recommends", reference: makeReference({ tag: "opt-a" }) });

--- a/src/renderer/src/extensions/collections/util/InstallDriver.ts
+++ b/src/renderer/src/extensions/collections/util/InstallDriver.ts
@@ -75,6 +75,14 @@ export type Step =
 
 export type UpdateCB = () => void;
 
+export type CollectionGameVersionSelection = "current" | "managed";
+
+export interface ICollectionGameVersionChoice {
+  status: "not-required" | "matched" | "available" | "unavailable";
+  actualVersion?: string;
+  targetVersion?: string;
+}
+
 class InstallDriver {
   private mApi: IExtensionApi;
   private mProfile: IProfile;
@@ -99,6 +107,7 @@ class InstallDriver {
   private mPrepare: Bluebird<void> = Bluebird.resolve();
   private mTimeStarted: number;
   private mPostprocessing: boolean = false;
+  private mGameVersionSelection: CollectionGameVersionSelection = "current";
 
   // Throttle the progress notification to avoid flooding Redux/UI on every single mod
   // event. (Session status writes are dispatched directly now - InstallManager is the
@@ -367,6 +376,7 @@ class InstallDriver {
     this.mProfile = profile;
     this.mLastCollection = this.mCollection = collection;
     this.mGameId = profile?.gameId ?? activeGameId(this.mApi.getState());
+    this.mGameVersionSelection = "current";
     this.mStep = "query";
     await this.initCollectionInfo();
     this.triggerUpdate();
@@ -393,6 +403,7 @@ class InstallDriver {
     this.mProfile = profile;
     this.mLastCollection = this.mCollection = collection;
     this.mGameId = profile?.gameId ?? activeGameId(this.mApi.getState());
+    this.mGameVersionSelection = "current";
 
     await this.startInstall();
     await this.initCollectionInfo();
@@ -604,6 +615,22 @@ class InstallDriver {
     return this.mCurrentSessionId;
   }
 
+  public setGameVersionSelection(selection: CollectionGameVersionSelection) {
+    this.mGameVersionSelection = selection;
+  }
+
+  public async inspectGameVersion(): Promise<ICollectionGameVersionChoice> {
+    const requiredVersions = await this.getRequiredGameVersions();
+    if (requiredVersions.length === 0) {
+      return { status: "not-required" };
+    }
+    return (
+      this.mApi.ext.inspectGameVersionTransition?.(this.mGameId, requiredVersions) ?? {
+        status: "unavailable",
+      }
+    );
+  }
+
   private async initCollectionInfo() {
     if (this.mCollection?.archiveId === undefined) {
       return;
@@ -621,6 +648,49 @@ class InstallDriver {
       // Not sure if/why this would happen on live, it did occur during testing because the
       // stuff was getting deleted from the DB directly
       this.mRevisionInfo?.collection;
+  }
+
+  private async loadRevisionInfo(): Promise<void> {
+    if (this.mRevisionInfo !== undefined || this.revisionId === undefined) {
+      return;
+    }
+    const state: IState = this.mApi.store.getState();
+    const modInfo = state.persistent.downloads.files[this.mCollection.archiveId]?.modInfo;
+    const nexusInfo = modInfo?.nexus;
+    try {
+      this.mRevisionInfo = Array.isArray(nexusInfo?.revisionInfo?.modFiles)
+        ? nexusInfo.revisionInfo
+        : await this.mInfoCache.getRevisionInfo(
+            this.revisionId,
+            this.collectionSlug,
+            this.revisionNumber,
+          );
+    } catch (err) {
+      log("error", "failed to get remote info for revision", {
+        revisionId: this.revisionId,
+        slug: this.collectionSlug,
+        revisionNumber: this.revisionNumber,
+        error: getErrorMessageOrDefault(err),
+      });
+    }
+  }
+
+  private async getRequiredGameVersions(): Promise<string[]> {
+    const state: IState = this.mApi.store.getState();
+    try {
+      const stagingPath = installPathForGame(state, this.mGameId);
+      const localCollection = await readCollection(
+        this.mApi,
+        path.join(stagingPath, this.mCollection.installationPath, "collection.json"),
+      );
+      if ((localCollection.info.gameVersions?.length ?? 0) > 0) {
+        return localCollection.info.gameVersions;
+      }
+    } catch {
+      // Remote revision metadata is the compatibility fallback.
+    }
+    await this.loadRevisionInfo();
+    return (this.mRevisionInfo?.gameVersions ?? []).map((gameVersion) => gameVersion.reference);
   }
 
   /**
@@ -828,26 +898,11 @@ class InstallDriver {
 
     const state: IState = this.mApi.store.getState();
     const mods = state.persistent.mods[gameId] ?? {};
-    const modInfo = state.persistent.downloads.files[collection.archiveId]?.modInfo;
-    const nexusInfo = modInfo?.nexus;
 
     const slug = this.collectionSlug;
     const revisionId = this.revisionId;
 
-    if (revisionId !== undefined) {
-      try {
-        this.mRevisionInfo = Array.isArray(nexusInfo?.revisionInfo?.modFiles)
-          ? nexusInfo.revisionInfo
-          : await this.mInfoCache.getRevisionInfo(revisionId, slug, this.revisionNumber);
-      } catch (err) {
-        log("error", "failed to get remote info for revision", {
-          revisionId,
-          slug,
-          revisionNumber: this.revisionNumber,
-          error: getErrorMessageOrDefault(err),
-        });
-      }
-    }
+    await this.loadRevisionInfo();
 
     const { userInfo } = state.persistent["nexus"] ?? {};
     // don't request a vote on own collection
@@ -857,11 +912,32 @@ class InstallDriver {
 
     const gameMode = gameId;
     const currentgame = getGame(gameMode);
-    const discovery = discoveryByGame(state, gameMode);
-    const gameVersion = await currentgame.getInstalledVersion(discovery);
-    const gvMatch = (gv) => gv.reference === gameVersion;
-    const revGameVersions = this.mRevisionInfo?.gameVersions ?? [];
-    if ((revGameVersions.length ?? 0 !== 0) && revGameVersions.find(gvMatch) === undefined) {
+    let discovery = discoveryByGame(state, gameMode);
+    let gameVersion = await currentgame.getInstalledVersion(discovery);
+    const requiredVersions = await this.getRequiredGameVersions();
+    let transitionResult: string = "unavailable";
+    if (requiredVersions.length > 0 && !requiredVersions.includes(gameVersion)) {
+      transitionResult = await this.mApi.ext.ensureGameVersion?.(
+        gameId,
+        requiredVersions,
+        this.mGameVersionSelection === "managed" ? "prepare" : "skip",
+      );
+      if (transitionResult === "canceled") {
+        this.mInstallDone = true;
+        return false;
+      }
+      if (transitionResult === "prepared") {
+        const updatedState = this.mApi.getState();
+        discovery = discoveryByGame(updatedState, gameMode);
+        gameVersion = await currentgame.getInstalledVersion(discovery);
+      }
+    }
+    if (
+      requiredVersions.length > 0 &&
+      !requiredVersions.includes(gameVersion) &&
+      transitionResult !== "matched" &&
+      transitionResult !== "prepared"
+    ) {
       const choice = await this.mApi.showDialog(
         "question",
         "Game version mismatch",
@@ -880,7 +956,7 @@ class InstallDriver {
             "while playing with the game version you have installed or to request advice from the curator.",
           parameters: {
             actual: gameVersion,
-            intended: revGameVersions.map((gv) => gv.reference).join(" or "),
+            intended: requiredVersions.join(" or "),
           },
         },
         [{ label: "Cancel" }, { label: "Continue" }],

--- a/src/renderer/src/extensions/collections/util/createCollectionFromProfile.ts
+++ b/src/renderer/src/extensions/collections/util/createCollectionFromProfile.ts
@@ -47,6 +47,8 @@ function createRulesFromProfile(
         modId !== existingId &&
         // no nested collections allowed
         mods[modId].type !== MOD_TYPE &&
+        // generated game versions are profile infrastructure, not collection mods
+        mods[modId].attributes?.gameVersionManaged !== true &&
         filterFunc(mods[modId]),
     )
     .map((modId) => {

--- a/src/renderer/src/extensions/collections/views/InstallDialog/InstallStartDialog.tsx
+++ b/src/renderer/src/extensions/collections/views/InstallDialog/InstallStartDialog.tsx
@@ -25,6 +25,10 @@ import { batchDispatch } from "../../../../util/util";
 import { DEFAULT_INSTRUCTIONS, NAMESPACE } from "../../constants";
 import { isGamebryoGame } from "../../util/gameSupport";
 import type InstallDriver from "../../util/InstallDriver";
+import type {
+  CollectionGameVersionSelection,
+  ICollectionGameVersionChoice,
+} from "../../util/InstallDriver";
 import CollectionThumbnail from "../CollectionTile";
 import YouCuratedTag from "./YouCuratedThisTag";
 
@@ -63,6 +67,9 @@ interface IInstallDialogState {
   confirmProfile: boolean;
   recommendedNewProfile: boolean;
   skipPluginRules: boolean;
+  gameVersionChoice?: ICollectionGameVersionChoice;
+  gameVersionLoading: boolean;
+  selectedGameVersion: CollectionGameVersionSelection;
 }
 
 function nop() {
@@ -116,6 +123,56 @@ function InstallDialogSelectProfile(props: IInstallDialogSelectProfileProps) {
   );
 }
 
+interface IInstallDialogSelectGameVersionProps {
+  t: TFunction;
+  choice: ICollectionGameVersionChoice;
+  selected: CollectionGameVersionSelection;
+  onSelect: (value: { value: CollectionGameVersionSelection; label: string }) => void;
+}
+
+function InstallDialogSelectGameVersion(props: IInstallDialogSelectGameVersionProps) {
+  const { t, choice, selected, onSelect } = props;
+  const currentLabel =
+    choice.status === "matched"
+      ? t("Use active game installation - compatible ({{version}})", {
+          replace: { version: choice.actualVersion },
+        })
+      : choice.status === "unavailable"
+        ? t("Continue Without Preparing - manual preparation required ({{version}})", {
+            replace: { version: choice.actualVersion ?? t("unknown version") },
+          })
+        : t("Continue Without Preparing - {{version}}", {
+            replace: { version: choice.actualVersion },
+          });
+  const options: Array<{ value: CollectionGameVersionSelection; label: string }> = [
+    { value: "current", label: currentLabel },
+  ];
+  if (choice.status === "available") {
+    options.unshift({
+      value: "managed",
+      label: t("Prepare Game Version - {{version}} (Recommended)", {
+        replace: { version: choice.targetVersion },
+      }),
+    });
+  }
+
+  return (
+    <FlexLayout id="collections-game-version-select" type="row">
+      <FlexLayout.Fixed>{t("Use game installation") + ":"}</FlexLayout.Fixed>
+
+      <FlexLayout.Flex>
+        <Select
+          clearable={false}
+          disabled={choice.status !== "available"}
+          options={options}
+          value={selected}
+          onChange={onSelect}
+        />
+      </FlexLayout.Flex>
+    </FlexLayout>
+  );
+}
+
 interface IInstallDialogConfirmProfileProps {
   t: TFunction;
   collectionName: string;
@@ -148,6 +205,7 @@ function InstallDialogConfirmProfile(props: IInstallDialogConfirmProfileProps) {
 class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
   private mLastCollection: IMod;
   private mUnsubscribeDriver?: () => void;
+  private mGameVersionRequest = 0;
   constructor(props: IProps) {
     super(props);
 
@@ -156,6 +214,8 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
       confirmProfile: false,
       recommendedNewProfile: false,
       skipPluginRules: false,
+      gameVersionLoading: true,
+      selectedGameVersion: "current",
     });
   }
 
@@ -164,6 +224,8 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
     // before this instance mounts (or on an instance that never mounts at all)
     if (this.props.driver !== undefined) {
       this.mUnsubscribeDriver = this.props.driver.onUpdate(() => this.forceUpdate());
+      this.mLastCollection = this.props.driver.collection;
+      void this.loadGameVersionChoice();
     }
   }
 
@@ -195,7 +257,11 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
       if (driver.collection !== this.mLastCollection) {
         this.nextState.confirmProfile = false;
         this.nextState.selectedProfile = undefined;
+        this.nextState.gameVersionChoice = undefined;
+        this.nextState.gameVersionLoading = true;
+        this.nextState.selectedGameVersion = "current";
         this.mLastCollection = driver.collection;
+        void this.loadGameVersionChoice();
       }
     }
   }
@@ -299,6 +365,26 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
             />
           )}
 
+          {this.state.gameVersionChoice?.status !== undefined &&
+          this.state.gameVersionChoice.status !== "not-required" ? (
+            <>
+              <FlexLayout type="row">
+                <p>
+                  {t(
+                    "Choose whether Vortex should prepare the required game version through the normal deployment system.",
+                  )}
+                </p>
+              </FlexLayout>
+
+              <InstallDialogSelectGameVersion
+                choice={this.state.gameVersionChoice}
+                selected={this.state.selectedGameVersion}
+                t={t}
+                onSelect={this.changeGameVersion}
+              />
+            </>
+          ) : null}
+
           <Toggle
             checked={this.props.collectionsInstallWhileDownloading}
             onToggle={this.props.onSetCollectionConcurrency}
@@ -332,7 +418,9 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
             <>
               <Button onClick={this.cancel}>{t("Later")}</Button>
 
-              <Button onClick={this.next}>{t("Install Now")}</Button>
+              <Button disabled={this.state.gameVersionLoading} onClick={this.next}>
+                {t("Install Now")}
+              </Button>
             </>
           )}
         </Modal.Footer>
@@ -343,6 +431,37 @@ class InstallDialog extends ComponentEx<IProps, IInstallDialogState> {
   private changeProfile = (value: { value: string; label: string }) => {
     if (value) {
       this.nextState.selectedProfile = value.value;
+    }
+  };
+
+  private changeGameVersion = (value: { value: CollectionGameVersionSelection; label: string }) => {
+    if (value) {
+      this.nextState.selectedGameVersion = value.value;
+      this.props.driver.setGameVersionSelection(value.value);
+    }
+  };
+
+  private loadGameVersionChoice = async () => {
+    const request = ++this.mGameVersionRequest;
+    try {
+      const choice = await this.props.driver.inspectGameVersion();
+      if (request !== this.mGameVersionRequest) {
+        return;
+      }
+      const selection = choice.status === "available" ? "managed" : "current";
+      this.nextState.gameVersionChoice = choice;
+      this.nextState.selectedGameVersion = selection;
+      this.props.driver.setGameVersionSelection(selection);
+    } catch {
+      if (request === this.mGameVersionRequest) {
+        this.nextState.gameVersionChoice = { status: "unavailable" };
+        this.nextState.selectedGameVersion = "current";
+        this.props.driver.setGameVersionSelection("current");
+      }
+    } finally {
+      if (request === this.mGameVersionRequest) {
+        this.nextState.gameVersionLoading = false;
+      }
     }
   };
 

--- a/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
+++ b/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
@@ -6,6 +6,7 @@ import type * as exeVersionT from "exe-version";
 
 import type { IExtensionApi } from "../../types/IExtensionContext";
 import type { IState } from "../../types/IState";
+import getVortexPath from "../../util/getVortexPath";
 import lazyRequire from "../../util/lazyRequire";
 import { getGame } from "../gamemode_management/util/getGame";
 import { addMod, setModAttribute } from "../mod_management/actions/mods";
@@ -82,6 +83,7 @@ export default class GameVersionTransitionManager {
   private mJobs = new Map<string, Promise<EnsureGameVersionResult>>();
   private mCatalogs = new Map<string, Promise<ILoadedGameVersionCatalog>>();
   private mUpdatingProfiles = new Set<string>();
+  private mDeployedVersions = new Map<string, string>();
 
   constructor(api: IExtensionApi, providers: IGameVersionTransitionProvider[]) {
     this.mApi = api;
@@ -131,9 +133,29 @@ export default class GameVersionTransitionManager {
     const current = this.mApi.getState() as IState;
     const profileId = current.settings.profiles.activeProfileId;
     const profile = current.persistent.profiles[profileId];
+    if (profile !== undefined) {
+      this.mDeployedVersions.set(profile.gameId, profile.features?.game_version ?? "store");
+    }
     if (profile?.features?.game_version?.startsWith?.("managed:")) {
       await this.prepareProfileVersion(profileId, true);
     }
+  }
+
+  public async handleDeployment(profileId: string): Promise<void> {
+    const state = this.mApi.getState() as IState;
+    const profile = state.persistent.profiles[profileId];
+    if (profile?.gameId !== "skyrimse") {
+      return;
+    }
+    const preference = profile.features?.game_version ?? "store";
+    if (this.mDeployedVersions.get(profile.gameId) === preference) {
+      return;
+    }
+    await fs.rm(
+      path.join(getVortexPath("localAppData"), "Skyrim Special Edition", "ContentCatalog.txt"),
+      { force: true },
+    );
+    this.mDeployedVersions.set(profile.gameId, preference);
   }
 
   public isUpdatingProfile(profileId: string): boolean {

--- a/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
+++ b/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
@@ -1,0 +1,707 @@
+import { randomUUID } from "crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import type * as exeVersionT from "exe-version";
+
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import type { IState } from "../../types/IState";
+import lazyRequire from "../../util/lazyRequire";
+import { getGame } from "../gamemode_management/util/getGame";
+import { addMod, setModAttribute } from "../mod_management/actions/mods";
+import { BACKUP_TAG } from "../mod_management/LinkingDeployment";
+import { installPathForGame } from "../mod_management/selectors";
+import type { IMod } from "../mod_management/types/IMod";
+import { getCurrentActivator } from "../mod_management/util/deploymentMethods";
+import { setFeature, setModEnabled } from "../profile_management/actions/profiles";
+import { setGameVersionJob } from "./actions";
+import { loadCatalog, versionMatches } from "./catalog";
+import type { ILoadedGameVersionCatalog } from "./catalog";
+import {
+  acquireArtifact,
+  applyChunkMap,
+  fingerprintDigest,
+  hashFile,
+  safePath,
+} from "./fileOperations";
+import type { GameVersionJobPhase } from "./types/IGameVersionState";
+import type {
+  IGameVersionFingerprint,
+  IGameVersionPatchOperation,
+  IGameVersionTarget,
+  IGameVersionTransition,
+  IGameVersionTransitionProvider,
+} from "./types/IGameVersionTransitionProvider";
+
+export type EnsureGameVersionResult =
+  | "matched"
+  | "prepared"
+  | "skipped"
+  | "canceled"
+  | "unavailable";
+
+export interface IGameVersionTransitionInspection {
+  status: "matched" | "available" | "unavailable";
+  actualVersion?: string;
+  targetVersion?: string;
+}
+
+export type GameVersionTransitionSelection = "prompt" | "prepare" | "skip";
+
+interface IResolvedTransition {
+  provider: IGameVersionTransitionProvider;
+  target: IGameVersionTarget;
+  transition: IGameVersionTransition;
+  catalogDigest: string;
+}
+
+interface ITransitionPlan extends IGameVersionTransitionInspection {
+  compatibilityNote?: string;
+  sourcePath?: string;
+  resolved?: IResolvedTransition;
+}
+
+const GAME_VERSION_MOD_TYPE = "game-version";
+const exeVersion: typeof exeVersionT = lazyRequire(() => require("exe-version"));
+
+function sanitizeSegment(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function normalizeVersion(input: string): string {
+  return input.trim().toLowerCase().replace(/\.0$/, "");
+}
+
+function isGameVersionMod(mod: IMod): boolean {
+  return mod.type === GAME_VERSION_MOD_TYPE && mod.attributes?.gameVersionManaged === true;
+}
+
+export default class GameVersionTransitionManager {
+  private mApi: IExtensionApi;
+  private mProviders: IGameVersionTransitionProvider[];
+  private mJobs = new Map<string, Promise<EnsureGameVersionResult>>();
+  private mCatalogs = new Map<string, Promise<ILoadedGameVersionCatalog>>();
+  private mUpdatingProfiles = new Set<string>();
+
+  constructor(api: IExtensionApi, providers: IGameVersionTransitionProvider[]) {
+    this.mApi = api;
+    this.mProviders = providers;
+  }
+
+  public ensure(
+    gameId: string,
+    requestedVersions: string[],
+    selection: GameVersionTransitionSelection = "prompt",
+  ): Promise<EnsureGameVersionResult> {
+    if (requestedVersions.length === 0) {
+      return Promise.resolve("unavailable");
+    }
+    const running = this.mJobs.get(gameId);
+    if (running !== undefined) {
+      return running;
+    }
+    const job = this.ensureImpl(gameId, requestedVersions, selection).finally(() =>
+      this.mJobs.delete(gameId),
+    );
+    this.mJobs.set(gameId, job);
+    return job;
+  }
+
+  public async inspect(
+    gameId: string,
+    requestedVersions: string[],
+  ): Promise<IGameVersionTransitionInspection> {
+    const { status, actualVersion, targetVersion } = await this.createPlan(
+      gameId,
+      requestedVersions,
+    );
+    return { status, actualVersion, targetVersion };
+  }
+
+  /** Reconcile generated mods and the active profile after startup. */
+  public async reconcile(): Promise<void> {
+    const state = this.mApi.getState() as IState;
+    for (const [gameId, mods] of Object.entries(state.persistent.mods)) {
+      for (const mod of Object.values(mods)) {
+        if (isGameVersionMod(mod) && mod.attributes?.source !== "other") {
+          this.mApi.store.dispatch(setModAttribute(gameId, mod.id, "source", "other"));
+        }
+      }
+    }
+    const current = this.mApi.getState() as IState;
+    const profileId = current.settings.profiles.activeProfileId;
+    const profile = current.persistent.profiles[profileId];
+    if (profile?.features?.game_version?.startsWith?.("managed:")) {
+      await this.prepareProfileVersion(profileId, true);
+    }
+  }
+
+  public isUpdatingProfile(profileId: string): boolean {
+    return this.mUpdatingProfiles.has(profileId);
+  }
+
+  public handleModStateChange(profileId: string, modId: string, enabled: boolean): void {
+    if (this.mUpdatingProfiles.has(profileId)) {
+      return;
+    }
+    const state = this.mApi.getState() as IState;
+    const profile = state.persistent.profiles[profileId];
+    const mod = state.persistent.mods[profile?.gameId]?.[modId];
+    if (profile === undefined || mod === undefined || !isGameVersionMod(mod)) {
+      return;
+    }
+
+    this.mUpdatingProfiles.add(profileId);
+    try {
+      if (enabled) {
+        for (const candidate of Object.values(state.persistent.mods[profile.gameId] ?? {})) {
+          if (isGameVersionMod(candidate) && candidate.id !== modId) {
+            this.mApi.store.dispatch(setModEnabled(profileId, candidate.id, false));
+          }
+        }
+        this.mApi.store.dispatch(
+          setFeature(
+            profileId,
+            "game_version",
+            `managed:${mod.attributes.gameVersionTargetVersion}`,
+          ),
+        );
+      } else {
+        const active = Object.values(state.persistent.mods[profile.gameId] ?? {}).find(
+          (candidate) =>
+            isGameVersionMod(candidate) && profile.modState?.[candidate.id]?.enabled === true,
+        );
+        this.mApi.store.dispatch(
+          setFeature(
+            profileId,
+            "game_version",
+            active === undefined
+              ? "store"
+              : `managed:${active.attributes.gameVersionTargetVersion}`,
+          ),
+        );
+      }
+    } finally {
+      this.mUpdatingProfiles.delete(profileId);
+    }
+  }
+
+  public async handleModRemoval(gameId: string, modId: string): Promise<void> {
+    const state = this.mApi.getState() as IState;
+    const mod = state.persistent.mods[gameId]?.[modId];
+    if (mod === undefined || !isGameVersionMod(mod)) {
+      return;
+    }
+    const preference = `managed:${mod.attributes.gameVersionTargetVersion}`;
+    for (const profile of Object.values(state.persistent.profiles)) {
+      if (profile.gameId === gameId && profile.features?.game_version === preference) {
+        this.mUpdatingProfiles.add(profile.id);
+        try {
+          this.mApi.store.dispatch(setFeature(profile.id, "game_version", "store"));
+        } finally {
+          this.mUpdatingProfiles.delete(profile.id);
+        }
+      }
+    }
+  }
+
+  public async getProfileChoices(gameId: string): Promise<Array<{ value: string; label: string }>> {
+    const state = this.mApi.getState() as IState;
+    const discovery = state.settings.gameMode.discovered[gameId];
+    const game = getGame(gameId);
+    if (discovery?.path === undefined || game === undefined) {
+      return [];
+    }
+    const sourceVersion = await this.storeVersion(gameId, discovery.path);
+    const result = [{ value: "store", label: `${sourceVersion} (Store)` }];
+    const provider = this.providerFor(gameId, discovery.store);
+    if (provider === undefined) {
+      return result;
+    }
+    let loaded: ILoadedGameVersionCatalog;
+    try {
+      loaded = await this.catalogFor(provider);
+    } catch {
+      return result;
+    }
+    const catalogGame = loaded.catalog.games.find(
+      (entry) => entry.gameId === gameId && entry.store === discovery.store,
+    );
+    for (const target of catalogGame?.targets ?? []) {
+      result.push({ value: `managed:${target.version}`, label: `${target.version} (Managed)` });
+    }
+    return result;
+  }
+
+  public async prepareProfileVersion(profileId: string, deployAfterSwitch = false): Promise<void> {
+    const state = this.mApi.getState() as IState;
+    const profile = state.persistent.profiles[profileId];
+    if (profile === undefined) {
+      return;
+    }
+    const preference = profile.features?.game_version ?? "store";
+    if (preference === "store") {
+      await this.setProfileVersion(profileId, "store", undefined, deployAfterSwitch);
+      return;
+    }
+    if (typeof preference !== "string" || !preference.startsWith("managed:")) {
+      throw new Error("The profile contains an invalid game-version selection");
+    }
+    const targetVersion = preference.slice("managed:".length);
+    const discovery = state.settings.gameMode.discovered[profile.gameId];
+    if (discovery?.path === undefined) {
+      throw new Error("The game is not discovered");
+    }
+
+    let mod = this.findVersionMod(profile.gameId, targetVersion);
+    if (mod === undefined) {
+      const resolved = await this.resolve(profile.gameId, discovery.store, discovery.path, [
+        targetVersion,
+      ]);
+      if (resolved === undefined) {
+        throw new Error(
+          `Managed game version ${targetVersion} cannot be prepared from this install`,
+        );
+      }
+      mod = await this.prepareVersionMod(profile.gameId, discovery.path, resolved);
+    }
+    await this.setProfileVersion(profileId, preference, mod.id, deployAfterSwitch);
+  }
+
+  private setProgress(
+    gameId: string,
+    targetVersion: string,
+    phase: GameVersionJobPhase,
+    progress: number,
+  ) {
+    this.mApi.store.dispatch(
+      setGameVersionJob({ gameId, job: { gameId, targetVersion, phase, progress } }),
+    );
+    this.mApi.sendNotification({
+      id: `game-version-transition-${gameId}`,
+      type: "activity",
+      title: "Preparing compatible game version",
+      message: `${phase[0].toUpperCase()}${phase.slice(1)} ${targetVersion}`,
+      progress,
+      noDismiss: true,
+    });
+  }
+
+  private providerFor(gameId: string, store: string) {
+    return this.mProviders.find(
+      (provider) =>
+        provider.supportedPlatforms.includes(process.platform) &&
+        provider.supportedGames.includes(gameId) &&
+        provider.supportedStores.includes(store),
+    );
+  }
+
+  private catalogFor(provider: IGameVersionTransitionProvider) {
+    let result = this.mCatalogs.get(provider.id);
+    if (result === undefined) {
+      result = loadCatalog(provider).catch((err) => {
+        this.mCatalogs.delete(provider.id);
+        throw err;
+      });
+      this.mCatalogs.set(provider.id, result);
+    }
+    return result;
+  }
+
+  private async resolve(
+    gameId: string,
+    store: string,
+    sourcePath: string,
+    requestedVersions: string[],
+  ): Promise<IResolvedTransition | undefined> {
+    const provider = this.providerFor(gameId, store);
+    if (provider === undefined) {
+      return undefined;
+    }
+    const loaded = await this.catalogFor(provider);
+    const game = loaded.catalog.games.find(
+      (entry) => entry.gameId === gameId && entry.store === store,
+    );
+    const target = game?.targets.find((candidate) =>
+      requestedVersions.some((version) => versionMatches(candidate, version)),
+    );
+    if (target === undefined) {
+      return undefined;
+    }
+    for (const transition of target.transitions) {
+      if (await this.verifyStoreFingerprint(sourcePath, transition.source)) {
+        return { provider, target, transition, catalogDigest: loaded.digest };
+      }
+    }
+    return undefined;
+  }
+
+  private async versionsEquivalent(
+    gameId: string,
+    store: string,
+    actualVersion: string,
+    requestedVersions: string[],
+  ): Promise<boolean> {
+    const provider = this.providerFor(gameId, store);
+    if (provider === undefined) {
+      return false;
+    }
+    const loaded = await this.catalogFor(provider);
+    const game = loaded.catalog.games.find(
+      (entry) => entry.gameId === gameId && entry.store === store,
+    );
+    return (
+      game?.targets.some(
+        (target) =>
+          versionMatches(target, actualVersion) &&
+          requestedVersions.some((version) => versionMatches(target, version)),
+      ) ?? false
+    );
+  }
+
+  private async createPlan(gameId: string, requestedVersions: string[]): Promise<ITransitionPlan> {
+    const state = this.mApi.getState() as IState;
+    const discovery = state.settings.gameMode.discovered[gameId];
+    const game = getGame(gameId);
+    if (discovery?.path === undefined || game === undefined) {
+      return { status: "unavailable" };
+    }
+    const actualVersion = await game.getInstalledVersion(discovery);
+    if (
+      requestedVersions.some(
+        (requestedVersion) =>
+          normalizeVersion(requestedVersion) === normalizeVersion(actualVersion),
+      )
+    ) {
+      return { status: "matched", actualVersion };
+    }
+    try {
+      if (
+        await this.versionsEquivalent(gameId, discovery.store, actualVersion, requestedVersions)
+      ) {
+        return { status: "matched", actualVersion };
+      }
+    } catch {
+      // Catalog failures fall through to the existing compatibility warning.
+    }
+    if (Object.keys(state.session.base.toolsRunning ?? {}).length > 0) {
+      return { status: "unavailable", actualVersion };
+    }
+    const resolved = await this.resolve(gameId, discovery.store, discovery.path, requestedVersions);
+    if (resolved === undefined) {
+      return { status: "unavailable", actualVersion };
+    }
+    return {
+      status: "available",
+      actualVersion,
+      targetVersion: resolved.target.version,
+      compatibilityNote: resolved.target.compatibilityNote,
+      sourcePath: discovery.path,
+      resolved,
+    };
+  }
+
+  private async ensureImpl(
+    gameId: string,
+    requestedVersions: string[],
+    selection: GameVersionTransitionSelection,
+  ): Promise<EnsureGameVersionResult> {
+    const plan = await this.createPlan(gameId, requestedVersions);
+    if (plan.status === "matched") {
+      return "matched";
+    }
+    if (plan.status !== "available") {
+      return "unavailable";
+    }
+
+    let prepare = selection === "prepare";
+    if (selection === "prompt") {
+      const choice = await this.mApi.showDialog(
+        "question",
+        "Prepare compatible game version",
+        {
+          text:
+            "Vortex can prepare the required game files as a managed mod. During deployment, " +
+            "the Hardlink Deployment method backs up the store files and restores them on purge." +
+            (plan.compatibilityNote === undefined ? "" : `\n\n${plan.compatibilityNote}`),
+          message: `Target version: ${plan.targetVersion}`,
+        },
+        [
+          { label: "Cancel" },
+          { label: "Continue Without Preparing" },
+          { label: "Prepare Game Version" },
+        ],
+      );
+      if (choice.action === "Cancel") {
+        return "canceled";
+      }
+      prepare = choice.action === "Prepare Game Version";
+    }
+    if (!prepare) {
+      return "skipped";
+    }
+
+    const profileId = (this.mApi.getState() as IState).settings.profiles.activeProfileId;
+    if (profileId === undefined) {
+      return "unavailable";
+    }
+    try {
+      const mod = await this.prepareVersionMod(gameId, plan.sourcePath, plan.resolved);
+      await this.setProfileVersion(
+        profileId,
+        `managed:${plan.resolved.target.version}`,
+        mod.id,
+        true,
+      );
+      return "prepared";
+    } catch (err) {
+      this.mApi.showErrorNotification("Failed to prepare a compatible game version", err, {
+        allowReport: false,
+      });
+      return "unavailable";
+    }
+  }
+
+  private async prepareVersionMod(
+    gameId: string,
+    sourcePath: string,
+    resolved: IResolvedTransition,
+  ): Promise<IMod> {
+    const state = this.mApi.getState() as IState;
+    const stagingPath = installPathForGame(state, gameId);
+    if (stagingPath === undefined) {
+      throw new Error("Game staging path is not configured");
+    }
+    if (getCurrentActivator(state, gameId, true)?.id !== "hardlink_activator") {
+      throw new Error("Managed game versions require Hardlink Deployment for this game");
+    }
+
+    const targetDigest = fingerprintDigest(resolved.target.fingerprint);
+    const modId = [
+      "vortex-game-version",
+      sanitizeSegment(resolved.provider.id),
+      sanitizeSegment(resolved.target.version),
+      targetDigest.slice(0, 12),
+    ].join("-");
+    const existing = (this.mApi.getState() as IState).persistent.mods[gameId]?.[modId];
+    const finalPath = safePath(stagingPath, modId);
+    if (
+      existing !== undefined &&
+      (await this.verifyPreparedFiles(finalPath, resolved.transition))
+    ) {
+      if (existing.attributes?.source === undefined) {
+        this.mApi.store.dispatch(setModAttribute(gameId, modId, "source", "other"));
+      }
+      return existing;
+    }
+
+    const temporaryPath = safePath(stagingPath, `.installing-${modId}-${randomUUID()}`);
+    const cacheRoot = safePath(stagingPath, path.join(".game-version-cache", "sha256"));
+    this.setProgress(gameId, resolved.target.version, "planning", 0);
+    await fs.mkdir(temporaryPath, { recursive: true });
+    try {
+      const patchOperations = resolved.transition.operations.filter(
+        (operation): operation is IGameVersionPatchOperation => operation.type === "patch",
+      );
+      for (const [index, operation] of patchOperations.entries()) {
+        this.setProgress(
+          gameId,
+          resolved.target.version,
+          "patching",
+          10 + Math.floor((index / Math.max(1, patchOperations.length)) * 80),
+        );
+        const sourceFile = await this.findStoreFile(
+          sourcePath,
+          operation.sourcePath,
+          operation.sourceSha256,
+        );
+        const artifact = await acquireArtifact(operation.artifact, cacheRoot);
+        const targetFile = safePath(temporaryPath, operation.targetPath);
+        await fs.mkdir(path.dirname(targetFile), { recursive: true });
+        if (operation.algorithm === "bsdiff40-v1") {
+          await window.api.bsdiff.patch(sourceFile, targetFile, artifact);
+        } else {
+          await applyChunkMap(sourceFile, artifact, targetFile, operation.targetSize);
+        }
+        const targetHash = await hashFile(targetFile);
+        if (
+          targetHash.hash.toLowerCase() !== operation.targetSha256.toLowerCase() ||
+          targetHash.numBytes !== operation.targetSize
+        ) {
+          throw new Error(`Patched game file failed verification: ${operation.targetPath}`);
+        }
+      }
+      this.setProgress(gameId, resolved.target.version, "committing", 95);
+      await fs.rm(finalPath, { recursive: true, force: true });
+      await fs.rename(temporaryPath, finalPath);
+
+      const mod: IMod = {
+        id: modId,
+        state: "installed",
+        type: GAME_VERSION_MOD_TYPE,
+        installationPath: modId,
+        attributes: {
+          name: `Game Version ${resolved.target.version}`,
+          version: resolved.target.version,
+          author: "Vortex",
+          source: "other",
+          description:
+            "Game-version files managed by Vortex. Purging or disabling this mod restores the backed-up store files.",
+          installTime: new Date(),
+          gameVersionManaged: true,
+          gameVersionProviderId: resolved.provider.id,
+          gameVersionCatalogDigest: resolved.catalogDigest,
+          gameVersionTargetVersion: resolved.target.version,
+          gameVersionFingerprint: resolved.target.fingerprint,
+          gameVersionRemovedFiles: resolved.transition.operations
+            .filter((operation) => operation.type === "remove")
+            .map((operation) => operation.targetPath),
+        },
+      };
+      this.mApi.store.dispatch(addMod(gameId, mod));
+      return mod;
+    } finally {
+      this.mApi.store.dispatch(setGameVersionJob({ gameId }));
+      this.mApi.dismissNotification(`game-version-transition-${gameId}`);
+      await fs.rm(temporaryPath, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  private async selectVersionMod(
+    profileId: string,
+    selectedModId: string | undefined,
+    deploy: boolean,
+  ): Promise<void> {
+    const state = this.mApi.getState() as IState;
+    const profile = state.persistent.profiles[profileId];
+    if (profile === undefined) {
+      return;
+    }
+    for (const mod of Object.values(state.persistent.mods[profile.gameId] ?? {})) {
+      if (isGameVersionMod(mod)) {
+        this.mApi.store.dispatch(setModEnabled(profileId, mod.id, mod.id === selectedModId));
+      }
+    }
+    if (deploy) {
+      await this.mApi.ext.awaitModsDeployment?.(profileId);
+    }
+    if (selectedModId !== undefined) {
+      const mod = (this.mApi.getState() as IState).persistent.mods[profile.gameId]?.[selectedModId];
+      this.mApi.sendNotification({
+        id: `managed-game-version-${profile.gameId}`,
+        type: "info",
+        message: `Game version ${mod?.attributes?.gameVersionTargetVersion} is deployed by the active profile.`,
+        allowSuppress: true,
+        actions: [
+          {
+            title: "View in Profile Settings",
+            action: (dismiss) => {
+              this.mApi.events.emit("show-main-page", "game-profiles");
+              dismiss();
+            },
+          },
+        ],
+      });
+    } else {
+      this.mApi.dismissNotification(`managed-game-version-${profile.gameId}`);
+    }
+  }
+
+  private async setProfileVersion(
+    profileId: string,
+    preference: string,
+    selectedModId: string | undefined,
+    deploy: boolean,
+  ): Promise<void> {
+    this.mUpdatingProfiles.add(profileId);
+    try {
+      this.mApi.store.dispatch(setFeature(profileId, "game_version", preference));
+      await this.selectVersionMod(profileId, selectedModId, deploy);
+    } finally {
+      this.mUpdatingProfiles.delete(profileId);
+    }
+  }
+
+  private findVersionMod(gameId: string, targetVersion: string): IMod | undefined {
+    return Object.values((this.mApi.getState() as IState).persistent.mods[gameId] ?? {}).find(
+      (mod) => isGameVersionMod(mod) && mod.attributes?.gameVersionTargetVersion === targetVersion,
+    );
+  }
+
+  private async verifyPreparedFiles(root: string, transition: IGameVersionTransition) {
+    try {
+      for (const operation of transition.operations) {
+        if (operation.type !== "patch") {
+          continue;
+        }
+        const result = await hashFile(safePath(root, operation.targetPath));
+        if (
+          result.hash.toLowerCase() !== operation.targetSha256.toLowerCase() ||
+          result.numBytes !== operation.targetSize
+        ) {
+          return false;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async verifyStoreFingerprint(root: string, fingerprint: IGameVersionFingerprint) {
+    for (const file of fingerprint.files) {
+      const deployedPath = safePath(root, file.path);
+      let matched = false;
+      for (const candidate of [deployedPath + BACKUP_TAG, deployedPath]) {
+        try {
+          const result = await hashFile(candidate);
+          if (
+            result.hash.toLowerCase() === file.sha256.toLowerCase() &&
+            (file.size === undefined || result.numBytes === file.size)
+          ) {
+            matched = true;
+            break;
+          }
+        } catch {
+          // Try the deployed path after the Vortex backup.
+        }
+      }
+      if (!matched) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private async findStoreFile(root: string, relativePath: string, expectedHash: string) {
+    const deployedPath = safePath(root, relativePath);
+    for (const candidate of [deployedPath + BACKUP_TAG, deployedPath]) {
+      try {
+        if ((await hashFile(candidate)).hash.toLowerCase() === expectedHash.toLowerCase()) {
+          return candidate;
+        }
+      } catch {
+        // Try the next candidate.
+      }
+    }
+    throw new Error(`Store game file does not match the catalog: ${relativePath}`);
+  }
+
+  private async storeVersion(gameId: string, gamePath: string): Promise<string> {
+    const game = getGame(gameId);
+    if (game === undefined) {
+      return "Unknown";
+    }
+    const executablePath = safePath(gamePath, game.executable(gamePath));
+    const backupPath = executablePath + BACKUP_TAG;
+    try {
+      await fs.stat(backupPath);
+      return exeVersion.default(backupPath);
+    } catch {
+      return game.getInstalledVersion({
+        ...(this.mApi.getState() as IState).settings.gameMode.discovered[gameId],
+        path: gamePath,
+      });
+    }
+  }
+}

--- a/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
+++ b/src/renderer/src/extensions/gameversion_management/GameVersionTransitionManager.ts
@@ -518,7 +518,7 @@ export default class GameVersionTransitionManager {
     }
 
     const temporaryPath = safePath(stagingPath, `.installing-${modId}-${randomUUID()}`);
-    const cacheRoot = safePath(stagingPath, path.join(".game-version-cache", "sha256"));
+    const cacheRoot = path.join(getVortexPath("userData"), "game-version-cache", "sha256");
     this.setProgress(gameId, resolved.target.version, "planning", 0);
     await fs.mkdir(temporaryPath, { recursive: true });
     try {

--- a/src/renderer/src/extensions/gameversion_management/actions.ts
+++ b/src/renderer/src/extensions/gameversion_management/actions.ts
@@ -1,0 +1,8 @@
+import { createAction } from "redux-act";
+
+import type { IGameVersionJob } from "./types/IGameVersionState";
+
+export const setGameVersionJob = createAction(
+  "SET_GAME_VERSION_JOB",
+  (payload: { gameId: string; job?: IGameVersionJob }) => payload,
+);

--- a/src/renderer/src/extensions/gameversion_management/bethesda.ts
+++ b/src/renderer/src/extensions/gameversion_management/bethesda.ts
@@ -1,0 +1,18 @@
+import type { IGameVersionTransitionProvider } from "./types/IGameVersionTransitionProvider";
+
+const bethesdaProvider: IGameVersionTransitionProvider = {
+  id: "bethesda-v1",
+  priority: 100,
+  supportedGames: ["skyrimse", "fallout4", "skyrimvr", "fallout4vr"],
+  supportedStores: ["steam"],
+  supportedPlatforms: ["win32"],
+  catalog: {
+    url: "https://raw.githubusercontent.com/Nexus-Mods/Vortex-Backend/main/out/game-versioning/bethesda-v1.json",
+    trustedKeys: {
+      "bethesda-v1-2026-08": "MCowBQYDK2VwAyEAyDjA758LrNa6y4LKSnqYcSojp02e5Ik83vBK91bHIUM=",
+    },
+  },
+  launchMode: "direct",
+};
+
+export default bethesdaProvider;

--- a/src/renderer/src/extensions/gameversion_management/catalog.test.ts
+++ b/src/renderer/src/extensions/gameversion_management/catalog.test.ts
@@ -1,0 +1,93 @@
+import { generateKeyPairSync, sign } from "crypto";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadCatalog, versionMatches } from "./catalog";
+import type {
+  IGameVersionCatalog,
+  IGameVersionTransitionProvider,
+} from "./types/IGameVersionTransitionProvider";
+
+function provider(publicKey: string): IGameVersionTransitionProvider {
+  return {
+    id: "test-provider",
+    priority: 1,
+    supportedGames: ["test-game"],
+    supportedStores: ["steam"],
+    supportedPlatforms: [process.platform],
+    catalog: {
+      url: "https://example.invalid/catalog.json",
+      trustedKeys: { current: publicKey },
+    },
+    launchMode: "direct",
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("loadCatalog", () => {
+  it("accepts a catalog signed by a trusted Ed25519 key", async () => {
+    const keys = generateKeyPairSync("ed25519");
+    const catalog: IGameVersionCatalog = {
+      schemaVersion: 1,
+      providerId: "test-provider",
+      games: [],
+    };
+    const payload = Buffer.from(JSON.stringify(catalog));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          keyId: "current",
+          payload: payload.toString("base64"),
+          signature: sign(null, payload, keys.privateKey).toString("base64"),
+        }),
+      }),
+    );
+
+    const result = await loadCatalog(
+      provider(keys.publicKey.export({ format: "pem", type: "spki" }).toString()),
+    );
+
+    expect(result.catalog).toEqual(catalog);
+    expect(result.digest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("rejects a modified catalog", async () => {
+    const keys = generateKeyPairSync("ed25519");
+    const signedPayload = Buffer.from(
+      JSON.stringify({ schemaVersion: 1, providerId: "test-provider", games: [] }),
+    );
+    const modifiedPayload = Buffer.from(
+      JSON.stringify({ schemaVersion: 1, providerId: "other-provider", games: [] }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          keyId: "current",
+          payload: modifiedPayload.toString("base64"),
+          signature: sign(null, signedPayload, keys.privateKey).toString("base64"),
+        }),
+      }),
+    );
+
+    await expect(
+      loadCatalog(provider(keys.publicKey.export({ format: "pem", type: "spki" }).toString())),
+    ).rejects.toThrow("signature is invalid");
+  });
+});
+
+describe("versionMatches", () => {
+  it("matches canonical versions and aliases without case sensitivity", () => {
+    const target = { version: "1.5.97.0", aliases: ["1.5.97"] };
+
+    expect(versionMatches(target, "1.5.97.0")).toBe(true);
+    expect(versionMatches(target, " 1.5.97 ")).toBe(true);
+    expect(versionMatches(target, "1.6.1170.0")).toBe(false);
+  });
+});

--- a/src/renderer/src/extensions/gameversion_management/catalog.ts
+++ b/src/renderer/src/extensions/gameversion_management/catalog.ts
@@ -1,0 +1,130 @@
+import { createHash, createPublicKey, verify } from "crypto";
+
+import type {
+  IGameVersionCatalog,
+  IGameVersionTransitionProvider,
+  ISignedGameVersionCatalog,
+} from "./types/IGameVersionTransitionProvider";
+
+export interface ILoadedGameVersionCatalog {
+  catalog: IGameVersionCatalog;
+  digest: string;
+}
+
+function publicKey(input: string) {
+  return input.includes("BEGIN PUBLIC KEY")
+    ? createPublicKey(input)
+    : createPublicKey({ key: Buffer.from(input, "base64"), format: "der", type: "spki" });
+}
+
+function validateCatalog(catalog: IGameVersionCatalog, providerId: string): void {
+  if (catalog?.schemaVersion !== 1 || catalog.providerId !== providerId) {
+    throw new Error("Game-version catalog identity or schema is invalid");
+  }
+  if (!Array.isArray(catalog.games)) {
+    throw new Error("Game-version catalog has no games list");
+  }
+  const validHash = (value: string) => /^[a-f0-9]{64}$/i.test(value);
+  const validPath = (value: string) =>
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.includes("\0") &&
+    !value.split(/[\\/]/).includes("..") &&
+    !/^(?:[a-z]:|[\\/])/i.test(value);
+  for (const game of catalog.games) {
+    if (!Array.isArray(game.targets)) {
+      throw new Error("Game-version catalog target list is invalid");
+    }
+    for (const target of game.targets) {
+      if (
+        target.compatibilityNote !== undefined &&
+        (typeof target.compatibilityNote !== "string" || target.compatibilityNote.length > 1000)
+      ) {
+        throw new Error("Game-version catalog compatibility note is invalid");
+      }
+      const fingerprints = [target.fingerprint, ...target.transitions.map((item) => item.source)];
+      if (
+        fingerprints.some(
+          (fingerprint) =>
+            !Array.isArray(fingerprint?.files) ||
+            fingerprint.files.length === 0 ||
+            fingerprint.files.some(
+              (file) =>
+                !validPath(file.path) ||
+                !validHash(file.sha256) ||
+                (file.size !== undefined && (!Number.isSafeInteger(file.size) || file.size < 0)),
+            ),
+        )
+      ) {
+        throw new Error("Game-version catalog fingerprint is invalid");
+      }
+      for (const transition of target.transitions) {
+        if (!Array.isArray(transition.operations)) {
+          throw new Error("Game-version catalog operation list is invalid");
+        }
+        for (const operation of transition.operations) {
+          if (!validPath(operation.targetPath)) {
+            throw new Error("Game-version catalog contains an unsafe path");
+          }
+          if (
+            operation.type === "patch" &&
+            (!["bsdiff40-v1", "chunk-map-v1"].includes(operation.algorithm) ||
+              !validPath(operation.sourcePath) ||
+              !validHash(operation.sourceSha256) ||
+              !validHash(operation.targetSha256) ||
+              !Number.isSafeInteger(operation.targetSize) ||
+              operation.targetSize < 0 ||
+              !validHash(operation.artifact?.sha256) ||
+              !Number.isSafeInteger(operation.artifact?.size) ||
+              operation.artifact.size < 0 ||
+              new URL(operation.artifact.url).protocol !== "https:")
+          ) {
+            throw new Error("Game-version catalog patch operation is invalid");
+          }
+          if (operation.type !== "patch" && operation.type !== "remove") {
+            throw new Error("Game-version catalog operation type is invalid");
+          }
+        }
+      }
+    }
+  }
+}
+
+export async function loadCatalog(
+  provider: IGameVersionTransitionProvider,
+): Promise<ILoadedGameVersionCatalog> {
+  const url = new URL(provider.catalog.url);
+  if (url.protocol !== "https:") {
+    throw new Error("Game-version catalogs must be served over HTTPS");
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load game-version catalog (${response.status})`);
+  }
+  const envelope = (await response.json()) as ISignedGameVersionCatalog;
+  if (envelope?.schemaVersion !== 1) {
+    throw new Error("Unsupported signed game-version catalog schema");
+  }
+  const trustedKey = provider.catalog.trustedKeys[envelope.keyId];
+  if (trustedKey === undefined) {
+    throw new Error(`Untrusted game-version catalog key: ${envelope.keyId}`);
+  }
+  const payload = Buffer.from(envelope.payload, "base64");
+  const signature = Buffer.from(envelope.signature, "base64");
+  if (!verify(null, payload, publicKey(trustedKey), signature)) {
+    throw new Error("Game-version catalog signature is invalid");
+  }
+  const catalog = JSON.parse(payload.toString("utf8")) as IGameVersionCatalog;
+  validateCatalog(catalog, provider.id);
+  return {
+    catalog,
+    digest: createHash("sha256").update(payload).digest("hex"),
+  };
+}
+
+export function versionMatches(target: { version: string; aliases?: string[] }, input: string) {
+  const normalized = input.trim().toLowerCase();
+  return [target.version, ...(target.aliases ?? [])].some(
+    (candidate) => candidate.trim().toLowerCase() === normalized,
+  );
+}

--- a/src/renderer/src/extensions/gameversion_management/fileOperations.test.ts
+++ b/src/renderer/src/extensions/gameversion_management/fileOperations.test.ts
@@ -1,0 +1,88 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { gzipSync } from "zlib";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { applyChunkMap, safePath } from "./fileOperations";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("safePath", () => {
+  it("accepts descendants and rejects paths outside the managed root", () => {
+    const root = path.resolve("managed-root");
+
+    expect(safePath(root, path.join("game", "file.exe"))).toBe(path.join(root, "game", "file.exe"));
+    expect(() => safePath(root, path.join("..", "outside.exe"))).toThrow("escapes its root");
+    expect(() => safePath(root, path.resolve("outside.exe"))).toThrow("Unsafe");
+  });
+});
+
+describe("applyChunkMap", () => {
+  it("streams copied source ranges and literal data into the target", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vortex-chunk-map-"));
+    temporaryRoots.push(temporaryRoot);
+    const source = path.join(temporaryRoot, "source.bin");
+    const artifact = path.join(temporaryRoot, "patch.vgcmp.gz");
+    const output = path.join(temporaryRoot, "output.bin");
+    await fs.writeFile(source, "abcdefghij");
+
+    const copy = Buffer.alloc(13);
+    copy[0] = 0x00;
+    copy.writeBigUInt64LE(2n, 1);
+    copy.writeUInt32LE(4, 9);
+    const literal = Buffer.alloc(7);
+    literal[0] = 0x01;
+    literal.writeUInt32LE(2, 1);
+    literal.write("XY", 5);
+    const data = Buffer.concat([Buffer.from("VGCMP1\0"), copy, literal, Buffer.from([0xff])]);
+    await fs.writeFile(artifact, gzipSync(data));
+
+    await applyChunkMap(source, artifact, output, 6);
+
+    expect(await fs.readFile(output, "utf8")).toBe("cdefXY");
+  });
+
+  it("removes incomplete output when an artifact is invalid", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vortex-chunk-map-"));
+    temporaryRoots.push(temporaryRoot);
+    const source = path.join(temporaryRoot, "source.bin");
+    const artifact = path.join(temporaryRoot, "patch.vgcmp.gz");
+    const output = path.join(temporaryRoot, "output.bin");
+    await fs.writeFile(source, "source");
+    await fs.writeFile(
+      artifact,
+      gzipSync(Buffer.concat([Buffer.from("VGCMP1\0"), Buffer.from([0xff])])),
+    );
+
+    await expect(applyChunkMap(source, artifact, output, 1)).rejects.toThrow("wrong size");
+    await expect(fs.stat(output)).rejects.toThrow();
+  });
+
+  it("rejects trailing instructions and removes their output", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vortex-chunk-map-"));
+    temporaryRoots.push(temporaryRoot);
+    const source = path.join(temporaryRoot, "source.bin");
+    const artifact = path.join(temporaryRoot, "patch.vgcmp.gz");
+    const output = path.join(temporaryRoot, "output.bin");
+    await fs.writeFile(source, "source");
+    const literal = Buffer.alloc(6);
+    literal[0] = 0x01;
+    literal.writeUInt32LE(1, 1);
+    literal[5] = 0x78;
+    await fs.writeFile(
+      artifact,
+      gzipSync(Buffer.concat([Buffer.from("VGCMP1\0"), literal, Buffer.from([0xff, 0xff])])),
+    );
+
+    await expect(applyChunkMap(source, artifact, output, 1)).rejects.toThrow("trailing data");
+    await expect(fs.stat(output)).rejects.toThrow();
+  });
+});

--- a/src/renderer/src/extensions/gameversion_management/fileOperations.ts
+++ b/src/renderer/src/extensions/gameversion_management/fileOperations.ts
@@ -1,0 +1,260 @@
+import { createHash } from "crypto";
+import * as fsSync from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { createGunzip } from "zlib";
+
+import type {
+  IGameVersionArtifact,
+  IGameVersionFingerprint,
+} from "./types/IGameVersionTransitionProvider";
+
+export function safePath(root: string, relativePath: string): string {
+  if (
+    typeof relativePath !== "string" ||
+    relativePath.length === 0 ||
+    relativePath.includes("\0") ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Unsafe game-version path: ${relativePath}`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Game-version path escapes its root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+export async function hashFile(filePath: string): Promise<{ hash: string; numBytes: number }> {
+  return window.api.hash.compute("sha256", filePath);
+}
+
+export async function verifyFingerprint(root: string, fingerprint: IGameVersionFingerprint) {
+  if (!Array.isArray(fingerprint?.files) || fingerprint.files.length === 0) {
+    return false;
+  }
+  for (const file of fingerprint.files) {
+    const filePath = safePath(root, file.path);
+    const result = await hashFile(filePath);
+    if (
+      result.hash.toLowerCase() !== file.sha256.toLowerCase() ||
+      (file.size !== undefined && result.numBytes !== file.size)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function fingerprintDigest(fingerprint: IGameVersionFingerprint): string {
+  const entries = fingerprint.files
+    .map((file) => `${file.path.replaceAll("\\", "/").toLowerCase()}\0${file.sha256.toLowerCase()}`)
+    .sort();
+  return createHash("sha256").update(entries.join("\n")).digest("hex");
+}
+
+export async function acquireArtifact(
+  artifact: IGameVersionArtifact,
+  cacheRoot: string,
+): Promise<string> {
+  if (!/^[a-f0-9]{64}$/i.test(artifact.sha256) || artifact.size < 0) {
+    throw new Error("Invalid game-version artifact metadata");
+  }
+  const target = safePath(cacheRoot, artifact.sha256.toLowerCase());
+  await fs.mkdir(cacheRoot, { recursive: true });
+  try {
+    const current = await hashFile(target);
+    if (
+      current.hash.toLowerCase() === artifact.sha256.toLowerCase() &&
+      current.numBytes === artifact.size
+    ) {
+      return target;
+    }
+  } catch {
+    // Missing or invalid cache entry: replace it below.
+  }
+  await fs.rm(target, { force: true });
+  const url = new URL(artifact.url);
+  if (url.protocol !== "https:") {
+    throw new Error("Game-version artifacts must be served over HTTPS");
+  }
+  const partial = `${target}.partial-${crypto.randomUUID()}`;
+  const response = await fetch(url);
+  if (!response.ok || response.body === null) {
+    throw new Error(`Failed to download game-version artifact (${response.status})`);
+  }
+  const declaredSize = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredSize) && declaredSize > artifact.size) {
+    throw new Error("Game-version artifact exceeds its declared size");
+  }
+  let received = 0;
+  let output: fs.FileHandle | undefined;
+  const reader = response.body.getReader();
+  try {
+    output = await fs.open(partial, "wx");
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      const chunk = Buffer.from(value);
+      if (received + chunk.length > artifact.size) {
+        throw new Error("Game-version artifact exceeds its declared size");
+      }
+      await writeBuffer(output, chunk, received);
+      received += chunk.length;
+    }
+  } catch (err) {
+    await reader.cancel().catch(() => undefined);
+    await output?.close();
+    await fs.rm(partial, { force: true });
+    throw err;
+  }
+  await output.close();
+  const downloaded = await hashFile(partial);
+  if (
+    downloaded.hash.toLowerCase() !== artifact.sha256.toLowerCase() ||
+    downloaded.numBytes !== artifact.size
+  ) {
+    await fs.rm(partial, { force: true });
+    throw new Error("Downloaded game-version artifact failed verification");
+  }
+  await fs.rename(partial, target);
+  return target;
+}
+
+const CHUNK_MAP_MAGIC = Buffer.from("VGCMP1\0", "ascii");
+const MAX_CHUNK_MAP_LITERAL = 16 * 1024 * 1024;
+const MAX_CHUNK_MAP_COPY = 64 * 1024 * 1024;
+
+class StreamReader {
+  private mIterator: AsyncIterator<Buffer>;
+  private mBuffered = Buffer.alloc(0);
+  private mEnded = false;
+
+  constructor(stream: AsyncIterable<Buffer | string>) {
+    this.mIterator = stream[Symbol.asyncIterator]() as AsyncIterator<Buffer>;
+  }
+
+  public async read(length: number, allowEnd = false): Promise<Buffer | undefined> {
+    while (this.mBuffered.length < length && !this.mEnded) {
+      const next = await this.mIterator.next();
+      this.mEnded = next.done === true;
+      if (!this.mEnded) {
+        const chunk = Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value);
+        this.mBuffered =
+          this.mBuffered.length === 0 ? chunk : Buffer.concat([this.mBuffered, chunk]);
+      }
+    }
+    if (this.mBuffered.length < length) {
+      if (allowEnd && this.mBuffered.length === 0) {
+        return undefined;
+      }
+      throw new Error("Chunk-map artifact ended unexpectedly");
+    }
+    const result = this.mBuffered.subarray(0, length);
+    this.mBuffered = this.mBuffered.subarray(length);
+    return result;
+  }
+}
+
+async function copyRange(
+  source: fs.FileHandle,
+  output: fs.FileHandle,
+  sourceOffset: number,
+  outputOffset: number,
+  length: number,
+): Promise<void> {
+  const buffer = Buffer.allocUnsafe(Math.min(length, 1024 * 1024));
+  let copied = 0;
+  while (copied < length) {
+    const requested = Math.min(buffer.length, length - copied);
+    const { bytesRead } = await source.read(buffer, 0, requested, sourceOffset + copied);
+    if (bytesRead !== requested) {
+      throw new Error("Chunk-map copy exceeds its source file");
+    }
+    await writeBuffer(output, buffer.subarray(0, bytesRead), outputOffset + copied);
+    copied += bytesRead;
+  }
+}
+
+async function writeBuffer(output: fs.FileHandle, data: Buffer, position: number): Promise<void> {
+  let written = 0;
+  while (written < data.length) {
+    const result = await output.write(data, written, data.length - written, position + written);
+    if (result.bytesWritten === 0) {
+      throw new Error("Failed to write chunk-map output");
+    }
+    written += result.bytesWritten;
+  }
+}
+
+/** Apply a gzip-compressed VGCMP1 stream without loading the source, target, or patch into memory. */
+export async function applyChunkMap(
+  sourcePath: string,
+  patchPath: string,
+  outputPath: string,
+  targetSize: number,
+): Promise<void> {
+  const source = await fs.open(sourcePath, "r");
+  const output = await fs.open(outputPath, "wx");
+  const compressed = fsSync.createReadStream(patchPath);
+  const uncompressed = compressed.pipe(createGunzip());
+  const reader = new StreamReader(uncompressed);
+  let outputOffset = 0;
+  let succeeded = false;
+  try {
+    const magic = await reader.read(CHUNK_MAP_MAGIC.length);
+    if (!magic?.equals(CHUNK_MAP_MAGIC)) {
+      throw new Error("Invalid chunk-map artifact header");
+    }
+    while (true) {
+      const opcode = (await reader.read(1))![0];
+      if (opcode === 0xff) {
+        break;
+      }
+      if (opcode === 0x00) {
+        const header = (await reader.read(12))!;
+        const sourceOffset = Number(header.readBigUInt64LE(0));
+        const length = header.readUInt32LE(8);
+        if (!Number.isSafeInteger(sourceOffset) || length === 0 || length > MAX_CHUNK_MAP_COPY) {
+          throw new Error("Invalid chunk-map copy instruction");
+        }
+        if (outputOffset + length > targetSize) {
+          throw new Error("Chunk-map output exceeds its declared size");
+        }
+        await copyRange(source, output, sourceOffset, outputOffset, length);
+        outputOffset += length;
+      } else if (opcode === 0x01) {
+        const length = (await reader.read(4))!.readUInt32LE(0);
+        if (length === 0 || length > MAX_CHUNK_MAP_LITERAL) {
+          throw new Error("Invalid chunk-map literal instruction");
+        }
+        if (outputOffset + length > targetSize) {
+          throw new Error("Chunk-map output exceeds its declared size");
+        }
+        const literal = (await reader.read(length))!;
+        await writeBuffer(output, literal, outputOffset);
+        outputOffset += literal.length;
+      } else {
+        throw new Error(`Unknown chunk-map opcode: ${opcode}`);
+      }
+    }
+    if (outputOffset !== targetSize) {
+      throw new Error("Chunk-map output has the wrong size");
+    }
+    if ((await reader.read(1, true)) !== undefined) {
+      throw new Error("Chunk-map artifact has trailing data");
+    }
+    succeeded = true;
+  } finally {
+    compressed.destroy();
+    uncompressed.destroy();
+    await Promise.all([source.close(), output.close()]);
+    if (!succeeded) {
+      await fs.rm(outputPath, { force: true });
+    }
+  }
+}

--- a/src/renderer/src/extensions/gameversion_management/index.ts
+++ b/src/renderer/src/extensions/gameversion_management/index.ts
@@ -1,13 +1,21 @@
+import PromiseBB from "bluebird";
+
 import type { IExtensionContext } from "../../types/IExtensionContext";
 import local from "../../util/local";
+import { activeGameId } from "../../util/selectors";
 import { wrapExtCBAsync } from "../../util/util";
+import { setFeature } from "../profile_management/actions/profiles";
+import bethesdaProvider from "./bethesda";
 import GameVersionManager from "./GameVersionManager";
+import GameVersionTransitionManager from "./GameVersionTransitionManager";
+import { sessionReducer } from "./reducers";
 import type {
   GameVersionProviderFunc,
   GameVersionProviderTest,
   IGameVersionProvider,
   IGameVersionProviderOptions,
 } from "./types/IGameVersionProvider";
+import type { IGameVersionTransitionProvider } from "./types/IGameVersionTransitionProvider";
 import {
   getExecGameVersion,
   getExtGameVersion,
@@ -19,13 +27,18 @@ import isVersionProvider from "./util/validation";
 // oh boy
 const $ = local<{
   gameVersionManager: GameVersionManager;
+  gameVersionTransitionManager: GameVersionTransitionManager;
 }>("gameversion-manager", {
   gameVersionManager: undefined,
+  gameVersionTransitionManager: undefined,
 });
 
 const gameVersionProviders: IGameVersionProvider[] = [];
+const transitionProviders: IGameVersionTransitionProvider[] = [];
 
 function init(context: IExtensionContext): boolean {
+  context.registerReducer(["session", "gameVersioning"], sessionReducer);
+
   context.registerGameVersionProvider = ((
     id: string,
     priority: number,
@@ -56,6 +69,23 @@ function init(context: IExtensionContext): boolean {
     gameVersionProviders.sort((lhs, rhs) => lhs.priority - rhs.priority);
   }) as any;
 
+  context.registerGameVersionTransitionProvider = (provider) => {
+    if (
+      provider?.id === undefined ||
+      provider.catalog?.url === undefined ||
+      Object.keys(provider.catalog.trustedKeys ?? {}).length === 0
+    ) {
+      context.api.showErrorNotification(
+        "Invalid game version transition provider",
+        "The provider is missing its id, catalog URL, or trusted key",
+        { allowReport: false },
+      );
+      return;
+    }
+    transitionProviders.push(provider);
+    transitionProviders.sort((lhs, rhs) => lhs.priority - rhs.priority);
+  };
+
   context.registerGameVersionProvider("ext-version-check", 20, testExtProvider, getExtGameVersion);
   context.registerGameVersionProvider(
     "exec-version-check",
@@ -69,10 +99,115 @@ function init(context: IExtensionContext): boolean {
     () => Promise.resolve(true),
     () => Promise.resolve("0.0.0"),
   );
+  context.registerGameVersionTransitionProvider(bethesdaProvider);
+
+  context.registerModType(
+    "game-version",
+    10,
+    (gameId) => transitionProviders.some((provider) => provider.supportedGames.includes(gameId)),
+    (game) => context.api.getState().settings.gameMode.discovered[game.id]?.path,
+    () => PromiseBB.resolve(false),
+    { mergeMods: true, name: "Game Version" },
+  );
+
+  context.registerProfileSelectFeature(
+    "game_version",
+    "revision",
+    "Game Version",
+    "Choose whether this profile uses the store installation or a managed game version.",
+    () => {
+      const gameId = activeGameId(context.api.getState());
+      const store =
+        gameId === undefined
+          ? undefined
+          : context.api.getState().settings.gameMode.discovered[gameId]?.store;
+      return (
+        gameId !== undefined &&
+        store !== undefined &&
+        transitionProviders.some(
+          (provider) =>
+            provider.supportedPlatforms.includes(process.platform) &&
+            provider.supportedGames.includes(gameId) &&
+            provider.supportedStores.includes(store),
+        )
+      );
+    },
+    (profile) => $.gameVersionTransitionManager?.getProfileChoices(profile.gameId) ?? [],
+    (value) => {
+      if (typeof value !== "string" || value === "store") {
+        return "Store installation";
+      }
+      return value.startsWith("managed:") ? `${value.slice("managed:".length)} (Managed)` : value;
+    },
+  );
 
   context.once(() => {
     $.gameVersionManager = new GameVersionManager(context.api, gameVersionProviders);
+    $.gameVersionTransitionManager = new GameVersionTransitionManager(
+      context.api,
+      transitionProviders,
+    );
+    context.api.onAsync("prepare-game-version-for-profile", (profileId: string) =>
+      $.gameVersionTransitionManager.prepareProfileVersion(profileId, false),
+    );
+    context.api.events.on("mod-enabled", (profileId: string, modId: string) =>
+      $.gameVersionTransitionManager.handleModStateChange(profileId, modId, true),
+    );
+    context.api.events.on("mod-disabled", (profileId: string, modId: string) =>
+      $.gameVersionTransitionManager.handleModStateChange(profileId, modId, false),
+    );
+    context.api.onAsync("will-remove-mod", (gameId: string, modId: string) =>
+      $.gameVersionTransitionManager.handleModRemoval(gameId, modId),
+    );
+
+    let applyingProfileSetting = false;
+    context.api.onStateChange(["persistent", "profiles"], (previous, current) => {
+      if (applyingProfileSetting) {
+        return;
+      }
+      const profileId = (context.api.getState() as any).settings.profiles.activeProfileId;
+      if (profileId === undefined) {
+        return;
+      }
+      if ($.gameVersionTransitionManager.isUpdatingProfile(profileId)) {
+        return;
+      }
+      const before = previous[profileId]?.features?.game_version ?? "store";
+      const after = current[profileId]?.features?.game_version ?? "store";
+      if (before === after) {
+        return;
+      }
+      applyingProfileSetting = true;
+      void $.gameVersionTransitionManager
+        .prepareProfileVersion(profileId, true)
+        .catch((err) => {
+          context.api.store.dispatch(setFeature(profileId, "game_version", before));
+          context.api.showErrorNotification("Failed to change the profile game version", err, {
+            allowReport: false,
+          });
+        })
+        .finally(() => {
+          applyingProfileSetting = false;
+        });
+    });
+    void $.gameVersionTransitionManager.reconcile();
   });
+
+  context.registerAPI(
+    "ensureGameVersion",
+    (gameId: string, versions: string[], selection?: "prompt" | "prepare" | "skip") =>
+      $.gameVersionTransitionManager?.ensure(gameId, versions, selection) ??
+      Promise.resolve("unavailable"),
+    { minArguments: 2 },
+  );
+
+  context.registerAPI(
+    "inspectGameVersionTransition",
+    (gameId: string, versions: string[]) =>
+      $.gameVersionTransitionManager?.inspect(gameId, versions) ??
+      Promise.resolve({ status: "unavailable" }),
+    { minArguments: 2 },
+  );
 
   return true;
 }

--- a/src/renderer/src/extensions/gameversion_management/index.ts
+++ b/src/renderer/src/extensions/gameversion_management/index.ts
@@ -159,6 +159,9 @@ function init(context: IExtensionContext): boolean {
     context.api.onAsync("will-remove-mod", (gameId: string, modId: string) =>
       $.gameVersionTransitionManager.handleModRemoval(gameId, modId),
     );
+    context.api.onAsync("did-deploy", (profileId: string) =>
+      $.gameVersionTransitionManager.handleDeployment(profileId),
+    );
 
     let applyingProfileSetting = false;
     context.api.onStateChange(["persistent", "profiles"], (previous, current) => {

--- a/src/renderer/src/extensions/gameversion_management/reducers.ts
+++ b/src/renderer/src/extensions/gameversion_management/reducers.ts
@@ -1,0 +1,14 @@
+import type { IReducerSpec } from "../../types/IExtensionContext";
+import { deleteOrNop, setSafe } from "../../util/storeHelper";
+import { setGameVersionJob } from "./actions";
+import type { IGameVersionSessionState } from "./types/IGameVersionState";
+
+export const sessionReducer: IReducerSpec<IGameVersionSessionState> = {
+  reducers: {
+    [setGameVersionJob as any]: (state, payload) =>
+      payload.job === undefined
+        ? deleteOrNop(state, ["jobs", payload.gameId])
+        : setSafe(state, ["jobs", payload.gameId], payload.job),
+  },
+  defaults: { jobs: {} },
+};

--- a/src/renderer/src/extensions/gameversion_management/types/IGameVersionState.ts
+++ b/src/renderer/src/extensions/gameversion_management/types/IGameVersionState.ts
@@ -1,0 +1,12 @@
+export type GameVersionJobPhase = "planning" | "patching" | "committing";
+
+export interface IGameVersionJob {
+  gameId: string;
+  targetVersion: string;
+  phase: GameVersionJobPhase;
+  progress: number;
+}
+
+export interface IGameVersionSessionState {
+  jobs: Record<string, IGameVersionJob>;
+}

--- a/src/renderer/src/extensions/gameversion_management/types/IGameVersionTransitionProvider.ts
+++ b/src/renderer/src/extensions/gameversion_management/types/IGameVersionTransitionProvider.ts
@@ -1,0 +1,85 @@
+export interface IGameVersionTransitionCatalogSource {
+  url: string;
+  trustedKeys: Record<string, string>;
+}
+
+export interface IGameVersionTransitionProvider {
+  id: string;
+  priority: number;
+  supportedGames: string[];
+  supportedStores: string[];
+  supportedPlatforms: NodeJS.Platform[];
+  catalog: IGameVersionTransitionCatalogSource;
+  launchMode: "direct";
+}
+
+export type GameVersionPatchAlgorithm = "bsdiff40-v1" | "chunk-map-v1";
+
+export interface IGameVersionFingerprintFile {
+  path: string;
+  sha256: string;
+  size?: number;
+}
+
+export interface IGameVersionFingerprint {
+  files: IGameVersionFingerprintFile[];
+}
+
+export interface IGameVersionArtifact {
+  url: string;
+  sha256: string;
+  size: number;
+}
+
+export interface IGameVersionPatchOperation {
+  type: "patch";
+  algorithm: GameVersionPatchAlgorithm;
+  sourcePath: string;
+  targetPath: string;
+  sourceSha256: string;
+  targetSha256: string;
+  targetSize: number;
+  artifact: IGameVersionArtifact;
+}
+
+export interface IGameVersionRemoveOperation {
+  type: "remove";
+  targetPath: string;
+}
+
+export type GameVersionTransitionOperation =
+  | IGameVersionPatchOperation
+  | IGameVersionRemoveOperation;
+
+export interface IGameVersionTransition {
+  source: IGameVersionFingerprint;
+  operations: GameVersionTransitionOperation[];
+}
+
+export interface IGameVersionTarget {
+  version: string;
+  aliases?: string[];
+  compatibilityNote?: string;
+  fingerprint: IGameVersionFingerprint;
+  transitions: IGameVersionTransition[];
+}
+
+export interface IGameVersionCatalogGame {
+  gameId: string;
+  store: string;
+  appId?: string;
+  targets: IGameVersionTarget[];
+}
+
+export interface IGameVersionCatalog {
+  schemaVersion: 1;
+  providerId: string;
+  games: IGameVersionCatalogGame[];
+}
+
+export interface ISignedGameVersionCatalog {
+  schemaVersion: 1;
+  keyId: string;
+  payload: string;
+  signature: string;
+}

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -461,6 +461,11 @@ function genOnProfileChange(
                 })
                 .then(() => {
                   log("info", "did deploy previously active profile", prev);
+                  log("info", "will prepare game version for next profile", current);
+                  return api.emitAndAwait("prepare-game-version-for-profile", current);
+                })
+                .then(() => {
+                  log("info", "did prepare game version for next profile", current);
                   log("info", "will deploy next active profile", current);
                   return deploy(api, current);
                 })
@@ -1014,6 +1019,30 @@ function init(context: IExtensionContext): boolean {
       label,
       description,
       supported,
+      namespace: extInfo?.namespace,
+    });
+  };
+
+  context.registerProfileSelectFeature = (
+    featureId: string,
+    icon: string,
+    label: string,
+    description: string,
+    supported: () => boolean,
+    choices: IProfileFeature["choices"],
+    formatValue?: IProfileFeature["formatValue"],
+    extPath?: string,
+    extInfo?: Partial<IRegisteredExtension>,
+  ) => {
+    profileFeatures.push({
+      id: featureId,
+      type: "select",
+      icon,
+      label,
+      description,
+      supported,
+      choices,
+      formatValue,
       namespace: extInfo?.namespace,
     });
   };

--- a/src/renderer/src/extensions/profile_management/types/IProfileFeature.ts
+++ b/src/renderer/src/extensions/profile_management/types/IProfileFeature.ts
@@ -1,3 +1,10 @@
+import type { IProfile } from "./IProfile";
+
+export interface IProfileFeatureChoice {
+  value: string;
+  label: string;
+}
+
 export interface IProfileFeature {
   id: string;
   icon: string;
@@ -10,5 +17,7 @@ export interface IProfileFeature {
   type: string;
   description: string;
   supported: () => boolean;
+  choices?: (profile: IProfile) => IProfileFeatureChoice[] | PromiseLike<IProfileFeatureChoice[]>;
+  formatValue?: (value: unknown) => string;
   namespace?: string;
 }

--- a/src/renderer/src/extensions/profile_management/views/ProfileEdit.tsx
+++ b/src/renderer/src/extensions/profile_management/views/ProfileEdit.tsx
@@ -1,13 +1,14 @@
 import update from "immutability-helper";
 import * as React from "react";
 import { FormControl, ListGroupItem, Panel } from "react-bootstrap";
+import Select from "react-select";
 
 import { ComponentEx } from "../../../controls/ComponentEx";
 import Toggle from "../../../controls/Toggle";
 import { Button } from "../../../controls/TooltipControls";
 import { getSafe, setSafe } from "../../../util/storeHelper";
 import type { IProfile } from "../types/IProfile";
-import type { IProfileFeature } from "../types/IProfileFeature";
+import type { IProfileFeature, IProfileFeatureChoice } from "../types/IProfileFeature";
 
 const MIN_PROFILE_NAME_LENGTH = 3;
 const MAX_PROFILE_NAME_LENGTH = 64;
@@ -15,6 +16,7 @@ const MAX_PROFILE_NAME_LENGTH = 64;
 export interface IEditState {
   edit: IProfile;
   features: IProfileFeature[];
+  choices: Record<string, IProfileFeatureChoice[]>;
 }
 
 export interface IEditProps {
@@ -42,6 +44,7 @@ class ProfileEdit extends ComponentEx<IEditProps, IEditState> {
         ? {
             edit: { ...props.profile },
             features,
+            choices: {},
           }
         : {
             edit: {
@@ -52,7 +55,12 @@ class ProfileEdit extends ComponentEx<IEditProps, IEditState> {
               lastActivated: 0,
             },
             features,
+            choices: {},
           };
+  }
+
+  public componentDidMount() {
+    void this.loadChoices();
   }
 
   public UNSAFE_componentWillReceiveProps(newProps: IEditProps) {
@@ -64,6 +72,7 @@ class ProfileEdit extends ComponentEx<IEditProps, IEditState> {
           },
         }),
       );
+      void this.loadChoices(newProps);
     }
   }
 
@@ -127,7 +136,7 @@ class ProfileEdit extends ComponentEx<IEditProps, IEditState> {
 
   private renderFeature = (feature: IProfileFeature) => {
     const { t } = this.props;
-    const { edit } = this.state;
+    const { choices, edit } = this.state;
     if (feature.type === "boolean") {
       return (
         <Toggle
@@ -150,7 +159,40 @@ class ProfileEdit extends ComponentEx<IEditProps, IEditState> {
           onChange={this.assignString}
         />
       );
+    } else if (feature.type === "select") {
+      const options = choices[feature.id] ?? [];
+      const selectedValue = getSafe(edit, ["features", feature.id], "store");
+      return (
+        <div className="profile-feature-select" key={feature.id}>
+          <label>{t(feature.label)}:</label>
+          <Select
+            clearable={false}
+            disabled={options.length === 0}
+            options={options}
+            value={selectedValue}
+            onChange={(choice: IProfileFeatureChoice) =>
+              this.assignChoice(feature.id, choice?.value ?? "store")
+            }
+          />
+        </div>
+      );
     }
+  };
+
+  private loadChoices = async (props: IEditProps = this.props) => {
+    const profile = this.state.edit;
+    const entries = await Promise.all(
+      this.state.features
+        .filter((feature) => feature.type === "select" && feature.choices !== undefined)
+        .map(async (feature) => [feature.id, await feature.choices(profile)] as const),
+    );
+    if (props === this.props) {
+      this.setState({ choices: Object.fromEntries(entries) });
+    }
+  };
+
+  private assignChoice = (featureId: string, value: string) => {
+    this.setState(setSafe(this.state, ["edit", "features", featureId], value));
   };
 
   private toggleCheckbox = (ticked: boolean, dataId: string) => {

--- a/src/renderer/src/extensions/profile_management/views/ProfileItem.tsx
+++ b/src/renderer/src/extensions/profile_management/views/ProfileItem.tsx
@@ -232,7 +232,9 @@ class ProfileItem extends ComponentEx<IProps, IComponentState> {
             {t(feature.label, { ns: feature.namespace })}
           </a>
         </div>
-        <div className="profile-feature-value">{this.renderFeatureValue(feature.type, value)}</div>
+        <div className="profile-feature-value">
+          {feature.formatValue?.(value) ?? this.renderFeatureValue(feature.type, value)}
+        </div>
       </React.Fragment>
     );
   }

--- a/src/renderer/src/types/IExtensionContext.ts
+++ b/src/renderer/src/types/IExtensionContext.ts
@@ -13,6 +13,7 @@ import type {
   GameVersionProviderTest,
   IGameVersionProviderOptions,
 } from "../extensions/gameversion_management/types/IGameVersionProvider";
+import type { IGameVersionTransitionProvider } from "../extensions/gameversion_management/types/IGameVersionTransitionProvider";
 import type { IHistoryEvent, IHistoryStack } from "../extensions/history_management/types";
 import type { IGameLoadOrderEntry } from "../extensions/mod_load_order/types/types";
 import type {
@@ -32,6 +33,8 @@ import type {
   TestSupported,
 } from "../extensions/mod_management/types/TestSupported";
 import type { INexusAPIExtension } from "../extensions/nexus_integration/types/INexusAPIExtension";
+import type { IProfile } from "../extensions/profile_management/types/IProfile";
+import type { IProfileFeatureChoice } from "../extensions/profile_management/types/IProfileFeature";
 import type ReduxProp from "../ReduxProp";
 import type { SanityCheck } from "../store/reduxSanity";
 import type { Archive } from "../util/archives";
@@ -1494,6 +1497,17 @@ export interface IExtensionContext {
     supported: () => boolean,
   ) => void;
 
+  /** Register a profile setting whose choices may be resolved asynchronously. */
+  registerProfileSelectFeature?: (
+    featureId: string,
+    icon: string,
+    label: string,
+    description: string,
+    supported: () => boolean,
+    choices: (profile: IProfile) => IProfileFeatureChoice[] | PromiseLike<IProfileFeatureChoice[]>,
+    formatValue?: (value: unknown) => string,
+  ) => void;
+
   /**
    * register a game version resolution provider.
    */
@@ -1504,6 +1518,9 @@ export interface IExtensionContext {
     getVersion: GameVersionProviderFunc,
     options?: IGameVersionProviderOptions,
   ) => void;
+
+  /** Register an opt-in provider for non-destructive game-version transitions. */
+  registerGameVersionTransitionProvider?: (provider: IGameVersionTransitionProvider) => void;
 
   /**
    * register a handler that can be used to preview or diff files.

--- a/src/renderer/src/types/IState.ts
+++ b/src/renderer/src/types/IState.ts
@@ -6,6 +6,7 @@ import type { ICategoryDictionary } from "../extensions/category_management/type
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
+import type { IGameVersionSessionState } from "../extensions/gameversion_management/types/IGameVersionState";
 import type { IHealthCheckPersistentState } from "../extensions/health_check/reducers/persistent";
 import type { IHealthCheckSessionState } from "../extensions/health_check/reducers/session";
 import type { IHistoryPersistent, IHistoryState } from "../extensions/history_management/reducers";
@@ -409,6 +410,7 @@ export interface ISessionState {
   history: IHistoryState;
   overlays: IOverlaysState;
   healthCheck: IHealthCheckSessionState;
+  gameVersioning: IGameVersionSessionState;
 }
 
 export interface IState {

--- a/src/renderer/src/types/api.ts
+++ b/src/renderer/src/types/api.ts
@@ -54,6 +54,10 @@ export type {
   IUnavailableReason,
 } from "../extensions/mod_management/types/IDeploymentMethod";
 export type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
+export type {
+  IGameVersionTransitionProvider,
+  IGameVersionCatalog,
+} from "../extensions/gameversion_management/types/IGameVersionTransitionProvider";
 export type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 export type { IDeploymentManifest } from "../extensions/mod_management/types/IDeploymentManifest";
 export type {

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -319,7 +319,7 @@ export interface FlagMetricsBucket {
 }
 
 /** Hash algorithms the app requests over `hash:compute`. Closed set; extend as callers need. */
-export type HashAlgorithm = "md5";
+export type HashAlgorithm = "md5" | "sha256";
 
 /** Type containing all known channels used by renderer processes to send to and receive messages from the main process */
 export interface InvokeChannels {

--- a/src/stylesheets/collections.scss
+++ b/src/stylesheets/collections.scss
@@ -1634,7 +1634,8 @@ ul.collection-mods-page-attrib-tooltip {
     margin-top: $gutter-width;
 }
 
-#collections-profile-select {
+#collections-profile-select,
+#collections-game-version-select {
     //@extend .gutter-above;
 
     place-items: center;

--- a/src/stylesheets/vortex/page-profile.scss
+++ b/src/stylesheets/vortex/page-profile.scss
@@ -97,8 +97,46 @@
 .profile-edit-panel {
     height: initial;
     margin: $half-gutter;
+    overflow: visible;
+
+    > .panel-body,
+    .list-group-item {
+        overflow: visible;
+    }
+
     .btn {
         margin: 0 4px;
+    }
+
+    .profile-feature-select {
+        display: flex;
+        align-items: center;
+        gap: $half-gutter;
+        margin-top: $gutter-width;
+
+        label {
+            flex: 0 0 auto;
+            margin: 0;
+        }
+
+        .Select {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+
+        .Select-menu-outer {
+            z-index: 10;
+        }
+
+        .Select-option.is-selected {
+            background-color: $input-bg;
+            color: $text-color;
+        }
+
+        .Select-option.is-focused {
+            background-color: $brand-secondary;
+            color: $text-color;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds profile-specific game-version preparation for Collections.

Managed versions are installed as internal mods through Vortex's existing staging, deployment and backup systems.

Includes:

- signed transition catalog support
- SHA-256 verification
- bsdiff and streaming chunk-map patches
- Collection installation options
- profile-specific version selection
- profile-switch synchronization
- enable, disable and remove support
- exclusion from Collection exports
- existing fallback warning for unsupported versions

Generation workspace: https://github.com/Modding-Forge/steamcmd-bethesda

Initial support covers Skyrim Special Edition and Fallout 4 on Steam for Windows.

Closes #23987

Companion PR: Nexus-Mods/Vortex-Backend#28