### PR TITLE
updater 3/5: resolve updates ourselves, max semver per channel

### DIFF
--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -1,0 +1,125 @@
+/**
+ * Local mock of the GitHub releases API + release assets, for live-testing
+ * the auto-updater without touching GitHub.
+ *
+ * Serves:
+ *   GET /repos/Nexus-Mods/<repo>/releases            release listing (fixture)
+ *   GET /Nexus-Mods/<repo>/releases/download/<tag>/latest.yml
+ *   GET /Nexus-Mods/<repo>/releases/download/<tag>/<installer>.exe
+ *
+ * latest.yml and a dummy installer are generated per release tag with a
+ * matching sha512, so electron-updater's download + hash verification pass.
+ * (Authenticode verification and the actual install still need a packaged,
+ * signed build — this covers resolve → notify → download.)
+ *
+ * Usage:
+ *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe]
+ *
+ * Then run Vortex with:
+ *   VORTEX_UPDATER_API_BASE=http://localhost:9877
+ *   VORTEX_UPDATER_DOWNLOAD_BASE=http://localhost:9877
+ *
+ * The default fixture is the resolver test fixture (the real interleaved
+ * release scenario). Edit a copy to reproduce field reports: set the release
+ * list to what the user saw and watch what the updater does.
+ * --installer serves a real exe (e.g. a locally built vortex-setup) instead
+ * of dummy bytes, which lets a packaged build complete a full update cycle.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const argv = process.argv.slice(2);
+function arg(name, fallback) {
+  const index = argv.indexOf(`--${name}`);
+  return index >= 0 && argv[index + 1] != null ? argv[index + 1] : fallback;
+}
+
+const port = Number(arg("port", "9877"));
+const fixturePath = arg(
+  "fixture",
+  path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "src",
+    "main",
+    "src",
+    "extensions",
+    "autoupdater",
+    "__fixtures__",
+    "releases.json",
+  ),
+);
+const installerPath = arg("installer", null);
+
+const releases = JSON.parse(readFileSync(fixturePath, "utf8"));
+const installerBytes =
+  installerPath != null
+    ? readFileSync(installerPath)
+    : Buffer.from(`mock vortex installer ${Date.now()}`);
+const installerSha512 = createHash("sha512").update(installerBytes).digest("base64");
+
+function installerNameForTag(tag) {
+  return `vortex-setup-${tag.replace(/^v/, "")}.exe`;
+}
+
+function latestYmlForTag(tag) {
+  const name = installerNameForTag(tag);
+  const version = tag.replace(/^v/, "");
+  return [
+    `version: ${version}`,
+    "files:",
+    `  - url: ${name}`,
+    `    sha512: ${installerSha512}`,
+    `    size: ${installerBytes.length}`,
+    `path: ${name}`,
+    `sha512: ${installerSha512}`,
+    `releaseDate: '${new Date().toISOString()}'`,
+    "",
+  ].join("\n");
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+  console.log(`${req.method} ${url.pathname}`);
+
+  const listing = /^\/repos\/Nexus-Mods\/[^/]+\/releases$/.exec(url.pathname);
+  if (listing != null) {
+    res.writeHead(200, { "content-type": "application/json", etag: '"mock-feed"' });
+    res.end(JSON.stringify(releases));
+    return;
+  }
+
+  const download = /^\/Nexus-Mods\/[^/]+\/releases\/download\/([^/]+)\/(.+)$/.exec(url.pathname);
+  if (download != null) {
+    const [, tag, asset] = download;
+    if (asset === "latest.yml") {
+      res.writeHead(200, { "content-type": "text/yaml" });
+      res.end(latestYmlForTag(tag));
+      return;
+    }
+    if (asset.toLowerCase().endsWith(".exe")) {
+      res.writeHead(200, {
+        "content-type": "application/octet-stream",
+        "content-length": installerBytes.length,
+      });
+      res.end(installerBytes);
+      return;
+    }
+  }
+
+  res.writeHead(404, { "content-type": "text/plain" });
+  res.end("not found");
+});
+
+server.listen(port, () => {
+  console.log(`mock update feed on http://localhost:${port}`);
+  console.log(`  fixture: ${fixturePath} (${releases.length} releases)`);
+  console.log(`  installer: ${installerPath ?? "generated dummy bytes"}`);
+  console.log("run Vortex with:");
+  console.log(`  VORTEX_UPDATER_API_BASE=http://localhost:${port}`);
+  console.log(`  VORTEX_UPDATER_DOWNLOAD_BASE=http://localhost:${port}`);
+});

--- a/src/main/src/extensions/autoupdater/__fixtures__/releases.json
+++ b/src/main/src/extensions/autoupdater/__fixtures__/releases.json
@@ -1,0 +1,56 @@
+[
+  {
+    "tag_name": "v2.6.0-beta.1",
+    "name": "2.6.0-beta.1",
+    "draft": false,
+    "prerelease": true,
+    "published_at": "2026-08-11T11:30:35Z",
+    "body_html": "<p>2.6.0-beta.1: new collections workflow</p>",
+    "assets": [{ "name": "vortex-setup-2.6.0-beta.1.exe" }, { "name": "latest.yml" }]
+  },
+  {
+    "tag_name": "v2.5.0",
+    "name": "2.5.0",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-08-10T12:24:50Z",
+    "body_html": "<p>2.5.0: stable rollup</p>",
+    "assets": [{ "name": "vortex-setup-2.5.0.exe" }, { "name": "latest.yml" }]
+  },
+  {
+    "tag_name": "v2.4.2",
+    "name": "2.4.2",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-07-30T08:49:12Z",
+    "body_html": "<p>2.4.2: hotfix published after 2.5.0-beta.2</p>",
+    "assets": [{ "name": "vortex-setup-2.4.2.exe" }, { "name": "latest.yml" }]
+  },
+  {
+    "tag_name": "v2.5.0-beta.2",
+    "name": "2.5.0-beta.2",
+    "draft": false,
+    "prerelease": true,
+    "published_at": "2026-07-30T08:19:26Z",
+    "body_html": "<p>2.5.0-beta.2: beta fixes</p>",
+    "assets": [{ "name": "vortex-setup-2.5.0-beta.2.exe" }, { "name": "latest.yml" }]
+  },
+  {
+    "tag_name": "v2.5.0-beta.1",
+    "name": "2.5.0-beta.1",
+    "draft": false,
+    "prerelease": true,
+    "published_at": "2026-07-29T12:27:01Z",
+    "body_html": "<p>2.5.0-beta.1: first beta</p>",
+    "assets": [{ "name": "vortex-setup-2.5.0-beta.1.exe" }, { "name": "latest.yml" }]
+  },
+  {
+    "tag_name": "v2.4.1",
+    "name": "2.4.1",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-07-29T11:53:19Z",
+    "body_html": "<p>2.4.1: stable hotfix</p>",
+    "assets": [{ "name": "vortex-setup-2.4.1.exe" }, { "name": "latest.yml" }]
+  }
+]

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -1,0 +1,265 @@
+import type { UpdateStatus } from "@vortex/shared/ipc";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ResolvedRelease } from "./releaseResolver";
+
+const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock } = vi.hoisted(() => {
+  return {
+    autoUpdaterMock: {
+      on: vi.fn(),
+      setFeedURL: vi.fn(),
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn(),
+      allowDowngrade: true,
+      autoDownload: true,
+      autoInstallOnAppQuit: true,
+    },
+    appMock: {
+      getVersion: vi.fn(() => "2.6.0"),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    },
+    ipcMock: { handle: vi.fn(), on: vi.fn() },
+    resolveUpdateMock: vi.fn(),
+  };
+});
+
+// @vortex/shared's error module has a duplicate-load guard that trips under
+// vi.resetModules; only these two helpers are used at runtime (the UpdateStatus
+// import is type-only and erased).
+vi.mock("@vortex/shared", () => ({
+  getErrorMessageOrDefault: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  unknownToError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+}));
+vi.mock("electron", () => ({
+  app: appMock,
+  dialog: { showMessageBoxSync: vi.fn() },
+}));
+vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
+vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));
+vi.mock("../../logging", () => ({ log: vi.fn() }));
+vi.mock("./releaseResolver", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveUpdate: resolveUpdateMock,
+}));
+
+function resolved(overrides: Partial<ResolvedRelease> = {}): ResolvedRelease {
+  return {
+    tag: "v2.7.0",
+    version: "2.7.0",
+    prerelease: false,
+    downloadBaseUrl: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
+    notesHtml: "<p>notes</p>",
+    ...overrides,
+  };
+}
+
+function ipcHandler(channel: string): (...args: unknown[]) => unknown {
+  const call = ipcMock.on.mock.calls.find(([name]) => name === channel);
+  expect(call, `ipc handler ${channel} registered`).toBeDefined();
+  return call![1] as (...args: unknown[]) => unknown;
+}
+
+function updaterEvent(name: string): ((...args: unknown[]) => void) | undefined {
+  const call = autoUpdaterMock.on.mock.calls.find(([event]) => event === name);
+  return call?.[1] as ((...args: unknown[]) => void) | undefined;
+}
+
+function getStatus(): UpdateStatus {
+  const call = ipcMock.handle.mock.calls.find(([name]) => name === "updater:get-status");
+  return (call![1] as () => UpdateStatus)();
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function setup(installType = "regular"): Promise<void> {
+  const { setupAutoUpdater } = await import("./index");
+  setupAutoUpdater(installType);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  appMock.getVersion.mockReturnValue("2.6.0");
+  autoUpdaterMock.checkForUpdates.mockResolvedValue({ cancellationToken: { cancel: vi.fn() } });
+  autoUpdaterMock.downloadUpdate.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("checkForUpdates", () => {
+  // Regression pin for the field bug: a release that is older than the
+  // running version (published later in time) must never become an update.
+  it("ignores a resolved release older than the running version", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.4.2", version: "2.4.2" }));
+
+    ipcHandler("updater:check-for-updates")(undefined, "beta", false);
+    await flush();
+
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    const status = getStatus();
+    expect(status.available).toBe(false);
+    expect(status.checking).toBe(false);
+  });
+
+  // Regression pin #23132: equal version must not trigger a spurious download.
+  it("reports no update when the resolved version equals the current one", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.0", version: "2.6.0" }));
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    expect(getStatus().available).toBe(false);
+  });
+
+  it("points the generic feed at the resolved release for an upgrade", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
+    });
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalled();
+    // minor upgrade: no auto-download
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  // Regression pin #22609: patch updates auto-download.
+  it("auto-downloads patch upgrades for regular installs", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+  });
+
+  it("never resolves when the channel is none", async () => {
+    await setup();
+    ipcHandler("updater:check-for-updates")(undefined, "none", false);
+    await flush();
+    expect(resolveUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and clears checking when resolution fails", async () => {
+    await setup();
+    resolveUpdateMock.mockRejectedValue(new Error("network down"));
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    const status = getStatus();
+    expect(status.checking).toBe(false);
+    expect(status.available).toBe(false);
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+  });
+});
+
+describe("updater:download", () => {
+  it("resolves the feed first when no prior check ran", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+
+    expect(resolveUpdateMock).toHaveBeenCalled();
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
+    });
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+  });
+
+  it("reuses the previously resolved feed", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    resolveUpdateMock.mockClear();
+    autoUpdaterMock.setFeedURL.mockClear();
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+
+    expect(resolveUpdateMock).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+  });
+
+  it("skips re-download and installs directly when already downloaded", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-downloaded")?.({ version: "2.7.0" });
+
+    ipcHandler("updater:download")(undefined, "stable", true);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    // NODE_ENV=test: install proceeds via quitAndInstall
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalled();
+  });
+});
+
+describe("release notes", () => {
+  it("prefers the resolver's collected notes over UpdateInfo", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ notesHtml: "<p>from resolver</p>" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    updaterEvent("update-available")?.({ version: "2.7.0", releaseNotes: null });
+
+    expect(getStatus().releaseNotes).toBe("<p>from resolver</p>");
+  });
+});
+
+// Regression pin #23326: transient installer locks retry, hard errors give up.
+describe("install retry", () => {
+  it("retries quitAndInstall on EBUSY up to the cap", async () => {
+    vi.useFakeTimers();
+    await setup();
+    autoUpdaterMock.quitAndInstall.mockImplementation(() => {
+      throw new Error("spawn EBUSY");
+    });
+
+    ipcHandler("updater:restart-and-install")(undefined);
+    for (let i = 0; i < 6; i += 1) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(5);
+    expect(getStatus().error).toContain("EBUSY");
+  });
+
+  it("gives up immediately on a non-lock error", async () => {
+    vi.useFakeTimers();
+    await setup();
+    autoUpdaterMock.quitAndInstall.mockImplementation(() => {
+      throw new Error("catastrophic failure");
+    });
+
+    ipcHandler("updater:restart-and-install")(undefined);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    expect(getStatus().error).toContain("catastrophic");
+  });
+});

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -98,6 +98,9 @@ describe("checkForUpdates", () => {
   // running version (published later in time) must never become an update.
   it("ignores a resolved release older than the running version", async () => {
     await setup();
+    // drive available to true first so the assertion pins an actual reset
+    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
+    expect(getStatus().available).toBe(true);
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.4.2", version: "2.4.2" }));
 
     ipcHandler("updater:check-for-updates")(undefined, "beta", false);
@@ -107,12 +110,14 @@ describe("checkForUpdates", () => {
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
     const status = getStatus();
     expect(status.available).toBe(false);
+    expect(status.version).toBeUndefined();
     expect(status.checking).toBe(false);
   });
 
   // Regression pin #23132: equal version must not trigger a spurious download.
   it("reports no update when the resolved version equals the current one", async () => {
     await setup();
+    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.0", version: "2.6.0" }));
 
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
@@ -157,8 +162,10 @@ describe("checkForUpdates", () => {
     expect(resolveUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("logs and clears checking when resolution fails", async () => {
+  it("clears checking but leaves availability untouched when resolution fails", async () => {
     await setup();
+    // a previously known update survives an offline/failed check
+    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
     resolveUpdateMock.mockRejectedValue(new Error("network down"));
 
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
@@ -166,7 +173,7 @@ describe("checkForUpdates", () => {
 
     const status = getStatus();
     expect(status.checking).toBe(false);
-    expect(status.available).toBe(false);
+    expect(status.available).toBe(true);
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
   });
 });
@@ -187,18 +194,27 @@ describe("updater:download", () => {
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
   });
 
-  it("reuses the previously resolved feed", async () => {
+  // Regression pin: a download must resolve for the channel it was asked
+  // about — a cached resolution from another channel must never be reused.
+  it("re-resolves for the requested channel on every download", async () => {
     await setup();
-    resolveUpdateMock.mockResolvedValue(resolved());
-    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    resolveUpdateMock.mockResolvedValue(
+      resolved({ tag: "v2.8.0-beta.1", version: "2.8.0-beta.1" }),
+    );
+    ipcHandler("updater:check-for-updates")(undefined, "beta", false);
     await flush();
     resolveUpdateMock.mockClear();
     autoUpdaterMock.setFeedURL.mockClear();
+    resolveUpdateMock.mockResolvedValue(resolved());
 
     ipcHandler("updater:download")(undefined, "stable", false);
     await flush();
 
-    expect(resolveUpdateMock).not.toHaveBeenCalled();
+    expect(resolveUpdateMock).toHaveBeenCalledWith("stable", "2.6.0");
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
+    });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
   });
 

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -12,8 +12,8 @@ import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import * as semver from "semver";
 
-import { betterIpcMain } from "../ipc";
-import { log } from "../logging";
+import { betterIpcMain } from "../../ipc";
+import { log } from "../../logging";
 
 /**
  * Show warning dialog before update installs on quit.

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -3,6 +3,12 @@
  *
  * Handles Electron auto-updater functionality in main process.
  * UI/notifications are handled by the renderer - this just manages the update mechanics.
+ *
+ * Release resolution is ours (releaseResolver.ts): the GitHub releases API is
+ * queried directly and the max-semver release for the active channel wins.
+ * electron-updater is then pointed at that release's assets via a generic
+ * feed, so its job reduces to sha512-verified download, installer signature
+ * verification (publisherName from the packaged app-update.yml), and install.
  */
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
@@ -14,6 +20,13 @@ import * as semver from "semver";
 
 import { betterIpcMain } from "../../ipc";
 import { log } from "../../logging";
