### PR TITLE
updater 4/6: push updater status to the renderer

### DIFF
--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -20,7 +20,7 @@ const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock } = vi.hoisted(() =
       on: vi.fn(),
       removeListener: vi.fn(),
     },
-    ipcMock: { handle: vi.fn(), on: vi.fn() },
+    ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
     resolveUpdateMock: vi.fn(),
   };
 });
@@ -35,6 +35,7 @@ vi.mock("@vortex/shared", () => ({
 vi.mock("electron", () => ({
   app: appMock,
   dialog: { showMessageBoxSync: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [{ webContents: {} }] },
 }));
 vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
 vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -13,7 +13,7 @@
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import type { UpdateStatus } from "@vortex/shared/ipc";
-import { app, dialog } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import * as semver from "semver";
@@ -121,11 +121,11 @@ export function setupAutoUpdater(installType: string): void {
         attempts: installAttempts,
       });
       updateStatus.error = err.message;
+      broadcastStatus();
     }
   }
 
-  // Register invoke handler for status queries
-  betterIpcMain.handle("updater:get-status", (): UpdateStatus => {
+  function statusSnapshot(): UpdateStatus {
     return {
       available: updateStatus.available,
       downloaded: updateStatus.downloaded,
@@ -136,7 +136,19 @@ export function setupAutoUpdater(installType: string): void {
       downgrade: updateStatus.downgrade,
       checking: updateStatus.checking,
     };
-  });
+  }
+
+  // Push the current status to every window; the renderer reacts to these
+  // instead of polling (getStatus remains for the initial sync).
+  function broadcastStatus(): void {
+    const snapshot = statusSnapshot();
+    for (const win of BrowserWindow.getAllWindows()) {
+      betterIpcMain.send(win.webContents, "updater:status-changed", snapshot);
+    }
+  }
+
+  // Register invoke handler for status queries
+  betterIpcMain.handle("updater:get-status", (): UpdateStatus => statusSnapshot());
 
   log("info", "setupAutoUpdater", { installType, currentVersion });
 
@@ -156,6 +168,7 @@ export function setupAutoUpdater(installType: string): void {
     if (installPending) {
       handleInstallFailure(unknownToError(err));
     }
+    broadcastStatus();
   });
 
   // Update not available
@@ -163,6 +176,7 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "No update available", { channel: updateChannel });
     updateStatus.available = false;
     updateStatus.error = undefined;
+    broadcastStatus();
   });
 
   // Update available
@@ -182,12 +196,20 @@ export function setupAutoUpdater(installType: string): void {
         .map((note) => (typeof note === "string" ? note : note.note))
         .join("\n\n");
     }
+    broadcastStatus();
   });
 
-  // Download progress
+  // Download progress. Progress events fire many times per second on a
+  // ~360 MB installer; broadcast only whole-percent changes.
+  let lastBroadcastPercent = -1;
   autoUpdater.on("download-progress", (progress: { percent: number }) => {
     log("debug", "Download progress", { percent: progress.percent });
     updateStatus.downloadProgress = progress.percent;
+    const wholePercent = Math.floor(progress.percent);
+    if (wholePercent !== lastBroadcastPercent) {
+      lastBroadcastPercent = wholePercent;
+      broadcastStatus();
+    }
   });
 
   // Track whether to auto-install after download
@@ -198,6 +220,7 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "Update downloaded", { version: updateInfo.version });
     updateStatus.downloaded = true;
     updateStatus.downloadProgress = 100;