+import type { ResolveChannel, ResolvedRelease } from "./releaseResolver";
+import {
+  classifyUpdate,
+  RateLimitError,
+  resolveUpdate,
+  shouldAutoDownload,
+} from "./releaseResolver";
 
 /**
  * Show warning dialog before update installs on quit.
@@ -38,14 +51,21 @@ const updateStatus: UpdateStatus = {
   downloaded: false,
 };
 
+function toResolveChannel(channel: string): ResolveChannel {
+  return channel === "beta" || channel === "next" ? channel : "stable";
+}
+
 /**
  * Set up the auto-updater in main process.
  * Handles checking for updates, downloading, and installing.
  */
 export function setupAutoUpdater(installType: string): void {
   let cancellationToken: CancellationToken | undefined = undefined;
-  const currentVersion = semver.parse(app.getVersion());
+  const currentVersion = app.getVersion();
   let updateChannel = "stable";
+  // The release the last successful check resolved to; its download base URL
+  // is what the generic feed points at.
+  let lastResolved: ResolvedRelease | null = null;
 
   // Launching the freshly downloaded installer can fail transiently with EBUSY
   // (and similar lock errors) while antivirus still has the ~360 MB file open.
@@ -109,18 +129,18 @@ export function setupAutoUpdater(installType: string): void {
       releaseNotes: updateStatus.releaseNotes,
       downloadProgress: updateStatus.downloadProgress,
       error: updateStatus.error,
+      downgrade: updateStatus.downgrade,
+      checking: updateStatus.checking,
     };
   });
 
-  log("info", "setupAutoUpdater", {
-    installType,
-    currentVersion: currentVersion?.version,
-  });
+  log("info", "setupAutoUpdater", { installType, currentVersion });
 
-  // Configure autoUpdater
-  autoUpdater.allowDowngrade = true;
+  // Configure autoUpdater. Downgrades are never taken from background checks;
+  // the resolver decides what "latest" means and only strictly-newer versions
+  // are handed to electron-updater at all.
+  autoUpdater.allowDowngrade = false;
   autoUpdater.autoDownload = false;
-  autoUpdater.fullChangelog = true;
   autoUpdater.autoInstallOnAppQuit = false;
 
   // Error handler
@@ -143,15 +163,15 @@ export function setupAutoUpdater(installType: string): void {
 
   // Update available
   autoUpdater.on("update-available", (info: UpdateInfo) => {
-    log("info", "Update available", {
-      version: info.version,
-      currentVersion: currentVersion?.version,
-    });
+    log("info", "Update available", { version: info.version, currentVersion });
     updateStatus.available = true;
     updateStatus.version = info.version;
     updateStatus.error = undefined;
-    // Capture release notes - can be string or array of release note objects
-    if (typeof info.releaseNotes === "string") {
+    // The generic feed's latest.yml carries no release notes; the resolver
+    // collects them from the GitHub releases instead.
+    if (lastResolved?.notesHtml != null) {
+      updateStatus.releaseNotes = lastResolved.notesHtml;
+    } else if (typeof info.releaseNotes === "string") {
       updateStatus.releaseNotes = info.releaseNotes;
     } else if (Array.isArray(info.releaseNotes)) {
       updateStatus.releaseNotes = info.releaseNotes
@@ -190,6 +210,16 @@ export function setupAutoUpdater(installType: string): void {
     }
   });
 
+  // Point electron-updater at the resolved release and let it re-check;
+  // resolves once the library has accepted the feed.
+  function applyResolvedFeed(resolved: ResolvedRelease): Promise<void> {
+    lastResolved = resolved;
+    autoUpdater.setFeedURL({ provider: "generic", url: resolved.downloadBaseUrl });
+    return autoUpdater.checkForUpdates().then((check) => {
+      cancellationToken = check?.cancellationToken;
+    });
+  }
+
   // Check for updates
   const checkForUpdates = (channel: string, manual: boolean = false) => {
     if (!channel || channel === "none") {
@@ -197,59 +227,60 @@ export function setupAutoUpdater(installType: string): void {
       return;
     }
 
-    const isPreviewBuild = process.env.IS_PREVIEW_BUILD === "true";
     updateChannel = channel;
+    updateStatus.checking = true;
+    log("info", "Checking for updates", { channel, manual, currentVersion });
 
-    log("info", "Checking for updates", { channel, manual, isPreviewBuild });
-
-    autoUpdater.allowPrerelease = channel !== "stable";
-    // publisherName for installer signature verification comes from the packaged
-    // app-update.yml (win.signtoolOptions.publisherName in the builder config);
-    // electron-updater 6.x ignores it in setFeedURL options.
-    autoUpdater.setFeedURL({
-      provider: "github",
-      owner: "Nexus-Mods",
-      repo: isPreviewBuild ? "Vortex-Staging" : "Vortex",
-    });
-
-    autoUpdater
-      .checkForUpdates()
-      .then((check) => {
-        log("info", "Update check completed");
-        cancellationToken = check?.cancellationToken;
-
-        const updateVersion = check?.updateInfo?.version;
-
-        // Auto-download patch updates for regular installs;
-        // minor/major updates require user-initiated download via renderer.
-        // Require strict-newer: with allowDowngrade = true the feed may
-        // report the current version as "latest", which would otherwise
-        // satisfy the `~current` range and trigger a bogus downloadUpdate
-        // that electron-updater rejects with "Please check update first".
-        if (
-          installType === "regular" &&
-          currentVersion != null &&
-          updateVersion != null &&
-          semver.gt(updateVersion, currentVersion.version) &&
-          semver.satisfies(updateVersion, `~${currentVersion.version}`, {
-            includePrerelease: true,
-          })
-        ) {
-          log("info", "Patch update detected, auto-downloading", {
-            from: currentVersion.version,
-            to: updateVersion,
-          });
-          autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
-            log("warn", "Auto-download failed", {
-              error: getErrorMessageOrDefault(err),
+    resolveUpdate(toResolveChannel(channel), currentVersion)
+      .then((resolved) => {
+        // Note: switchToStable stays false until the explicit channel-switch
+        // downgrade flow ships with its UI; a lower "latest" is ignored here
+        // rather than offered (offering it is the old field bug).
+        const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
+          switchToStable: false,
+        });
+        if (resolved == null || verdict !== "upgrade") {
+          if (resolved != null && semver.lt(resolved.version, currentVersion)) {
+            log("info", "Latest release is older than the running version, ignoring", {
+              resolved: resolved.version,
+              currentVersion,
+              channel,
             });
-          });
+          } else {
+            log("info", "No update available", { channel, resolved: resolved?.version });
+          }
+          updateStatus.available = false;
+          updateStatus.error = undefined;
+          updateStatus.checking = false;
+          return;
         }
+
+        return applyResolvedFeed(resolved).then(() => {
+          log("info", "Update check completed", { version: resolved.version });
+          updateStatus.checking = false;
+
+          // Auto-download patch updates for regular installs; minor/major
+          // updates require user-initiated download via renderer.
+          if (shouldAutoDownload(currentVersion, resolved.version, installType)) {
+            log("info", "Patch update detected, auto-downloading", {
+              from: currentVersion,
+              to: resolved.version,
+            });
+            autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
+              log("warn", "Auto-download failed", {
+                error: getErrorMessageOrDefault(err),
+              });
+            });
+          }
+        });
       })
       .catch((err) => {
-        log("warn", "Update check failed", {
-          error: getErrorMessageOrDefault(err),
-        });
+        updateStatus.checking = false;
+        if (err instanceof RateLimitError) {
+          log("warn", "Update check rate-limited", { resetAt: err.resetAt.toISOString() });
+        } else {
+          log("warn", "Update check failed", { error: getErrorMessageOrDefault(err) });
+        }
       });
   };
 
@@ -260,6 +291,7 @@ export function setupAutoUpdater(installType: string): void {
     if (cancellationToken) {
       cancellationToken.cancel();
     }
+    lastResolved = null;
 
     if (channel !== "none" && process.env.IGNORE_UPDATES !== "yes") {
       checkForUpdates(channel, manual);
@@ -290,20 +322,29 @@ export function setupAutoUpdater(installType: string): void {
 
     installAfterDownloadFlag = installAfterDownload;
 
-    const isPreviewBuild = process.env.IS_PREVIEW_BUILD === "true";
-    autoUpdater.allowPrerelease = channel !== "stable";
-    autoUpdater.setFeedURL({
-      provider: "github",
-      owner: "Nexus-Mods",
-      repo: isPreviewBuild ? "Vortex-Staging" : "Vortex",
-    });
+    // A prior check normally resolved the feed already; if not (e.g. the
+    // renderer requests a download right after startup), resolve it now.
+    const feedReady =
+      lastResolved != null
+        ? Promise.resolve()
+        : resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
+            const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
+              switchToStable: false,
+            });
+            if (resolved == null || verdict !== "upgrade") {
+              throw new Error("no newer release available to download");
+            }
+            return applyResolvedFeed(resolved);
+          });
 
-    autoUpdater.downloadUpdate().catch((unknownErr) => {
-      const err = unknownToError(unknownErr);
-      log("error", "Download failed", { error: err.message });
-      updateStatus.error = err.message;
-      installAfterDownloadFlag = false;
-    });
+    feedReady
+      .then(() => autoUpdater.downloadUpdate())
+      .catch((unknownErr) => {
+        const err = unknownToError(unknownErr);
+        log("error", "Download failed", { error: err.message });
+        updateStatus.error = err.message;
+        installAfterDownloadFlag = false;
+      });
   });
 
   betterIpcMain.on("updater:restart-and-install", () => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -63,9 +63,13 @@ export function setupAutoUpdater(installType: string): void {
   let cancellationToken: CancellationToken | undefined = undefined;
   const currentVersion = app.getVersion();
   let updateChannel = "stable";
-  // The release the last successful check resolved to; its download base URL
-  // is what the generic feed points at.
+  // The release the last successful check resolved to — used only to prefer
+  // the resolver's collected release notes over the (empty) generic-feed ones.
+  // Downloads never trust it: updater:download re-resolves every time.
   let lastResolved: ResolvedRelease | null = null;
+  // Overlapping checks are possible (set-channel + manual check-now); only
+  // the newest one may write checking/availability/cancellation state.
+  let checkGeneration = 0;
 
   // Launching the freshly downloaded installer can fail transiently with EBUSY
   // (and similar lock errors) while antivirus still has the ~360 MB file open.
@@ -211,12 +215,43 @@ export function setupAutoUpdater(installType: string): void {
   });
 
   // Point electron-updater at the resolved release and let it re-check;
-  // resolves once the library has accepted the feed.
-  function applyResolvedFeed(resolved: ResolvedRelease): Promise<void> {
+  // resolves once the library has accepted the feed. Every download goes
+  // through this first, so check-before-download holds structurally.
+  function applyResolvedFeed(resolved: ResolvedRelease, generation: number): Promise<void> {
     lastResolved = resolved;
     autoUpdater.setFeedURL({ provider: "generic", url: resolved.downloadBaseUrl });
     return autoUpdater.checkForUpdates().then((check) => {
-      cancellationToken = check?.cancellationToken;
+      if (generation === checkGeneration) {
+        cancellationToken = check?.cancellationToken;
+      }
+    });
+  }
+
+  // Resolve the channel's target release and, when it's an upgrade, hand the
+  // feed to electron-updater. Resolves to the release or null (no upgrade).
+  function resolveAndApply(channel: string, generation: number): Promise<ResolvedRelease | null> {
+    return resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
+      // Note: switchToStable stays false until the explicit channel-switch
+      // downgrade flow ships with its UI; a lower "latest" is ignored here
+      // rather than offered (offering it is the old field bug).
+      const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
+        switchToStable: false,
+      });
+      if (resolved == null || verdict !== "upgrade") {
+        const current = semver.valid(currentVersion);
+        if (resolved != null && current != null && semver.lt(resolved.version, current)) {
+          log("info", "Latest release is older than the running version, ignoring", {
+            resolved: resolved.version,
+            currentVersion,
+            channel,
+          });
+        } else {
+          log("info", "No update available", { channel, resolved: resolved?.version });
+        }
+        lastResolved = null;
+        return null;
+      }
+      return applyResolvedFeed(resolved, generation).then(() => resolved);
     });
   }
 