+    broadcastStatus();
 
     // Set up auto-install on quit (unless dev mode)
     if (process.env.NODE_ENV !== "development") {
@@ -265,6 +288,7 @@ export function setupAutoUpdater(installType: string): void {
     updateChannel = channel;
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    broadcastStatus();
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
     resolveAndApply(channel, generation)
@@ -278,8 +302,10 @@ export function setupAutoUpdater(installType: string): void {
           updateStatus.version = undefined;
           updateStatus.releaseNotes = undefined;
           updateStatus.error = undefined;
+          broadcastStatus();
           return;
         }
+        broadcastStatus();
         log("info", "Update check completed", { version: resolved.version });
 
         // Auto-download patch updates for regular installs; minor/major
@@ -299,6 +325,7 @@ export function setupAutoUpdater(installType: string): void {
       .catch((err) => {
         if (generation === checkGeneration) {
           updateStatus.checking = false;
+          broadcastStatus();
         }
         if (err instanceof RateLimitError) {
           log("warn", "Update check rate-limited", { resetAt: err.resetAt.toISOString() });
@@ -349,10 +376,18 @@ export function setupAutoUpdater(installType: string): void {
     // Always re-resolve for the channel the renderer asked about: a cached
     // resolution could belong to a different channel, and re-applying the
     // feed guarantees the library-side check-before-download. The resolver's
-    // ETag cache makes the repeat lookup cheap.
+    // ETag cache makes the repeat lookup cheap. The download owns the
+    // checking lifecycle for the generation it claims, so a check it
+    // superseded can't strand checking:true.
     const generation = ++checkGeneration;
+    updateStatus.checking = true;
+    broadcastStatus();
     resolveAndApply(channel, generation)
       .then((resolved) => {
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+          broadcastStatus();
+        }
         if (resolved == null) {
           throw new Error("no newer release available to download");
         }
@@ -363,6 +398,10 @@ export function setupAutoUpdater(installType: string): void {
         log("error", "Download failed", { error: err.message });
         updateStatus.error = err.message;
         installAfterDownloadFlag = false;
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+        }
+        broadcastStatus();
       });
   });
 

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -124,6 +124,12 @@ try {
       downloadUpdate: (channel: string, installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download", channel, installAfterDownload),
       restartAndInstall: () => betterIpcRenderer.send("updater:restart-and-install"),
+      onStatusChanged: (callback) => {
+        const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) =>
+          callback(status);
+        ipcRenderer.on("updater:status-changed", listener);
+        return () => ipcRenderer.removeListener("updater:status-changed", listener);
+      },
     },
 
     dialog: {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IExtensionContext } from "../../types/IExtensionContext";
+import init from "./index";
+
+interface FakeStatus {
+  available: boolean;
+  downloaded: boolean;
+  version?: string;
+  releaseNotes?: string;
+  downgrade?: boolean;
+  checking?: boolean;
+}
+
+function makeContext() {
+  const onceCallbacks: Array<() => void> = [];
+  const sendNotification = vi.fn();
+  const state = {
+    app: { installType: "regular" },
+    settings: { update: { channel: "stable" } },
+  };
+  const context = {
+    registerReducer: vi.fn(),
+    registerSettings: vi.fn(),
+    once: (cb: () => void) => onceCallbacks.push(cb),
+    api: {
+      getState: () => state,
+      sendNotification,
+      showDialog: vi.fn().mockResolvedValue({ action: "Close" }),
+      onStateChange: vi.fn(),
+      store: { getState: () => state },
+    },
+  } as unknown as IExtensionContext;
+  return { context, sendNotification, runOnce: () => onceCallbacks.forEach((cb) => cb()) };
+}
+
+function makeUpdaterApi(initialStatus: FakeStatus) {
+  let statusListener: ((status: FakeStatus) => void) | undefined;
+  const updater = {
+    getStatus: vi.fn().mockResolvedValue(initialStatus),
+    setChannel: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    restartAndInstall: vi.fn(),
+    onStatusChanged: vi.fn((cb: (status: FakeStatus) => void) => {
+      statusListener = cb;
+      return () => undefined;
+    }),
+  };
+  return { updater, pushStatus: (status: FakeStatus) => statusListener?.(status) };
+}
+
+const idleStatus: FakeStatus = { available: false, downloaded: false };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+async function setup(initialStatus: FakeStatus = idleStatus) {
+  const { context, sendNotification, runOnce } = makeContext();
+  const { updater, pushStatus } = makeUpdaterApi(initialStatus);
+  vi.stubGlobal("window", { api: { updater } });
+  init(context);
+  runOnce();
+  // let the initial getStatus sync settle
+  await vi.advanceTimersByTimeAsync(0);
+  return { sendNotification, updater, pushStatus };
+}
+
+describe("updater status handling", () => {
+  it("shows the update notification when a pushed status is available", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const notification = sendNotification.mock.calls[0]![0];
+    expect(notification.id).toBe("vortex-update-available");
+    expect(notification.message).toContain("2.7.0");
+    expect(notification.actions[1].title).toBe("Install");
+  });
+
+  // Regression pin #22826: a later "downloaded" status must update the same
+  // notification (same id — upsert), flipping the action to Restart.
+  it("updates the same notification when the download completes", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    pushStatus({ available: true, downloaded: true, version: "2.7.0" });
+
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    const first = sendNotification.mock.calls[0]![0];
+    const second = sendNotification.mock.calls[1]![0];
+    expect(second.id).toBe(first.id);
+    expect(second.actions[1].title).toBe("Restart");
+  });
+
+  it("never presents a downgrade status as a regular update", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("syncs the initial status via getStatus for checks that finished early", async () => {
+    const { sendNotification } = await setup({
+      available: true,
+      downloaded: false,
+      version: "2.8.0",
+    });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification.mock.calls[0]![0].message).toContain("2.8.0");
+  });
+
+  it("ignores non-available statuses (checking, progress)", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, checking: true });
+    pushStatus({ available: false, downloaded: false });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -16,11 +16,15 @@ function init(context: IExtensionContext): boolean {
 
     let haveSetChannel = false;
 
-    // Show update details dialog with HTML release notes
+    type UpdateStatus = Awaited<ReturnType<typeof window.api.updater.getStatus>>;
+
+    // Show update details dialog with HTML release notes. Buttons act via
+    // their own callbacks rather than label matching, so a renamed or
+    // translated label can't silently break the action.
     const showUpdateDialog = async (version: string, releaseNotes?: string) => {
       const status = await window.api.updater.getStatus();
 
-      const result = await context.api.showDialog(
+      await context.api.showDialog(
         "info",
         `What's New in ${version}`,
         {
@@ -33,52 +37,55 @@ function init(context: IExtensionContext): boolean {
           {
             label: status.downloaded ? "Restart & Install" : "Download",
             default: true,
+            action: () => {
+              if (status.downloaded) {
+                window.api.updater.restartAndInstall();
+              } else {
+                const channel = context.api.store.getState().settings.update.channel;
+                window.api.updater.downloadUpdate(channel);
+              }
+            },
           },
         ],
         "new-update-changelog-dialog",
       );
-
-      if (result.action === "Restart & Install") {
-        window.api.updater.restartAndInstall();
-      } else if (result.action === "Download" && !status.downloaded) {
-        const channel = context.api.store.getState().settings.update.channel;
-        window.api.updater.downloadUpdate(channel);
-      }
     };
 
-    // Query update status and show notification if update is available
-    const checkUpdateStatus = async () => {
-      try {
-        const status = await window.api.updater.getStatus();
-        if (status.available && status.version) {
-          context.api.sendNotification({
-            id: "vortex-update-available",
-            type: "info",
-            message: `Vortex ${status.version} is available`,
-            actions: [
-              {
-                title: "More",
-                action: () => {
-                  void showUpdateDialog(status.version!, status.releaseNotes);
-                },
+    // React to a status pushed from main (or fetched for the initial sync):
+    // upsert the update notification — same id, so repeated statuses update
+    // it in place rather than stacking.
+    const handleUpdateStatus = (status: UpdateStatus) => {
+      if (status.downgrade) {
+        // downgrade offers get their own flow when the channel-switch UX
+        // ships; never present one as a regular update
+        return;
+      }
+      if (status.available && status.version) {
+        context.api.sendNotification({
+          id: "vortex-update-available",
+          type: "info",
+          message: `Vortex ${status.version} is available`,
+          actions: [
+            {
+              title: "More",
+              action: () => {
+                void showUpdateDialog(status.version!, status.releaseNotes);
               },
-              {
-                title: status.downloaded ? "Restart" : "Install",
-                action: (dismiss) => {
-                  if (status.downloaded) {
-                    window.api.updater.restartAndInstall();
-                  } else {
-                    const channel = context.api.store.getState().settings.update.channel;
-                    window.api.updater.downloadUpdate(channel, true);
-                  }
-                  dismiss();
-                },
+            },
+            {
+              title: status.downloaded ? "Restart" : "Install",
+              action: (dismiss) => {
+                if (status.downloaded) {
+                  window.api.updater.restartAndInstall();
+                } else {
+                  const channel = context.api.store.getState().settings.update.channel;
+                  window.api.updater.downloadUpdate(channel, true);
+                }
+                dismiss();
               },
-            ],
-          });
-        }
-      } catch {
-        // Silently ignore status check errors
+            },
+          ],
+        });
       }
     };
 
@@ -100,10 +107,13 @@ function init(context: IExtensionContext): boolean {
       }
     }, 5000);
 
-    // Check update status once after update check completes (give it time)
-    setTimeout(() => {
-      void checkUpdateStatus();
-    }, 15000);
+    // Main pushes every status change; the one-time getStatus covers a check
+    // that finished before this subscription existed (e.g. window reload).
+    window.api.updater.onStatusChanged(handleUpdateStatus);
+    window.api.updater
+      .getStatus()
+      .then(handleUpdateStatus)
+      .catch(() => undefined);
   });
 
   return true;

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -308,6 +308,9 @@ export interface MainChannels extends MainCallbackChannels {
 
   // Feature flags: main pushes updated flags after each successful poll
   "flags:synchronize": (flags: FeatureFlag[]) => void;
+
+  // Auto-updater: main pushes the full status snapshot on every change
+  "updater:status-changed": (status: UpdateStatus) => void;
 }
 
 /** Context data the renderer can push to refine feature flag evaluation */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -476,6 +476,12 @@ export interface UpdaterApi {
    * Trigger restart and install of the downloaded update.
    */
   restartAndInstall(): void;
+
+  /**
+   * Subscribe to update-status changes pushed from the main process.
+   * Returns an unsubscribe function.
+   */
+  onStatusChanged(callback: (status: UpdateStatus) => void): () => void;
 }
 
 /** API for interacting with the DownloadManager in main */


### PR DESCRIPTION
Merges after #23992.

The renderer used to poll for update status once, 15 seconds after startup. Anything that resolved later was missed until the next launch. Main now pushes every status change to all windows and the renderer renders what it's told. Progress broadcasts are throttled to whole percents.