@@ -228,54 +263,43 @@ export function setupAutoUpdater(installType: string): void {
     }
 
     updateChannel = channel;
+    const generation = ++checkGeneration;
     updateStatus.checking = true;
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
-    resolveUpdate(toResolveChannel(channel), currentVersion)
+    resolveAndApply(channel, generation)
       .then((resolved) => {
-        // Note: switchToStable stays false until the explicit channel-switch
-        // downgrade flow ships with its UI; a lower "latest" is ignored here
-        // rather than offered (offering it is the old field bug).
-        const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
-          switchToStable: false,
-        });
-        if (resolved == null || verdict !== "upgrade") {
-          if (resolved != null && semver.lt(resolved.version, currentVersion)) {
-            log("info", "Latest release is older than the running version, ignoring", {
-              resolved: resolved.version,
-              currentVersion,
-              channel,
-            });
-          } else {
-            log("info", "No update available", { channel, resolved: resolved?.version });
-          }
+        if (generation !== checkGeneration) {
+          return; // superseded by a newer check; let that one own the status
+        }
+        updateStatus.checking = false;
+        if (resolved == null) {
           updateStatus.available = false;
+          updateStatus.version = undefined;
+          updateStatus.releaseNotes = undefined;
           updateStatus.error = undefined;
-          updateStatus.checking = false;
           return;
         }
+        log("info", "Update check completed", { version: resolved.version });
 
-        return applyResolvedFeed(resolved).then(() => {
-          log("info", "Update check completed", { version: resolved.version });
-          updateStatus.checking = false;
-
-          // Auto-download patch updates for regular installs; minor/major
-          // updates require user-initiated download via renderer.
-          if (shouldAutoDownload(currentVersion, resolved.version, installType)) {
-            log("info", "Patch update detected, auto-downloading", {
-              from: currentVersion,
-              to: resolved.version,
+        // Auto-download patch updates for regular installs; minor/major
+        // updates require user-initiated download via renderer.
+        if (shouldAutoDownload(currentVersion, resolved.version, installType)) {
+          log("info", "Patch update detected, auto-downloading", {
+            from: currentVersion,
+            to: resolved.version,
+          });
+          autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
+            log("warn", "Auto-download failed", {
+              error: getErrorMessageOrDefault(err),
             });
-            autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
-              log("warn", "Auto-download failed", {
-                error: getErrorMessageOrDefault(err),
-              });
-            });
-          }
-        });
+          });
+        }
       })
       .catch((err) => {
-        updateStatus.checking = false;
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+        }
         if (err instanceof RateLimitError) {
           log("warn", "Update check rate-limited", { resetAt: err.resetAt.toISOString() });
         } else {
@@ -322,23 +346,18 @@ export function setupAutoUpdater(installType: string): void {
 
     installAfterDownloadFlag = installAfterDownload;
 
-    // A prior check normally resolved the feed already; if not (e.g. the
-    // renderer requests a download right after startup), resolve it now.
-    const feedReady =
-      lastResolved != null
-        ? Promise.resolve()
-        : resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
-            const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
-              switchToStable: false,
-            });
-            if (resolved == null || verdict !== "upgrade") {
-              throw new Error("no newer release available to download");
-            }
-            return applyResolvedFeed(resolved);
-          });
-
-    feedReady
-      .then(() => autoUpdater.downloadUpdate())
+    // Always re-resolve for the channel the renderer asked about: a cached
+    // resolution could belong to a different channel, and re-applying the
+    // feed guarantees the library-side check-before-download. The resolver's
+    // ETag cache makes the repeat lookup cheap.
+    const generation = ++checkGeneration;
+    resolveAndApply(channel, generation)
+      .then((resolved) => {
+        if (resolved == null) {
+          throw new Error("no newer release available to download");
+        }
+        return autoUpdater.downloadUpdate();
+      })
       .catch((unknownErr) => {
         const err = unknownToError(unknownErr);
         log("error", "Download failed", { error: err.message });

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -1,0 +1,228 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GithubReleaseLite } from "./releaseResolver";
+import {
+  _resetCacheForTests,
+  classifyUpdate,
+  pickRelease,
+  RateLimitError,
+  repoForChannel,
+  resolveUpdate,
+  shouldAutoDownload,
+} from "./releaseResolver";
+
+vi.mock("../../logging", () => ({ log: vi.fn() }));
+
+const fixture = JSON.parse(
+  readFileSync(path.join(__dirname, "__fixtures__", "releases.json"), "utf8"),
+) as GithubReleaseLite[];
+
+function release(overrides: Partial<GithubReleaseLite>): GithubReleaseLite {
+  return {
+    tag_name: "v1.0.0",
+    draft: false,
+    prerelease: false,
+    assets: [{ name: "latest.yml" }, { name: "vortex-setup-1.0.0.exe" }],
+    ...overrides,
+  };
+}
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  const status = init.status ?? 200;
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  if (status === 304) {
+    // Response's constructor rejects null-body statuses like 304.
+    const headers = new Headers(init.headers ?? {});
+    return { status, ok: false, headers, text: () => Promise.resolve("") } as unknown as Response;
+  }
+  return new Response(text, { status, headers: init.headers ?? {} });
+}
+
+afterEach(() => {
+  _resetCacheForTests();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("pickRelease", () => {
+  // Regression pin for the shipped bug: electron-updater 4.6.5 walked the
+  // atom feed by publish date, so beta users on 2.5.0-beta.2 were offered the
+  // older stable 2.4.2 (published later) as an "update" — a bogus downgrade.
+  it("picks max semver per channel from date-interleaved releases", () => {
+    expect(pickRelease(fixture, "stable")?.tag_name).toBe("v2.5.0");
+    expect(pickRelease(fixture, "beta")?.tag_name).toBe("v2.6.0-beta.1");
+    expect(classifyUpdate("2.5.0-beta.2", "2.5.0", { switchToStable: false })).toBe("upgrade");
+  });
+
+  it("prefers a newer stable over an older beta on the beta channel", () => {
+    const subset = fixture.filter((entry) => ["v2.5.0", "v2.5.0-beta.2"].includes(entry.tag_name));
+    expect(pickRelease(subset, "beta")?.tag_name).toBe("v2.5.0");
+  });
+
+  it("excludes drafts even when they are max semver", () => {
+    const withDraft = [release({ tag_name: "v9.9.9", draft: true }), ...fixture];
+    expect(pickRelease(withDraft, "stable")?.tag_name).toBe("v2.5.0");
+    expect(pickRelease(withDraft, "beta")?.tag_name).toBe("v2.6.0-beta.1");
+  });
+
+  it("excludes releases whose prerelease flag disagrees with the version suffix", () => {
+    const disagreeing = [
+      release({ tag_name: "v9.0.0", prerelease: true }),
+      release({ tag_name: "v9.1.0-beta.1", prerelease: false }),
+      release({ tag_name: "v2.0.0" }),
+    ];
+    expect(pickRelease(disagreeing, "beta")?.tag_name).toBe("v2.0.0");
+  });
+
+  it("skips malformed tags", () => {
+    const malformed = [
+      release({ tag_name: "nightly-20250801" }),
+      release({ tag_name: "v2.6" }),
+      release({ tag_name: "" }),
+      release({ tag_name: "v1.2.3" }),
+    ];
+    expect(pickRelease(malformed, "stable")?.tag_name).toBe("v1.2.3");
+  });
+
+  it("skips releases missing both latest.yml and an installer asset", () => {
+    const releases = [
+      release({ tag_name: "v3.0.0", assets: [{ name: "notes.txt" }] }),
+      release({ tag_name: "v2.0.0", assets: [{ name: "latest.yml" }] }),
+    ];
+    expect(pickRelease(releases, "stable")?.tag_name).toBe("v2.0.0");
+  });
+
+  it("returns null for empty or all-draft lists", () => {
+    expect(pickRelease([], "stable")).toBeNull();
+    expect(pickRelease([release({ tag_name: "v1.0.0", draft: true })], "beta")).toBeNull();
+    expect(classifyUpdate("2.5.0", null, { switchToStable: false })).toBe("none");
+  });
+});
+
+describe("classifyUpdate", () => {
+  it("classifies equal, newer, and older versions", () => {
+    expect(classifyUpdate("2.5.0", "2.5.0", { switchToStable: false })).toBe("none");
+    expect(classifyUpdate("2.5.0", "2.6.0", { switchToStable: false })).toBe("upgrade");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: false })).toBe("none");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: true })).toBe(
+      "downgrade-offer",
+    );
+    expect(classifyUpdate("garbage", "2.5.0", { switchToStable: true })).toBe("none");
+  });
+});
+
+// Regression pin for #22609 (patch auto-download not triggering).
+describe("shouldAutoDownload", () => {
+  it("auto-downloads patch deltas only, for regular installs only", () => {
+    expect(shouldAutoDownload("2.6.0", "2.6.1", "regular")).toBe(true);
+    expect(shouldAutoDownload("2.6.0", "2.7.0", "regular")).toBe(false);
+    expect(shouldAutoDownload("2.6.0-beta.1", "2.6.0-beta.2", "regular")).toBe(true);
+    expect(shouldAutoDownload("2.6.0", "2.6.0", "regular")).toBe(false);
+    expect(shouldAutoDownload("2.6.0", "2.6.1", "managed")).toBe(false);
+  });
+});
+
+describe("repoForChannel", () => {
+  it("selects the staging repo only for preview builds", () => {
+    vi.stubEnv("IS_PREVIEW_BUILD", "");
+    expect(repoForChannel()).toBe("Vortex");
+    vi.stubEnv("IS_PREVIEW_BUILD", "true");
+    expect(repoForChannel()).toBe("Vortex-Staging");
+  });
+});
+
+describe("resolveUpdate fetching", () => {
+  beforeEach(() => {
+    vi.stubEnv("IS_PREVIEW_BUILD", "");
+  });
+
+  it("resolves the picked release with download url and collected notes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(fixture));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolved = await resolveUpdate("beta", "2.5.0-beta.1");
+    expect(resolved).toMatchObject({
+      tag: "v2.6.0-beta.1",
+      version: "2.6.0-beta.1",
+      prerelease: true,
+      downloadBaseUrl: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.6.0-beta.1",
+    });
+    // notes: candidates in (2.5.0-beta.1, 2.6.0-beta.1], newest first
+    expect(resolved?.notesHtml).toContain("2.6.0-beta.1");
+    expect(resolved?.notesHtml).toContain("2.5.0");
+    expect(resolved?.notesHtml).not.toContain("2.4.1");
+  });
+
+  it("serves the cached body on 304 and sends if-none-match", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(fixture, { headers: { etag: '"abc"' } }))
+      .mockResolvedValueOnce(jsonResponse("", { status: 304 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await resolveUpdate("stable", "2.4.0");
+    const second = await resolveUpdate("stable", "2.4.0");
+    expect(first?.version).toBe("2.5.0");
+    expect(second?.version).toBe("2.5.0");
+
+    const secondCall = fetchMock.mock.calls[1]![1] as { headers: Record<string, string> };
+    expect(secondCall.headers["if-none-match"]).toBe('"abc"');
+  });
+
+  it("throws RateLimitError and short-circuits until reset without refetching", async () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600;
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse("rate limited", {
+        status: 403,
+        headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(resetAt) },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveUpdate("stable", "2.4.0")).rejects.toBeInstanceOf(RateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(resolveUpdate("stable", "2.4.0")).rejects.toBeInstanceOf(RateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows Link pagination and stops at the page cap", async () => {
+    const pageOf = (tag: string) => [release({ tag_name: tag, assets: [{ name: "latest.yml" }] })];
+    const linkTo = (page: number) =>
+      `<https://api.github.com/repos/Nexus-Mods/Vortex/releases?per_page=100&page=${page}>; rel="next"`;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(pageOf("v1.0.0"), { headers: { link: linkTo(2) } }))
+      .mockResolvedValueOnce(jsonResponse(pageOf("v1.1.0"), { headers: { link: linkTo(3) } }))
+      .mockResolvedValueOnce(jsonResponse(pageOf("v1.2.0"), { headers: { link: linkTo(4) } }))
+      .mockResolvedValue(jsonResponse(pageOf("v9.9.9")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolved = await resolveUpdate("stable", "0.1.0");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(resolved?.version).toBe("1.2.0");
+  });
+
+  it("throws on malformed JSON", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse("not json {{")));
+    await expect(resolveUpdate("stable", "2.4.0")).rejects.toThrow(/malformed JSON/);
+  });
+
+  it("uses the env overrides for api and download bases", async () => {
+    vi.stubEnv("VORTEX_UPDATER_API_BASE", "http://localhost:9999");
+    vi.stubEnv("VORTEX_UPDATER_DOWNLOAD_BASE", "http://localhost:9999");
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(fixture));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolved = await resolveUpdate("stable", "2.4.0");
+    expect(String(fetchMock.mock.calls[0]![0])).toMatch(/^http:\/\/localhost:9999\//);
+    expect(resolved?.downloadBaseUrl).toBe(
+      "http://localhost:9999/Nexus-Mods/Vortex/releases/download/v2.5.0",
+    );
+  });
+});

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -191,6 +191,22 @@ describe("resolveUpdate fetching", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to a one-minute reset when the rate-limit reset header is garbage", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse("rate limited", {
+        status: 403,
+        headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "not-a-number" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveUpdate("stable", "2.4.0")).rejects.toBeInstanceOf(RateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // the fallback reset is in the future, so the short-circuit still engages
+    await expect(resolveUpdate("stable", "2.4.0")).rejects.toBeInstanceOf(RateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("follows Link pagination and stops at the page cap", async () => {
     const pageOf = (tag: string) => [release({ tag_name: tag, assets: [{ name: "latest.yml" }] })];
     const linkTo = (page: number) =>

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -58,6 +58,8 @@ export function repoForChannel(): string {
   return process.env.IS_PREVIEW_BUILD === "true" ? "Vortex-Staging" : "Vortex";
 }
 
+// Build metadata compares equal under semver (2.5.0+build == 2.5.0); ties in
+// pickRelease keep the first-seen release. Vortex doesn't tag with metadata.
 function versionFromTag(tag: string): string | null {
   return semver.valid(tag.replace(/^v/, ""));
 }
@@ -161,6 +163,7 @@ export function shouldAutoDownload(
 interface CacheEntry {
   etag: string;
   body: string;
+  linkHeader: string | null;
 }
 
 const etagCache = new Map<string, CacheEntry>();
@@ -192,16 +195,21 @@ async function fetchPage(url: string): Promise<{ body: string; linkHeader: strin
   const response = await fetch(url, { headers });
 
   if (response.status === 304 && cached != null) {
-    return { body: cached.body, linkHeader: response.headers.get("link") };
+    return { body: cached.body, linkHeader: response.headers.get("link") ?? cached.linkHeader };
   }
 
   if (
     (response.status === 403 || response.status === 429) &&
     response.headers.get("x-ratelimit-remaining") === "0"
   ) {
-    const resetHeader = response.headers.get("x-ratelimit-reset");
+    // A proxy or mock feed can send a garbage reset header; NaN or 0 would
+    // produce an Invalid Date (whose toISOString throws) or a 1970 reset that
+    // never short-circuits. Fall back to a minute in either case.
+    const parsed = Number(response.headers.get("x-ratelimit-reset"));
     const resetAt =
-      resetHeader != null ? new Date(Number(resetHeader) * 1000) : new Date(Date.now() + 60_000);
+      Number.isFinite(parsed) && parsed > 0
+        ? new Date(parsed * 1000)
+        : new Date(Date.now() + 60_000);
     rateLimitedUntil = resetAt;
     throw new RateLimitError(resetAt);
   }
@@ -213,10 +221,11 @@ async function fetchPage(url: string): Promise<{ body: string; linkHeader: strin
 
   const body = await response.text();
   const etag = response.headers.get("etag");
+  const linkHeader = response.headers.get("link");
   if (etag != null) {
-    etagCache.set(url, { etag, body });
+    etagCache.set(url, { etag, body, linkHeader });
   }
-  return { body, linkHeader: response.headers.get("link") };
+  return { body, linkHeader };
 }
 
 function nextPageUrl(linkHeader: string | null): string | null {

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -1,0 +1,298 @@
+/**
+ * Deterministic release resolution for the auto-updater.
+ *
+ * electron-updater's GitHub provider walks the releases atom feed in
+ * publish-date order, so a stable hotfix published after a beta gets offered
+ * to beta users as "the latest version". This module resolves the target
+ * release ourselves — GitHub REST API, filter, max semver per channel — and
+ * the updater is then pointed at that release's assets via a generic feed.
+ *
+ * Must stay loadable in plain node (vitest): no electron imports.
+ */
+
+import * as semver from "semver";
+
+import { log } from "../../logging";
+
+export type ResolveChannel = "stable" | "beta" | "next";
+
+export interface GithubReleaseLite {
+  tag_name: string;
+  name?: string;
+  draft: boolean;
+  prerelease: boolean;
+  published_at?: string;
+  body_html?: string;
+  assets: Array<{ name: string }>;
+}
+
+export interface ResolvedRelease {
+  tag: string;
+  version: string;
+  prerelease: boolean;
+  downloadBaseUrl: string;
+  notesHtml?: string;
+}
+
+export class RateLimitError extends Error {
+  constructor(public readonly resetAt: Date) {
+    super(`GitHub API rate limit exceeded, resets at ${resetAt.toISOString()}`);
+    this.name = "RateLimitError";
+  }
+}
+
+const OWNER = "Nexus-Mods";
+const MAX_PAGES = 3;
+const INSTALLER_ASSET = /^vortex-setup-.*\.exe$/i;
+
+// Overridable so tests and the mock update feed can stand in for GitHub.
+function apiBase(): string {
+  return process.env.VORTEX_UPDATER_API_BASE || "https://api.github.com";
+}
+
+function downloadBase(): string {
+  return process.env.VORTEX_UPDATER_DOWNLOAD_BASE || "https://github.com";
+}
+
+export function repoForChannel(): string {
+  return process.env.IS_PREVIEW_BUILD === "true" ? "Vortex-Staging" : "Vortex";
+}
+
+function versionFromTag(tag: string): string | null {
+  return semver.valid(tag.replace(/^v/, ""));
+}
+
+function isEligible(release: GithubReleaseLite): boolean {
+  if (release.draft) {
+    return false;
+  }
+  const version = versionFromTag(release.tag_name);
+  if (version == null) {
+    return false;
+  }
+  const hasUpdateAssets = release.assets.some(
+    (asset) => asset.name === "latest.yml" || INSTALLER_ASSET.test(asset.name),
+  );
+  if (!hasUpdateAssets) {
+    return false;
+  }
+  // The prerelease flag and the version suffix are two signals for the same
+  // fact; when they disagree the release was mispublished — don't trust it.
+  const hasPrereleaseSuffix = semver.prerelease(version) != null;
+  if (release.prerelease !== hasPrereleaseSuffix) {
+    log("warn", "Release prerelease flag disagrees with its version suffix, skipping", {
+      tag: release.tag_name,
+      prerelease: release.prerelease,
+    });
+    return false;
+  }
+  return true;
+}
+
+function candidatesForChannel(
+  releases: GithubReleaseLite[],
+  channel: ResolveChannel,
+): GithubReleaseLite[] {
+  const eligible = releases.filter(isEligible);
+  // beta/next take everything: a newer stable beats an older beta.
+  return channel === "stable" ? eligible.filter((release) => !release.prerelease) : eligible;
+}
+
+/**
+ * Pick the target release for a channel: max semver among eligible
+ * candidates. Never depends on array order or publish dates.
+ */
+export function pickRelease(
+  releases: GithubReleaseLite[],
+  channel: ResolveChannel,
+): GithubReleaseLite | null {
+  let best: GithubReleaseLite | null = null;
+  let bestVersion: string | null = null;
+  for (const release of candidatesForChannel(releases, channel)) {
+    const version = versionFromTag(release.tag_name)!;
+    if (bestVersion == null || semver.gt(version, bestVersion)) {
+      best = release;
+      bestVersion = version;
+    }
+  }
+  return best;
+}
+
+/**
+ * Classify what the resolved version means relative to the running version.
+ * A lower version is only ever surfaced as a "downgrade-offer" when the user
+ * explicitly switched to the stable channel; background checks ignore it.
+ */
+export function classifyUpdate(
+  currentVersion: string,
+  resolvedVersion: string | null,
+  opts: { switchToStable: boolean },
+): "upgrade" | "downgrade-offer" | "none" {
+  const current = semver.valid(currentVersion);
+  if (current == null) {
+    log("warn", "Current version is not valid semver", { currentVersion });
+    return "none";
+  }
+  if (resolvedVersion == null || semver.eq(resolvedVersion, current)) {
+    return "none";
+  }
+  if (semver.gt(resolvedVersion, current)) {
+    return "upgrade";
+  }
+  return opts.switchToStable ? "downgrade-offer" : "none";
+}
+
+/**
+ * Patch-level updates auto-download for regular installs; minor/major wait
+ * for the user. Same gate the updater has always applied.
+ */
+export function shouldAutoDownload(
+  currentVersion: string,
+  targetVersion: string,
+  installType: string,
+): boolean {
+  return (
+    installType === "regular" &&
+    semver.gt(targetVersion, currentVersion) &&
+    semver.satisfies(targetVersion, `~${currentVersion}`, { includePrerelease: true })
+  );
+}
+
+interface CacheEntry {
+  etag: string;
+  body: string;
+}
+
+const etagCache = new Map<string, CacheEntry>();
+let rateLimitedUntil: Date | null = null;
+
+export function _resetCacheForTests(): void {
+  etagCache.clear();
+  rateLimitedUntil = null;
+}
+
+async function fetchPage(url: string): Promise<{ body: string; linkHeader: string | null }> {
+  if (rateLimitedUntil != null) {
+    if (Date.now() < rateLimitedUntil.getTime()) {
+      throw new RateLimitError(rateLimitedUntil);
+    }
+    rateLimitedUntil = null;
+  }
+
+  const cached = etagCache.get(url);
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github.html+json",
+    "x-github-api-version": "2022-11-28",
+    "user-agent": "Vortex",
+  };
+  if (cached != null) {
+    headers["if-none-match"] = cached.etag;
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (response.status === 304 && cached != null) {
+    return { body: cached.body, linkHeader: response.headers.get("link") };
+  }
+
+  if (
+    (response.status === 403 || response.status === 429) &&
+    response.headers.get("x-ratelimit-remaining") === "0"
+  ) {
+    const resetHeader = response.headers.get("x-ratelimit-reset");
+    const resetAt =
+      resetHeader != null ? new Date(Number(resetHeader) * 1000) : new Date(Date.now() + 60_000);
+    rateLimitedUntil = resetAt;
+    throw new RateLimitError(resetAt);
+  }
+
+  if (!response.ok) {
+    const snippet = (await response.text()).slice(0, 200);
+    throw new Error(`Release feed request failed with status ${response.status}: ${snippet}`);
+  }
+
+  const body = await response.text();
+  const etag = response.headers.get("etag");
+  if (etag != null) {
+    etagCache.set(url, { etag, body });
+  }
+  return { body, linkHeader: response.headers.get("link") };
+}
+
+function nextPageUrl(linkHeader: string | null): string | null {
+  if (linkHeader == null) {
+    return null;
+  }
+  for (const part of linkHeader.split(",")) {
+    const match = /<([^>]+)>\s*;\s*rel="next"/.exec(part);
+    if (match?.[1] != null) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+async function fetchReleases(repo: string): Promise<GithubReleaseLite[]> {
+  const releases: GithubReleaseLite[] = [];
+  let url: string | null = `${apiBase()}/repos/${OWNER}/${repo}/releases?per_page=100`;
+  let pages = 0;
+
+  while (url != null && pages < MAX_PAGES) {
+    const { body, linkHeader } = await fetchPage(url);
+    let page: unknown;
+    try {
+      page = JSON.parse(body);
+    } catch {
+      throw new Error("Release feed returned malformed JSON");
+    }
+    if (!Array.isArray(page)) {
+      throw new Error("Release feed returned an unexpected shape");
+    }
+    releases.push(...(page as GithubReleaseLite[]));
+    pages += 1;
+    url = nextPageUrl(linkHeader);
+  }
+
+  if (url != null) {
+    log("warn", "Release listing truncated at page cap", { repo, pages });
+  }
+
+  return releases;
+}
+
+/**
+ * Resolve the update target for a channel. Returns null when no eligible
+ * release exists. Network and rate-limit errors propagate — the caller logs
+ * and skips the check, same as being offline.
+ */
+export async function resolveUpdate(
+  channel: ResolveChannel,
+  currentVersion: string,
+): Promise<ResolvedRelease | null> {
+  const repo = repoForChannel();
+  const releases = await fetchReleases(repo);
+  const picked = pickRelease(releases, channel);
+  if (picked == null) {
+    return null;
+  }
+  const pickedVersion = versionFromTag(picked.tag_name)!;
+
+  const current = semver.valid(currentVersion);
+  const notes = candidatesForChannel(releases, channel)
+    .map((release) => ({ release, version: versionFromTag(release.tag_name)! }))
+    .filter(
+      ({ version }) =>
+        current != null && semver.gt(version, current) && semver.lte(version, pickedVersion),
+    )
+    .sort((lhs, rhs) => semver.rcompare(lhs.version, rhs.version))
+    .map(({ release }) => release.body_html)
+    .filter((body): body is string => body != null && body.trim().length > 0);
+
+  return {
+    tag: picked.tag_name,
+    version: pickedVersion,
+    prerelease: picked.prerelease,
+    downloadBaseUrl: `${downloadBase()}/${OWNER}/${repo}/releases/download/${picked.tag_name}`,
+    notesHtml: notes.length > 0 ? notes.join("\n\n") : undefined,
+  };
+}

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -65,6 +65,13 @@ export interface UpdateStatus {
   downloadProgress?: number;
   /** Error message if update check failed */
   error?: string;
+  /**
+   * The offered version is lower than the running one. Only ever set after
+   * an explicit switch to the stable channel, never for background checks.
+   */
+  downgrade?: boolean;
+  /** An update check is in flight */
+  checking?: boolean;
 }
 
 /** Vortex application paths */


### PR DESCRIPTION
Merges after #23991.

electron-updater's GitHub provider picks the newest release by publish date. That's how beta users got offered older stables as "updates" whenever we shipped a hotfix after a beta. We now query the releases API ourselves, pick the highest eligible semver for the channel, and point electron-updater at that one release via a generic feed. Its job shrinks to download, verify, install. There's a mock feed (`scripts/mock-update-feed.mjs`) so the whole cycle runs offline, and the real interleaved-release scenario that caused the bug is pinned in tests.
