### PR TITLE
updater 4/5: state machine, status polling, downgrade flow, notification UX

### DIFF
--- a/etc/Dependency Report.md
+++ b/etc/Dependency Report.md
@@ -52,7 +52,7 @@ This is a list of all modules leaked by Vortex to extensions. Any module listed 
 | drivelist | 10.0.2 |
 | electron-context-menu | 3.6.1 |
 | electron-redux | 1.4.9-sync |
-| electron-updater | 4.6.5 |
+| electron-updater | 6.8.9 |
 | encoding-down | 6.3.0 |
 | exe-version | link:../../packages/exe-version |
 | feedparser | 2.3.0 |

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -10,7 +10,7 @@
  * latest.yml and a dummy installer are generated per release tag with a
  * matching sha512, so electron-updater's download + hash verification pass.
  * (Authenticode verification and the actual install still need a packaged,
- * signed build — this covers resolve → notify → download.)
+ * signed build; this covers resolve -> notify -> download.)
  *
  * Usage:
  *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe] [--assets dir] [--throttle MBps]
@@ -151,7 +151,7 @@ const server = createServer((req, res) => {
     // blockmaps must match the actual installer bytes); a per-tag
     // subdirectory wins over the flat dir, so tag-specific files that share
     // a name across releases (latest.yml) can coexist. Reject ".."-bearing
-    // segments outright — the character class alone would admit them.
+    // segments outright, the character class alone would admit them.
     const safeSegment = (segment) => /^[\w.-]+$/.test(segment) && !segment.includes("..");
     if (assetsDir != null && safeSegment(asset) && safeSegment(tag)) {
       try {

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -90,12 +90,24 @@ function latestYmlForTag(tag) {
   ].join("\n");
 }
 
+function fmtSize(bytes) {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
+
 const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${port}`);
-  console.log(`${req.method} ${url.pathname}`);
 
   const listing = /^\/repos\/Nexus-Mods\/[^/]+\/releases$/.exec(url.pathname);
   if (listing != null) {
+    console.log(
+      `${req.method} ${url.pathname} -> 200 (release listing, ${releases.length} releases)`,
+    );
     res.writeHead(200, { "content-type": "application/json", etag: '"mock-feed"' });
     res.end(JSON.stringify(releases));
     return;
@@ -104,6 +116,7 @@ const server = createServer((req, res) => {
   const download = /^\/Nexus-Mods\/[^/]+\/releases\/download\/([^/]+)\/(.+)$/.exec(url.pathname);
   if (download != null) {
     const [, tag, asset] = download;
+    const label = `${req.method} ${tag}/${asset}`;
     // real files win over generated dummies (needed for blockmap testing:
     // blockmaps must match the actual installer bytes); a per-tag
     // subdirectory wins over the flat dir, so tag-specific files that share
@@ -111,10 +124,13 @@ const server = createServer((req, res) => {
     if (assetsDir != null && /^[\w.-]+$/.test(asset) && /^[\w.-]+$/.test(tag)) {
       try {
         let content;
+        let source;
         try {
           content = readFileSync(path.join(assetsDir, tag, asset));
+          source = `assets\\${tag}`;
         } catch {
           content = readFileSync(path.join(assetsDir, asset));
+          source = "assets";
         }
         // the differential downloader fetches byte ranges of the installer
         const range = /^bytes=(\d+)-(\d+)?$/.exec(req.headers.range ?? "");
@@ -122,6 +138,9 @@ const server = createServer((req, res) => {
           const start = Number(range[1]);
           const end = range[2] != null ? Number(range[2]) : content.length - 1;
           const slice = content.subarray(start, end + 1);
+          console.log(
+            `${label} -> 206 bytes ${start}-${end} (${fmtSize(slice.length)}) [${source}]`,
+          );
           res.writeHead(206, {
             "content-type": "application/octet-stream",
             "content-length": slice.length,
@@ -131,6 +150,7 @@ const server = createServer((req, res) => {
           res.end(slice);
           return;
         }
+        console.log(`${label} -> 200 full file (${fmtSize(content.length)}) [${source}]`);
         res.writeHead(200, {
           "content-type": "application/octet-stream",
           "content-length": content.length,
@@ -144,16 +164,19 @@ const server = createServer((req, res) => {
     }
     if (asset.endsWith(".blockmap")) {
       // no real blockmap available: 404 exercises the full-download fallback
+      console.log(`${label} -> 404 (no blockmap on disk; full-download fallback)`);
       res.writeHead(404, { "content-type": "text/plain" });
       res.end("no blockmap");
       return;
     }
     if (asset === "latest.yml") {
+      console.log(`${label} -> 200 (generated latest.yml for ${tag})`);
       res.writeHead(200, { "content-type": "text/yaml" });
       res.end(latestYmlForTag(tag));
       return;
     }
     if (asset.toLowerCase().endsWith(".exe")) {
+      console.log(`${label} -> 200 (generated dummy installer, ${fmtSize(installerBytes.length)})`);
       res.writeHead(200, {
         "content-type": "application/octet-stream",
         "content-length": installerBytes.length,
@@ -163,6 +186,7 @@ const server = createServer((req, res) => {
     }
   }
 
+  console.log(`${req.method} ${url.pathname} -> 404`);
   res.writeHead(404, { "content-type": "text/plain" });
   res.end("not found");
 });

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -13,7 +13,14 @@
  * signed build — this covers resolve → notify → download.)
  *
  * Usage:
- *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe]
+ *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe] [--assets dir]
+ *
+ * --assets serves real files (installers and their .exe.blockmap siblings)
+ * by exact name from a directory, taking precedence over the generated
+ * dummies. Point it at two packaged builds' dist output to exercise the
+ * differential (blockmap) download path end to end: electron-updater logs
+ * "Download block maps (old..., new...)" when it engages, and falls back to
+ * a full download when a blockmap 404s.
  *
  * Then run Vortex with:
  *   VORTEX_UPDATER_API_BASE=http://localhost:9877
@@ -54,6 +61,7 @@ const fixturePath = arg(
   ),
 );
 const installerPath = arg("installer", null);
+const assetsDir = arg("assets", null);
 
 const releases = JSON.parse(readFileSync(fixturePath, "utf8"));
 const installerBytes =
@@ -96,6 +104,44 @@ const server = createServer((req, res) => {
   const download = /^\/Nexus-Mods\/[^/]+\/releases\/download\/([^/]+)\/(.+)$/.exec(url.pathname);
   if (download != null) {
     const [, tag, asset] = download;
+    // real files win over generated dummies (needed for blockmap testing:
+    // blockmaps must match the actual installer bytes)
+    if (assetsDir != null && /^[\w.-]+$/.test(asset)) {
+      try {
+        const filePath = path.join(assetsDir, asset);
+        const content = readFileSync(filePath);
+        // the differential downloader fetches byte ranges of the installer
+        const range = /^bytes=(\d+)-(\d+)?$/.exec(req.headers.range ?? "");
+        if (range != null) {
+          const start = Number(range[1]);
+          const end = range[2] != null ? Number(range[2]) : content.length - 1;
+          const slice = content.subarray(start, end + 1);
+          res.writeHead(206, {
+            "content-type": "application/octet-stream",
+            "content-length": slice.length,
+            "content-range": `bytes ${start}-${end}/${content.length}`,
+            "accept-ranges": "bytes",
+          });
+          res.end(slice);
+          return;
+        }
+        res.writeHead(200, {
+          "content-type": "application/octet-stream",
+          "content-length": content.length,
+          "accept-ranges": "bytes",
+        });
+        res.end(content);
+        return;
+      } catch {
+        // fall through to generated assets / 404
+      }
+    }
+    if (asset.endsWith(".blockmap")) {
+      // no real blockmap available: 404 exercises the full-download fallback
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("no blockmap");
+      return;
+    }
     if (asset === "latest.yml") {
       res.writeHead(200, { "content-type": "text/yaml" });
       res.end(latestYmlForTag(tag));

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -13,7 +13,11 @@
  * signed build — this covers resolve → notify → download.)
  *
  * Usage:
- *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe] [--assets dir]
+ *   node scripts/mock-update-feed.mjs [--port 9877] [--fixture path.json] [--installer path.exe] [--assets dir] [--throttle MBps]
+ *
+ * --throttle caps asset transfer speed (megabytes per second) so a download
+ * from localhost takes long enough to watch the progress UI; e.g. --throttle 20
+ * stretches a 365 MB installer to about 18 seconds.
  *
  * --assets serves real files (installers and their .exe.blockmap siblings)
  * by exact name from a directory, taking precedence over the generated
@@ -62,6 +66,32 @@ const fixturePath = arg(
 );
 const installerPath = arg("installer", null);
 const assetsDir = arg("assets", null);
+const throttleMBps = Number(arg("throttle", "0"));
+
+// Writes a body either in one go or, when throttled, in ten slices per
+// second sized to the requested rate.
+function sendBody(res, body) {
+  if (!(throttleMBps > 0)) {
+    res.end(body);
+    return;
+  }
+  const chunk = Math.max(1, Math.floor((throttleMBps * 1024 * 1024) / 10));
+  let offset = 0;
+  const tick = () => {
+    if (res.destroyed) {
+      return;
+    }
+    const end = Math.min(offset + chunk, body.length);
+    res.write(body.subarray(offset, end));
+    offset = end;
+    if (offset >= body.length) {
+      res.end();
+    } else {
+      setTimeout(tick, 100);
+    }
+  };
+  tick();
+}
 
 const releases = JSON.parse(readFileSync(fixturePath, "utf8"));
 const installerBytes =
@@ -158,7 +188,7 @@ const server = createServer((req, res) => {
             "content-range": `bytes ${start}-${end}/${content.length}`,
             "accept-ranges": "bytes",
           });
-          res.end(slice);
+          sendBody(res, slice);
           return;
         }
         console.log(`${label} -> 200 full file (${fmtSize(content.length)}) [${source}]`);
@@ -167,7 +197,7 @@ const server = createServer((req, res) => {
           "content-length": content.length,
           "accept-ranges": "bytes",
         });
-        res.end(content);
+        sendBody(res, content);
         return;
       } catch {
         // fall through to generated assets / 404

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -105,11 +105,17 @@ const server = createServer((req, res) => {
   if (download != null) {
     const [, tag, asset] = download;
     // real files win over generated dummies (needed for blockmap testing:
-    // blockmaps must match the actual installer bytes)
-    if (assetsDir != null && /^[\w.-]+$/.test(asset)) {
+    // blockmaps must match the actual installer bytes); a per-tag
+    // subdirectory wins over the flat dir, so tag-specific files that share
+    // a name across releases (latest.yml) can coexist
+    if (assetsDir != null && /^[\w.-]+$/.test(asset) && /^[\w.-]+$/.test(tag)) {
       try {
-        const filePath = path.join(assetsDir, asset);
-        const content = readFileSync(filePath);
+        let content;
+        try {
+          content = readFileSync(path.join(assetsDir, tag, asset));
+        } catch {
+          content = readFileSync(path.join(assetsDir, asset));
+        }
         // the differential downloader fetches byte ranges of the installer
         const range = /^bytes=(\d+)-(\d+)?$/.exec(req.headers.range ?? "");
         if (range != null) {

--- a/scripts/mock-update-feed.mjs
+++ b/scripts/mock-update-feed.mjs
@@ -120,8 +120,10 @@ const server = createServer((req, res) => {
     // real files win over generated dummies (needed for blockmap testing:
     // blockmaps must match the actual installer bytes); a per-tag
     // subdirectory wins over the flat dir, so tag-specific files that share
-    // a name across releases (latest.yml) can coexist
-    if (assetsDir != null && /^[\w.-]+$/.test(asset) && /^[\w.-]+$/.test(tag)) {
+    // a name across releases (latest.yml) can coexist. Reject ".."-bearing
+    // segments outright — the character class alone would admit them.
+    const safeSegment = (segment) => /^[\w.-]+$/.test(segment) && !segment.includes("..");
+    if (assetsDir != null && safeSegment(asset) && safeSegment(tag)) {
       try {
         let content;
         let source;
@@ -136,7 +138,16 @@ const server = createServer((req, res) => {
         const range = /^bytes=(\d+)-(\d+)?$/.exec(req.headers.range ?? "");
         if (range != null) {
           const start = Number(range[1]);
-          const end = range[2] != null ? Number(range[2]) : content.length - 1;
+          const end = Math.min(
+            range[2] != null ? Number(range[2]) : content.length - 1,
+            content.length - 1,
+          );
+          if (start >= content.length || start > end) {
+            console.log(`${label} -> 416 (unsatisfiable range ${req.headers.range})`);
+            res.writeHead(416, { "content-range": `bytes */${content.length}` });
+            res.end();
+            return;
+          }
           const slice = content.subarray(start, end + 1);
           console.log(
             `${label} -> 206 bytes ${start}-${end} (${fmtSize(slice.length)}) [${source}]`,
@@ -191,7 +202,9 @@ const server = createServer((req, res) => {
   res.end("not found");
 });
 
-server.listen(port, () => {
+// loopback only: without an explicit host Node binds 0.0.0.0, exposing the
+// assets directory to the local network
+server.listen(port, "127.0.0.1", () => {
   console.log(`mock update feed on http://localhost:${port}`);
   console.log(`  fixture: ${fixturePath} (${releases.length} releases)`);
   console.log(`  installer: ${installerPath ?? "generated dummy bytes"}`);

--- a/scripts/updater-e2e-staging.mjs
+++ b/scripts/updater-e2e-staging.mjs
@@ -1,0 +1,167 @@
+/**
+ * Staging dress rehearsal for the auto-updater, against a real GitHub repo.
+ *
+ * Publishes fixture releases to a SCRATCH repo (never the live Vortex or
+ * Vortex-Staging repos) so a packaged Vortex, pointed at it via
+ * VORTEX_UPDATER_REPO=owner/repo, exercises the GitHub-specific edges the
+ * local mock feed can't: real API shapes, the objects.githubusercontent.com
+ * CDN redirect, rate limiting, prerelease/draft semantics, and signature
+ * verification with CI-signed installers.
+ *
+ * Assets come from the draft releases CI parks on Vortex-Staging (dispatch
+ * .github/workflows/package.yml with staging-release on, release and
+ * upload-to-r2 off). Drafts are invisible to unauthenticated clients, so
+ * nothing real users can see is ever touched.
+ *
+ * Usage (requires gh, authenticated):
+ *   node scripts/updater-e2e-staging.mjs setup --repo owner/scratch --versions v9.0.0,v9.0.1
+ *   node scripts/updater-e2e-staging.mjs teardown --repo owner/scratch
+ *
+ * setup:
+ *   - downloads each version's assets from the Vortex-Staging draft with the
+ *     same tag (installer, latest.yml, blockmap)
+ *   - creates the release on the scratch repo, prerelease flag derived from
+ *     the version (contains "-" = prerelease), IN ARGUMENT ORDER, so listing
+ *     a newer beta before an older stable recreates the interleaved-dates
+ *     scenario that caused the original field bug
+ *   - releases are tagged in the body so teardown only ever deletes its own
+ * teardown:
+ *   - deletes every release (and tag) on the scratch repo whose body carries
+ *     the marker
+ *
+ * Options:
+ *   --repo owner/name      scratch repo (required)
+ *   --source owner/name    where CI parked the drafts (default Nexus-Mods/Vortex-Staging)
+ *   --versions a,b,c       tags to publish, in publish order (setup only)
+ *   --keep-drafts          leave the source drafts in place (default: leave them)
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+const MARKER = "updater-e2e-rehearsal";
+
+const argv = process.argv.slice(2);
+const command = argv[0];
+
+function opt(name, fallback = null) {
+  const index = argv.indexOf(`--${name}`);
+  return index >= 0 && argv[index + 1] != null ? argv[index + 1] : fallback;
+}
+
+function gh(args, opts = {}) {
+  return execFileSync("gh", args, { encoding: "utf8", ...opts });
+}
+
+const repo = opt("repo");
+const source = opt("source", "Nexus-Mods/Vortex-Staging");
+
+function usage(message) {
+  console.error(message);
+  console.error(
+    "usage: node scripts/updater-e2e-staging.mjs setup|teardown --repo owner/scratch [--versions v9.0.0,v9.0.1] [--source owner/name]",
+  );
+  process.exit(1);
+}
+
+if (repo == null || !repo.includes("/")) {
+  usage("--repo owner/name is required");
+}
+if (/Nexus-Mods\/(Vortex|Vortex-Staging)$/i.test(repo)) {
+  usage(`refusing to publish rehearsal releases to the live repo ${repo}; use a scratch repo`);
+}
+
+function setup() {
+  const versions = (opt("versions") ?? "").split(",").filter(Boolean);
+  if (versions.length === 0) {
+    usage("setup needs --versions (comma-separated tags, in publish order)");
+  }
+
+  for (const tag of versions) {
+    const version = tag.replace(/^v/, "");
+    const prerelease = version.includes("-");
+    const dir = mkdtempSync(path.join(tmpdir(), `updater-e2e-${version}-`));
+
+    console.log(`# ${tag}: downloading assets from ${source} draft`);
+    gh(["release", "download", tag, "--repo", source, "--dir", dir], {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    const assets = readdirSync(dir).map((name) => path.join(dir, name));
+    const names = assets.map((file) => path.basename(file));
+    const missing = ["latest.yml"].filter((needed) => !names.includes(needed));
+    if (missing.length > 0 || !names.some((name) => name.endsWith(".exe"))) {
+      throw new Error(`${tag}: draft on ${source} is missing assets (have: ${names.join(", ")})`);
+    }
+    if (!names.some((name) => name.endsWith(".blockmap"))) {
+      console.warn(
+        `${tag}: no blockmap in the draft; differential downloads will fall back to full`,
+      );
+    }
+
+    console.log(`# ${tag}: publishing on ${repo} (prerelease: ${prerelease})`);
+    gh(
+      [
+        "release",
+        "create",
+        tag,
+        "--repo",
+        repo,
+        "--title",
+        version,
+        "--notes",
+        `Rehearsal release for ${version}.\n\n<!-- ${MARKER} -->`,
+        ...(prerelease ? ["--prerelease"] : []),
+        "--latest=false",
+        ...assets,
+      ],
+      { stdio: ["ignore", "inherit", "inherit"] },
+    );
+
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  console.log("\ndone. point a packaged Vortex at it with:");
+  console.log(`  [Environment]::SetEnvironmentVariable("VORTEX_UPDATER_REPO", "${repo}", "User")`);
+  console.log("and make sure VORTEX_UPDATER_API_BASE / VORTEX_UPDATER_DOWNLOAD_BASE are cleared");
+  console.log("(the rehearsal must hit real GitHub). Clear VORTEX_UPDATER_REPO when finished.");
+}
+
+function teardown() {
+  const listing = JSON.parse(
+    gh(["release", "list", "--repo", repo, "--limit", "100", "--json", "tagName", "--jq", "."]),
+  );
+  let deleted = 0;
+  for (const entry of listing) {
+    const body = gh([
+      "release",
+      "view",
+      entry.tagName,
+      "--repo",
+      repo,
+      "--json",
+      "body",
+      "--jq",
+      ".body",
+    ]);
+    if (!body.includes(MARKER)) {
+      console.log(`# skipping ${entry.tagName}: not a rehearsal release`);
+      continue;
+    }
+    console.log(`# deleting ${entry.tagName}`);
+    gh(["release", "delete", entry.tagName, "--repo", repo, "--cleanup-tag", "--yes"], {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    deleted += 1;
+  }
+  console.log(`\ndone. deleted ${deleted} rehearsal release(s) from ${repo}.`);
+}
+
+if (command === "setup") {
+  setup();
+} else if (command === "teardown") {
+  teardown();
+} else {
+  usage(`unknown command: ${command ?? "(none)"}`);
+}

--- a/scripts/updater-e2e-staging.mjs
+++ b/scripts/updater-e2e-staging.mjs
@@ -18,6 +18,8 @@
  *   node scripts/updater-e2e-staging.mjs teardown --repo owner/scratch
  *
  * setup:
+ *   - seeds the scratch repo with a README if it has no commits yet (GitHub
+ *     can't tag, and so can't release, on an empty repo)
  *   - downloads each version's assets from the Vortex-Staging draft with the
  *     same tag (installer, latest.yml, blockmap)
  *   - creates the release on the scratch repo, prerelease flag derived from
@@ -73,11 +75,46 @@ if (/Nexus-Mods\/(Vortex|Vortex-Staging)$/i.test(repo)) {
   usage(`refusing to publish rehearsal releases to the live repo ${repo}; use a scratch repo`);
 }
 
+// A release needs a tag and a tag needs a commit, so a brand-new scratch repo
+// makes `gh release create` fail with "422 Repository is empty". Seed a README.
+function ensureRepoHasCommit() {
+  try {
+    gh(["api", `repos/${repo}/commits?per_page=1`], { stdio: ["ignore", "pipe", "ignore"] });
+    return;
+  } catch {
+    // 409 for an empty repo; anything else will resurface on the first release create
+  }
+  console.log(`# ${repo} is empty, seeding a README so releases can be tagged`);
+  const readme = [
+    `# ${repo.split("/")[1]}`,
+    "",
+    "Scratch repo for Vortex auto-updater rehearsals. Releases here are throwaway",
+    "test fixtures published by `scripts/updater-e2e-staging.mjs` in Nexus-Mods/Vortex;",
+    "they are not real Vortex builds.",
+    "",
+  ].join("\n");
+  gh(
+    [
+      "api",
+      "-X",
+      "PUT",
+      `repos/${repo}/contents/README.md`,
+      "-f",
+      "message=seed for updater rehearsal releases",
+      "-f",
+      `content=${Buffer.from(readme).toString("base64")}`,
+    ],
+    { stdio: ["ignore", "ignore", "inherit"] },
+  );
+}
+
 function setup() {
   const versions = (opt("versions") ?? "").split(",").filter(Boolean);
   if (versions.length === 0) {
     usage("setup needs --versions (comma-separated tags, in publish order)");
   }
+
+  ensureRepoHasCommit();
 
   for (const tag of versions) {
     const version = tag.replace(/^v/, "");

--- a/scripts/verify-packaged-asar.mjs
+++ b/scripts/verify-packaged-asar.mjs
@@ -13,8 +13,8 @@
  *
  * Checks every nested package (node_modules/<pkg>/node_modules/<dep>) in the
  * deploy tree: if the asar contains that slot, its version must match. Slots
- * absent from the asar entirely are allowed — the packager may legitimately
- * exclude dev-only trees — but a slot present with the WRONG version is
+ * absent from the asar entirely are allowed (the packager may legitimately
+ * exclude dev-only trees) but a slot present with the WRONG version is
  * exactly the corruption this guards against, and fails the run.
  */
 
@@ -81,7 +81,7 @@ function asarVersion(rel) {
   try {
     return JSON.parse(asar.extractFile(asarPath, rel.split("/").join(path.sep)).toString()).version;
   } catch {
-    return null; // not in the asar at all — allowed
+    return null; // not in the asar at all, allowed
   }
 }
 

--- a/src/main/dev-app-update.yml
+++ b/src/main/dev-app-update.yml
@@ -1,0 +1,13 @@
+# Config for electron-updater when running from source with
+# VORTEX_DEV_UPDATER=1 (see extensions/autoupdater). Packaged builds use the
+# app-update.yml that electron-builder generates instead; this file is only
+# read when the dev updater is explicitly opted into.
+#
+# The url is a placeholder: the release resolver overrides the feed on every
+# check. Pair with scripts/mock-update-feed.mjs and the
+# VORTEX_UPDATER_API_BASE / VORTEX_UPDATER_DOWNLOAD_BASE overrides.
+# No publisherName on purpose: signature verification is skipped so the mock
+# feed can serve unsigned dummy installers.
+provider: generic
+url: http://localhost:9877
+updaterCacheDirName: vortex-updater-dev

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -663,6 +663,8 @@ class Application {
     if (isMajorDowngrade(lastVersion, currentVersion)) {
       // A downgrade the user explicitly confirmed through the updater's
       // channel-switch flow sets a one-shot marker; don't warn about it.
+      // "" is the cleared sentinel: the persistence layer stores it as '""',
+      // which readPersistedValue parses back to "" and the guard below skips.
       const expectedDowngrade = await readPersistedValue<string>("app", ["expectedDowngradeTo"]);
       if (expectedDowngrade != null && expectedDowngrade !== "") {
         await writePersistedValue("app", ["expectedDowngradeTo"], "");
@@ -672,6 +674,8 @@ class Application {
           from: lastVersion,
           to: currentVersion,
         });
+        // Returning here also bypasses the update-migration branch below,
+        // which is correct: a downgrade can never satisfy its gt() condition.
         return;
       }
 

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -661,6 +661,20 @@ class Application {
     }
 
     if (isMajorDowngrade(lastVersion, currentVersion)) {
+      // A downgrade the user explicitly confirmed through the updater's
+      // channel-switch flow sets a one-shot marker; don't warn about it.
+      const expectedDowngrade = await readPersistedValue<string>("app", ["expectedDowngradeTo"]);
+      if (expectedDowngrade != null && expectedDowngrade !== "") {
+        await writePersistedValue("app", ["expectedDowngradeTo"], "");
+      }
+      if (expectedDowngrade === currentVersion) {
+        log("info", "Expected downgrade detected, skipping warning", {
+          from: lastVersion,
+          to: currentVersion,
+        });
+        return;
+      }
+
       const res = await this.showDialog({
         type: "warning",
         title: "Downgrade detected",

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -3,27 +3,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ResolvedRelease } from "./releaseResolver";
 
-const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock } = vi.hoisted(() => {
-  return {
-    autoUpdaterMock: {
-      on: vi.fn(),
-      setFeedURL: vi.fn(),
-      checkForUpdates: vi.fn(),
-      downloadUpdate: vi.fn(),
-      quitAndInstall: vi.fn(),
-      allowDowngrade: true,
-      autoDownload: true,
-      autoInstallOnAppQuit: true,
-    },
-    appMock: {
-      getVersion: vi.fn(() => "2.6.0"),
-      on: vi.fn(),
-      removeListener: vi.fn(),
-    },
-    ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
-    resolveUpdateMock: vi.fn(),
-  };
-});
+const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock, writePersistedValueMock } =
+  vi.hoisted(() => {
+    return {
+      autoUpdaterMock: {
+        on: vi.fn(),
+        setFeedURL: vi.fn(),
+        checkForUpdates: vi.fn(),
+        downloadUpdate: vi.fn(),
+        quitAndInstall: vi.fn(),
+        allowDowngrade: true,
+        autoDownload: true,
+        autoInstallOnAppQuit: true,
+      },
+      appMock: {
+        getVersion: vi.fn(() => "2.6.0"),
+        on: vi.fn(),
+        removeListener: vi.fn(),
+      },
+      ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
+      resolveUpdateMock: vi.fn(),
+      writePersistedValueMock: vi.fn(),
+    };
+  });
 
 // @vortex/shared's error module has a duplicate-load guard that trips under
 // vi.resetModules; only these two helpers are used at runtime (the UpdateStatus
@@ -40,17 +42,19 @@ vi.mock("electron", () => ({
 vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
 vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));
 vi.mock("../../logging", () => ({ log: vi.fn() }));
+vi.mock("../../store/mainPersistence", () => ({ writePersistedValue: writePersistedValueMock }));
 vi.mock("./releaseResolver", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   resolveUpdate: resolveUpdateMock,
 }));
 
 function resolved(overrides: Partial<ResolvedRelease> = {}): ResolvedRelease {
+  const tag = overrides.tag ?? "v2.7.0";
   return {
-    tag: "v2.7.0",
-    version: "2.7.0",
+    tag,
+    version: tag.replace(/^v/, ""),
     prerelease: false,
-    downloadBaseUrl: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
+    downloadBaseUrl: `https://github.com/Nexus-Mods/Vortex/releases/download/${tag}`,
     notesHtml: "<p>notes</p>",
     ...overrides,
   };
@@ -88,6 +92,7 @@ beforeEach(() => {
   appMock.getVersion.mockReturnValue("2.6.0");
   autoUpdaterMock.checkForUpdates.mockResolvedValue({ cancellationToken: { cancel: vi.fn() } });
   autoUpdaterMock.downloadUpdate.mockResolvedValue([]);
+  writePersistedValueMock.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -245,6 +250,70 @@ describe("release notes", () => {
     updaterEvent("update-available")?.({ version: "2.7.0", releaseNotes: null });
 
     expect(getStatus().releaseNotes).toBe("<p>from resolver</p>");
+  });
+});
+
+describe("downgrade offers", () => {
+  it("offers a downgrade only for a manual switch to stable on a prerelease build", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    const status = getStatus();
+    expect(status.available).toBe(true);
+    expect(status.downgrade).toBe(true);
+    expect(status.version).toBe("2.5.0");
+    // nothing downloads until the user confirms
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("never offers a downgrade on a background channel sync", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+
+    // the 5s fallback sends manual=false
+    ipcHandler("updater:set-channel")(undefined, "stable", false);
+    await flush();
+
+    const status = getStatus();
+    expect(status.downgrade).toBeUndefined();
+    expect(status.available).toBe(false);
+  });
+
+  it("ignores download-downgrade when no offer is outstanding", async () => {
+    await setup();
+
+    ipcHandler("updater:download-downgrade")(undefined, true);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+  });
+
+  it("downloads a confirmed downgrade with allowDowngrade raised only for that flow", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    ipcHandler("updater:download-downgrade")(undefined, true);
+    await flush();
+
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.5.0",
+    });
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+    // dropped again once the library accepted the feed
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+    // one-shot marker for the startup downgrade warning
+    expect(writePersistedValueMock).toHaveBeenCalledWith("app", ["expectedDowngradeTo"], "2.5.0");
   });
 });
 

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -941,3 +941,29 @@ describe("cancelling a download", () => {
     expect(getStatus(0).changes.some((entry) => entry.state.type === "error")).toBe(false);
   });
 });
+
+describe("checks while a download is running", () => {
+  // Field-tested: Check now mid-download moved the state to checking then
+  // available while the library kept downloading, and "ready to install"
+  // arrived out of nowhere ten seconds later.
+  it("ignores check requests while downloading, so the state keeps telling the truth", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0", version: "2.7.0" }));
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+    expect(getState().type).toBe("downloading");
+    resolveUpdateMock.mockClear();
+    const before = getStatus().seq;
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+
+    expect(resolveUpdateMock).not.toHaveBeenCalled();
+    expect(getState()).toMatchObject({ type: "downloading", version: "2.7.0" });
+    expect(getStatus(before).changes).toEqual([]);
+
+    // the download still completes normally
+    updaterEvent("update-downloaded")?.({ version: "2.7.0" });
+    expect(getState()).toMatchObject({ type: "staged", version: "2.7.0" });
+  });
+});

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -1,4 +1,4 @@
-import type { UpdateStatus } from "@vortex/shared/ipc";
+import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ResolvedRelease } from "./releaseResolver";
@@ -37,8 +37,8 @@ const {
 });
 
 // @vortex/shared's error module has a duplicate-load guard that trips under
-// vi.resetModules; only these two helpers are used at runtime (the UpdateStatus
-// import is type-only and erased).
+// vi.resetModules; only these two helpers are used at runtime (the type
+// imports are compile-time only and erased).
 vi.mock("@vortex/shared", () => ({
   getErrorMessageOrDefault: (err: unknown) => (err instanceof Error ? err.message : String(err)),
   unknownToError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
@@ -83,9 +83,13 @@ function updaterEvent(name: string): ((...args: unknown[]) => void) | undefined 
   return call?.[1] as ((...args: unknown[]) => void) | undefined;
 }
 
-function getStatus(): UpdateStatus {
+function getSnapshot(): UpdaterSnapshot {
   const call = ipcMock.handle.mock.calls.find(([name]) => name === "updater:get-status");
-  return (call![1] as () => UpdateStatus)();
+  return (call![1] as () => UpdaterSnapshot)();
+}
+
+function getState(): UpdaterState {
+  return getSnapshot().state;
 }
 
 async function flush(): Promise<void> {
@@ -126,26 +130,26 @@ describe("checkForUpdates", () => {
   // running version (published later in time) must never become an update.
   it("ignores a resolved release older than the running version", async () => {
     await setup();
-    // drive available to true first so the assertion pins an actual reset
-    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
-    expect(getStatus().available).toBe(true);
-    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.4.2", version: "2.4.2" }));
+    // establish a known update first so the assertion pins an actual reset
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.9.9" }));
+    ipcHandler("updater:check-for-updates")(undefined, "beta", false);
+    await flush();
+    expect(getState()).toMatchObject({ type: "available", version: "2.9.9" });
+    autoUpdaterMock.setFeedURL.mockClear();
+    autoUpdaterMock.downloadUpdate.mockClear();
 
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.4.2", version: "2.4.2" }));
     ipcHandler("updater:check-for-updates")(undefined, "beta", false);
     await flush();
 
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
-    const status = getStatus();
-    expect(status.available).toBe(false);
-    expect(status.version).toBeUndefined();
-    expect(status.checking).toBe(false);
+    expect(getState().type).toBe("idle");
   });
 
   // Regression pin #23132: equal version must not trigger a spurious download.
-  it("reports no update when the resolved version equals the current one", async () => {
+  it("reports idle when the resolved version equals the current one", async () => {
     await setup();
-    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.0", version: "2.6.0" }));
 
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
@@ -153,7 +157,7 @@ describe("checkForUpdates", () => {
 
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
-    expect(getStatus().available).toBe(false);
+    expect(getState().type).toBe("idle");
   });
 
   it("points the generic feed at the resolved release for an upgrade", async () => {
@@ -169,9 +173,22 @@ describe("checkForUpdates", () => {
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
     });
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalled();
-    // minor upgrade: no auto-download, and not labeled a patch
+    // minor upgrade: no auto-download, waits for the user
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
-    expect(getStatus().patch).toBe(false);
+    expect(getState()).toMatchObject({ type: "available", version: "2.7.0" });
+  });
+
+  it("carries the resolver's release notes on the available state", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ notesHtml: "<p>from resolver</p>" }));
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    expect(getState()).toMatchObject({
+      type: "available",
+      releaseNotes: "<p>from resolver</p>",
+    });
   });
 
   // Regression pin #22609: patch updates auto-download.
@@ -183,8 +200,24 @@ describe("checkForUpdates", () => {
     await flush();
 
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
-    // labeled for the renderer's quieter patch notification
-    expect(getStatus().patch).toBe(true);
+    expect(getState()).toMatchObject({ type: "downloading", version: "2.6.1", kind: "patch" });
+  });
+
+  it("exposes manual checks as a manual checking state", async () => {
+    await setup();
+    let release: (value: unknown) => void = () => undefined;
+    resolveUpdateMock.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    expect(getState()).toMatchObject({ type: "checking", manual: true });
+
+    release(resolved({ tag: "v2.6.0", version: "2.6.0" }));
+    await flush();
+    expect(getState().type).toBe("idle");
   });
 
   it("never resolves when the channel is none", async () => {
@@ -200,73 +233,34 @@ describe("checkForUpdates", () => {
     resolveUpdateMock.mockResolvedValue(resolved());
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
-    updaterEvent("update-available")?.({ version: "2.7.0", releaseNotes: null });
-    expect(getStatus().available).toBe(true);
+    expect(getState().type).toBe("available");
     ipcMock.send.mockClear();
 
     ipcHandler("updater:set-channel")(undefined, "none", true);
 
-    const status = getStatus();
-    expect(status.available).toBe(false);
-    expect(status.version).toBeUndefined();
-    expect(status.downgrade).toBeUndefined();
+    expect(getState().type).toBe("disabled");
     // the withdrawal is broadcast so the renderer can dismiss
     expect(ipcMock.send).toHaveBeenCalled();
   });
 
-  // Review finding: a failed download left stale progress, stranding the
-  // renderer on "Downloading…" with the retry button hidden.
-  it("clears download progress when a download fails", async () => {
-    await setup();
-    resolveUpdateMock.mockResolvedValue(resolved());
-    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("net::ERR_CONNECTION_REFUSED"));
-
-    ipcHandler("updater:download")(undefined, "stable", false);
-    await flush();
-    updaterEvent("download-progress")?.({ percent: 40 });
-
-    // the library error event also clears it
-    updaterEvent("error")?.(new Error("net::ERR_CONNECTION_REFUSED"));
-
-    const status = getStatus();
-    expect(status.downloadProgress).toBeUndefined();
-    expect(status.error).toContain("ERR_CONNECTION_REFUSED");
-  });
-
-  // Review finding: cancelling a download (channel switch) surfaced as a red
-  // error notification for a deliberate user action.
-  it("does not surface a cancelled download as an error", async () => {
-    await setup();
-    updaterEvent("download-progress")?.({ percent: 40 });
-
-    const cancellation = new Error("cancelled");
-    cancellation.name = "CancellationError";
-    updaterEvent("error")?.(cancellation);
-
-    const status = getStatus();
-    expect(status.error).toBeUndefined();
-    expect(status.downloadProgress).toBeUndefined();
-  });
-
-  it("clears checking but leaves availability untouched when resolution fails", async () => {
+  it("restores what the user could see when a background check fails", async () => {
     await setup();
     // a previously known update survives an offline/failed check
-    updaterEvent("update-available")?.({ version: "2.9.9", releaseNotes: null });
-    resolveUpdateMock.mockRejectedValue(new Error("network down"));
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    expect(getState()).toMatchObject({ type: "available", version: "2.7.0" });
 
+    resolveUpdateMock.mockRejectedValue(new Error("network down"));
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
 
-    const status = getStatus();
-    expect(status.checking).toBe(false);
-    expect(status.available).toBe(true);
-    // offline is normal: a BACKGROUND check failure stays out of the status
-    // (it would otherwise raise a red notification every launch and 4h tick)
-    expect(status.error).toBeUndefined();
-    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+    // offline is normal: no error state for a BACKGROUND check (it would
+    // raise a red notification every launch and 4h tick)
+    expect(getState()).toMatchObject({ type: "available", version: "2.7.0" });
   });
 
-  it("surfaces a failed MANUAL check via the error field", async () => {
+  it("surfaces a failed MANUAL check as an error state", async () => {
     await setup();
     resolveUpdateMock.mockRejectedValue(new Error("network down"));
 
@@ -274,7 +268,7 @@ describe("checkForUpdates", () => {
     await flush();
 
     // a failed manual check must not read as "up to date"
-    expect(getStatus().error).toContain("network down");
+    expect(getState()).toMatchObject({ type: "error", manual: true });
   });
 });
 
@@ -312,26 +306,77 @@ describe("updater:download", () => {
     await flush();
 
     expect(resolveUpdateMock).toHaveBeenCalledWith("stable", "2.6.0");
-    expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
-      provider: "generic",
-      useMultipleRangeRequest: false,
-      url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
-    });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
   });
 
-  // Review finding: the download path used to inherit the patch label from
-  // resolveAndApply, flipping a user-initiated download into the silent
-  // patch presentation mid-flight.
-  it("never labels a user-initiated download as a patch", async () => {
+  // A user download is always presented as a regular update, even when the
+  // version is patch-sized — the silent patch flow is auto-download only.
+  it("downloads user requests as regular updates", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
-
+    // pre-existing patch auto-download would have consumed it; simulate the
+    // user pressing Download from an error-retry
     ipcHandler("updater:download")(undefined, "stable", false);
     await flush();
 
+    expect(getState()).toMatchObject({ type: "downloading", kind: "update" });
+  });
+
+  it("skips re-download and installs directly when already staged", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-downloaded")?.({ version: "2.7.0" });
+    expect(getState()).toMatchObject({ type: "staged", version: "2.7.0" });
+    autoUpdaterMock.downloadUpdate.mockClear();
+
+    ipcHandler("updater:download")(undefined, "stable", true);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalled();
+  });
+
+  it("does not short-circuit a download when the staged installer is a different version", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
+
+    // a newer beta is now advertised; downloading must re-fetch, not install
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.8.0-beta.1", prerelease: true }));
+    ipcHandler("updater:check-for-updates")(undefined, "beta", false);
+    await flush();
+    autoUpdaterMock.quitAndInstall.mockClear();
+    autoUpdaterMock.downloadUpdate.mockClear();
+
+    ipcHandler("updater:download")(undefined, "beta", true);
+    await flush();
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
-    expect(getStatus().patch).toBeUndefined();
+  });
+
+  // Review finding: a failed download left stale progress, stranding the
+  // renderer on "Downloading..." with the retry hidden. The error state now
+  // carries the still-known update for a working retry.
+  it("fails a download into an error state that carries a retry", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("net::ERR_CONNECTION_REFUSED"));
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+
+    expect(getState()).toMatchObject({
+      type: "error",
+      manual: true,
+      retry: { version: "2.7.0" },
+    });
   });
 
   // Review finding: a download that lost the generation race could still call
@@ -360,75 +405,77 @@ describe("updater:download", () => {
 
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
   });
+});
 
-  it("skips re-download and installs directly when already downloaded", async () => {
+describe("library events", () => {
+  it("tracks progress as whole-percent downloading updates", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    ipcMock.send.mockClear();
+
+    updaterEvent("download-progress")?.({ percent: 41.2 });
+    updaterEvent("download-progress")?.({ percent: 41.9 });
+    updaterEvent("download-progress")?.({ percent: 42.1 });
+
+    expect(getState()).toMatchObject({ type: "downloading", percent: 42 });
+    // 41.2 and 42.1 broadcast; 41.9 is the same whole percent as 41.2
+    expect(ipcMock.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("stages the download and arms install-on-quit for packaged builds", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+
+    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
+
+    expect(getState()).toMatchObject({ type: "staged", version: "2.6.1", kind: "patch" });
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+  });
+
+  // A channel flip and back must not forget an installer already on disk.
+  it("re-checks land on staged when the resolved version is already downloaded", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved());
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
     updaterEvent("update-downloaded")?.({ version: "2.7.0" });
 
-    ipcHandler("updater:download")(undefined, "stable", true);
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
 
+    expect(getState()).toMatchObject({ type: "staged", version: "2.7.0" });
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
-    // NODE_ENV=test: install proceeds via quitAndInstall
-    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalled();
   });
-});
 
-describe("downloaded-state lifecycle", () => {
-  // Field bug: 2.5.0 was downloaded on stable, then a beta switch advertised
-  // 2.6.0-beta.1 with the stale downloaded flag — offering Restart & Install
-  // for a build that isn't on disk.
-  it("resets the downloaded flag when a different version becomes available", async () => {
+  it("fails an active download into an error state via the error event", async () => {
     await setup();
-    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1" }));
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
-    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
-    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
-    expect(getStatus().downloaded).toBe(true);
+    expect(getState().type).toBe("downloading");
 
-    updaterEvent("update-available")?.({ version: "2.8.0-beta.1", releaseNotes: null });
-    const afterSwitch = getStatus();
-    expect(afterSwitch.version).toBe("2.8.0-beta.1");
-    expect(afterSwitch.downloaded).toBe(false);
+    updaterEvent("error")?.(new Error("net::ERR_CONNECTION_REFUSED"));
 
-    // switching back to the version whose installer is on disk restores it
-    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
-    expect(getStatus().downloaded).toBe(true);
+    expect(getState()).toMatchObject({ type: "error", manual: true });
   });
 
-  it("does not short-circuit a download when the disk installer is a different version", async () => {
+  // Review finding: cancelling a download (channel switch) surfaced as a red
+  // error notification for a deliberate user action.
+  it("does not surface a cancelled download as an error", async () => {
     await setup();
-    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1" }));
-    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
-    await flush();
-    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
-    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
-
-    // a newer beta is now advertised; downloading must re-fetch, not install 2.6.1
-    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.8.0-beta.1", prerelease: true }));
-    updaterEvent("update-available")?.({ version: "2.8.0-beta.1", releaseNotes: null });
-    ipcHandler("updater:download")(undefined, "beta", true);
-    await flush();
-
-    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
-    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
-  });
-});
-
-describe("release notes", () => {
-  it("prefers the resolver's collected notes over UpdateInfo", async () => {
-    await setup();
-    resolveUpdateMock.mockResolvedValue(resolved({ notesHtml: "<p>from resolver</p>" }));
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
 
-    updaterEvent("update-available")?.({ version: "2.7.0", releaseNotes: null });
+    const cancellation = new Error("cancelled");
+    cancellation.name = "CancellationError";
+    updaterEvent("error")?.(cancellation);
 
-    expect(getStatus().releaseNotes).toBe("<p>from resolver</p>");
+    expect(getState().type).toBe("idle");
   });
 });
 
@@ -441,10 +488,7 @@ describe("downgrade offers", () => {
     ipcHandler("updater:set-channel")(undefined, "stable", true);
     await flush();
 
-    const status = getStatus();
-    expect(status.available).toBe(true);
-    expect(status.downgrade).toBe(true);
-    expect(status.version).toBe("2.5.0");
+    expect(getState()).toMatchObject({ type: "downgrade-offered", version: "2.5.0" });
     // nothing downloads until the user confirms
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
@@ -461,17 +505,12 @@ describe("downgrade offers", () => {
     // the 5s launch fallback sends manual=false
     ipcHandler("updater:set-channel")(undefined, "stable", false);
     await flush();
-
-    let status = getStatus();
-    expect(status.downgrade).toBeUndefined();
-    expect(status.available).toBe(false);
+    expect(getState().type).toBe("idle");
 
     // Check now on the stable channel doesn't offer either
     ipcHandler("updater:check-for-updates")(undefined, "stable", true);
     await flush();
-    status = getStatus();
-    expect(status.downgrade).toBeUndefined();
-    expect(status.available).toBe(false);
+    expect(getState().type).toBe("idle");
   });
 
   it("declining clears the offer until the next switch to stable", async () => {
@@ -483,10 +522,7 @@ describe("downgrade offers", () => {
 
     ipcHandler("updater:decline-downgrade")(undefined);
 
-    const status = getStatus();
-    expect(status.available).toBe(false);
-    expect(status.downgrade).toBeUndefined();
-    expect(status.version).toBeUndefined();
+    expect(getState().type).toBe("idle");
 
     // the declined offer is consumed: a late confirm must not download
     ipcHandler("updater:download-downgrade")(undefined, true);
@@ -496,7 +532,7 @@ describe("downgrade offers", () => {
     // ...but another purposeful switch to stable raises it again
     ipcHandler("updater:set-channel")(undefined, "stable", true);
     await flush();
-    expect(getStatus().downgrade).toBe(true);
+    expect(getState().type).toBe("downgrade-offered");
   });
 
   it("ignores a decline when no offer is outstanding", async () => {
@@ -504,8 +540,8 @@ describe("downgrade offers", () => {
 
     ipcHandler("updater:decline-downgrade")(undefined);
 
-    expect(getStatus().available).toBe(false);
-    // no spurious status broadcast for a stray decline
+    expect(getState().type).toBe("idle");
+    // no spurious broadcast for a stray decline
     expect(ipcMock.send).not.toHaveBeenCalled();
   });
 
@@ -519,7 +555,7 @@ describe("downgrade offers", () => {
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
   });
 
-  it("downloads a confirmed downgrade with allowDowngrade raised only for that flow", async () => {
+  it("downloads a confirmed downgrade with allowDowngrade raised only for the feed apply", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
@@ -532,7 +568,7 @@ describe("downgrade offers", () => {
       allowDowngradeDuringFeedApply = autoUpdaterMock.allowDowngrade;
     });
 
-    ipcHandler("updater:download-downgrade")(undefined, true);
+    ipcHandler("updater:download-downgrade")(undefined, false);
     await flush();
 
     expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
@@ -546,38 +582,13 @@ describe("downgrade offers", () => {
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
     // one-shot marker for the startup downgrade warning
     expect(writePersistedValueMock).toHaveBeenCalledWith("app", ["expectedDowngradeTo"], "2.5.0");
-    // past confirmation the offer flag drops, but the flow stays labeled as a
-    // downgrade so the renderer never presents it as a regular update
-    expect(getStatus().downgrade).toBeUndefined();
-    expect(getStatus().downgrading).toBe(true);
+    // the flow is labeled a downgrade from the moment of the confirm
+    expect(getState()).toMatchObject({ type: "downloading", kind: "downgrade" });
 
-    // the label survives the download completing (the renderer's "restarting
-    // to install" message depends on downloaded + downgrading together)
+    // the label survives the download completing (the renderer's "update on
+    // restart" wording depends on the staged kind)
     updaterEvent("update-downloaded")?.({ version: "2.5.0" });
-    expect(getStatus().downgrading).toBe(true);
-    expect(getStatus().downloaded).toBe(true);
-  });
-
-  // Review finding: a failed downgrade download left available:true with the
-  // older version — the renderer then presented the downgrade as a regular
-  // available update whose Download button could only ever fail.
-  it("resets availability when the downgrade download fails", async () => {
-    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
-    await setup();
-    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
-    ipcHandler("updater:set-channel")(undefined, "stable", true);
-    await flush();
-
-    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("sha512 mismatch"));
-    ipcHandler("updater:download-downgrade")(undefined, false);
-    await flush();
-
-    const status = getStatus();
-    expect(status.available).toBe(false);
-    expect(status.version).toBeUndefined();
-    expect(status.downgrading).toBeUndefined();
-    expect(status.error).toContain("sha512");
-    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+    expect(getState()).toMatchObject({ type: "staged", version: "2.5.0", kind: "downgrade" });
   });
 
   it("consumes the offer on confirmation so a double-confirm is a no-op", async () => {
@@ -594,6 +605,25 @@ describe("downgrade offers", () => {
 
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1);
     expect(writePersistedValueMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Review finding: a failed downgrade download left the older version
+  // advertised as a regular available update whose Download could only fail.
+  it("fails a downgrade download into an error state without a retry", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("sha512 mismatch"));
+    ipcHandler("updater:download-downgrade")(undefined, false);
+    await flush();
+
+    const state = getState();
+    expect(state).toMatchObject({ type: "error", manual: true });
+    expect((state as { retry?: unknown }).retry).toBeUndefined();
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
   });
 });
 
@@ -643,7 +673,7 @@ describe("install retry", () => {
     }
 
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(5);
-    expect(getStatus().error).toContain("EBUSY");
+    expect(getState()).toMatchObject({ type: "error", manual: true });
   });
 
   it("gives up immediately on a non-lock error", async () => {
@@ -657,7 +687,7 @@ describe("install retry", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-    expect(getStatus().error).toContain("catastrophic");
+    expect(getState()).toMatchObject({ type: "error", message: "catastrophic failure" });
   });
 });
 
@@ -670,20 +700,20 @@ describe("post-update notice", () => {
     await flush();
 
     expect(readPersistedValueMock).toHaveBeenCalledWith("app", ["appVersion"]);
-    expect(getStatus().justUpdatedFrom).toBe("2.5.9");
+    expect(getSnapshot().justUpdatedFrom).toBe("2.5.9");
   });
 
   it("stays unset for a same-version launch or after a downgrade", async () => {
     readPersistedValueMock.mockResolvedValue("2.6.0");
     await setup();
     await flush();
-    expect(getStatus().justUpdatedFrom).toBeUndefined();
+    expect(getSnapshot().justUpdatedFrom).toBeUndefined();
 
     vi.resetModules();
     readPersistedValueMock.mockResolvedValue("2.7.0");
     await setup();
     await flush();
-    expect(getStatus().justUpdatedFrom).toBeUndefined();
+    expect(getSnapshot().justUpdatedFrom).toBeUndefined();
   });
 
   it("serves the changelog for the versions the update covered", async () => {
@@ -698,9 +728,12 @@ describe("post-update notice", () => {
       ([name]) => name === "updater:get-update-changelog",
     );
     expect(call).toBeDefined();
-    await expect((call![1] as () => Promise<string | null>)()).resolves.toBe(
-      "<p>2.6.0 changes</p>",
-    );
+    await expect(
+      (call![1] as (event: unknown, channel: string) => Promise<string | null>)(
+        undefined,
+        "stable",
+      ),
+    ).resolves.toBe("<p>2.6.0 changes</p>");
     // resolved from the pre-update version so the notes span the whole update
     expect(resolveUpdateMock).toHaveBeenCalledWith("stable", "2.5.9");
   });
@@ -712,7 +745,12 @@ describe("post-update notice", () => {
     const call = ipcMock.handle.mock.calls.find(
       ([name]) => name === "updater:get-update-changelog",
     );
-    await expect((call![1] as () => Promise<string | null>)()).resolves.toBeNull();
+    await expect(
+      (call![1] as (event: unknown, channel: string) => Promise<string | null>)(
+        undefined,
+        "stable",
+      ),
+    ).resolves.toBeNull();
     expect(resolveUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -194,6 +194,60 @@ describe("checkForUpdates", () => {
     expect(resolveUpdateMock).not.toHaveBeenCalled();
   });
 
+  // Review finding: disabling updates left the previous offer advertised.
+  it("withdraws the current offer when the channel is set to none", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-available")?.({ version: "2.7.0", releaseNotes: null });
+    expect(getStatus().available).toBe(true);
+    ipcMock.send.mockClear();
+
+    ipcHandler("updater:set-channel")(undefined, "none", true);
+
+    const status = getStatus();
+    expect(status.available).toBe(false);
+    expect(status.version).toBeUndefined();
+    expect(status.downgrade).toBeUndefined();
+    // the withdrawal is broadcast so the renderer can dismiss
+    expect(ipcMock.send).toHaveBeenCalled();
+  });
+
+  // Review finding: a failed download left stale progress, stranding the
+  // renderer on "Downloading…" with the retry button hidden.
+  it("clears download progress when a download fails", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved());
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("net::ERR_CONNECTION_REFUSED"));
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+    updaterEvent("download-progress")?.({ percent: 40 });
+
+    // the library error event also clears it
+    updaterEvent("error")?.(new Error("net::ERR_CONNECTION_REFUSED"));
+
+    const status = getStatus();
+    expect(status.downloadProgress).toBeUndefined();
+    expect(status.error).toContain("ERR_CONNECTION_REFUSED");
+  });
+
+  // Review finding: cancelling a download (channel switch) surfaced as a red
+  // error notification for a deliberate user action.
+  it("does not surface a cancelled download as an error", async () => {
+    await setup();
+    updaterEvent("download-progress")?.({ percent: 40 });
+
+    const cancellation = new Error("cancelled");
+    cancellation.name = "CancellationError";
+    updaterEvent("error")?.(cancellation);
+
+    const status = getStatus();
+    expect(status.error).toBeUndefined();
+    expect(status.downloadProgress).toBeUndefined();
+  });
+
   it("clears checking but leaves availability untouched when resolution fails", async () => {
     await setup();
     // a previously known update survives an offline/failed check
@@ -206,10 +260,21 @@ describe("checkForUpdates", () => {
     const status = getStatus();
     expect(status.checking).toBe(false);
     expect(status.available).toBe(true);
-    // the failure is surfaced, not swallowed — a failed manual check must
-    // not read as "up to date"
-    expect(status.error).toContain("network down");
+    // offline is normal: a BACKGROUND check failure stays out of the status
+    // (it would otherwise raise a red notification every launch and 4h tick)
+    expect(status.error).toBeUndefined();
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed MANUAL check via the error field", async () => {
+    await setup();
+    resolveUpdateMock.mockRejectedValue(new Error("network down"));
+
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+
+    // a failed manual check must not read as "up to date"
+    expect(getStatus().error).toContain("network down");
   });
 });
 

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -100,6 +100,9 @@ beforeEach(() => {
   autoUpdaterMock.allowDowngrade = false;
   autoUpdaterMock.forceDevUpdateConfig = false;
   appMock.isPackaged = true;
+  // a developer machine may have the dev-updater opt-in persisted in the
+  // user environment; tests must never depend on ambient env
+  vi.stubEnv("VORTEX_DEV_UPDATER", "");
 });
 
 afterEach(() => {

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -341,9 +341,10 @@ describe("downgrade offers", () => {
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
   });
 
-  // A declined offer must come back on the next check — launch sync and the
-  // periodic re-check included — so background stable-channel checks offer too.
-  it("re-offers the downgrade on background stable-channel checks", async () => {
+  // Field report: the offer showed on plain app launch. Downgrades must only
+  // ever be offered on a purposeful switch to stable, never from the launch
+  // sync, Check now, or the periodic re-check.
+  it("never offers a downgrade on a background channel sync", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
@@ -352,13 +353,19 @@ describe("downgrade offers", () => {
     ipcHandler("updater:set-channel")(undefined, "stable", false);
     await flush();
 
-    const status = getStatus();
-    expect(status.downgrade).toBe(true);
-    expect(status.available).toBe(true);
-    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    let status = getStatus();
+    expect(status.downgrade).toBeUndefined();
+    expect(status.available).toBe(false);
+
+    // Check now on the stable channel doesn't offer either
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+    status = getStatus();
+    expect(status.downgrade).toBeUndefined();
+    expect(status.available).toBe(false);
   });
 
-  it("declining clears the offer until the next check", async () => {
+  it("declining clears the offer until the next switch to stable", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
@@ -377,8 +384,8 @@ describe("downgrade offers", () => {
     await flush();
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
 
-    // ...but the next stable-channel check raises it again
-    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    // ...but another purposeful switch to stable raises it again
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
     await flush();
     expect(getStatus().downgrade).toBe(true);
   });

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -477,6 +477,33 @@ describe("library events", () => {
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
   });
 
+  // Funnel protection: a patch whose auto-download just failed is not
+  // re-fetched by every subsequent check; it is offered as a downloadable
+  // update instead, and a user-initiated download may retry immediately.
+  it("holds a failed patch auto-download and offers it instead", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    expect(getState().type).toBe("downloading");
+
+    updaterEvent("error")?.(new Error("net::ERR_CONNECTION_REFUSED"));
+    // the failed patch keeps a working Download via retry
+    expect(getState()).toMatchObject({ type: "error", retry: { version: "2.6.1" } });
+    autoUpdaterMock.downloadUpdate.mockClear();
+
+    // the next background check does NOT re-download; it offers
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    expect(getState()).toMatchObject({ type: "available", version: "2.6.1" });
+
+    // a user-initiated download bypasses the hold
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+  });
+
   it("fails an active download into an error state via the error event", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -206,6 +206,9 @@ describe("checkForUpdates", () => {
     const status = getStatus();
     expect(status.checking).toBe(false);
     expect(status.available).toBe(true);
+    // the failure is surfaced, not swallowed — a failed manual check must
+    // not read as "up to date"
+    expect(status.error).toContain("network down");
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
   });
 });

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -248,6 +248,48 @@ describe("updater:download", () => {
   });
 });
 
+describe("downloaded-state lifecycle", () => {
+  // Field bug: 2.5.0 was downloaded on stable, then a beta switch advertised
+  // 2.6.0-beta.1 with the stale downloaded flag — offering Restart & Install
+  // for a build that isn't on disk.
+  it("resets the downloaded flag when a different version becomes available", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
+    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
+    expect(getStatus().downloaded).toBe(true);
+
+    updaterEvent("update-available")?.({ version: "2.8.0-beta.1", releaseNotes: null });
+    const afterSwitch = getStatus();
+    expect(afterSwitch.version).toBe("2.8.0-beta.1");
+    expect(afterSwitch.downloaded).toBe(false);
+
+    // switching back to the version whose installer is on disk restores it
+    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
+    expect(getStatus().downloaded).toBe(true);
+  });
+
+  it("does not short-circuit a download when the disk installer is a different version", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-available")?.({ version: "2.6.1", releaseNotes: null });
+    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
+
+    // a newer beta is now advertised; downloading must re-fetch, not install 2.6.1
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.8.0-beta.1", prerelease: true }));
+    updaterEvent("update-available")?.({ version: "2.8.0-beta.1", releaseNotes: null });
+    ipcHandler("updater:download")(undefined, "beta", true);
+    await flush();
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+  });
+});
+
 describe("release notes", () => {
   it("prefers the resolver's collected notes over UpdateInfo", async () => {
     await setup();

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -15,11 +15,13 @@ const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock, writePersistedValu
         allowDowngrade: true,
         autoDownload: true,
         autoInstallOnAppQuit: true,
+        forceDevUpdateConfig: false,
       },
       appMock: {
         getVersion: vi.fn(() => "2.6.0"),
         on: vi.fn(),
         removeListener: vi.fn(),
+        isPackaged: true,
       },
       ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
       resolveUpdateMock: vi.fn(),
@@ -96,10 +98,13 @@ beforeEach(() => {
   // start from the real post-init state so assertions on the flag observe
   // the handlers, not setupAutoUpdater's initialization
   autoUpdaterMock.allowDowngrade = false;
+  autoUpdaterMock.forceDevUpdateConfig = false;
+  appMock.isPackaged = true;
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 describe("checkForUpdates", () => {
@@ -342,6 +347,37 @@ describe("downgrade offers", () => {
 
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1);
     expect(writePersistedValueMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("dev updater", () => {
+  it("forces the dev update config only for unpackaged builds that opt in", async () => {
+    appMock.isPackaged = false;
+    vi.stubEnv("VORTEX_DEV_UPDATER", "1");
+    await setup();
+    expect(autoUpdaterMock.forceDevUpdateConfig).toBe(true);
+  });
+
+  it("stays off without the opt-in or in packaged builds", async () => {
+    appMock.isPackaged = false;
+    await setup();
+    expect(autoUpdaterMock.forceDevUpdateConfig).toBe(false);
+
+    vi.resetModules();
+    appMock.isPackaged = true;
+    vi.stubEnv("VORTEX_DEV_UPDATER", "1");
+    await setup();
+    expect(autoUpdaterMock.forceDevUpdateConfig).toBe(false);
+  });
+
+  it("never installs from an unpackaged build", async () => {
+    appMock.isPackaged = false;
+    vi.stubEnv("VORTEX_DEV_UPDATER", "1");
+    await setup();
+
+    ipcHandler("updater:restart-and-install")(undefined);
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
   });
 });
 

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -20,7 +20,7 @@ const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock } = vi.hoisted(() =
       on: vi.fn(),
       removeListener: vi.fn(),
     },
-    ipcMock: { handle: vi.fn(), on: vi.fn() },
+    ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
     resolveUpdateMock: vi.fn(),
   };
 });
@@ -35,6 +35,7 @@ vi.mock("@vortex/shared", () => ({
 vi.mock("electron", () => ({
   app: appMock,
   dialog: { showMessageBoxSync: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [{ webContents: {} }] },
 }));
 vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
 vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -617,6 +617,29 @@ describe("downgrade offers", () => {
     expect(getState()).toMatchObject({ type: "staged", version: "2.5.0", kind: "downgrade" });
   });
 
+  // Field-tested: a manual check while a confirmed downgrade was staged
+  // settled to idle, orphaning the downloaded installer and disarming its
+  // install-on-quit. A confirmed downgrade survives checks that (correctly)
+  // ignore the lower version.
+  it("keeps a staged downgrade staged across checks", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+    ipcHandler("updater:download-downgrade")(undefined, false);
+    await flush();
+    updaterEvent("update-downloaded")?.({ version: "2.5.0" });
+    expect(getState()).toMatchObject({ type: "staged", kind: "downgrade" });
+
+    // a manual re-check ignores the lower version — but must not forget the
+    // staged downgrade the user already confirmed
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+
+    expect(getState()).toMatchObject({ type: "staged", version: "2.5.0", kind: "downgrade" });
+  });
+
   it("consumes the offer on confirmation so a double-confirm is a no-op", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -3,31 +3,38 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ResolvedRelease } from "./releaseResolver";
 
-const { autoUpdaterMock, appMock, ipcMock, resolveUpdateMock, writePersistedValueMock } =
-  vi.hoisted(() => {
-    return {
-      autoUpdaterMock: {
-        on: vi.fn(),
-        setFeedURL: vi.fn(),
-        checkForUpdates: vi.fn(),
-        downloadUpdate: vi.fn(),
-        quitAndInstall: vi.fn(),
-        allowDowngrade: true,
-        autoDownload: true,
-        autoInstallOnAppQuit: true,
-        forceDevUpdateConfig: false,
-      },
-      appMock: {
-        getVersion: vi.fn(() => "2.6.0"),
-        on: vi.fn(),
-        removeListener: vi.fn(),
-        isPackaged: true,
-      },
-      ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
-      resolveUpdateMock: vi.fn(),
-      writePersistedValueMock: vi.fn(),
-    };
-  });
+const {
+  autoUpdaterMock,
+  appMock,
+  ipcMock,
+  resolveUpdateMock,
+  writePersistedValueMock,
+  readPersistedValueMock,
+} = vi.hoisted(() => {
+  return {
+    autoUpdaterMock: {
+      on: vi.fn(),
+      setFeedURL: vi.fn(),
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn(),
+      allowDowngrade: true,
+      autoDownload: true,
+      autoInstallOnAppQuit: true,
+      forceDevUpdateConfig: false,
+    },
+    appMock: {
+      getVersion: vi.fn(() => "2.6.0"),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      isPackaged: true,
+    },
+    ipcMock: { handle: vi.fn(), on: vi.fn(), send: vi.fn() },
+    resolveUpdateMock: vi.fn(),
+    writePersistedValueMock: vi.fn(),
+    readPersistedValueMock: vi.fn(),
+  };
+});
 
 // @vortex/shared's error module has a duplicate-load guard that trips under
 // vi.resetModules; only these two helpers are used at runtime (the UpdateStatus
@@ -44,7 +51,10 @@ vi.mock("electron", () => ({
 vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
 vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));
 vi.mock("../../logging", () => ({ log: vi.fn() }));
-vi.mock("../../store/mainPersistence", () => ({ writePersistedValue: writePersistedValueMock }));
+vi.mock("../../store/mainPersistence", () => ({
+  writePersistedValue: writePersistedValueMock,
+  readPersistedValue: readPersistedValueMock,
+}));
 vi.mock("./releaseResolver", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   resolveUpdate: resolveUpdateMock,
@@ -95,6 +105,7 @@ beforeEach(() => {
   autoUpdaterMock.checkForUpdates.mockResolvedValue({ cancellationToken: { cancel: vi.fn() } });
   autoUpdaterMock.downloadUpdate.mockResolvedValue([]);
   writePersistedValueMock.mockResolvedValue(undefined);
+  readPersistedValueMock.mockResolvedValue(null);
   // start from the real post-init state so assertions on the flag observe
   // the handlers, not setupAutoUpdater's initialization
   autoUpdaterMock.allowDowngrade = false;
@@ -158,8 +169,9 @@ describe("checkForUpdates", () => {
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
     });
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalled();
-    // minor upgrade: no auto-download
+    // minor upgrade: no auto-download, and not labeled a patch
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    expect(getStatus().patch).toBe(false);
   });
 
   // Regression pin #22609: patch updates auto-download.
@@ -171,6 +183,8 @@ describe("checkForUpdates", () => {
     await flush();
 
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+    // labeled for the renderer's quieter patch notification
+    expect(getStatus().patch).toBe(true);
   });
 
   it("never resolves when the channel is none", async () => {
@@ -310,7 +324,7 @@ describe("release notes", () => {
 });
 
 describe("downgrade offers", () => {
-  it("offers a downgrade only for a manual switch to stable on a prerelease build", async () => {
+  it("offers a downgrade for a switch to stable on a prerelease build", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
@@ -327,18 +341,56 @@ describe("downgrade offers", () => {
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
   });
 
-  it("never offers a downgrade on a background channel sync", async () => {
+  // A declined offer must come back on the next check — launch sync and the
+  // periodic re-check included — so background stable-channel checks offer too.
+  it("re-offers the downgrade on background stable-channel checks", async () => {
     appMock.getVersion.mockReturnValue("2.6.0-beta.1");
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
 
-    // the 5s fallback sends manual=false
+    // the 5s launch fallback sends manual=false
     ipcHandler("updater:set-channel")(undefined, "stable", false);
     await flush();
 
     const status = getStatus();
-    expect(status.downgrade).toBeUndefined();
+    expect(status.downgrade).toBe(true);
+    expect(status.available).toBe(true);
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("declining clears the offer until the next check", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    ipcHandler("updater:decline-downgrade")(undefined);
+
+    const status = getStatus();
     expect(status.available).toBe(false);
+    expect(status.downgrade).toBeUndefined();
+    expect(status.version).toBeUndefined();
+
+    // the declined offer is consumed: a late confirm must not download
+    ipcHandler("updater:download-downgrade")(undefined, true);
+    await flush();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+
+    // ...but the next stable-channel check raises it again
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+    expect(getStatus().downgrade).toBe(true);
+  });
+
+  it("ignores a decline when no offer is outstanding", async () => {
+    await setup();
+
+    ipcHandler("updater:decline-downgrade")(undefined);
+
+    expect(getStatus().available).toBe(false);
+    // no spurious status broadcast for a stray decline
+    expect(ipcMock.send).not.toHaveBeenCalled();
   });
 
   it("ignores download-downgrade when no offer is outstanding", async () => {
@@ -378,8 +430,16 @@ describe("downgrade offers", () => {
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
     // one-shot marker for the startup downgrade warning
     expect(writePersistedValueMock).toHaveBeenCalledWith("app", ["expectedDowngradeTo"], "2.5.0");
-    // past confirmation the status is an ordinary in-flight download
+    // past confirmation the offer flag drops, but the flow stays labeled as a
+    // downgrade so the renderer never presents it as a regular update
     expect(getStatus().downgrade).toBeUndefined();
+    expect(getStatus().downgrading).toBe(true);
+
+    // the label survives the download completing (the renderer's "restarting
+    // to install" message depends on downloaded + downgrading together)
+    updaterEvent("update-downloaded")?.({ version: "2.5.0" });
+    expect(getStatus().downgrading).toBe(true);
+    expect(getStatus().downloaded).toBe(true);
   });
 
   it("consumes the offer on confirmation so a double-confirm is a no-op", async () => {
@@ -460,5 +520,61 @@ describe("install retry", () => {
 
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     expect(getStatus().error).toContain("catastrophic");
+  });
+});
+
+// The persisted appVersion still holds the previous run's version at startup;
+// an increase means this launch is the first after an update.
+describe("post-update notice", () => {
+  it("sets justUpdatedFrom when the app version increased since the last run", async () => {
+    readPersistedValueMock.mockResolvedValue("2.5.9");
+    await setup();
+    await flush();
+
+    expect(readPersistedValueMock).toHaveBeenCalledWith("app", ["appVersion"]);
+    expect(getStatus().justUpdatedFrom).toBe("2.5.9");
+  });
+
+  it("stays unset for a same-version launch or after a downgrade", async () => {
+    readPersistedValueMock.mockResolvedValue("2.6.0");
+    await setup();
+    await flush();
+    expect(getStatus().justUpdatedFrom).toBeUndefined();
+
+    vi.resetModules();
+    readPersistedValueMock.mockResolvedValue("2.7.0");
+    await setup();
+    await flush();
+    expect(getStatus().justUpdatedFrom).toBeUndefined();
+  });
+
+  it("serves the changelog for the versions the update covered", async () => {
+    readPersistedValueMock.mockResolvedValue("2.5.9");
+    await setup();
+    await flush();
+    resolveUpdateMock.mockResolvedValue(
+      resolved({ tag: "v2.6.0", version: "2.6.0", notesHtml: "<p>2.6.0 changes</p>" }),
+    );
+
+    const call = ipcMock.handle.mock.calls.find(
+      ([name]) => name === "updater:get-update-changelog",
+    );
+    expect(call).toBeDefined();
+    await expect((call![1] as () => Promise<string | null>)()).resolves.toBe(
+      "<p>2.6.0 changes</p>",
+    );
+    // resolved from the pre-update version so the notes span the whole update
+    expect(resolveUpdateMock).toHaveBeenCalledWith("stable", "2.5.9");
+  });
+
+  it("returns no changelog when the launch did not follow an update", async () => {
+    await setup();
+    await flush();
+
+    const call = ipcMock.handle.mock.calls.find(
+      ([name]) => name === "updater:get-update-changelog",
+    );
+    await expect((call![1] as () => Promise<string | null>)()).resolves.toBeNull();
+    expect(resolveUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -93,6 +93,9 @@ beforeEach(() => {
   autoUpdaterMock.checkForUpdates.mockResolvedValue({ cancellationToken: { cancel: vi.fn() } });
   autoUpdaterMock.downloadUpdate.mockResolvedValue([]);
   writePersistedValueMock.mockResolvedValue(undefined);
+  // start from the real post-init state so assertions on the flag observe
+  // the handlers, not setupAutoUpdater's initialization
+  autoUpdaterMock.allowDowngrade = false;
 });
 
 afterEach(() => {
@@ -302,6 +305,12 @@ describe("downgrade offers", () => {
     ipcHandler("updater:set-channel")(undefined, "stable", true);
     await flush();
 
+    // observe the flag at the moment the feed is applied
+    let allowDowngradeDuringFeedApply: boolean | undefined;
+    autoUpdaterMock.setFeedURL.mockImplementation(() => {
+      allowDowngradeDuringFeedApply = autoUpdaterMock.allowDowngrade;
+    });
+
     ipcHandler("updater:download-downgrade")(undefined, true);
     await flush();
 
@@ -310,10 +319,29 @@ describe("downgrade offers", () => {
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.5.0",
     });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
-    // dropped again once the library accepted the feed
+    // raised for the feed apply, dropped again once the library accepted it
+    expect(allowDowngradeDuringFeedApply).toBe(true);
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
     // one-shot marker for the startup downgrade warning
     expect(writePersistedValueMock).toHaveBeenCalledWith("app", ["expectedDowngradeTo"], "2.5.0");
+    // past confirmation the status is an ordinary in-flight download
+    expect(getStatus().downgrade).toBeUndefined();
+  });
+
+  it("consumes the offer on confirmation so a double-confirm is a no-op", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    ipcHandler("updater:download-downgrade")(undefined, true);
+    await flush();
+    ipcHandler("updater:download-downgrade")(undefined, true);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(writePersistedValueMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -897,3 +897,47 @@ describe("status polling", () => {
     expect(response.snapshot.justUpdatedFrom).toBe("2.5.9");
   });
 });
+
+describe("cancelling a download", () => {
+  it("cancels the running download's token when the user asks, and only then", async () => {
+    await setup();
+    const cancel = vi.fn();
+    autoUpdaterMock.checkForUpdates.mockResolvedValue({ cancellationToken: { cancel } });
+
+    // nothing running: a stray cancel is ignored
+    ipcHandler("updater:cancel-download")(undefined);
+    expect(cancel).not.toHaveBeenCalled();
+
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0", version: "2.7.0" }));
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+    expect(getState().type).toBe("downloading");
+    // the user download rides the check's token so it is cancellable at all
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ cancel }),
+    );
+
+    ipcHandler("updater:cancel-download")(undefined);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  // builder-util-runtime's CancellationError keeps name "Error" and message
+  // "cancelled", and electron-updater does not emit its error event for it:
+  // the rejection of downloadUpdate is the only signal.
+  it("settles to idle without an error when the cancelled download rejects", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0", version: "2.7.0" }));
+    class CancellationError extends Error {
+      constructor() {
+        super("cancelled");
+      }
+    }
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new CancellationError());
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+
+    expect(getState().type).toBe("idle");
+    expect(getStatus(0).changes.some((entry) => entry.state.type === "error")).toBe(false);
+  });
+});

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -1,4 +1,4 @@
-import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
+import type { UpdaterSnapshot, UpdaterState, UpdaterStatusResponse } from "@vortex/shared/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ResolvedRelease } from "./releaseResolver";
@@ -46,7 +46,6 @@ vi.mock("@vortex/shared", () => ({
 vi.mock("electron", () => ({
   app: appMock,
   dialog: { showMessageBoxSync: vi.fn() },
-  BrowserWindow: { getAllWindows: () => [{ webContents: {} }] },
 }));
 vi.mock("electron-updater", () => ({ autoUpdater: autoUpdaterMock }));
 vi.mock("../../ipc", () => ({ betterIpcMain: ipcMock }));
@@ -83,9 +82,13 @@ function updaterEvent(name: string): ((...args: unknown[]) => void) | undefined 
   return call?.[1] as ((...args: unknown[]) => void) | undefined;
 }
 
-function getSnapshot(): UpdaterSnapshot {
+function getStatus(since?: number): UpdaterStatusResponse {
   const call = ipcMock.handle.mock.calls.find(([name]) => name === "updater:get-status");
-  return (call![1] as () => UpdaterSnapshot)();
+  return (call![1] as (event: unknown, since?: number) => UpdaterStatusResponse)({}, since);
+}
+
+function getSnapshot(): UpdaterSnapshot {
+  return getStatus().snapshot;
 }
 
 function getState(): UpdaterState {
@@ -234,13 +237,14 @@ describe("checkForUpdates", () => {
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
     expect(getState().type).toBe("available");
-    ipcMock.send.mockClear();
+    const before = getStatus().seq;
 
     ipcHandler("updater:set-channel")(undefined, "none", true);
 
     expect(getState().type).toBe("disabled");
-    // the withdrawal is broadcast so the renderer can dismiss
-    expect(ipcMock.send).toHaveBeenCalled();
+    // the withdrawal is a recorded transition, so the renderer's next poll
+    // sees it and dismisses
+    expect(getStatus(before).changes.map((entry) => entry.state.type)).toEqual(["disabled"]);
   });
 
   it("restores what the user could see when a background check fails", async () => {
@@ -413,15 +417,18 @@ describe("library events", () => {
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
     await flush();
-    ipcMock.send.mockClear();
+    const before = getStatus().seq;
 
     updaterEvent("download-progress")?.({ percent: 41.2 });
     updaterEvent("download-progress")?.({ percent: 41.9 });
     updaterEvent("download-progress")?.({ percent: 42.1 });
 
     expect(getState()).toMatchObject({ type: "downloading", percent: 42 });
-    // 41.2 and 42.1 broadcast; 41.9 is the same whole percent as 41.2
-    expect(ipcMock.send).toHaveBeenCalledTimes(2);
+    // 41.2 and 42.1 are recorded; 41.9 is the same whole percent as 41.2
+    expect(getStatus(before).changes.map((entry) => entry.state)).toMatchObject([
+      { percent: 41 },
+      { percent: 42 },
+    ]);
   });
 
   it("stages the download and arms a VISIBLE install-on-quit", async () => {
@@ -590,12 +597,13 @@ describe("downgrade offers", () => {
 
   it("ignores a decline when no offer is outstanding", async () => {
     await setup();
+    const before = getStatus().seq;
 
     ipcHandler("updater:decline-downgrade")(undefined);
 
     expect(getState().type).toBe("idle");
-    // no spurious broadcast for a stray decline
-    expect(ipcMock.send).not.toHaveBeenCalled();
+    // no spurious transition recorded for a stray decline
+    expect(getStatus(before).changes).toEqual([]);
   });
 
   it("ignores download-downgrade when no offer is outstanding", async () => {
@@ -828,5 +836,64 @@ describe("post-update notice", () => {
       ),
     ).resolves.toBeNull();
     expect(resolveUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("status polling", () => {
+  // The renderer pulls status (like downloads and uploads). Because the UI
+  // reacts to transitions, a poll carries the last sequence number it saw and
+  // gets every snapshot since, so a short-lived state is never sampled past.
+  it("replays every transition since the given sequence number, in order", async () => {
+    await setup();
+    const before = getStatus().seq;
+
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0", version: "2.7.0" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+
+    const response = getStatus(before);
+    expect(response.changes.map((entry) => entry.state.type)).toEqual(["checking", "available"]);
+    expect(response.snapshot.state).toMatchObject({ type: "available", version: "2.7.0" });
+    expect(response.seq).toBe(before + 2);
+  });
+
+  it("returns no changes when the caller is caught up, and none without a since", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0", version: "2.7.0" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+
+    const head = getStatus().seq;
+    expect(getStatus(head).changes).toEqual([]);
+    expect(getStatus().changes).toEqual([]);
+    expect(getStatus().snapshot.state.type).toBe("available");
+  });
+
+  it("keeps a bounded history but always the latest snapshot", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    const before = getStatus().seq;
+
+    for (let percent = 1; percent <= 60; percent += 1) {
+      updaterEvent("download-progress")?.({ percent });
+    }
+
+    const response = getStatus(before);
+    expect(response.changes.length).toBeLessThanOrEqual(32);
+    expect(response.changes.at(-1)?.state).toMatchObject({ type: "downloading", percent: 60 });
+    expect(response.snapshot.state).toMatchObject({ type: "downloading", percent: 60 });
+    expect(response.seq).toBe(before + 60);
+  });
+
+  it("counts the post-update notice as a change so a poll picks it up", async () => {
+    readPersistedValueMock.mockResolvedValue("2.5.9");
+    await setup();
+    await flush();
+
+    const response = getStatus(0);
+    expect(response.changes.some((entry) => entry.justUpdatedFrom === "2.5.9")).toBe(true);
+    expect(response.snapshot.justUpdatedFrom).toBe("2.5.9");
   });
 });

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -424,7 +424,7 @@ describe("library events", () => {
     expect(ipcMock.send).toHaveBeenCalledTimes(2);
   });
 
-  it("stages the download and arms install-on-quit for packaged builds", async () => {
+  it("stages the download and arms a VISIBLE install-on-quit", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
     ipcHandler("updater:check-for-updates")(undefined, "stable", false);
@@ -433,7 +433,33 @@ describe("library events", () => {
     updaterEvent("update-downloaded")?.({ version: "2.6.1" });
 
     expect(getState()).toMatchObject({ type: "staged", version: "2.6.1", kind: "patch" });
-    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+    // never the library's silent /S quit-install path
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
+    // our quit hook runs the same visible install as Restart Now
+    const quitHook = appMock.on.mock.calls.find(([event]) => event === "before-quit");
+    expect(quitHook).toBeDefined();
+    (quitHook![1] as () => void)();
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install a stale staged installer on quit", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    updaterEvent("update-downloaded")?.({ version: "2.6.1" });
+
+    // a newer version is advertised since; the staged 2.6.1 is no longer what
+    // the user was told about
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", false);
+    await flush();
+    expect(getState()).toMatchObject({ type: "available", version: "2.7.0" });
+
+    const quitHook = appMock.on.mock.calls.find(([event]) => event === "before-quit");
+    (quitHook![1] as () => void)();
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
   });
 
   // A channel flip and back must not forget an installer already on disk.

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -290,7 +290,7 @@ describe("updater:download", () => {
   });
 
   // Regression pin: a download must resolve for the channel it was asked
-  // about — a cached resolution from another channel must never be reused.
+  // about, a cached resolution from another channel must never be reused.
   it("re-resolves for the requested channel on every download", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(
@@ -310,7 +310,7 @@ describe("updater:download", () => {
   });
 
   // A user download is always presented as a regular update, even when the
-  // version is patch-sized — the silent patch flow is auto-download only.
+  // version is patch-sized, the silent patch flow is auto-download only.
   it("downloads user requests as regular updates", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
@@ -380,7 +380,7 @@ describe("updater:download", () => {
   });
 
   // Review finding: a download that lost the generation race could still call
-  // downloadUpdate — potentially while a confirmed downgrade's temporarily
+  // downloadUpdate, potentially while a confirmed downgrade's temporarily
   // raised allowDowngrade was in effect.
   it("does not download when superseded by a newer check", async () => {
     await setup();
@@ -659,7 +659,7 @@ describe("downgrade offers", () => {
     updaterEvent("update-downloaded")?.({ version: "2.5.0" });
     expect(getState()).toMatchObject({ type: "staged", kind: "downgrade" });
 
-    // a manual re-check ignores the lower version — but must not forget the
+    // a manual re-check ignores the lower version, but must not forget the
     // staged downgrade the user already confirmed
     ipcHandler("updater:check-for-updates")(undefined, "stable", true);
     await flush();

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -154,6 +154,7 @@ describe("checkForUpdates", () => {
 
     expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
       provider: "generic",
+      useMultipleRangeRequest: false,
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
     });
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalled();
@@ -206,6 +207,7 @@ describe("updater:download", () => {
     expect(resolveUpdateMock).toHaveBeenCalled();
     expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
       provider: "generic",
+      useMultipleRangeRequest: false,
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
     });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
@@ -230,6 +232,7 @@ describe("updater:download", () => {
     expect(resolveUpdateMock).toHaveBeenCalledWith("stable", "2.6.0");
     expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
       provider: "generic",
+      useMultipleRangeRequest: false,
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.7.0",
     });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
@@ -366,6 +369,7 @@ describe("downgrade offers", () => {
 
     expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
       provider: "generic",
+      useMultipleRangeRequest: false,
       url: "https://github.com/Nexus-Mods/Vortex/releases/download/v2.5.0",
     });
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();

--- a/src/main/src/extensions/autoupdater/index.test.ts
+++ b/src/main/src/extensions/autoupdater/index.test.ts
@@ -252,6 +252,47 @@ describe("updater:download", () => {
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
   });
 
+  // Review finding: the download path used to inherit the patch label from
+  // resolveAndApply, flipping a user-initiated download into the silent
+  // patch presentation mid-flight.
+  it("never labels a user-initiated download as a patch", async () => {
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.6.1", version: "2.6.1" }));
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled();
+    expect(getStatus().patch).toBeUndefined();
+  });
+
+  // Review finding: a download that lost the generation race could still call
+  // downloadUpdate — potentially while a confirmed downgrade's temporarily
+  // raised allowDowngrade was in effect.
+  it("does not download when superseded by a newer check", async () => {
+    await setup();
+    let resolveFirst: (value: unknown) => void = () => undefined;
+    resolveUpdateMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    ipcHandler("updater:download")(undefined, "stable", false);
+
+    // a newer manual check supersedes the download's generation (2.7.0 is a
+    // minor upgrade, so the check itself won't auto-download)
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.7.0" }));
+    ipcHandler("updater:check-for-updates")(undefined, "stable", true);
+    await flush();
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+
+    resolveFirst(resolved({ tag: "v2.7.0" }));
+    await flush();
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+  });
+
   it("skips re-download and installs directly when already downloaded", async () => {
     await setup();
     resolveUpdateMock.mockResolvedValue(resolved());
@@ -447,6 +488,28 @@ describe("downgrade offers", () => {
     updaterEvent("update-downloaded")?.({ version: "2.5.0" });
     expect(getStatus().downgrading).toBe(true);
     expect(getStatus().downloaded).toBe(true);
+  });
+
+  // Review finding: a failed downgrade download left available:true with the
+  // older version — the renderer then presented the downgrade as a regular
+  // available update whose Download button could only ever fail.
+  it("resets availability when the downgrade download fails", async () => {
+    appMock.getVersion.mockReturnValue("2.6.0-beta.1");
+    await setup();
+    resolveUpdateMock.mockResolvedValue(resolved({ tag: "v2.5.0", version: "2.5.0" }));
+    ipcHandler("updater:set-channel")(undefined, "stable", true);
+    await flush();
+
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error("sha512 mismatch"));
+    ipcHandler("updater:download-downgrade")(undefined, false);
+    await flush();
+
+    const status = getStatus();
+    expect(status.available).toBe(false);
+    expect(status.version).toBeUndefined();
+    expect(status.downgrading).toBeUndefined();
+    expect(status.error).toContain("sha512");
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
   });
 
   it("consumes the offer on confirmation so a double-confirm is a no-op", async () => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -9,10 +9,18 @@
  * electron-updater is then pointed at that release's assets via a generic
  * feed, so its job reduces to sha512-verified download, installer signature
  * verification (publisherName from the packaged app-update.yml), and install.
+ *
+ * The updater is modeled as an explicit state machine (UpdaterState in
+ * @vortex/shared/ipc, patterned on VS Code's updater): exactly one state at a
+ * time, every transition goes through setState, and the renderer renders
+ * purely from the broadcast state. electron-updater's own events never drive
+ * the state directly — we already resolved what "latest" means; the library
+ * events only feed bookkeeping (downloaded-installer tracking, progress,
+ * failures of an active download).
  */
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
-import type { UpdateStatus } from "@vortex/shared/ipc";
+import type { UpdateKind, UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
 import { app, BrowserWindow, dialog } from "electron";
 import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
@@ -51,14 +59,27 @@ function showUpdateWarning() {
   });
 }
 
-// Track update status for renderer queries
-const updateStatus: UpdateStatus = {
-  available: false,
-  downloaded: false,
-};
-
 function toResolveChannel(channel: string): ResolveChannel {
   return channel === "beta" || channel === "next" ? channel : "stable";
+}
+
+function describeState(state: UpdaterState): string {
+  switch (state.type) {
+    case "checking":
+      return state.manual ? "checking(manual)" : "checking";
+    case "available":
+      return `available ${state.version}`;
+    case "downgrade-offered":
+      return `downgrade-offered ${state.version}`;
+    case "downloading":
+      return `downloading ${state.version} (${state.kind}${state.percent != null ? ` ${state.percent}%` : ""})`;
+    case "staged":
+      return `staged ${state.version} (${state.kind})`;
+    case "error":
+      return `error${state.manual ? "(manual)" : ""}`;
+    default:
+      return state.type;
+  }
 }
 
 /**
@@ -68,7 +89,6 @@ function toResolveChannel(channel: string): ResolveChannel {
 export function setupAutoUpdater(installType: string): void {
   let cancellationToken: CancellationToken | undefined = undefined;
   const currentVersion = app.getVersion();
-  let updateChannel = "stable";
   // The release the last successful check resolved to — used only to prefer
   // the resolver's collected release notes over the (empty) generic-feed ones.
   // Downloads never trust it: updater:download re-resolves every time.
@@ -77,8 +97,48 @@ export function setupAutoUpdater(installType: string): void {
   // user's confirmation via updater:download-downgrade. Cleared by any check.
   let pendingDowngrade: ResolvedRelease | null = null;
   // Overlapping checks are possible (set-channel + manual check-now); only
-  // the newest one may write checking/availability/cancellation state.
+  // the newest one may own the state and the shared electron-updater.
   let checkGeneration = 0;
+  // Install-after-download requested (patch auto-flow never sets this).
+  let installAfterDownloadFlag = false;
+  // The version the downloaded installer on disk actually contains; a staged
+  // state is only ever valid for this version.
+  let downloadedVersion: string | null = null;
+
+  // ---- state machine ------------------------------------------------------
+
+  let current: UpdaterState = { type: "idle" };
+  // One-time post-update notice; orthogonal to the state machine.
+  let justUpdatedFrom: string | undefined;
+
+  function snapshot(): UpdaterSnapshot {
+    return { state: current, justUpdatedFrom };
+  }
+
+  function broadcast(): void {
+    const payload = snapshot();
+    for (const win of BrowserWindow.getAllWindows()) {
+      betterIpcMain.send(win.webContents, "updater:status-changed", payload);
+    }
+  }
+
+  function setState(next: UpdaterState): void {
+    // progress ticks are debug noise; real transitions are info
+    const progressTick = current.type === "downloading" && next.type === "downloading";
+    log(progressTick ? "debug" : "info", "Updater state", {
+      from: describeState(current),
+      to: describeState(next),
+    });
+    current = next;
+    broadcast();
+  }
+
+  // What kind of update a version represents for the running install.
+  function kindFor(version: string): UpdateKind {
+    return shouldAutoDownload(currentVersion, version, installType) ? "patch" : "update";
+  }
+
+  // ---- install ------------------------------------------------------------
 
   // Launching the freshly downloaded installer can fail transiently with EBUSY
   // (and similar lock errors) while antivirus still has the ~360 MB file open.
@@ -132,43 +192,26 @@ export function setupAutoUpdater(installType: string): void {
         error: err.message,
         attempts: installAttempts,
       });
-      updateStatus.error = err.message;
-      broadcastStatus();
+      // an install is always user-visible; the installer is still staged
+      setState({ type: "error", message: err.message, manual: true });
     }
   }
 
-  function statusSnapshot(): UpdateStatus {
-    // updateStatus holds only serializable scalars; a spread can't silently
-    // drop a newly added field the way a hand-maintained list can
-    return { ...updateStatus };
-  }
+  // ---- IPC: status + changelog --------------------------------------------
 
-  // Push the current status to every window; the renderer reacts to these
-  // instead of polling (getStatus remains for the initial sync).
-  function broadcastStatus(): void {
-    const snapshot = statusSnapshot();
-    for (const win of BrowserWindow.getAllWindows()) {
-      betterIpcMain.send(win.webContents, "updater:status-changed", snapshot);
-    }
-  }
-
-  // Register invoke handler for status queries
-  betterIpcMain.handle("updater:get-status", (): UpdateStatus => statusSnapshot());
+  betterIpcMain.handle("updater:get-status", (): UpdaterSnapshot => snapshot());
 
   // Release notes for the update the app just went through — the renderer's
   // post-update "View changes". The resolver collects body_html of releases
   // above the given version, so resolving from the pre-update version yields
   // exactly the versions this update covered. The renderer supplies its
   // persisted channel: this handler is clickable before the first check has
-  // set updateChannel, which would otherwise default beta users to stable
-  // notes. Cached so repeat clicks don't share rate-limit fate with real
-  // update checks.
+  // run. Cached so repeat clicks don't share rate-limit fate with real checks.
   let changelogCache: { channel: string; notes: string | null } | null = null;
   betterIpcMain.handle(
     "updater:get-update-changelog",
     async (_event, channel: string): Promise<string | null> => {
-      const previous = updateStatus.justUpdatedFrom;
-      if (previous == null) {
+      if (justUpdatedFrom == null) {
         return null;
       }
       const resolveChannel = toResolveChannel(channel);
@@ -176,7 +219,7 @@ export function setupAutoUpdater(installType: string): void {
         return changelogCache.notes;
       }
       try {
-        const resolvedRelease = await resolveUpdate(resolveChannel, previous);
+        const resolvedRelease = await resolveUpdate(resolveChannel, justUpdatedFrom);
         const notes = resolvedRelease?.notesHtml ?? null;
         if (notes != null) {
           changelogCache = { channel: resolveChannel, notes };
@@ -204,8 +247,8 @@ export function setupAutoUpdater(installType: string): void {
           semver.valid(currentVersion) != null &&
           semver.gt(currentVersion, previous)
         ) {
-          updateStatus.justUpdatedFrom = previous;
-          broadcastStatus();
+          justUpdatedFrom = previous;
+          broadcast();
         }
       })
       .catch((err: unknown) => {
@@ -217,9 +260,11 @@ export function setupAutoUpdater(installType: string): void {
 
   log("info", "setupAutoUpdater", { installType, currentVersion });
 
-  // Configure autoUpdater. Downgrades are never taken from background checks;
-  // the resolver decides what "latest" means and only strictly-newer versions
-  // are handed to electron-updater at all.
+  // ---- electron-updater configuration --------------------------------------
+
+  // Downgrades are never taken from background checks; the resolver decides
+  // what "latest" means and only strictly-newer versions are handed to
+  // electron-updater at all.
   autoUpdater.allowDowngrade = false;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
@@ -246,98 +291,77 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "Dev updater enabled (forceDevUpdateConfig, dev-app-update.yml)");
   }
 
-  // Error handler
+  // ---- electron-updater events (bookkeeping, never primary state control) --
+
   autoUpdater.on("error", (err) => {
     const message = getErrorMessageOrDefault(err);
-    // A dead download's progress must not linger: the renderer hides the
-    // Download (retry) button and keeps saying "Downloading…" while progress
-    // is set, so a failure would otherwise strand a frozen notification.
-    updateStatus.downloadProgress = undefined;
     // A cancelled download (channel switch mid-download) is the user's own
-    // doing, not a failure to report.
-    const cancelled = err instanceof Error && err.name === "CancellationError";
-    if (cancelled) {
+    // doing, not a failure to report. The superseding check owns the state.
+    if (err instanceof Error && err.name === "CancellationError") {
       log("info", "Update download cancelled");
-      broadcastStatus();
+      if (current.type === "downloading") {
+        setState({ type: "idle" });
+      }
       return;
     }
     log("error", "Auto-updater error", { error: message });
-    updateStatus.error = message;
     // A failed installer launch surfaces here; retry if it's a transient lock.
     if (installPending) {
       handleInstallFailure(unknownToError(err));
+      return;
     }
-    broadcastStatus();
+    // A dying download is always user-relevant (a download only starts after
+    // a successful check, so the network was just up). retry keeps a working
+    // Download available alongside the error for regular updates.
+    if (current.type === "downloading") {
+      setState({
+        type: "error",
+        message,
+        manual: true,
+        retry:
+          current.kind === "update"
+            ? { version: current.version, releaseNotes: lastResolved?.notesHtml }
+            : undefined,
+      });
+    }
+    // Errors outside a download (e.g. a library-side check hiccup) are owned
+    // by the promise chain that started the operation.
   });
 
-  // Update not available
-  autoUpdater.on("update-not-available", () => {
-    log("info", "No update available", { channel: updateChannel });
-    updateStatus.available = false;
-    updateStatus.error = undefined;
-    broadcastStatus();
-  });
-
-  // Update available
+  // The resolver already decided availability; these events only maintain the
+  // downloaded-installer bookkeeping.
   autoUpdater.on("update-available", (info: UpdateInfo) => {
-    log("info", "Update available", { version: info.version, currentVersion });
-    updateStatus.available = true;
-    updateStatus.version = info.version;
-    updateStatus.error = undefined;
-    // A previously downloaded installer belongs to the version it was
-    // downloaded for; advertising a different version with downloaded:true
-    // would offer "Restart & Install" for a build that isn't on disk.
-    // Re-advertising the downloaded version (e.g. switching a channel back)
-    // restores it.
-    if (info.version !== downloadedVersion) {
-      updateStatus.downloaded = false;
-      updateStatus.downloadProgress = undefined;
-    } else if (downloadedVersion != null) {
-      updateStatus.downloaded = true;
-      updateStatus.downloadProgress = 100;
-    }
-    // The generic feed's latest.yml carries no release notes; the resolver
-    // collects them from the GitHub releases instead.
-    if (lastResolved?.notesHtml != null) {
-      updateStatus.releaseNotes = lastResolved.notesHtml;
-    } else if (typeof info.releaseNotes === "string") {
-      updateStatus.releaseNotes = info.releaseNotes;
-    } else if (Array.isArray(info.releaseNotes)) {
-      updateStatus.releaseNotes = info.releaseNotes
-        .map((note) => (typeof note === "string" ? note : note.note))
-        .join("\n\n");
-    }
-    broadcastStatus();
+    log("debug", "Library advertises version", { version: info.version });
+  });
+  autoUpdater.on("update-not-available", () => {
+    log("debug", "Library advertises no update", { channel: "generic feed" });
   });
 
   // Download progress. Progress events fire many times per second on a
   // ~360 MB installer; broadcast only whole-percent changes.
-  let lastBroadcastPercent = -1;
   autoUpdater.on("download-progress", (progress: { percent: number }) => {
-    log("debug", "Download progress", { percent: progress.percent });
-    updateStatus.downloadProgress = progress.percent;
+    if (current.type !== "downloading") {
+      return;
+    }
     const wholePercent = Math.floor(progress.percent);
-    if (wholePercent !== lastBroadcastPercent) {
-      lastBroadcastPercent = wholePercent;
-      broadcastStatus();
+    if (wholePercent !== current.percent) {
+      setState({ ...current, percent: wholePercent });
     }
   });
 
-  // Track whether to auto-install after download
-  let installAfterDownloadFlag = false;
-  // The version the downloaded installer actually contains; the downloaded
-  // flag is only meaningful for this version.
-  let downloadedVersion: string | null = null;
-
-  // Update downloaded
   autoUpdater.on("update-downloaded", (updateInfo: UpdateInfo) => {
     log("info", "Update downloaded", { version: updateInfo.version });
     downloadedVersion = updateInfo.version;
-    updateStatus.downloaded = true;
-    updateStatus.version = updateInfo.version;
-    updateStatus.downloadProgress = 100;
-    lastBroadcastPercent = -1;
-    broadcastStatus();
+    const kind: UpdateKind =
+      current.type === "downloading" && current.version === updateInfo.version
+        ? current.kind
+        : kindFor(updateInfo.version);
+    setState({
+      type: "staged",
+      version: updateInfo.version,
+      kind,
+      releaseNotes: lastResolved?.notesHtml,
+    });
 
     // Set up auto-install on quit (packaged builds only — an unpackaged run
     // with the dev updater must never install what it downloaded)
@@ -354,6 +378,8 @@ export function setupAutoUpdater(installType: string): void {
       }
     }
   });
+
+  // ---- resolution ----------------------------------------------------------
 
   // Point electron-updater at the resolved release and let it re-check;
   // resolves once the library has accepted the feed. Every download goes
@@ -395,8 +421,8 @@ export function setupAutoUpdater(installType: string): void {
         switchToStable: allowDowngradeOffer,
       });
       if (resolved == null || verdict === "none") {
-        const current = semver.valid(currentVersion);
-        if (resolved != null && current != null && semver.lt(resolved.version, current)) {
+        const currentValid = semver.valid(currentVersion);
+        if (resolved != null && currentValid != null && semver.lt(resolved.version, currentValid)) {
           log("info", "Latest release is older than the running version, ignoring", {
             resolved: resolved.version,
             currentVersion,
@@ -423,6 +449,8 @@ export function setupAutoUpdater(installType: string): void {
     });
   }
 
+  // ---- check ---------------------------------------------------------------
+
   // Check for updates. allowDowngradeOffer is only set for a purposeful
   // switch to the stable channel — the one flow where a lower version may be
   // offered. Background checks (launch sync, periodic, Check now) never
@@ -437,90 +465,94 @@ export function setupAutoUpdater(installType: string): void {
       return;
     }
 
-    updateChannel = channel;
     const generation = ++checkGeneration;
     pendingDowngrade = null;
-    updateStatus.downgrade = undefined;
-    updateStatus.downgrading = undefined;
-    updateStatus.patch = undefined;
-    updateStatus.checking = true;
-    updateStatus.manual = manual;
-    broadcastStatus();
+    // remembered so a failed BACKGROUND check can restore what the user could
+    // already see instead of stranding "checking" or wiping a known update
+    const before = current;
+    setState({ type: "checking", manual });
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
     resolveAndApply(channel, generation, allowDowngradeOffer)
       .then((outcome) => {
         if (generation !== checkGeneration) {
-          return; // superseded by a newer check; let that one own the status
+          return; // superseded by a newer check; let that one own the state
         }
-        updateStatus.checking = false;
         if (outcome.verdict === "none") {
-          updateStatus.available = false;
-          updateStatus.version = undefined;
-          updateStatus.releaseNotes = undefined;
-          updateStatus.error = undefined;
-          broadcastStatus();
+          setState({ type: "idle" });
           return;
         }
         if (outcome.verdict === "downgrade-offer") {
           // Surface the offer; nothing downloads until the user confirms via
           // updater:download-downgrade.
           pendingDowngrade = outcome.release;
-          updateStatus.available = true;
-          updateStatus.downgrade = true;
-          updateStatus.version = outcome.release.version;
-          updateStatus.releaseNotes = undefined;
-          updateStatus.error = undefined;
-          broadcastStatus();
+          setState({ type: "downgrade-offered", version: outcome.release.version });
           return;
         }
         const resolved = outcome.release;
-        // Classify for the renderer: patch updates auto-download and get
-        // quieter notifications. Only the winning generation writes the flag
-        // (this block already returned above when superseded), so a slow
-        // stale check can't relabel a different offer.
-        updateStatus.patch = shouldAutoDownload(currentVersion, resolved.version, installType);
-        broadcastStatus();
         log("info", "Update check completed", { version: resolved.version });
 
-        // Auto-download patch updates for regular installs; minor/major
-        // updates require user-initiated download via renderer.
-        if (updateStatus.patch === true) {
+        // An installer already on disk for exactly this version: it is staged,
+        // not merely available (a channel flip and back must not forget it).
+        if (downloadedVersion === resolved.version) {
+          setState({
+            type: "staged",
+            version: resolved.version,
+            kind: kindFor(resolved.version),
+            releaseNotes: resolved.notesHtml,
+          });
+          return;
+        }
+
+        // Patch updates auto-download for regular installs; minor/major
+        // updates wait for a user decision.
+        if (kindFor(resolved.version) === "patch") {
           log("info", "Patch update detected, auto-downloading", {
             from: currentVersion,
             to: resolved.version,
           });
+          setState({ type: "downloading", version: resolved.version, kind: "patch" });
           autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
-            log("warn", "Auto-download failed", {
-              error: getErrorMessageOrDefault(err),
-            });
+            // state transition owned by the "error" event handler
+            log("warn", "Auto-download failed", { error: getErrorMessageOrDefault(err) });
           });
+          return;
         }
+
+        setState({
+          type: "available",
+          version: resolved.version,
+          releaseNotes: resolved.notesHtml,
+        });
       })
       .catch((err) => {
-        if (generation === checkGeneration) {
-          updateStatus.checking = false;
-          // Surface MANUAL check failures: without this they read as "up to
-          // date". Background failures stay log-only — offline is normal for
-          // a gaming machine, not a red notification every launch and every
-          // periodic re-check.
-          if (manual) {
-            updateStatus.error =
-              err instanceof RateLimitError
-                ? "update check rate-limited by GitHub, try again later"
-                : getErrorMessageOrDefault(err);
-          }
-          broadcastStatus();
-        }
         if (err instanceof RateLimitError) {
           log("warn", "Update check rate-limited", { resetAt: err.resetAt.toISOString() });
         } else {
           log("warn", "Update check failed", { error: getErrorMessageOrDefault(err) });
         }
+        if (generation !== checkGeneration) {
+          return;
+        }
+        if (manual) {
+          // a pressed button always gets an answer
+          setState({
+            type: "error",
+            message:
+              err instanceof RateLimitError
+                ? "update check rate-limited by GitHub, try again later"
+                : getErrorMessageOrDefault(err),
+            manual: true,
+          });
+        } else {
+          // offline is normal: restore whatever the user could already see
+          setState(before.type === "checking" ? { type: "idle" } : before);
+        }
       });
   };
 
-  // IPC Handlers
+  // ---- IPC: commands --------------------------------------------------------
+
   betterIpcMain.on("updater:set-channel", (_event, channel, manual) => {
     log("info", "Update channel changed", { channel, manual });
 
@@ -533,15 +565,7 @@ export function setupAutoUpdater(installType: string): void {
       // Updates disabled: withdraw whatever was on offer, or a standing
       // notification keeps live buttons for an update the user opted out of.
       pendingDowngrade = null;
-      updateStatus.available = false;
-      updateStatus.version = undefined;
-      updateStatus.releaseNotes = undefined;
-      updateStatus.downloadProgress = undefined;
-      updateStatus.downgrade = undefined;
-      updateStatus.downgrading = undefined;
-      updateStatus.patch = undefined;
-      updateStatus.error = undefined;
-      broadcastStatus();
+      setState({ type: "disabled" });
       return;
     }
 
@@ -557,25 +581,30 @@ export function setupAutoUpdater(installType: string): void {
   });
 
   betterIpcMain.on("updater:download", (_event, channel: string, installAfterDownload: boolean) => {
-    log("info", "Download update requested", {
-      channel,
-      installAfterDownload,
-    });
+    log("info", "Download update requested", { channel, installAfterDownload });
 
     // Already downloaded: don't re-fetch the full installer. Re-issuing
     // downloadUpdate when the file is already present can resolve without
     // re-emitting "update-downloaded", which would strand the install request.
     // Install directly instead — but only when the installer on disk is the
-    // version currently being offered; a channel switch can leave a stale
-    // download for a different version.
+    // version currently on offer; a channel switch can leave a stale download
+    // for a different version.
     if (
-      updateStatus.downloaded &&
       downloadedVersion != null &&
-      downloadedVersion === updateStatus.version
+      (current.type === "staged" || current.type === "available") &&
+      current.version === downloadedVersion
     ) {
       log("info", "Update already downloaded, skipping re-download", {
         version: downloadedVersion,
       });
+      if (current.type !== "staged") {
+        setState({
+          type: "staged",
+          version: downloadedVersion,
+          kind: kindFor(downloadedVersion),
+          releaseNotes: current.type === "available" ? current.releaseNotes : undefined,
+        });
+      }
       if (installAfterDownload) {
         attemptInstall();
       }
@@ -584,24 +613,27 @@ export function setupAutoUpdater(installType: string): void {
 
     installAfterDownloadFlag = installAfterDownload;
 
+    // Press feedback: the version being asked about is whatever is on offer.
+    // The resolver may still supersede it below (it re-resolves every time).
+    const requestedVersion =
+      current.type === "available"
+        ? current.version
+        : current.type === "error" && current.retry != null
+          ? current.retry.version
+          : null;
+
     // Always re-resolve for the channel the renderer asked about: a cached
     // resolution could belong to a different channel, and re-applying the
     // feed guarantees the library-side check-before-download. The resolver's
-    // ETag cache makes the repeat lookup cheap. The download owns the
-    // checking lifecycle for the generation it claims, so a check it
-    // superseded can't strand checking:true.
+    // ETag cache makes the repeat lookup cheap.
     const generation = ++checkGeneration;
-    updateStatus.checking = true;
-    updateStatus.manual = false; // a download is not a check
-    updateStatus.patch = undefined; // user-initiated, never the patch auto-flow
-    lastBroadcastPercent = -1;
-    broadcastStatus();
+    if (requestedVersion != null) {
+      setState({ type: "downloading", version: requestedVersion, kind: "update" });
+    } else {
+      setState({ type: "checking", manual: true });
+    }
     resolveAndApply(channel, generation)
       .then((outcome) => {
-        if (generation === checkGeneration) {
-          updateStatus.checking = false;
-          broadcastStatus();
-        }
         if (outcome.verdict !== "upgrade") {
           throw new Error("no newer release available to download");
         }
@@ -615,20 +647,27 @@ export function setupAutoUpdater(installType: string): void {
         // a user download never legitimately needs the downgrade override; a
         // superseded downgrade flow may still be mid-feed-apply with it raised
         autoUpdater.allowDowngrade = false;
+        if (current.type !== "downloading" || current.version !== outcome.release.version) {
+          setState({ type: "downloading", version: outcome.release.version, kind: "update" });
+        }
         return autoUpdater.downloadUpdate();
       })
       .catch((unknownErr) => {
         const err = unknownToError(unknownErr);
         log("error", "Download failed", { error: err.message });
-        updateStatus.error = err.message;
-        // stale progress would strand the renderer on "Downloading…" with the
-        // retry button hidden
-        updateStatus.downloadProgress = undefined;
         installAfterDownloadFlag = false;
-        if (generation === checkGeneration) {
-          updateStatus.checking = false;
+        if (generation !== checkGeneration) {
+          return;
         }
-        broadcastStatus();
+        setState({
+          type: "error",
+          message: err.message,
+          manual: true,
+          retry:
+            requestedVersion != null
+              ? { version: requestedVersion, releaseNotes: lastResolved?.notesHtml }
+              : undefined,
+        });
       });
   });
 
@@ -647,17 +686,8 @@ export function setupAutoUpdater(installType: string): void {
 
     installAfterDownloadFlag = installAfterDownload;
     const generation = ++checkGeneration;
-    updateStatus.checking = true;
-    updateStatus.manual = false; // a download is not a check
-    // Past confirmation the offer flag drops (keeping it would re-trigger the
-    // offer UI on every progress push), but the flow stays labeled as a
-    // downgrade via `downgrading` — presenting it as a regular update
-    // download would misdescribe what is about to be installed.
-    updateStatus.downgrade = undefined;
-    updateStatus.downgrading = true;
-    updateStatus.patch = undefined; // a downgrade is never a patch update
-    lastBroadcastPercent = -1;
-    broadcastStatus();
+    // press feedback: the confirm is visible immediately
+    setState({ type: "downloading", version: target.version, kind: "downgrade" });
 
     // One-shot marker so the next launch's "Downgrade detected" warning is
     // suppressed for the version the user knowingly chose. Written before
@@ -680,27 +710,19 @@ export function setupAutoUpdater(installType: string): void {
           log("info", "Downgrade download superseded by a newer check, not downloading");
           return;
         }
-        updateStatus.checking = false;
-        broadcastStatus();
         return autoUpdater.downloadUpdate();
       })
       .catch((unknownErr) => {
         autoUpdater.allowDowngrade = false;
         const err = unknownToError(unknownErr);
         log("error", "Downgrade download failed", { error: err.message });
-        updateStatus.error = err.message;
-        updateStatus.downgrading = undefined;
-        updateStatus.downloadProgress = undefined;
-        // Without the offer (consumed above) the failed target must not be
-        // left advertised: the renderer would present the older version as a
-        // regular available update whose Download can only ever fail.
-        updateStatus.available = false;
-        updateStatus.version = undefined;
         installAfterDownloadFlag = false;
-        if (generation === checkGeneration) {
-          updateStatus.checking = false;
+        if (generation !== checkGeneration) {
+          return;
         }
-        broadcastStatus();
+        // The offer was consumed, so there is nothing valid to retry — the
+        // failed target must not be re-advertised as a regular update.
+        setState({ type: "error", message: err.message, manual: true });
       });
   });
 
@@ -713,10 +735,7 @@ export function setupAutoUpdater(installType: string): void {
     }
     log("info", "Downgrade offer declined", { version: pendingDowngrade.version });
     pendingDowngrade = null;
-    updateStatus.available = false;
-    updateStatus.downgrade = undefined;
-    updateStatus.version = undefined;
-    broadcastStatus();
+    setState({ type: "idle" });
   });
 
   betterIpcMain.on("updater:restart-and-install", () => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -249,6 +249,18 @@ export function setupAutoUpdater(installType: string): void {
   // Error handler
   autoUpdater.on("error", (err) => {
     const message = getErrorMessageOrDefault(err);
+    // A dead download's progress must not linger: the renderer hides the
+    // Download (retry) button and keeps saying "Downloading…" while progress
+    // is set, so a failure would otherwise strand a frozen notification.
+    updateStatus.downloadProgress = undefined;
+    // A cancelled download (channel switch mid-download) is the user's own
+    // doing, not a failure to report.
+    const cancelled = err instanceof Error && err.name === "CancellationError";
+    if (cancelled) {
+      log("info", "Update download cancelled");
+      broadcastStatus();
+      return;
+    }
     log("error", "Auto-updater error", { error: message });
     updateStatus.error = message;
     // A failed installer launch surfaces here; retry if it's a transient lock.
@@ -488,13 +500,16 @@ export function setupAutoUpdater(installType: string): void {
       .catch((err) => {
         if (generation === checkGeneration) {
           updateStatus.checking = false;
-          // surface the failure: without this a failed manual check reads as
-          // "up to date", and a background failure is invisible everywhere
-          // but the log
-          updateStatus.error =
-            err instanceof RateLimitError
-              ? "update check rate-limited by GitHub, try again later"
-              : getErrorMessageOrDefault(err);
+          // Surface MANUAL check failures: without this they read as "up to
+          // date". Background failures stay log-only — offline is normal for
+          // a gaming machine, not a red notification every launch and every
+          // periodic re-check.
+          if (manual) {
+            updateStatus.error =
+              err instanceof RateLimitError
+                ? "update check rate-limited by GitHub, try again later"
+                : getErrorMessageOrDefault(err);
+          }
           broadcastStatus();
         }
         if (err instanceof RateLimitError) {
@@ -514,7 +529,23 @@ export function setupAutoUpdater(installType: string): void {
     }
     lastResolved = null;
 
-    if (channel !== "none" && process.env.IGNORE_UPDATES !== "yes") {
+    if (channel === "none") {
+      // Updates disabled: withdraw whatever was on offer, or a standing
+      // notification keeps live buttons for an update the user opted out of.
+      pendingDowngrade = null;
+      updateStatus.available = false;
+      updateStatus.version = undefined;
+      updateStatus.releaseNotes = undefined;
+      updateStatus.downloadProgress = undefined;
+      updateStatus.downgrade = undefined;
+      updateStatus.downgrading = undefined;
+      updateStatus.patch = undefined;
+      updateStatus.error = undefined;
+      broadcastStatus();
+      return;
+    }
+
+    if (process.env.IGNORE_UPDATES !== "yes") {
       // A user-initiated switch to stable is the one flow allowed to offer a
       // downgrade (e.g. leaving the beta channel from a beta build).
       checkForUpdates(channel, manual, manual === true && channel === "stable");
@@ -590,6 +621,9 @@ export function setupAutoUpdater(installType: string): void {
         const err = unknownToError(unknownErr);
         log("error", "Download failed", { error: err.message });
         updateStatus.error = err.message;
+        // stale progress would strand the renderer on "Downloading…" with the
+        // retry button hidden
+        updateStatus.downloadProgress = undefined;
         installAfterDownloadFlag = false;
         if (generation === checkGeneration) {
           updateStatus.checking = false;
@@ -656,6 +690,7 @@ export function setupAutoUpdater(installType: string): void {
         log("error", "Downgrade download failed", { error: err.message });
         updateStatus.error = err.message;
         updateStatus.downgrading = undefined;
+        updateStatus.downloadProgress = undefined;
         // Without the offer (consumed above) the failed target must not be
         // left advertised: the renderer would present the older version as a
         // regular available update whose Download can only ever fail.

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -20,8 +20,13 @@
  */
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
-import type { UpdateKind, UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
-import { app, BrowserWindow } from "electron";
+import type {
+  UpdateKind,
+  UpdaterSnapshot,
+  UpdaterState,
+  UpdaterStatusResponse,
+} from "@vortex/shared/ipc";
+import { app } from "electron";
 import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import * as semver from "semver";
@@ -99,11 +104,31 @@ export function setupAutoUpdater(installType: string): void {
     return { state: current, justUpdatedFrom };
   }
 
-  function broadcast(): void {
-    const payload = snapshot();
-    for (const win of BrowserWindow.getAllWindows()) {
-      betterIpcMain.send(win.webContents, "updater:status-changed", payload);
+  // The renderer polls for status, like downloads (IPCDownloadAdapter.ts) and
+  // uploads (uploadV3.ts); nothing is pushed. Its UI reacts to transitions and
+  // some states last well under a poll interval, so every snapshot is numbered
+  // and kept briefly and a poll asks for everything since the last one it saw.
+  const HISTORY_CAP = 32;
+  let seq = 0;
+  const history: Array<{ seq: number; snapshot: UpdaterSnapshot }> = [];
+
+  function record(): void {
+    seq += 1;
+    history.push({ seq, snapshot: snapshot() });
+    if (history.length > HISTORY_CAP) {
+      history.shift();
     }
+  }
+
+  function statusSince(since: number | undefined): UpdaterStatusResponse {
+    return {
+      seq,
+      snapshot: snapshot(),
+      changes:
+        since == null
+          ? []
+          : history.filter((entry) => entry.seq > since).map((entry) => entry.snapshot),
+    };
   }
 
   function setState(next: UpdaterState): void {
@@ -114,7 +139,7 @@ export function setupAutoUpdater(installType: string): void {
       to: describeState(next),
     });
     current = next;
-    broadcast();
+    record();
   }
 
   // What kind of update a version represents for the running install.
@@ -208,7 +233,10 @@ export function setupAutoUpdater(installType: string): void {
 
   // ---- IPC: status + changelog --------------------------------------------
 
-  betterIpcMain.handle("updater:get-status", (): UpdaterSnapshot => snapshot());
+  betterIpcMain.handle(
+    "updater:get-status",
+    (_event, since?: number): UpdaterStatusResponse => statusSince(since),
+  );
 
   // Release notes for the update the app just went through, the renderer's
   // post-update "View changes". The resolver collects body_html of releases
@@ -257,7 +285,7 @@ export function setupAutoUpdater(installType: string): void {
           semver.gt(currentVersion, previous)
         ) {
           justUpdatedFrom = previous;
-          broadcast();
+          record();
         }
       })
       .catch((err: unknown) => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -20,7 +20,7 @@ import * as semver from "semver";
 
 import { betterIpcMain } from "../../ipc";
 import { log } from "../../logging";
-import { writePersistedValue } from "../../store/mainPersistence";
+import { readPersistedValue, writePersistedValue } from "../../store/mainPersistence";
 import type { ResolveChannel, ResolvedRelease } from "./releaseResolver";
 import {
   classifyUpdate,
@@ -146,8 +146,11 @@ export function setupAutoUpdater(installType: string): void {
       downloadProgress: updateStatus.downloadProgress,
       error: updateStatus.error,
       downgrade: updateStatus.downgrade,
+      downgrading: updateStatus.downgrading,
       checking: updateStatus.checking,
       manual: updateStatus.manual,
+      patch: updateStatus.patch,
+      justUpdatedFrom: updateStatus.justUpdatedFrom,
     };
   }
 
@@ -162,6 +165,50 @@ export function setupAutoUpdater(installType: string): void {
 
   // Register invoke handler for status queries
   betterIpcMain.handle("updater:get-status", (): UpdateStatus => statusSnapshot());
+
+  // Release notes for the update the app just went through — the renderer's
+  // post-update "View changes". The resolver collects body_html of releases
+  // above the given version, so resolving from the pre-update version yields
+  // exactly the versions this update covered.
+  betterIpcMain.handle("updater:get-update-changelog", async (): Promise<string | null> => {
+    const previous = updateStatus.justUpdatedFrom;
+    if (previous == null) {
+      return null;
+    }
+    try {
+      const resolvedRelease = await resolveUpdate(toResolveChannel(updateChannel), previous);
+      return resolvedRelease?.notesHtml ?? null;
+    } catch (err) {
+      log("warn", "Failed to fetch post-update changelog", {
+        error: getErrorMessageOrDefault(err),
+      });
+      return null;
+    }
+  });
+
+  // Surface "Vortex was updated" on the first launch after an update: the
+  // renderer store persists appVersion each run, so at startup it still holds
+  // the previous run's version. Not in dev, where the version is a moving
+  // placeholder.
+  if (process.env.NODE_ENV !== "development") {
+    void readPersistedValue<string>("app", ["appVersion"])
+      .then((previous) => {
+        if (
+          previous != null &&
+          semver.valid(previous) != null &&
+          semver.valid(currentVersion) != null &&
+          semver.gt(currentVersion, previous)
+        ) {
+          updateStatus.justUpdatedFrom = previous;
+          broadcastStatus();
+        }
+      })
+      .catch((err: unknown) => {
+        log("debug", "Could not read previous app version", {
+          error: getErrorMessageOrDefault(err),
+        });
+      });
+  }
 
   log("info", "setupAutoUpdater", { installType, currentVersion });
 
@@ -319,7 +366,7 @@ export function setupAutoUpdater(installType: string): void {
   // Resolve the channel's target release. Upgrades get handed to
   // electron-updater as the feed; downgrade offers are returned for the
   // caller to surface (only ever produced when allowDowngradeOffer is set,
-  // i.e. after an explicit switch to stable). A lower "latest" is otherwise
+  // i.e. for checks on the stable channel). A lower "latest" is otherwise
   // ignored — offering it unasked is the old field bug.
   function resolveAndApply(
     channel: string,
@@ -328,7 +375,7 @@ export function setupAutoUpdater(installType: string): void {
   ): Promise<ResolveOutcome> {
     return resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
       const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
-        switchToStable: allowDowngradeOffer,
+        stableChannel: allowDowngradeOffer,
       });
       if (resolved == null || verdict === "none") {
         const current = semver.valid(currentVersion);
@@ -352,6 +399,10 @@ export function setupAutoUpdater(installType: string): void {
         lastResolved = null;
         return { verdict, release: resolved };
       }
+      // Classify before the feed apply: the library's update-available fires
+      // during it, and the renderer needs the patch flag in that broadcast
+      // (patch updates auto-download and get their own quieter notification).
+      updateStatus.patch = shouldAutoDownload(currentVersion, resolved.version, installType);
       return applyResolvedFeed(resolved, generation).then(() => ({
         verdict: "upgrade" as const,
         release: resolved,
@@ -359,22 +410,23 @@ export function setupAutoUpdater(installType: string): void {
     });
   }
 
-  // Check for updates. allowDowngradeOffer is only set for a manual switch
-  // to the stable channel — the one flow where a lower version may be offered.
-  const checkForUpdates = (
-    channel: string,
-    manual: boolean = false,
-    allowDowngradeOffer: boolean = false,
-  ) => {
+  // Check for updates. Downgrade offers are only ever raised on the stable
+  // channel (a prerelease build whose user chose stable): every check there —
+  // channel switch, manual, periodic, launch — re-raises a declined offer,
+  // and a decline holds until the next one.
+  const checkForUpdates = (channel: string, manual: boolean = false) => {
     if (!channel || channel === "none") {
       log("debug", "Updates disabled");
       return;
     }
+    const allowDowngradeOffer = channel === "stable";
 
     updateChannel = channel;
     const generation = ++checkGeneration;
     pendingDowngrade = null;
     updateStatus.downgrade = undefined;
+    updateStatus.downgrading = undefined;
+    updateStatus.patch = undefined;
     updateStatus.checking = true;
     updateStatus.manual = manual;
     broadcastStatus();
@@ -412,7 +464,7 @@ export function setupAutoUpdater(installType: string): void {
 
         // Auto-download patch updates for regular installs; minor/major
         // updates require user-initiated download via renderer.
-        if (shouldAutoDownload(currentVersion, resolved.version, installType)) {
+        if (updateStatus.patch === true) {
           log("info", "Patch update detected, auto-downloading", {
             from: currentVersion,
             to: resolved.version,
@@ -447,9 +499,7 @@ export function setupAutoUpdater(installType: string): void {
     lastResolved = null;
 
     if (channel !== "none" && process.env.IGNORE_UPDATES !== "yes") {
-      // A user-initiated switch to stable is the one flow allowed to offer a
-      // downgrade (e.g. leaving the beta channel from a beta build).
-      checkForUpdates(channel, manual, manual === true && channel === "stable");
+      checkForUpdates(channel, manual);
     }
   });
 
@@ -536,9 +586,13 @@ export function setupAutoUpdater(installType: string): void {
     const generation = ++checkGeneration;
     updateStatus.checking = true;
     updateStatus.manual = false; // a download is not a check
-    // Past confirmation this is an ordinary in-flight download; keeping the
-    // downgrade flag would re-trigger the offer UI on every progress push.
+    // Past confirmation the offer flag drops (keeping it would re-trigger the
+    // offer UI on every progress push), but the flow stays labeled as a
+    // downgrade via `downgrading` — presenting it as a regular update
+    // download would misdescribe what is about to be installed.
     updateStatus.downgrade = undefined;
+    updateStatus.downgrading = true;
+    updateStatus.patch = undefined; // a downgrade is never a patch update
     lastBroadcastPercent = -1;
     broadcastStatus();
 
@@ -568,12 +622,29 @@ export function setupAutoUpdater(installType: string): void {
         const err = unknownToError(unknownErr);
         log("error", "Downgrade download failed", { error: err.message });
         updateStatus.error = err.message;
+        updateStatus.downgrading = undefined;
         installAfterDownloadFlag = false;
         if (generation === checkGeneration) {
           updateStatus.checking = false;
         }
         broadcastStatus();
       });
+  });
+
+  // The user declined the outstanding downgrade offer: forget it. The next
+  // check (manual, periodic, or next launch) will raise it again if the
+  // situation still holds.
+  betterIpcMain.on("updater:decline-downgrade", () => {
+    if (pendingDowngrade == null) {
+      log("debug", "Downgrade decline with no offer outstanding");
+      return;
+    }
+    log("info", "Downgrade offer declined", { version: pendingDowngrade.version });
+    pendingDowngrade = null;
+    updateStatus.available = false;
+    updateStatus.downgrade = undefined;
+    updateStatus.version = undefined;
+    broadcastStatus();
   });
 
   betterIpcMain.on("updater:restart-and-install", () => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -165,6 +165,9 @@ export function setupAutoUpdater(installType: string): void {
   autoUpdater.allowDowngrade = false;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
+  // Vortex ships full NSIS installers only; refuse web-installer files (which
+  // can lack signature verification).
+  autoUpdater.disableWebInstaller = true;
 
   // Route the library's own log lines (differential-download fallbacks,
   // signature verification, cache decisions) into vortex.log — by default

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -366,7 +366,7 @@ export function setupAutoUpdater(installType: string): void {
   // Resolve the channel's target release. Upgrades get handed to
   // electron-updater as the feed; downgrade offers are returned for the
   // caller to surface (only ever produced when allowDowngradeOffer is set,
-  // i.e. for checks on the stable channel). A lower "latest" is otherwise
+  // i.e. after an explicit switch to stable). A lower "latest" is otherwise
   // ignored — offering it unasked is the old field bug.
   function resolveAndApply(
     channel: string,
@@ -375,7 +375,7 @@ export function setupAutoUpdater(installType: string): void {
   ): Promise<ResolveOutcome> {
     return resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
       const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
-        stableChannel: allowDowngradeOffer,
+        switchToStable: allowDowngradeOffer,
       });
       if (resolved == null || verdict === "none") {
         const current = semver.valid(currentVersion);
@@ -410,16 +410,19 @@ export function setupAutoUpdater(installType: string): void {
     });
   }
 
-  // Check for updates. Downgrade offers are only ever raised on the stable
-  // channel (a prerelease build whose user chose stable): every check there —
-  // channel switch, manual, periodic, launch — re-raises a declined offer,
-  // and a decline holds until the next one.
-  const checkForUpdates = (channel: string, manual: boolean = false) => {
+  // Check for updates. allowDowngradeOffer is only set for a purposeful
+  // switch to the stable channel — the one flow where a lower version may be
+  // offered. Background checks (launch sync, periodic, Check now) never
+  // surface downgrades.
+  const checkForUpdates = (
+    channel: string,
+    manual: boolean = false,
+    allowDowngradeOffer: boolean = false,
+  ) => {
     if (!channel || channel === "none") {
       log("debug", "Updates disabled");
       return;
     }
-    const allowDowngradeOffer = channel === "stable";
 
     updateChannel = channel;
     const generation = ++checkGeneration;
@@ -499,7 +502,9 @@ export function setupAutoUpdater(installType: string): void {
     lastResolved = null;
 
     if (channel !== "none" && process.env.IGNORE_UPDATES !== "yes") {
-      checkForUpdates(channel, manual);
+      // A user-initiated switch to stable is the one flow allowed to offer a
+      // downgrade (e.g. leaving the beta channel from a beta build).
+      checkForUpdates(channel, manual, manual === true && channel === "stable");
     }
   });
 
@@ -631,9 +636,8 @@ export function setupAutoUpdater(installType: string): void {
       });
   });
 
-  // The user declined the outstanding downgrade offer: forget it. The next
-  // check (manual, periodic, or next launch) will raise it again if the
-  // situation still holds.
+  // The user declined the outstanding downgrade offer: forget it. Only
+  // another purposeful switch to stable raises it again.
   betterIpcMain.on("updater:decline-downgrade", () => {
     if (pendingDowngrade == null) {
       log("debug", "Downgrade decline with no offer outstanding");

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -20,6 +20,7 @@ import * as semver from "semver";
 
 import { betterIpcMain } from "../../ipc";
 import { log } from "../../logging";
+import { writePersistedValue } from "../../store/mainPersistence";
 import type { ResolveChannel, ResolvedRelease } from "./releaseResolver";
 import {
   classifyUpdate,
@@ -67,6 +68,9 @@ export function setupAutoUpdater(installType: string): void {
   // the resolver's collected release notes over the (empty) generic-feed ones.
   // Downloads never trust it: updater:download re-resolves every time.
   let lastResolved: ResolvedRelease | null = null;
+  // The downgrade offered after an explicit switch to stable, awaiting the
+  // user's confirmation via updater:download-downgrade. Cleared by any check.
+  let pendingDowngrade: ResolvedRelease | null = null;
   // Overlapping checks are possible (set-channel + manual check-now); only
   // the newest one may write checking/availability/cancellation state.
   let checkGeneration = 0;
@@ -220,6 +224,7 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "Update downloaded", { version: updateInfo.version });
     updateStatus.downloaded = true;
     updateStatus.downloadProgress = 100;
+    lastBroadcastPercent = -1;
     broadcastStatus();
 
     // Set up auto-install on quit (unless dev mode)
@@ -250,17 +255,25 @@ export function setupAutoUpdater(installType: string): void {
     });
   }
 
-  // Resolve the channel's target release and, when it's an upgrade, hand the
-  // feed to electron-updater. Resolves to the release or null (no upgrade).
-  function resolveAndApply(channel: string, generation: number): Promise<ResolvedRelease | null> {
+  type ResolveOutcome =
+    | { verdict: "upgrade" | "downgrade-offer"; release: ResolvedRelease }
+    | { verdict: "none"; release: null };
+
+  // Resolve the channel's target release. Upgrades get handed to
+  // electron-updater as the feed; downgrade offers are returned for the
+  // caller to surface (only ever produced when allowDowngradeOffer is set,
+  // i.e. after an explicit switch to stable). A lower "latest" is otherwise
+  // ignored — offering it unasked is the old field bug.
+  function resolveAndApply(
+    channel: string,
+    generation: number,
+    allowDowngradeOffer: boolean = false,
+  ): Promise<ResolveOutcome> {
     return resolveUpdate(toResolveChannel(channel), currentVersion).then((resolved) => {
-      // Note: switchToStable stays false until the explicit channel-switch
-      // downgrade flow ships with its UI; a lower "latest" is ignored here
-      // rather than offered (offering it is the old field bug).
       const verdict = classifyUpdate(currentVersion, resolved?.version ?? null, {
-        switchToStable: false,
+        switchToStable: allowDowngradeOffer,
       });
-      if (resolved == null || verdict !== "upgrade") {
+      if (resolved == null || verdict === "none") {
         const current = semver.valid(currentVersion);
         if (resolved != null && current != null && semver.lt(resolved.version, current)) {
           log("info", "Latest release is older than the running version, ignoring", {
@@ -272,14 +285,30 @@ export function setupAutoUpdater(installType: string): void {
           log("info", "No update available", { channel, resolved: resolved?.version });
         }
         lastResolved = null;
-        return null;
+        return { verdict: "none", release: null };
       }
-      return applyResolvedFeed(resolved, generation).then(() => resolved);
+      if (verdict === "downgrade-offer") {
+        log("info", "Stable release is older than the running version, offering downgrade", {
+          resolved: resolved.version,
+          currentVersion,
+        });
+        lastResolved = null;
+        return { verdict, release: resolved };
+      }
+      return applyResolvedFeed(resolved, generation).then(() => ({
+        verdict: "upgrade" as const,
+        release: resolved,
+      }));
     });
   }
 
-  // Check for updates
-  const checkForUpdates = (channel: string, manual: boolean = false) => {
+  // Check for updates. allowDowngradeOffer is only set for a manual switch
+  // to the stable channel — the one flow where a lower version may be offered.
+  const checkForUpdates = (
+    channel: string,
+    manual: boolean = false,
+    allowDowngradeOffer: boolean = false,
+  ) => {
     if (!channel || channel === "none") {
       log("debug", "Updates disabled");
       return;
@@ -287,17 +316,19 @@ export function setupAutoUpdater(installType: string): void {
 
     updateChannel = channel;
     const generation = ++checkGeneration;
+    pendingDowngrade = null;
+    updateStatus.downgrade = undefined;
     updateStatus.checking = true;
     broadcastStatus();
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
-    resolveAndApply(channel, generation)
-      .then((resolved) => {
+    resolveAndApply(channel, generation, allowDowngradeOffer)
+      .then((outcome) => {
         if (generation !== checkGeneration) {
           return; // superseded by a newer check; let that one own the status
         }
         updateStatus.checking = false;
-        if (resolved == null) {
+        if (outcome.verdict === "none") {
           updateStatus.available = false;
           updateStatus.version = undefined;
           updateStatus.releaseNotes = undefined;
@@ -305,6 +336,19 @@ export function setupAutoUpdater(installType: string): void {
           broadcastStatus();
           return;
         }
+        if (outcome.verdict === "downgrade-offer") {
+          // Surface the offer; nothing downloads until the user confirms via
+          // updater:download-downgrade.
+          pendingDowngrade = outcome.release;
+          updateStatus.available = true;
+          updateStatus.downgrade = true;
+          updateStatus.version = outcome.release.version;
+          updateStatus.releaseNotes = undefined;
+          updateStatus.error = undefined;
+          broadcastStatus();
+          return;
+        }
+        const resolved = outcome.release;
         broadcastStatus();
         log("info", "Update check completed", { version: resolved.version });
 
@@ -345,7 +389,9 @@ export function setupAutoUpdater(installType: string): void {
     lastResolved = null;
 
     if (channel !== "none" && process.env.IGNORE_UPDATES !== "yes") {
-      checkForUpdates(channel, manual);
+      // A user-initiated switch to stable is the one flow allowed to offer a
+      // downgrade (e.g. leaving the beta channel from a beta build).
+      checkForUpdates(channel, manual, manual === true && channel === "stable");
     }
   });
 
@@ -381,14 +427,15 @@ export function setupAutoUpdater(installType: string): void {
     // superseded can't strand checking:true.
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    lastBroadcastPercent = -1;
     broadcastStatus();
     resolveAndApply(channel, generation)
-      .then((resolved) => {
+      .then((outcome) => {
         if (generation === checkGeneration) {
           updateStatus.checking = false;
           broadcastStatus();
         }
-        if (resolved == null) {
+        if (outcome.verdict !== "upgrade") {
           throw new Error("no newer release available to download");
         }
         return autoUpdater.downloadUpdate();
@@ -396,6 +443,54 @@ export function setupAutoUpdater(installType: string): void {
       .catch((unknownErr) => {
         const err = unknownToError(unknownErr);
         log("error", "Download failed", { error: err.message });
+        updateStatus.error = err.message;
+        installAfterDownloadFlag = false;
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+        }
+        broadcastStatus();
+      });
+  });
+
+  // Download the downgrade the user explicitly confirmed. Only honored while
+  // an offer is outstanding. allowDowngrade is raised for just this flow and
+  // dropped again once the library has accepted the feed.
+  betterIpcMain.on("updater:download-downgrade", (_event, installAfterDownload: boolean) => {
+    const target = pendingDowngrade;
+    if (target == null) {
+      log("warn", "Downgrade download requested but no downgrade offer is outstanding");
+      return;
+    }
+    log("info", "Downgrade download confirmed", { version: target.version });
+
+    installAfterDownloadFlag = installAfterDownload;
+    const generation = ++checkGeneration;
+    updateStatus.checking = true;
+    lastBroadcastPercent = -1;
+    broadcastStatus();
+
+    autoUpdater.allowDowngrade = true;
+    // One-shot marker so the next launch's "Downgrade detected" warning is
+    // suppressed for the version the user knowingly chose.
+    writePersistedValue("app", ["expectedDowngradeTo"], target.version)
+      .catch((err: unknown) => {
+        log("warn", "Failed to persist downgrade marker", {
+          error: getErrorMessageOrDefault(err),
+        });
+      })
+      .then(() => applyResolvedFeed(target, generation))
+      .then(() => {
+        autoUpdater.allowDowngrade = false;
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+          broadcastStatus();
+        }
+        return autoUpdater.downloadUpdate();
+      })
+      .catch((unknownErr) => {
+        autoUpdater.allowDowngrade = false;
+        const err = unknownToError(unknownErr);
+        log("error", "Downgrade download failed", { error: err.message });
         updateStatus.error = err.message;
         installAfterDownloadFlag = false;
         if (generation === checkGeneration) {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -488,6 +488,13 @@ export function setupAutoUpdater(installType: string): void {
       .catch((err) => {
         if (generation === checkGeneration) {
           updateStatus.checking = false;
+          // surface the failure: without this a failed manual check reads as
+          // "up to date", and a background failure is invisible everywhere
+          // but the log
+          updateStatus.error =
+            err instanceof RateLimitError
+              ? "update check rate-limited by GitHub, try again later"
+              : getErrorMessageOrDefault(err);
           broadcastStatus();
         }
         if (err instanceof RateLimitError) {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -14,7 +14,7 @@
  * @vortex/shared/ipc, patterned on VS Code's updater): exactly one state at a
  * time, every transition goes through setState, and the renderer renders
  * purely from the broadcast state. electron-updater's own events never drive
- * the state directly — we already resolved what "latest" means; the library
+ * the state directly, we already resolved what "latest" means; the library
  * events only feed bookkeeping (downloaded-installer tracking, progress,
  * failures of an active download).
  */
@@ -67,7 +67,7 @@ function describeState(state: UpdaterState): string {
 export function setupAutoUpdater(installType: string): void {
   let cancellationToken: CancellationToken | undefined = undefined;
   const currentVersion = app.getVersion();
-  // The release the last successful check resolved to — used only to prefer
+  // The release the last successful check resolved to, used only to prefer
   // the resolver's collected release notes over the (empty) generic-feed ones.
   // Downloads never trust it: updater:download re-resolves every time.
   let lastResolved: ResolvedRelease | null = null;
@@ -160,7 +160,7 @@ export function setupAutoUpdater(installType: string): void {
   }
 
   // Install on quit, visibly. The library's autoInstallOnAppQuit path runs
-  // the installer silently (/S) — half a minute of disk churn with zero
+  // the installer silently (/S), half a minute of disk churn with zero
   // feedback. Quitting with an update staged instead triggers the exact same
   // visible install as Restart Now (auto-update wizard + finish page).
   // One-shot: quit processing can re-fire before-quit.
@@ -210,7 +210,7 @@ export function setupAutoUpdater(installType: string): void {
 
   betterIpcMain.handle("updater:get-status", (): UpdaterSnapshot => snapshot());
 
-  // Release notes for the update the app just went through — the renderer's
+  // Release notes for the update the app just went through, the renderer's
   // post-update "View changes". The resolver collects body_html of releases
   // above the given version, so resolving from the pre-update version yields
   // exactly the versions this update covered. The renderer supplies its
@@ -282,7 +282,7 @@ export function setupAutoUpdater(installType: string): void {
   autoUpdater.disableWebInstaller = true;
 
   // Route the library's own log lines (differential-download fallbacks,
-  // signature verification, cache decisions) into vortex.log — by default
+  // signature verification, cache decisions) into vortex.log, by default
   // they only reach the console and are invisible in the field.
   autoUpdater.logger = {
     info: (message: unknown) => log("info", "electron-updater", { message }),
@@ -323,7 +323,7 @@ export function setupAutoUpdater(installType: string): void {
     // a successful check, so the network was just up). retry keeps a working
     // Download available alongside the error for regular updates.
     if (current.type === "downloading") {
-      // don't auto-retry this version for a while — every check would
+      // don't auto-retry this version for a while, every check would
       // otherwise re-fetch the full delta against the same failure
       if (current.kind === "patch") {
         autoDownloadHold = {
@@ -385,7 +385,7 @@ export function setupAutoUpdater(installType: string): void {
     // autoInstallOnAppQuit remains false for the whole app lifetime.
     armInstallOnQuit();
 
-    // If user requested immediate install, do it now (packaged builds only —
+    // If user requested immediate install, do it now (packaged builds only;
     // an unpackaged run with the dev updater must never install)
     if (installAfterDownloadFlag && process.env.NODE_ENV !== "development" && app.isPackaged) {
       log("info", "Auto-installing after download");
@@ -401,7 +401,7 @@ export function setupAutoUpdater(installType: string): void {
   // through this first, so check-before-download holds structurally.
   function applyResolvedFeed(resolved: ResolvedRelease, generation: number): Promise<void> {
     lastResolved = resolved;
-    // useMultipleRangeRequest: false — GitHub's release downloads are
+    // useMultipleRangeRequest: false, GitHub's release downloads are
     // S3-backed and don't serve multipart/byteranges; without this every
     // differential download degrades to a full download (electron-updater's
     // own GitHub provider hard-codes the same).
@@ -425,7 +425,7 @@ export function setupAutoUpdater(installType: string): void {
   // electron-updater as the feed; downgrade offers are returned for the
   // caller to surface (only ever produced when allowDowngradeOffer is set,
   // i.e. after an explicit switch to stable). A lower "latest" is otherwise
-  // ignored — offering it unasked is the old field bug.
+  // ignored, offering it unasked is the old field bug.
   function resolveAndApply(
     channel: string,
     generation: number,
@@ -467,7 +467,7 @@ export function setupAutoUpdater(installType: string): void {
   // ---- check ---------------------------------------------------------------
 
   // Check for updates. allowDowngradeOffer is only set for a purposeful
-  // switch to the stable channel — the one flow where a lower version may be
+  // switch to the stable channel, the one flow where a lower version may be
   // offered. Background checks (launch sync, periodic, Check now) never
   // surface downgrades.
   const checkForUpdates = (
@@ -495,7 +495,7 @@ export function setupAutoUpdater(installType: string): void {
         }
         if (outcome.verdict === "none") {
           // A staged downgrade the user already confirmed survives checks
-          // that (correctly) ignore the lower version — settling to idle
+          // that (correctly) ignore the lower version, settling to idle
           // would orphan the downloaded installer and silently disarm its
           // install-on-quit.
           if (
@@ -534,7 +534,7 @@ export function setupAutoUpdater(installType: string): void {
 
         // Patch updates auto-download for regular installs; minor/major
         // updates wait for a user decision. A patch found by a MANUAL check
-        // downloads visibly — the user's press set it in motion.
+        // downloads visibly, the user's press set it in motion.
         const held =
           autoDownloadHold != null &&
           autoDownloadHold.version === resolved.version &&
@@ -627,7 +627,7 @@ export function setupAutoUpdater(installType: string): void {
     // Already downloaded: don't re-fetch the full installer. Re-issuing
     // downloadUpdate when the file is already present can resolve without
     // re-emitting "update-downloaded", which would strand the install request.
-    // Install directly instead — but only when the installer on disk is the
+    // Install directly instead, but only when the installer on disk is the
     // version currently on offer; a channel switch can leave a stale download
     // for a different version.
     if (
@@ -767,7 +767,7 @@ export function setupAutoUpdater(installType: string): void {
         if (generation !== checkGeneration) {
           return;
         }
-        // The offer was consumed, so there is nothing valid to retry — the
+        // The offer was consumed, so there is nothing valid to retry, the
         // failed target must not be re-advertised as a regular update.
         setState({ type: "error", message: err.message, manual: true });
       });

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -13,7 +13,7 @@
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import type { UpdateStatus } from "@vortex/shared/ipc";
-import { app, dialog } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import * as semver from "semver";
@@ -121,11 +121,11 @@ export function setupAutoUpdater(installType: string): void {
         attempts: installAttempts,
       });
       updateStatus.error = err.message;
+      broadcastStatus();
     }
   }
 
-  // Register invoke handler for status queries
-  betterIpcMain.handle("updater:get-status", (): UpdateStatus => {
+  function statusSnapshot(): UpdateStatus {
     return {
       available: updateStatus.available,
       downloaded: updateStatus.downloaded,
@@ -136,7 +136,19 @@ export function setupAutoUpdater(installType: string): void {
       downgrade: updateStatus.downgrade,
       checking: updateStatus.checking,
     };
-  });
+  }
+
+  // Push the current status to every window; the renderer reacts to these
+  // instead of polling (getStatus remains for the initial sync).
+  function broadcastStatus(): void {
+    const snapshot = statusSnapshot();
+    for (const win of BrowserWindow.getAllWindows()) {
+      betterIpcMain.send(win.webContents, "updater:status-changed", snapshot);
+    }
+  }
+
+  // Register invoke handler for status queries
+  betterIpcMain.handle("updater:get-status", (): UpdateStatus => statusSnapshot());
 
   log("info", "setupAutoUpdater", { installType, currentVersion });
 
@@ -156,6 +168,7 @@ export function setupAutoUpdater(installType: string): void {
     if (installPending) {
       handleInstallFailure(unknownToError(err));
     }
+    broadcastStatus();
   });
 
   // Update not available
@@ -163,6 +176,7 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "No update available", { channel: updateChannel });
     updateStatus.available = false;
     updateStatus.error = undefined;
+    broadcastStatus();
   });
 
   // Update available
@@ -182,12 +196,20 @@ export function setupAutoUpdater(installType: string): void {
         .map((note) => (typeof note === "string" ? note : note.note))
         .join("\n\n");
     }
+    broadcastStatus();
   });
 
-  // Download progress
+  // Download progress. Progress events fire many times per second on a
+  // ~360 MB installer; broadcast only whole-percent changes.
+  let lastBroadcastPercent = -1;
   autoUpdater.on("download-progress", (progress: { percent: number }) => {
     log("debug", "Download progress", { percent: progress.percent });
     updateStatus.downloadProgress = progress.percent;
+    const wholePercent = Math.floor(progress.percent);
+    if (wholePercent !== lastBroadcastPercent) {
+      lastBroadcastPercent = wholePercent;
+      broadcastStatus();
+    }
   });
 
   // Track whether to auto-install after download
@@ -198,6 +220,7 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "Update downloaded", { version: updateInfo.version });
     updateStatus.downloaded = true;
     updateStatus.downloadProgress = 100;
+    broadcastStatus();
 
     // Set up auto-install on quit (unless dev mode)
     if (process.env.NODE_ENV !== "development") {
@@ -265,6 +288,7 @@ export function setupAutoUpdater(installType: string): void {
     updateChannel = channel;
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    broadcastStatus();
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
     resolveAndApply(channel, generation)
@@ -278,8 +302,10 @@ export function setupAutoUpdater(installType: string): void {
           updateStatus.version = undefined;
           updateStatus.releaseNotes = undefined;
           updateStatus.error = undefined;
+          broadcastStatus();
           return;
         }
+        broadcastStatus();
         log("info", "Update check completed", { version: resolved.version });
 
         // Auto-download patch updates for regular installs; minor/major
@@ -299,6 +325,7 @@ export function setupAutoUpdater(installType: string): void {
       .catch((err) => {
         if (generation === checkGeneration) {
           updateStatus.checking = false;
+          broadcastStatus();
         }
         if (err instanceof RateLimitError) {
           log("warn", "Update check rate-limited", { resetAt: err.resetAt.toISOString() });
@@ -349,10 +376,18 @@ export function setupAutoUpdater(installType: string): void {
     // Always re-resolve for the channel the renderer asked about: a cached
     // resolution could belong to a different channel, and re-applying the
     // feed guarantees the library-side check-before-download. The resolver's
-    // ETag cache makes the repeat lookup cheap.
+    // ETag cache makes the repeat lookup cheap. The download owns the
+    // checking lifecycle for the generation it claims, so a check it
+    // superseded can't strand checking:true.
     const generation = ++checkGeneration;
+    updateStatus.checking = true;
+    broadcastStatus();
     resolveAndApply(channel, generation)
       .then((resolved) => {
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+          broadcastStatus();
+        }
         if (resolved == null) {
           throw new Error("no newer release available to download");
         }
@@ -363,6 +398,10 @@ export function setupAutoUpdater(installType: string): void {
         log("error", "Download failed", { error: err.message });
         updateStatus.error = err.message;
         installAfterDownloadFlag = false;
+        if (generation === checkGeneration) {
+          updateStatus.checking = false;
+        }
+        broadcastStatus();
       });
   });
 

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -330,15 +330,28 @@ export function setupAutoUpdater(installType: string): void {
 
   // ---- electron-updater events (bookkeeping, never primary state control) --
 
+  // builder-util-runtime's CancellationError keeps the default name ("Error")
+  // and the message "cancelled"; the library also does not emit its error
+  // event for it, so cancellations arrive as rejections of downloadUpdate.
+  function isCancellation(err: Error): boolean {
+    return err.constructor.name === "CancellationError" || err.message === "cancelled";
+  }
+
+  // A cancelled download (dismissed notification or channel switch) is the
+  // user's own doing, not a failure to report: settle to idle, nothing on offer
+  // until the next check.
+  function settleCancelledDownload(): void {
+    log("info", "Update download cancelled");
+    installAfterDownloadFlag = false;
+    if (current.type === "downloading") {
+      setState({ type: "idle" });
+    }
+  }
+
   autoUpdater.on("error", (err) => {
     const message = getErrorMessageOrDefault(err);
-    // A cancelled download (channel switch mid-download) is the user's own
-    // doing, not a failure to report. The superseding check owns the state.
-    if (err instanceof Error && err.name === "CancellationError") {
-      log("info", "Update download cancelled");
-      if (current.type === "downloading") {
-        setState({ type: "idle" });
-      }
+    if (err instanceof Error && isCancellation(err)) {
+      settleCancelledDownload();
       return;
     }
     log("error", "Auto-updater error", { error: message });
@@ -573,9 +586,14 @@ export function setupAutoUpdater(installType: string): void {
             to: resolved.version,
           });
           setState({ type: "downloading", version: resolved.version, kind: "patch", manual });
-          autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
+          autoUpdater.downloadUpdate(cancellationToken).catch((unknownErr) => {
+            const err = unknownToError(unknownErr);
+            if (isCancellation(err)) {
+              settleCancelledDownload();
+              return;
+            }
             // state transition owned by the "error" event handler
-            log("warn", "Auto-download failed", { error: getErrorMessageOrDefault(err) });
+            log("warn", "Auto-download failed", { error: err.message });
           });
           return;
         }
@@ -725,10 +743,16 @@ export function setupAutoUpdater(installType: string): void {
             manual: true,
           });
         }
-        return autoUpdater.downloadUpdate();
+        // the check's token, so a channel switch or a dismissed notification
+        // can cancel this download (a fresh token would be unreachable)
+        return autoUpdater.downloadUpdate(cancellationToken);
       })
       .catch((unknownErr) => {
         const err = unknownToError(unknownErr);
+        if (isCancellation(err)) {
+          settleCancelledDownload();
+          return;
+        }
         log("error", "Download failed", { error: err.message });
         installAfterDownloadFlag = false;
         if (generation !== checkGeneration) {
@@ -785,11 +809,15 @@ export function setupAutoUpdater(installType: string): void {
           log("info", "Downgrade download superseded by a newer check, not downloading");
           return;
         }
-        return autoUpdater.downloadUpdate();
+        return autoUpdater.downloadUpdate(cancellationToken);
       })
       .catch((unknownErr) => {
         autoUpdater.allowDowngrade = false;
         const err = unknownToError(unknownErr);
+        if (isCancellation(err)) {
+          settleCancelledDownload();
+          return;
+        }
         log("error", "Downgrade download failed", { error: err.message });
         installAfterDownloadFlag = false;
         if (generation !== checkGeneration) {
@@ -811,6 +839,19 @@ export function setupAutoUpdater(installType: string): void {
     log("info", "Downgrade offer declined", { version: pendingDowngrade.version });
     pendingDowngrade = null;
     setState({ type: "idle" });
+  });
+
+  // The user closed the download notification: stop the download. The
+  // library's CancellationError then settles the state to idle (the error
+  // handler treats a cancellation as the user's own doing, not a failure).
+  betterIpcMain.on("updater:cancel-download", () => {
+    if (current.type !== "downloading") {
+      log("debug", "Cancel requested with no download running");
+      return;
+    }
+    log("info", "Update download cancelled by the user", { version: current.version });
+    installAfterDownloadFlag = false;
+    cancellationToken?.cancel();
   });
 
   betterIpcMain.on("updater:restart-and-install", () => {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -461,24 +461,32 @@ export function setupAutoUpdater(installType: string): void {
       log("warn", "Downgrade download requested but no downgrade offer is outstanding");
       return;
     }
+    // One-shot consume: a second confirmation must not re-enter the flow.
+    pendingDowngrade = null;
     log("info", "Downgrade download confirmed", { version: target.version });
 
     installAfterDownloadFlag = installAfterDownload;
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    // Past confirmation this is an ordinary in-flight download; keeping the
+    // downgrade flag would re-trigger the offer UI on every progress push.
+    updateStatus.downgrade = undefined;
     lastBroadcastPercent = -1;
     broadcastStatus();
 
-    autoUpdater.allowDowngrade = true;
     // One-shot marker so the next launch's "Downgrade detected" warning is
-    // suppressed for the version the user knowingly chose.
+    // suppressed for the version the user knowingly chose. Written before
+    // allowDowngrade is raised so the raised window is only the feed apply.
     writePersistedValue("app", ["expectedDowngradeTo"], target.version)
       .catch((err: unknown) => {
         log("warn", "Failed to persist downgrade marker", {
           error: getErrorMessageOrDefault(err),
         });
       })
-      .then(() => applyResolvedFeed(target, generation))
+      .then(() => {
+        autoUpdater.allowDowngrade = true;
+        return applyResolvedFeed(target, generation);
+      })
       .then(() => {
         autoUpdater.allowDowngrade = false;
         if (generation === checkGeneration) {

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -142,6 +142,7 @@ export function setupAutoUpdater(installType: string): void {
       error: updateStatus.error,
       downgrade: updateStatus.downgrade,
       checking: updateStatus.checking,
+      manual: updateStatus.manual,
     };
   }
 
@@ -370,6 +371,7 @@ export function setupAutoUpdater(installType: string): void {
     pendingDowngrade = null;
     updateStatus.downgrade = undefined;
     updateStatus.checking = true;
+    updateStatus.manual = manual;
     broadcastStatus();
     log("info", "Checking for updates", { channel, manual, currentVersion });
 
@@ -486,6 +488,7 @@ export function setupAutoUpdater(installType: string): void {
     // superseded can't strand checking:true.
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    updateStatus.manual = false; // a download is not a check
     lastBroadcastPercent = -1;
     broadcastStatus();
     resolveAndApply(channel, generation)
@@ -527,6 +530,7 @@ export function setupAutoUpdater(installType: string): void {
     installAfterDownloadFlag = installAfterDownload;
     const generation = ++checkGeneration;
     updateStatus.checking = true;
+    updateStatus.manual = false; // a download is not a check
     // Past confirmation this is an ordinary in-flight download; keeping the
     // downgrade flag would re-trigger the offer UI on every progress push.
     updateStatus.downgrade = undefined;

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -290,7 +290,15 @@ export function setupAutoUpdater(installType: string): void {
   // through this first, so check-before-download holds structurally.
   function applyResolvedFeed(resolved: ResolvedRelease, generation: number): Promise<void> {
     lastResolved = resolved;
-    autoUpdater.setFeedURL({ provider: "generic", url: resolved.downloadBaseUrl });
+    // useMultipleRangeRequest: false — GitHub's release downloads are
+    // S3-backed and don't serve multipart/byteranges; without this every
+    // differential download degrades to a full download (electron-updater's
+    // own GitHub provider hard-codes the same).
+    autoUpdater.setFeedURL({
+      provider: "generic",
+      url: resolved.downloadBaseUrl,
+      useMultipleRangeRequest: false,
+    });
     return autoUpdater.checkForUpdates().then((check) => {
       if (generation === checkGeneration) {
         cancellationToken = check?.cancellationToken;

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -21,7 +21,7 @@
 
 import { getErrorMessageOrDefault, unknownToError } from "@vortex/shared";
 import type { UpdateKind, UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
-import { app, BrowserWindow, dialog } from "electron";
+import { app, BrowserWindow } from "electron";
 import type { CancellationToken, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import * as semver from "semver";
@@ -36,28 +36,6 @@ import {
   resolveUpdate,
   shouldAutoDownload,
 } from "./releaseResolver";
-
-/**
- * Warn once, non-blocking, that the downloaded update installs on quit.
- * The old implementation used showMessageBoxSync in before-quit: it blocked
- * the quitting main process (the dialog could not be dismissed) and the
- * handler was never removed, so every re-entered quit attempt stacked
- * another modal — an unkillable dialog loop in the field.
- */
-function showUpdateWarning() {
-  // one-shot: quit processing can re-fire before-quit
-  app.removeListener("before-quit", showUpdateWarning);
-  void dialog.showMessageBox({
-    type: "info",
-    title: "Vortex update",
-    message:
-      "An update has been downloaded and will now install. " +
-      "Please do not turn off your computer until it's done. " +
-      "If the installation process is interrupted, Vortex may not work correctly.",
-    buttons: ["Continue"],
-    noLink: true,
-  });
-}
 
 function toResolveChannel(channel: string): ResolveChannel {
   return channel === "beta" || channel === "next" ? channel : "stable";
@@ -165,13 +143,38 @@ export function setupAutoUpdater(installType: string): void {
     }
     installPending = true;
     installAttempts += 1;
-    // Drop the before-quit warning so retries don't stack duplicate dialogs.
-    app.removeListener("before-quit", showUpdateWarning);
+    // The quit this triggers must not re-enter the install via the quit hook.
+    app.removeListener("before-quit", installOnQuit);
     log("info", "Installing update", { attempt: installAttempts });
     try {
       autoUpdater.quitAndInstall();
     } catch (unknownErr) {
       handleInstallFailure(unknownToError(unknownErr));
+    }
+  }
+
+  // Install on quit, visibly. The library's autoInstallOnAppQuit path runs
+  // the installer silently (/S) — half a minute of disk churn with zero
+  // feedback. Quitting with an update staged instead triggers the exact same
+  // visible install as Restart Now (auto-update wizard + finish page).
+  // One-shot: quit processing can re-fire before-quit.
+  function installOnQuit(): void {
+    app.removeListener("before-quit", installOnQuit);
+    // only a settled staged update installs; anything else (a different
+    // version advertised since, a download in flight) must not run a stale
+    // installer on the way out
+    if (current.type === "staged") {
+      log("info", "Installing staged update on quit");
+      attemptInstall();
+    }
+  }
+
+  // (re-)arm the quit hook; called whenever a staged installer becomes current
+  function armInstallOnQuit(): void {
+    if (process.env.NODE_ENV !== "development" && app.isPackaged) {
+      app.removeListener("before-quit", installOnQuit);
+      app.on("before-quit", installOnQuit);
+      log("info", "Visible install-on-quit armed");
     }
   }
 
@@ -363,19 +366,16 @@ export function setupAutoUpdater(installType: string): void {
       releaseNotes: lastResolved?.notesHtml,
     });
 
-    // Set up auto-install on quit (packaged builds only — an unpackaged run
-    // with the dev updater must never install what it downloaded)
-    if (process.env.NODE_ENV !== "development" && app.isPackaged) {
-      autoUpdater.autoInstallOnAppQuit = true;
-      app.on("before-quit", showUpdateWarning);
-      log("info", "Auto-install on quit enabled");
+    // Install on quit stays OURS (visible), never the library's silent path:
+    // autoInstallOnAppQuit remains false for the whole app lifetime.
+    armInstallOnQuit();
 
-      // If user requested immediate install, do it now
-      if (installAfterDownloadFlag) {
-        log("info", "Auto-installing after download");
-        installAfterDownloadFlag = false;
-        attemptInstall();
-      }
+    // If user requested immediate install, do it now (packaged builds only —
+    // an unpackaged run with the dev updater must never install)
+    if (installAfterDownloadFlag && process.env.NODE_ENV !== "development" && app.isPackaged) {
+      log("info", "Auto-installing after download");
+      installAfterDownloadFlag = false;
+      attemptInstall();
     }
   });
 
@@ -501,6 +501,7 @@ export function setupAutoUpdater(installType: string): void {
             kind: kindFor(resolved.version),
             releaseNotes: resolved.notesHtml,
           });
+          armInstallOnQuit();
           return;
         }
 
@@ -604,6 +605,7 @@ export function setupAutoUpdater(installType: string): void {
           kind: kindFor(downloadedVersion),
           releaseNotes: current.type === "available" ? current.releaseNotes : undefined,
         });
+        armInstallOnQuit();
       }
       if (installAfterDownload) {
         attemptInstall();

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -82,6 +82,12 @@ export function setupAutoUpdater(installType: string): void {
   // The version the downloaded installer on disk actually contains; a staged
   // state is only ever valid for this version.
   let downloadedVersion: string | null = null;
+  // A version whose AUTO-download just failed is not auto-retried for a
+  // cooldown (every periodic/manual check would otherwise re-fetch the full
+  // delta); it is offered as a normal downloadable update instead, and a
+  // user-initiated download may always retry immediately.
+  const AUTO_DOWNLOAD_HOLD_MS = 15 * 60 * 1000;
+  let autoDownloadHold: { version: string; until: number } | null = null;
 
   // ---- state machine ------------------------------------------------------
 
@@ -317,12 +323,20 @@ export function setupAutoUpdater(installType: string): void {
     // a successful check, so the network was just up). retry keeps a working
     // Download available alongside the error for regular updates.
     if (current.type === "downloading") {
+      // don't auto-retry this version for a while — every check would
+      // otherwise re-fetch the full delta against the same failure
+      if (current.kind === "patch") {
+        autoDownloadHold = {
+          version: current.version,
+          until: Date.now() + AUTO_DOWNLOAD_HOLD_MS,
+        };
+      }
       setState({
         type: "error",
         message,
         manual: true,
         retry:
-          current.kind === "update"
+          current.kind !== "downgrade"
             ? { version: current.version, releaseNotes: lastResolved?.notesHtml }
             : undefined,
       });
@@ -355,6 +369,7 @@ export function setupAutoUpdater(installType: string): void {
   autoUpdater.on("update-downloaded", (updateInfo: UpdateInfo) => {
     log("info", "Update downloaded", { version: updateInfo.version });
     downloadedVersion = updateInfo.version;
+    autoDownloadHold = null; // a success clears any failure cooldown
     const kind: UpdateKind =
       current.type === "downloading" && current.version === updateInfo.version
         ? current.kind
@@ -520,7 +535,11 @@ export function setupAutoUpdater(installType: string): void {
         // Patch updates auto-download for regular installs; minor/major
         // updates wait for a user decision. A patch found by a MANUAL check
         // downloads visibly — the user's press set it in motion.
-        if (kindFor(resolved.version) === "patch") {
+        const held =
+          autoDownloadHold != null &&
+          autoDownloadHold.version === resolved.version &&
+          Date.now() < autoDownloadHold.until;
+        if (kindFor(resolved.version) === "patch" && !held) {
           log("info", "Patch update detected, auto-downloading", {
             from: currentVersion,
             to: resolved.version,
@@ -531,6 +550,14 @@ export function setupAutoUpdater(installType: string): void {
             log("warn", "Auto-download failed", { error: getErrorMessageOrDefault(err) });
           });
           return;
+        }
+        if (held) {
+          // a patch that just failed its auto-download is offered like a
+          // regular update instead: the user keeps a working Download button
+          // and background checks stop re-fetching against the same failure
+          log("info", "Auto-download on hold after a recent failure, offering instead", {
+            version: resolved.version,
+          });
         }
 
         setState({

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -166,6 +166,16 @@ export function setupAutoUpdater(installType: string): void {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
 
+  // Route the library's own log lines (differential-download fallbacks,
+  // signature verification, cache decisions) into vortex.log — by default
+  // they only reach the console and are invisible in the field.
+  autoUpdater.logger = {
+    info: (message: unknown) => log("info", "electron-updater", { message }),
+    warn: (message: unknown) => log("warn", "electron-updater", { message }),
+    error: (message: unknown) => log("warn", "electron-updater error", { message }),
+    debug: (message: string) => log("debug", "electron-updater", { message }),
+  };
+
   // Run-from-source builds skip the library's check ("application is not
   // packed"). Opting in via VORTEX_DEV_UPDATER=1 makes it read
   // dev-app-update.yml (in src/main) instead, so check/notify/download can be

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -91,8 +91,11 @@ export function setupAutoUpdater(installType: string): void {
   // on failure it reports via the "error" event (or, rarely, throws), which we
   // route to handleInstallFailure to decide whether to retry.
   function attemptInstall(): void {
-    if (process.env.NODE_ENV === "development") {
-      log("info", "Skipping install (dev mode)");
+    // Never install from an unpackaged (run-from-source) build: with the dev
+    // updater enabled a real installer may have been downloaded, and running
+    // it would install over the machine's actual Vortex.
+    if (process.env.NODE_ENV === "development" || !app.isPackaged) {
+      log("info", "Skipping install (unpackaged/dev build)");
       return;
     }
     installPending = true;
@@ -163,6 +166,15 @@ export function setupAutoUpdater(installType: string): void {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
 
+  // Run-from-source builds skip the library's check ("application is not
+  // packed"). Opting in via VORTEX_DEV_UPDATER=1 makes it read
+  // dev-app-update.yml (in src/main) instead, so check/notify/download can be
+  // exercised against the mock feed. Installs stay packaged-only regardless.
+  if (!app.isPackaged && process.env.VORTEX_DEV_UPDATER === "1") {
+    autoUpdater.forceDevUpdateConfig = true;
+    log("info", "Dev updater enabled (forceDevUpdateConfig, dev-app-update.yml)");
+  }
+
   // Error handler
   autoUpdater.on("error", (err) => {
     const message = getErrorMessageOrDefault(err);
@@ -227,8 +239,9 @@ export function setupAutoUpdater(installType: string): void {
     lastBroadcastPercent = -1;
     broadcastStatus();
 
-    // Set up auto-install on quit (unless dev mode)
-    if (process.env.NODE_ENV !== "development") {
+    // Set up auto-install on quit (packaged builds only — an unpackaged run
+    // with the dev updater must never install what it downloaded)
+    if (process.env.NODE_ENV !== "development" && app.isPackaged) {
       autoUpdater.autoInstallOnAppQuit = true;
       app.on("before-quit", showUpdateWarning);
       log("info", "Auto-install on quit enabled");

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -211,6 +211,18 @@ export function setupAutoUpdater(installType: string): void {
     updateStatus.available = true;
     updateStatus.version = info.version;
     updateStatus.error = undefined;
+    // A previously downloaded installer belongs to the version it was
+    // downloaded for; advertising a different version with downloaded:true
+    // would offer "Restart & Install" for a build that isn't on disk.
+    // Re-advertising the downloaded version (e.g. switching a channel back)
+    // restores it.
+    if (info.version !== downloadedVersion) {
+      updateStatus.downloaded = false;
+      updateStatus.downloadProgress = undefined;
+    } else if (downloadedVersion != null) {
+      updateStatus.downloaded = true;
+      updateStatus.downloadProgress = 100;
+    }
     // The generic feed's latest.yml carries no release notes; the resolver
     // collects them from the GitHub releases instead.
     if (lastResolved?.notesHtml != null) {
@@ -240,11 +252,16 @@ export function setupAutoUpdater(installType: string): void {
 
   // Track whether to auto-install after download
   let installAfterDownloadFlag = false;
+  // The version the downloaded installer actually contains; the downloaded
+  // flag is only meaningful for this version.
+  let downloadedVersion: string | null = null;
 
   // Update downloaded
   autoUpdater.on("update-downloaded", (updateInfo: UpdateInfo) => {
     log("info", "Update downloaded", { version: updateInfo.version });
+    downloadedVersion = updateInfo.version;
     updateStatus.downloaded = true;
+    updateStatus.version = updateInfo.version;
     updateStatus.downloadProgress = 100;
     lastBroadcastPercent = -1;
     broadcastStatus();
@@ -431,9 +448,17 @@ export function setupAutoUpdater(installType: string): void {
     // Already downloaded: don't re-fetch the full installer. Re-issuing
     // downloadUpdate when the file is already present can resolve without
     // re-emitting "update-downloaded", which would strand the install request.
-    // Install directly instead.
-    if (updateStatus.downloaded) {
-      log("info", "Update already downloaded, skipping re-download");
+    // Install directly instead — but only when the installer on disk is the
+    // version currently being offered; a channel switch can leave a stale
+    // download for a different version.
+    if (
+      updateStatus.downloaded &&
+      downloadedVersion != null &&
+      downloadedVersion === updateStatus.version
+    ) {
+      log("info", "Update already downloaded, skipping re-download", {
+        version: downloadedVersion,
+      });
       if (installAfterDownload) {
         attemptInstall();
       }

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -664,6 +664,18 @@ export function setupAutoUpdater(installType: string): void {
   });
 
   betterIpcMain.on("updater:check-for-updates", (_event, channel, manual) => {
+    // A check would only re-resolve the version already downloading, while
+    // the library kept downloading underneath a state that no longer said
+    // so. The download's own notification is the feedback here; the Settings
+    // button is disabled for the same reason. Channel switches are different
+    // (they cancel the download first) and take the set-channel path.
+    if (current.type === "downloading") {
+      log("info", "Update check skipped, a download is running", {
+        version: current.version,
+        manual,
+      });
+      return;
+    }
     checkForUpdates(channel, manual);
   });
 

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -30,11 +30,16 @@ import {
 } from "./releaseResolver";
 
 /**
- * Show warning dialog before update installs on quit.
- * Prevents users from turning off computer during installation.
+ * Warn once, non-blocking, that the downloaded update installs on quit.
+ * The old implementation used showMessageBoxSync in before-quit: it blocked
+ * the quitting main process (the dialog could not be dismissed) and the
+ * handler was never removed, so every re-entered quit attempt stacked
+ * another modal — an unkillable dialog loop in the field.
  */
 function showUpdateWarning() {
-  dialog.showMessageBoxSync({
+  // one-shot: quit processing can re-fire before-quit
+  app.removeListener("before-quit", showUpdateWarning);
+  void dialog.showMessageBox({
     type: "info",
     title: "Vortex update",
     message:

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -138,20 +138,9 @@ export function setupAutoUpdater(installType: string): void {
   }
 
   function statusSnapshot(): UpdateStatus {
-    return {
-      available: updateStatus.available,
-      downloaded: updateStatus.downloaded,
-      version: updateStatus.version,
-      releaseNotes: updateStatus.releaseNotes,
-      downloadProgress: updateStatus.downloadProgress,
-      error: updateStatus.error,
-      downgrade: updateStatus.downgrade,
-      downgrading: updateStatus.downgrading,
-      checking: updateStatus.checking,
-      manual: updateStatus.manual,
-      patch: updateStatus.patch,
-      justUpdatedFrom: updateStatus.justUpdatedFrom,
-    };
+    // updateStatus holds only serializable scalars; a spread can't silently
+    // drop a newly added field the way a hand-maintained list can
+    return { ...updateStatus };
   }
 
   // Push the current status to every window; the renderer reacts to these
@@ -169,22 +158,38 @@ export function setupAutoUpdater(installType: string): void {
   // Release notes for the update the app just went through — the renderer's
   // post-update "View changes". The resolver collects body_html of releases
   // above the given version, so resolving from the pre-update version yields
-  // exactly the versions this update covered.
-  betterIpcMain.handle("updater:get-update-changelog", async (): Promise<string | null> => {
-    const previous = updateStatus.justUpdatedFrom;
-    if (previous == null) {
-      return null;
-    }
-    try {
-      const resolvedRelease = await resolveUpdate(toResolveChannel(updateChannel), previous);
-      return resolvedRelease?.notesHtml ?? null;
-    } catch (err) {
-      log("warn", "Failed to fetch post-update changelog", {
-        error: getErrorMessageOrDefault(err),
-      });
-      return null;
-    }
-  });
+  // exactly the versions this update covered. The renderer supplies its
+  // persisted channel: this handler is clickable before the first check has
+  // set updateChannel, which would otherwise default beta users to stable
+  // notes. Cached so repeat clicks don't share rate-limit fate with real
+  // update checks.
+  let changelogCache: { channel: string; notes: string | null } | null = null;
+  betterIpcMain.handle(
+    "updater:get-update-changelog",
+    async (_event, channel: string): Promise<string | null> => {
+      const previous = updateStatus.justUpdatedFrom;
+      if (previous == null) {
+        return null;
+      }
+      const resolveChannel = toResolveChannel(channel);
+      if (changelogCache != null && changelogCache.channel === resolveChannel) {
+        return changelogCache.notes;
+      }
+      try {
+        const resolvedRelease = await resolveUpdate(resolveChannel, previous);
+        const notes = resolvedRelease?.notesHtml ?? null;
+        if (notes != null) {
+          changelogCache = { channel: resolveChannel, notes };
+        }
+        return notes;
+      } catch (err) {
+        log("warn", "Failed to fetch post-update changelog", {
+          error: getErrorMessageOrDefault(err),
+        });
+        return null;
+      }
+    },
+  );
 
   // Surface "Vortex was updated" on the first launch after an update: the
   // renderer store persists appVersion each run, so at startup it still holds
@@ -399,10 +404,6 @@ export function setupAutoUpdater(installType: string): void {
         lastResolved = null;
         return { verdict, release: resolved };
       }
-      // Classify before the feed apply: the library's update-available fires
-      // during it, and the renderer needs the patch flag in that broadcast
-      // (patch updates auto-download and get their own quieter notification).
-      updateStatus.patch = shouldAutoDownload(currentVersion, resolved.version, installType);
       return applyResolvedFeed(resolved, generation).then(() => ({
         verdict: "upgrade" as const,
         release: resolved,
@@ -462,6 +463,11 @@ export function setupAutoUpdater(installType: string): void {
           return;
         }
         const resolved = outcome.release;
+        // Classify for the renderer: patch updates auto-download and get
+        // quieter notifications. Only the winning generation writes the flag
+        // (this block already returned above when superseded), so a slow
+        // stale check can't relabel a different offer.
+        updateStatus.patch = shouldAutoDownload(currentVersion, resolved.version, installType);
         broadcastStatus();
         log("info", "Update check completed", { version: resolved.version });
 
@@ -549,6 +555,7 @@ export function setupAutoUpdater(installType: string): void {
     const generation = ++checkGeneration;
     updateStatus.checking = true;
     updateStatus.manual = false; // a download is not a check
+    updateStatus.patch = undefined; // user-initiated, never the patch auto-flow
     lastBroadcastPercent = -1;
     broadcastStatus();
     resolveAndApply(channel, generation)
@@ -560,6 +567,16 @@ export function setupAutoUpdater(installType: string): void {
         if (outcome.verdict !== "upgrade") {
           throw new Error("no newer release available to download");
         }
+        if (generation !== checkGeneration) {
+          // superseded by a newer check/download: that flow owns the updater
+          // now, and downloading here could ride a downgrade's temporarily
+          // raised allowDowngrade
+          log("info", "Download superseded by a newer check, not downloading");
+          return;
+        }
+        // a user download never legitimately needs the downgrade override; a
+        // superseded downgrade flow may still be mid-feed-apply with it raised
+        autoUpdater.allowDowngrade = false;
         return autoUpdater.downloadUpdate();
       })
       .catch((unknownErr) => {
@@ -616,10 +633,14 @@ export function setupAutoUpdater(installType: string): void {
       })
       .then(() => {
         autoUpdater.allowDowngrade = false;
-        if (generation === checkGeneration) {
-          updateStatus.checking = false;
-          broadcastStatus();
+        if (generation !== checkGeneration) {
+          // a newer check superseded the confirmed downgrade mid-apply;
+          // downloading now would fight that flow over the shared updater
+          log("info", "Downgrade download superseded by a newer check, not downloading");
+          return;
         }
+        updateStatus.checking = false;
+        broadcastStatus();
         return autoUpdater.downloadUpdate();
       })
       .catch((unknownErr) => {
@@ -628,6 +649,11 @@ export function setupAutoUpdater(installType: string): void {
         log("error", "Downgrade download failed", { error: err.message });
         updateStatus.error = err.message;
         updateStatus.downgrading = undefined;
+        // Without the offer (consumed above) the failed target must not be
+        // left advertised: the renderer would present the older version as a
+        // regular available update whose Download can only ever fail.
+        updateStatus.available = false;
+        updateStatus.version = undefined;
         installAfterDownloadFlag = false;
         if (generation === checkGeneration) {
           updateStatus.checking = false;

--- a/src/main/src/extensions/autoupdater/index.ts
+++ b/src/main/src/extensions/autoupdater/index.ts
@@ -479,7 +479,19 @@ export function setupAutoUpdater(installType: string): void {
           return; // superseded by a newer check; let that one own the state
         }
         if (outcome.verdict === "none") {
-          setState({ type: "idle" });
+          // A staged downgrade the user already confirmed survives checks
+          // that (correctly) ignore the lower version — settling to idle
+          // would orphan the downloaded installer and silently disarm its
+          // install-on-quit.
+          if (
+            before.type === "staged" &&
+            before.kind === "downgrade" &&
+            downloadedVersion === before.version
+          ) {
+            setState(before);
+          } else {
+            setState({ type: "idle" });
+          }
           return;
         }
         if (outcome.verdict === "downgrade-offer") {
@@ -506,13 +518,14 @@ export function setupAutoUpdater(installType: string): void {
         }
 
         // Patch updates auto-download for regular installs; minor/major
-        // updates wait for a user decision.
+        // updates wait for a user decision. A patch found by a MANUAL check
+        // downloads visibly — the user's press set it in motion.
         if (kindFor(resolved.version) === "patch") {
           log("info", "Patch update detected, auto-downloading", {
             from: currentVersion,
             to: resolved.version,
           });
-          setState({ type: "downloading", version: resolved.version, kind: "patch" });
+          setState({ type: "downloading", version: resolved.version, kind: "patch", manual });
           autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
             // state transition owned by the "error" event handler
             log("warn", "Auto-download failed", { error: getErrorMessageOrDefault(err) });
@@ -630,7 +643,7 @@ export function setupAutoUpdater(installType: string): void {
     // ETag cache makes the repeat lookup cheap.
     const generation = ++checkGeneration;
     if (requestedVersion != null) {
-      setState({ type: "downloading", version: requestedVersion, kind: "update" });
+      setState({ type: "downloading", version: requestedVersion, kind: "update", manual: true });
     } else {
       setState({ type: "checking", manual: true });
     }
@@ -650,7 +663,12 @@ export function setupAutoUpdater(installType: string): void {
         // superseded downgrade flow may still be mid-feed-apply with it raised
         autoUpdater.allowDowngrade = false;
         if (current.type !== "downloading" || current.version !== outcome.release.version) {
-          setState({ type: "downloading", version: outcome.release.version, kind: "update" });
+          setState({
+            type: "downloading",
+            version: outcome.release.version,
+            kind: "update",
+            manual: true,
+          });
         }
         return autoUpdater.downloadUpdate();
       })
@@ -689,7 +707,7 @@ export function setupAutoUpdater(installType: string): void {
     installAfterDownloadFlag = installAfterDownload;
     const generation = ++checkGeneration;
     // press feedback: the confirm is visible immediately
-    setState({ type: "downloading", version: target.version, kind: "downgrade" });
+    setState({ type: "downloading", version: target.version, kind: "downgrade", manual: true });
 
     // One-shot marker so the next launch's "Downgrade detected" warning is
     // suppressed for the version the user knowingly chose. Written before

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -57,7 +57,7 @@ describe("pickRelease", () => {
   it("picks max semver per channel from date-interleaved releases", () => {
     expect(pickRelease(fixture, "stable")?.tag_name).toBe("v2.5.0");
     expect(pickRelease(fixture, "beta")?.tag_name).toBe("v2.6.0-beta.1");
-    expect(classifyUpdate("2.5.0-beta.2", "2.5.0", { switchToStable: false })).toBe("upgrade");
+    expect(classifyUpdate("2.5.0-beta.2", "2.5.0", { stableChannel: false })).toBe("upgrade");
   });
 
   it("prefers a newer stable over an older beta on the beta channel", () => {
@@ -101,19 +101,19 @@ describe("pickRelease", () => {
   it("returns null for empty or all-draft lists", () => {
     expect(pickRelease([], "stable")).toBeNull();
     expect(pickRelease([release({ tag_name: "v1.0.0", draft: true })], "beta")).toBeNull();
-    expect(classifyUpdate("2.5.0", null, { switchToStable: false })).toBe("none");
+    expect(classifyUpdate("2.5.0", null, { stableChannel: false })).toBe("none");
   });
 });
 
 describe("classifyUpdate", () => {
   it("classifies equal, newer, and older versions", () => {
-    expect(classifyUpdate("2.5.0", "2.5.0", { switchToStable: false })).toBe("none");
-    expect(classifyUpdate("2.5.0", "2.6.0", { switchToStable: false })).toBe("upgrade");
-    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: false })).toBe("none");
-    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: true })).toBe(
+    expect(classifyUpdate("2.5.0", "2.5.0", { stableChannel: false })).toBe("none");
+    expect(classifyUpdate("2.5.0", "2.6.0", { stableChannel: false })).toBe("upgrade");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { stableChannel: false })).toBe("none");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { stableChannel: true })).toBe(
       "downgrade-offer",
     );
-    expect(classifyUpdate("garbage", "2.5.0", { switchToStable: true })).toBe("none");
+    expect(classifyUpdate("garbage", "2.5.0", { stableChannel: true })).toBe("none");
   });
 });
 

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -140,6 +140,10 @@ describe("repoForChannel", () => {
 describe("resolveUpdate fetching", () => {
   beforeEach(() => {
     vi.stubEnv("IS_PREVIEW_BUILD", "");
+    // a developer machine may have the mock-feed overrides persisted in the
+    // user environment; tests must never depend on ambient env
+    vi.stubEnv("VORTEX_UPDATER_API_BASE", "");
+    vi.stubEnv("VORTEX_UPDATER_DOWNLOAD_BASE", "");
   });
 
   it("resolves the picked release with download url and collected notes", async () => {

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -57,7 +57,7 @@ describe("pickRelease", () => {
   it("picks max semver per channel from date-interleaved releases", () => {
     expect(pickRelease(fixture, "stable")?.tag_name).toBe("v2.5.0");
     expect(pickRelease(fixture, "beta")?.tag_name).toBe("v2.6.0-beta.1");
-    expect(classifyUpdate("2.5.0-beta.2", "2.5.0", { stableChannel: false })).toBe("upgrade");
+    expect(classifyUpdate("2.5.0-beta.2", "2.5.0", { switchToStable: false })).toBe("upgrade");
   });
 
   it("prefers a newer stable over an older beta on the beta channel", () => {
@@ -101,19 +101,19 @@ describe("pickRelease", () => {
   it("returns null for empty or all-draft lists", () => {
     expect(pickRelease([], "stable")).toBeNull();
     expect(pickRelease([release({ tag_name: "v1.0.0", draft: true })], "beta")).toBeNull();
-    expect(classifyUpdate("2.5.0", null, { stableChannel: false })).toBe("none");
+    expect(classifyUpdate("2.5.0", null, { switchToStable: false })).toBe("none");
   });
 });
 
 describe("classifyUpdate", () => {
   it("classifies equal, newer, and older versions", () => {
-    expect(classifyUpdate("2.5.0", "2.5.0", { stableChannel: false })).toBe("none");
-    expect(classifyUpdate("2.5.0", "2.6.0", { stableChannel: false })).toBe("upgrade");
-    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { stableChannel: false })).toBe("none");
-    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { stableChannel: true })).toBe(
+    expect(classifyUpdate("2.5.0", "2.5.0", { switchToStable: false })).toBe("none");
+    expect(classifyUpdate("2.5.0", "2.6.0", { switchToStable: false })).toBe("upgrade");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: false })).toBe("none");
+    expect(classifyUpdate("2.6.0-beta.1", "2.5.0", { switchToStable: true })).toBe(
       "downgrade-offer",
     );
-    expect(classifyUpdate("garbage", "2.5.0", { stableChannel: true })).toBe("none");
+    expect(classifyUpdate("garbage", "2.5.0", { switchToStable: true })).toBe("none");
   });
 });
 

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 describe("pickRelease", () => {
   // Regression pin for the shipped bug: electron-updater 4.6.5 walked the
   // atom feed by publish date, so beta users on 2.5.0-beta.2 were offered the
-  // older stable 2.4.2 (published later) as an "update" — a bogus downgrade.
+  // older stable 2.4.2 (published later) as an "update", a bogus downgrade.
   it("picks max semver per channel from date-interleaved releases", () => {
     expect(pickRelease(fixture, "stable")?.tag_name).toBe("v2.5.0");
     expect(pickRelease(fixture, "beta")?.tag_name).toBe("v2.6.0-beta.1");

--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -10,6 +10,7 @@ import {
   pickRelease,
   RateLimitError,
   repoForChannel,
+  repoOwner,
   resolveUpdate,
   shouldAutoDownload,
 } from "./releaseResolver";
@@ -130,9 +131,22 @@ describe("shouldAutoDownload", () => {
 
 describe("repoForChannel", () => {
   it("selects the staging repo only for preview builds", () => {
+    vi.stubEnv("VORTEX_UPDATER_REPO", "");
     vi.stubEnv("IS_PREVIEW_BUILD", "");
     expect(repoForChannel()).toBe("Vortex");
     vi.stubEnv("IS_PREVIEW_BUILD", "true");
+    expect(repoForChannel()).toBe("Vortex-Staging");
+  });
+
+  // Test override for the staging rehearsal: a scratch repo with real GitHub
+  // semantics, so live repos are never touched by tests.
+  it("honors the VORTEX_UPDATER_REPO override", () => {
+    vi.stubEnv("IS_PREVIEW_BUILD", "true");
+    vi.stubEnv("VORTEX_UPDATER_REPO", "someuser/updater-e2e");
+    expect(repoOwner()).toBe("someuser");
+    expect(repoForChannel()).toBe("updater-e2e");
+    vi.stubEnv("VORTEX_UPDATER_REPO", "");
+    expect(repoOwner()).toBe("Nexus-Mods");
     expect(repoForChannel()).toBe("Vortex-Staging");
   });
 });
@@ -144,6 +158,7 @@ describe("resolveUpdate fetching", () => {
     // user environment; tests must never depend on ambient env
     vi.stubEnv("VORTEX_UPDATER_API_BASE", "");
     vi.stubEnv("VORTEX_UPDATER_DOWNLOAD_BASE", "");
+    vi.stubEnv("VORTEX_UPDATER_REPO", "");
   });
 
   it("resolves the picked release with download url and collected notes", async () => {

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -120,13 +120,15 @@ export function pickRelease(
 
 /**
  * Classify what the resolved version means relative to the running version.
- * A lower version is only ever surfaced as a "downgrade-offer" when the user
- * explicitly switched to the stable channel; background checks ignore it.
+ * A lower version is only ever surfaced as a "downgrade-offer" for checks on
+ * the stable channel (the user chose stable while running something newer);
+ * checks on prerelease channels ignore it — offering it there unasked is the
+ * old field bug.
  */
 export function classifyUpdate(
   currentVersion: string,
   resolvedVersion: string | null,
-  opts: { switchToStable: boolean },
+  opts: { stableChannel: boolean },
 ): "upgrade" | "downgrade-offer" | "none" {
   const current = semver.valid(currentVersion);
   if (current == null) {
@@ -139,7 +141,7 @@ export function classifyUpdate(
   if (semver.gt(resolvedVersion, current)) {
     return "upgrade";
   }
-  return opts.switchToStable ? "downgrade-offer" : "none";
+  return opts.stableChannel ? "downgrade-offer" : "none";
 }
 
 /**

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -4,7 +4,7 @@
  * electron-updater's GitHub provider walks the releases atom feed in
  * publish-date order, so a stable hotfix published after a beta gets offered
  * to beta users as "the latest version". This module resolves the target
- * release ourselves — GitHub REST API, filter, max semver per channel — and
+ * release ourselves (GitHub REST API, filter, max semver per channel) and
  * the updater is then pointed at that release's assets via a generic feed.
  *
  * Must stay loadable in plain node (vitest): no electron imports.
@@ -80,7 +80,7 @@ function versionFromTag(tag: string): string | null {
 }
 
 // The prerelease flag and the version suffix are two signals for the same
-// fact; when they disagree the release was mispublished — don't trust it.
+// fact; when they disagree the release was mispublished, don't trust it.
 // (The whole 1.x era trips this: odd-minor betas were flagged prerelease with
 // no version suffix, so this is summarized once per fetch, not warned per tag.)
 function hasMismatchedPrereleaseFlag(release: GithubReleaseLite): boolean {
@@ -136,7 +136,7 @@ export function pickRelease(
 /**
  * Classify what the resolved version means relative to the running version.
  * A lower version is only ever surfaced as a "downgrade-offer" when the user
- * explicitly switched to the stable channel; background checks ignore it —
+ * explicitly switched to the stable channel; background checks ignore it;
  * offering it unasked is the old field bug.
  */
 export function classifyUpdate(
@@ -296,7 +296,7 @@ async function fetchReleases(repo: string): Promise<GithubReleaseLite[]> {
 
 /**
  * Resolve the update target for a channel. Returns null when no eligible
- * release exists. Network and rate-limit errors propagate — the caller logs
+ * release exists. Network and rate-limit errors propagate, the caller logs
  * and skips the check, same as being offline.
  */
 export async function resolveUpdate(

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -120,15 +120,14 @@ export function pickRelease(
 
 /**
  * Classify what the resolved version means relative to the running version.
- * A lower version is only ever surfaced as a "downgrade-offer" for checks on
- * the stable channel (the user chose stable while running something newer);
- * checks on prerelease channels ignore it — offering it there unasked is the
- * old field bug.
+ * A lower version is only ever surfaced as a "downgrade-offer" when the user
+ * explicitly switched to the stable channel; background checks ignore it —
+ * offering it unasked is the old field bug.
  */
 export function classifyUpdate(
   currentVersion: string,
   resolvedVersion: string | null,
-  opts: { stableChannel: boolean },
+  opts: { switchToStable: boolean },
 ): "upgrade" | "downgrade-offer" | "none" {
   const current = semver.valid(currentVersion);
   if (current == null) {
@@ -141,7 +140,7 @@ export function classifyUpdate(
   if (semver.gt(resolvedVersion, current)) {
     return "upgrade";
   }
-  return opts.stableChannel ? "downgrade-offer" : "none";
+  return opts.switchToStable ? "downgrade-offer" : "none";
 }
 
 /**

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -55,7 +55,22 @@ function downloadBase(): string {
 }
 
 export function repoForChannel(): string {
+  // Test override ("owner/repo"): lets the staging rehearsal run against a
+  // scratch repo with real GitHub semantics instead of the live repos (see
+  // docs/updater-testing.md and scripts/updater-e2e-staging.mjs).
+  const override = process.env.VORTEX_UPDATER_REPO;
+  if (override != null && override !== "") {
+    return override.includes("/") ? override.split("/")[1]! : override;
+  }
   return process.env.IS_PREVIEW_BUILD === "true" ? "Vortex-Staging" : "Vortex";
+}
+
+export function repoOwner(): string {
+  const override = process.env.VORTEX_UPDATER_REPO;
+  if (override != null && override.includes("/")) {
+    return override.split("/")[0]!;
+  }
+  return OWNER;
 }
 
 // Build metadata compares equal under semver (2.5.0+build == 2.5.0); ties in
@@ -242,7 +257,7 @@ function nextPageUrl(linkHeader: string | null): string | null {
 
 async function fetchReleases(repo: string): Promise<GithubReleaseLite[]> {
   const releases: GithubReleaseLite[] = [];
-  let url: string | null = `${apiBase()}/repos/${OWNER}/${repo}/releases?per_page=100`;
+  let url: string | null = `${apiBase()}/repos/${repoOwner()}/${repo}/releases?per_page=100`;
   let pages = 0;
 
   while (url != null && pages < MAX_PAGES) {
@@ -311,7 +326,7 @@ export async function resolveUpdate(
     tag: picked.tag_name,
     version: pickedVersion,
     prerelease: picked.prerelease,
-    downloadBaseUrl: `${downloadBase()}/${OWNER}/${repo}/releases/download/${picked.tag_name}`,
+    downloadBaseUrl: `${downloadBase()}/${repoOwner()}/${repo}/releases/download/${picked.tag_name}`,
     notesHtml: notes.length > 0 ? notes.join("\n\n") : undefined,
   };
 }

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -64,12 +64,20 @@ function versionFromTag(tag: string): string | null {
   return semver.valid(tag.replace(/^v/, ""));
 }
 
+// The prerelease flag and the version suffix are two signals for the same
+// fact; when they disagree the release was mispublished — don't trust it.
+// (The whole 1.x era trips this: odd-minor betas were flagged prerelease with
+// no version suffix, so this is summarized once per fetch, not warned per tag.)
+function hasMismatchedPrereleaseFlag(release: GithubReleaseLite): boolean {
+  const version = versionFromTag(release.tag_name);
+  return version != null && release.prerelease !== (semver.prerelease(version) != null);
+}
+
 function isEligible(release: GithubReleaseLite): boolean {
   if (release.draft) {
     return false;
   }
-  const version = versionFromTag(release.tag_name);
-  if (version == null) {
+  if (versionFromTag(release.tag_name) == null) {
     return false;
   }
   const hasUpdateAssets = release.assets.some(
@@ -78,17 +86,7 @@ function isEligible(release: GithubReleaseLite): boolean {
   if (!hasUpdateAssets) {
     return false;
   }
-  // The prerelease flag and the version suffix are two signals for the same
-  // fact; when they disagree the release was mispublished — don't trust it.
-  const hasPrereleaseSuffix = semver.prerelease(version) != null;
-  if (release.prerelease !== hasPrereleaseSuffix) {
-    log("warn", "Release prerelease flag disagrees with its version suffix, skipping", {
-      tag: release.tag_name,
-      prerelease: release.prerelease,
-    });
-    return false;
-  }
-  return true;
+  return !hasMismatchedPrereleaseFlag(release);
 }
 
 function candidatesForChannel(
@@ -263,7 +261,18 @@ async function fetchReleases(repo: string): Promise<GithubReleaseLite[]> {
   }
 
   if (url != null) {
-    log("warn", "Release listing truncated at page cap", { repo, pages });
+    // expected on the main repo (300+ historical releases); newest releases
+    // are always on page 1, so this never affects the max-semver pick
+    log("debug", "Release listing truncated at page cap", { repo, pages });
+  }
+
+  const mismatched = releases.filter(hasMismatchedPrereleaseFlag);
+  if (mismatched.length > 0) {
+    log("info", "Skipping releases whose prerelease flag disagrees with the version suffix", {
+      repo,
+      count: mismatched.length,
+      sample: mismatched.slice(0, 3).map((release) => release.tag_name),
+    });
   }
 
   return releases;

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -124,6 +124,12 @@ try {
       downloadUpdate: (channel: string, installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download", channel, installAfterDownload),
       restartAndInstall: () => betterIpcRenderer.send("updater:restart-and-install"),
+      onStatusChanged: (callback) => {
+        const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) =>
+          callback(status);
+        ipcRenderer.on("updater:status-changed", listener);
+        return () => ipcRenderer.removeListener("updater:status-changed", listener);
+      },
     },
 
     dialog: {

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -124,6 +124,8 @@ try {
       downloadUpdate: (channel: string, installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download", channel, installAfterDownload),
       restartAndInstall: () => betterIpcRenderer.send("updater:restart-and-install"),
+      downloadDowngrade: (installAfterDownload: boolean = false) =>
+        betterIpcRenderer.send("updater:download-downgrade", installAfterDownload),
       onStatusChanged: (callback) => {
         const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) =>
           callback(status);

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -117,7 +117,8 @@ try {
 
     updater: {
       getStatus: () => betterIpcRenderer.invoke("updater:get-status"),
-      getUpdateChangelog: () => betterIpcRenderer.invoke("updater:get-update-changelog"),
+      getUpdateChangelog: (channel: string) =>
+        betterIpcRenderer.invoke("updater:get-update-changelog", channel),
       setChannel: (channel: string, manual: boolean) =>
         betterIpcRenderer.send("updater:set-channel", channel, manual),
       checkForUpdates: (channel: string, manual: boolean) =>

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -116,7 +116,7 @@ try {
     },
 
     updater: {
-      getStatus: () => betterIpcRenderer.invoke("updater:get-status"),
+      getStatus: (since?: number) => betterIpcRenderer.invoke("updater:get-status", since),
       getUpdateChangelog: (channel: string) =>
         betterIpcRenderer.invoke("updater:get-update-changelog", channel),
       setChannel: (channel: string, manual: boolean) =>
@@ -129,12 +129,6 @@ try {
       downloadDowngrade: (installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download-downgrade", installAfterDownload),
       declineDowngrade: () => betterIpcRenderer.send("updater:decline-downgrade"),
-      onStatusChanged: (callback) => {
-        const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) =>
-          callback(status);
-        ipcRenderer.on("updater:status-changed", listener);
-        return () => ipcRenderer.removeListener("updater:status-changed", listener);
-      },
     },
 
     dialog: {

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -129,6 +129,7 @@ try {
       downloadDowngrade: (installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download-downgrade", installAfterDownload),
       declineDowngrade: () => betterIpcRenderer.send("updater:decline-downgrade"),
+      cancelDownload: () => betterIpcRenderer.send("updater:cancel-download"),
     },
 
     dialog: {

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -117,6 +117,7 @@ try {
 
     updater: {
       getStatus: () => betterIpcRenderer.invoke("updater:get-status"),
+      getUpdateChangelog: () => betterIpcRenderer.invoke("updater:get-update-changelog"),
       setChannel: (channel: string, manual: boolean) =>
         betterIpcRenderer.send("updater:set-channel", channel, manual),
       checkForUpdates: (channel: string, manual: boolean) =>
@@ -126,6 +127,7 @@ try {
       restartAndInstall: () => betterIpcRenderer.send("updater:restart-and-install"),
       downloadDowngrade: (installAfterDownload: boolean = false) =>
         betterIpcRenderer.send("updater:download-downgrade", installAfterDownload),
+      declineDowngrade: () => betterIpcRenderer.send("updater:decline-downgrade"),
       onStatusChanged: (callback) => {
         const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) =>
           callback(status);

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -28,7 +28,8 @@ interface IActionProps {
 
 interface ISettingsUpdateState {
   checkUpdateButtonDisabled: boolean;
-  checking: boolean;
+  // what the updater is doing right now, if anything; the button waits it out
+  busy: "checking" | "downloading" | null;
 }
 
 type IProps = IActionProps & IConnectedProps;
@@ -44,7 +45,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
 
     this.initState({
       checkUpdateButtonDisabled: false,
-      checking: false,
+      busy: null,
     });
   }
 
@@ -53,11 +54,13 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
     // label reflects the updater's actual state (read from the extension's
     // status poller), not a blind timer
     const poller = getUpdaterStatus();
-    const isManualChecking = (snapshot: UpdaterSnapshot | undefined) =>
-      snapshot?.state.type === "checking" && snapshot.state.manual;
-    this.nextState.checking = isManualChecking(poller?.current()) === true;
+    const busyFor = (snapshot: UpdaterSnapshot | undefined): ISettingsUpdateState["busy"] =>
+      snapshot?.state.type === "checking" || snapshot?.state.type === "downloading"
+        ? snapshot.state.type
+        : null;
+    this.nextState.busy = busyFor(poller?.current());
     this.unsubscribeStatus = poller?.subscribe((snapshot) => {
-      this.nextState.checking = isManualChecking(snapshot) === true;
+      this.nextState.busy = busyFor(snapshot);
     });
   }
 
@@ -99,7 +102,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
   public render(): JSX.Element {
     const { t, installType, updateChannel } = this.props;
 
-    const { checkUpdateButtonDisabled, checking } = this.state;
+    const { checkUpdateButtonDisabled, busy } = this.state;
 
     // managed or development
     if (installType === "managed") {
@@ -154,10 +157,14 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
 
               <Button
                 brand="neutral"
-                disabled={checkUpdateButtonDisabled || checking}
+                disabled={checkUpdateButtonDisabled || busy !== null}
                 onClick={this.manualUpdateCheck}
               >
-                {checking ? t("Checking...") : t("Check now")}
+                {busy === "checking"
+                  ? t("Checking...")
+                  : busy === "downloading"
+                    ? t("Downloading...")
+                    : t("Check now")}
               </Button>
             </div>
 

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -1,3 +1,4 @@
+import type { UpdaterSnapshot } from "@vortex/shared/ipc";
 import * as React from "react";
 import { FormGroup } from "react-bootstrap";
 import type * as Redux from "redux";
@@ -14,6 +15,7 @@ import { Typography } from "../../ui/components/typography/Typography";
 import Debouncer from "../../util/Debouncer";
 import { log } from "../../util/log";
 import { setUpdateChannel } from "./actions";
+import { getUpdaterStatus } from "./updaterStatus";
 
 interface IConnectedProps {
   updateChannel: UpdateChannel;
@@ -48,9 +50,14 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
 
   public componentDidMount(): void {
     // a pressed button gives feedback for as long as the work runs: the
-    // label reflects the updater's actual state, not a blind timer
-    this.unsubscribeStatus = window.api.updater.onStatusChanged((snapshot) => {
-      this.nextState.checking = snapshot.state.type === "checking" && snapshot.state.manual;
+    // label reflects the updater's actual state (read from the extension's
+    // status poller), not a blind timer
+    const poller = getUpdaterStatus();
+    const isManualChecking = (snapshot: UpdaterSnapshot | undefined) =>
+      snapshot?.state.type === "checking" && snapshot.state.manual;
+    this.nextState.checking = isManualChecking(poller?.current()) === true;
+    this.unsubscribeStatus = poller?.subscribe((snapshot) => {
+      this.nextState.checking = isManualChecking(snapshot) === true;
     });
   }
 
@@ -181,6 +188,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
     // send what updateChannel you are on, unless it's none, then send stable. manual check as well
     const channel = this.props.updateChannel === "none" ? "stable" : this.props.updateChannel;
     window.api.updater.checkForUpdates(channel, true);
+    getUpdaterStatus()?.wake();
   };
 
   private selectChannel = (value: UpdateChannel) => {

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -26,6 +26,7 @@ interface IActionProps {
 
 interface ISettingsUpdateState {
   checkUpdateButtonDisabled: boolean;
+  checking: boolean;
 }
 
 type IProps = IActionProps & IConnectedProps;
@@ -34,12 +35,27 @@ const CHECK_UPDATE_INTERVAL = 60000;
 class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
   //static contextType = MainContext
 
+  private unsubscribeStatus: (() => void) | undefined;
+
   constructor(props) {
     super(props);
 
     this.initState({
       checkUpdateButtonDisabled: false,
+      checking: false,
     });
+  }
+
+  public componentDidMount(): void {
+    // a pressed button gives feedback for as long as the work runs: the
+    // label reflects the updater's actual state, not a blind timer
+    this.unsubscribeStatus = window.api.updater.onStatusChanged((snapshot) => {
+      this.nextState.checking = snapshot.state.type === "checking" && snapshot.state.manual;
+    });
+  }
+
+  public componentWillUnmount(): void {
+    this.unsubscribeStatus?.();
   }
 
   private checkUpdateDebouncer = new Debouncer(
@@ -76,7 +92,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
   public render(): JSX.Element {
     const { t, installType, updateChannel } = this.props;
 
-    const { checkUpdateButtonDisabled } = this.state;
+    const { checkUpdateButtonDisabled, checking } = this.state;
 
     // managed or development
     if (installType === "managed") {
@@ -112,7 +128,7 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
                 {t(
                   "You can choose to either receive automatic updates only after they went through some " +
                     "community testing (Stable) or to always get the newest features (Beta). Manual checking for updates is " +
-                    "restricted to every 10 minutes.",
+                    "restricted to once per minute.",
                 )}
               </More>
             </Typography>
@@ -131,10 +147,10 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
 
               <Button
                 brand="neutral"
-                disabled={checkUpdateButtonDisabled}
+                disabled={checkUpdateButtonDisabled || checking}
                 onClick={this.manualUpdateCheck}
               >
-                {t("Check now")}
+                {checking ? t("Checking...") : t("Check now")}
               </Button>
             </div>
 

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -20,6 +20,8 @@ import { getUpdaterStatus } from "./updaterStatus";
 interface IConnectedProps {
   updateChannel: UpdateChannel;
   installType: VortexInstallType;
+  // what the updater is doing right now, if anything; the button waits it out
+  busy: "checking" | "downloading" | null;
 }
 
 interface IActionProps {
@@ -28,8 +30,6 @@ interface IActionProps {
 
 interface ISettingsUpdateState {
   checkUpdateButtonDisabled: boolean;
-  // what the updater is doing right now, if anything; the button waits it out
-  busy: "checking" | "downloading" | null;
 }
 
 type IProps = IActionProps & IConnectedProps;
@@ -38,34 +38,12 @@ const CHECK_UPDATE_INTERVAL = 60000;
 class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
   //static contextType = MainContext
 
-  private unsubscribeStatus: (() => void) | undefined;
-
   constructor(props) {
     super(props);
 
     this.initState({
       checkUpdateButtonDisabled: false,
-      busy: null,
     });
-  }
-
-  public componentDidMount(): void {
-    // a pressed button gives feedback for as long as the work runs: the
-    // label reflects the updater's actual state (read from the extension's
-    // status poller), not a blind timer
-    const poller = getUpdaterStatus();
-    const busyFor = (snapshot: UpdaterSnapshot | undefined): ISettingsUpdateState["busy"] =>
-      snapshot?.state.type === "checking" || snapshot?.state.type === "downloading"
-        ? snapshot.state.type
-        : null;
-    this.nextState.busy = busyFor(poller?.current());
-    this.unsubscribeStatus = poller?.subscribe((snapshot) => {
-      this.nextState.busy = busyFor(snapshot);
-    });
-  }
-
-  public componentWillUnmount(): void {
-    this.unsubscribeStatus?.();
   }
 
   private checkUpdateDebouncer = new Debouncer(
@@ -100,9 +78,9 @@ class SettingsUpdate extends ComponentEx<IProps, ISettingsUpdateState> {
   }
 
   public render(): JSX.Element {
-    const { t, installType, updateChannel } = this.props;
+    const { t, installType, updateChannel, busy } = this.props;
 
-    const { checkUpdateButtonDisabled, busy } = this.state;
+    const { checkUpdateButtonDisabled } = this.state;
 
     // managed or development
     if (installType === "managed") {
@@ -254,10 +232,20 @@ Are you sure you want to turn off updates?`,
   };
 }
 
+// a pressed button gives feedback for as long as the work runs: the label
+// reflects the updater's actual state (polled into session.updater), not a
+// blind timer, and survives leaving and re-entering the page
+function busyFor(snapshot: UpdaterSnapshot | undefined): IConnectedProps["busy"] {
+  return snapshot?.state.type === "checking" || snapshot?.state.type === "downloading"
+    ? snapshot.state.type
+    : null;
+}
+
 function mapStateToProps(state: IState): IConnectedProps {
   return {
     updateChannel: state.settings.update.channel,
     installType: state.app.installType,
+    busy: busyFor(state.session.updater?.snapshot),
   };
 }
 

--- a/src/renderer/src/extensions/updater/SettingsUpdate.tsx
+++ b/src/renderer/src/extensions/updater/SettingsUpdate.tsx
@@ -191,8 +191,10 @@ Are you sure you want to switch to the Beta update channel?`,
           ],
         );
       } else if (newChannel === "stable") {
-        // stable or latest
         this.props.onSetUpdateChannel(newChannel);
+        // Switching to stable from a pre-release build means the latest
+        // stable may be older than what's running; the updater will offer
+        // that downgrade separately and explicitly.
       } else if (newChannel === "none") {
         // none
 

--- a/src/renderer/src/extensions/updater/actions.ts
+++ b/src/renderer/src/extensions/updater/actions.ts
@@ -1,3 +1,4 @@
+import type { UpdaterSnapshot } from "@vortex/shared/ipc";
 import * as reduxAct from "redux-act";
 
 import safeCreateAction from "../../actions/safeCreateAction";
@@ -7,3 +8,13 @@ import safeCreateAction from "../../actions/safeCreateAction";
  * currently either 'beta', 'stable' or 'none'
  */
 export const setUpdateChannel = safeCreateAction("SET_UPDATE_CHANNEL", (channel) => channel);
+
+/**
+ * the latest updater snapshot the renderer has polled from main, kept in
+ * session state so UI (the Settings page) reads it like any other state and
+ * keeps it across navigation
+ */
+export const setUpdaterSnapshot = safeCreateAction(
+  "SET_UPDATER_SNAPSHOT",
+  (snapshot: UpdaterSnapshot) => snapshot,
+);

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -14,8 +14,11 @@ interface FakeStatus {
   version?: string;
   releaseNotes?: string;
   downgrade?: boolean;
+  downgrading?: boolean;
   checking?: boolean;
   manual?: boolean;
+  patch?: boolean;
+  justUpdatedFrom?: string;
 }
 
 interface FakeNotification {
@@ -48,6 +51,7 @@ function makeContext() {
     settings: { update: { channel: "stable" } },
     session: { notifications: { notifications } },
   };
+  const showDialog = vi.fn().mockResolvedValue({ action: "Close" });
   const context = {
     registerReducer: vi.fn(),
     registerSettings: vi.fn(),
@@ -56,7 +60,7 @@ function makeContext() {
       getState: () => state,
       sendNotification,
       dismissNotification,
-      showDialog: vi.fn().mockResolvedValue({ action: "Close" }),
+      showDialog,
       onStateChange: vi.fn(),
       store: { getState: () => state },
     },
@@ -65,6 +69,7 @@ function makeContext() {
     context,
     sendNotification,
     dismissNotification,
+    showDialog,
     notifications,
     runOnce: () => onceCallbacks.forEach((cb) => cb()),
   };
@@ -74,9 +79,12 @@ function makeUpdaterApi(initialStatus: FakeStatus) {
   let statusListener: ((status: FakeStatus) => void) | undefined;
   const updater = {
     getStatus: vi.fn().mockResolvedValue(initialStatus),
+    getUpdateChangelog: vi.fn().mockResolvedValue(null),
     setChannel: vi.fn(),
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
+    downloadDowngrade: vi.fn(),
+    declineDowngrade: vi.fn(),
     restartAndInstall: vi.fn(),
     onStatusChanged: vi.fn((cb: (status: FakeStatus) => void) => {
       statusListener = cb;
@@ -99,14 +107,15 @@ afterEach(() => {
 });
 
 async function setup(initialStatus: FakeStatus = idleStatus) {
-  const { context, sendNotification, dismissNotification, notifications, runOnce } = makeContext();
+  const { context, sendNotification, dismissNotification, showDialog, notifications, runOnce } =
+    makeContext();
   const { updater, pushStatus } = makeUpdaterApi(initialStatus);
   vi.stubGlobal("window", { api: { updater } });
   init(context);
   runOnce();
   // let the initial getStatus sync settle
   await vi.advanceTimersByTimeAsync(0);
-  return { sendNotification, dismissNotification, notifications, updater, pushStatus };
+  return { sendNotification, dismissNotification, showDialog, notifications, updater, pushStatus };
 }
 
 describe("updater status handling", () => {
@@ -136,9 +145,9 @@ describe("updater status handling", () => {
     const second = sendNotification.mock.calls[1]![0];
     expect(second.id).toBe(first.id);
     expect(first.actions[1].title).toBe("Download");
-    expect(second.actions[1].title).toBe("Restart & Install");
-    // install-on-quit is disclosed once the download is staged
-    expect(second.message).toContain("will install when you close Vortex");
+    expect(first.message).toContain("available to download");
+    expect(second.actions[1].title).toBe("Restart Now");
+    expect(second.message).toContain("ready to install");
   });
 
   it("presents a downgrade status as an explicit downgrade offer, not an update", async () => {
@@ -151,6 +160,103 @@ describe("updater status handling", () => {
     expect(notification.id).toBe("vortex-downgrade-offer");
     expect(notification.type).toBe("warning");
     expect(notification.message).toContain("older");
+  });
+
+  // Field report: declining left the warning notification up and the offer
+  // armed in main — "Stay on current version" must actually reset both.
+  it("declining the downgrade dismisses the notification and tells main", async () => {
+    const { sendNotification, dismissNotification, showDialog, updater, pushStatus } =
+      await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    const offer = sendNotification.mock.calls[0]![0];
+
+    // open the downgrade dialog via the notification's More action
+    offer.actions![0]!.action(() => undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const buttons = showDialog.mock.calls[0]![3] as Array<{
+      label: string;
+      action?: () => void;
+    }>;
+    const stay = buttons.find((button) => button.label === "Stay on current version");
+    expect(stay?.action).toBeDefined();
+    stay!.action!();
+
+    expect(dismissNotification).toHaveBeenCalledWith("vortex-downgrade-offer");
+    expect(updater.declineDowngrade).toHaveBeenCalledTimes(1);
+    expect(updater.downloadDowngrade).not.toHaveBeenCalled();
+  });
+
+  it("confirming the downgrade downloads without an automatic restart", async () => {
+    const { sendNotification, showDialog, updater, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    sendNotification.mock.calls[0]![0].actions![0]!.action(() => undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const buttons = showDialog.mock.calls[0]![3] as Array<{
+      label: string;
+      action?: () => void;
+    }>;
+    buttons.find((button) => button.label === "Downgrade to 2.5.0")!.action!();
+
+    expect(updater.downloadDowngrade).toHaveBeenCalledWith(false);
+  });
+
+  // Field report: a confirmed downgrade was narrated as a regular update
+  // ("9.0.0 is available" with a Download button) while it was downloading.
+  it("presents a confirmed downgrade as a downgrade, then as ready to install", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrading: true });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const downloading = sendNotification.mock.calls[0]![0];
+    expect(downloading.id).toBe("vortex-update-available");
+    expect(downloading.message).toContain("Downgrading to Vortex 2.5.0");
+    // committed flow: nothing for the user to click while it downloads
+    expect(downloading.actions).toBeUndefined();
+
+    // once staged it reads like any other staged update, same buttons
+    pushStatus({ available: true, downloaded: true, version: "2.5.0", downgrading: true });
+    const downloaded = sendNotification.mock.calls[1]![0];
+    expect(downloaded.message).toContain("2.5.0 is ready to install");
+    expect(downloaded.actions![0]!.title).toBe("What's New");
+    expect(downloaded.actions![1]!.title).toBe("Restart Now");
+  });
+
+  it("keeps a patch update quiet until staged, then offers a restart", async () => {
+    const { sendNotification, updater, pushStatus } = await setup();
+
+    // auto-downloading: nothing to decide, no notification churn
+    pushStatus({ available: true, downloaded: false, version: "2.6.1", patch: true });
+    expect(sendNotification).not.toHaveBeenCalled();
+
+    pushStatus({ available: true, downloaded: true, version: "2.6.1", patch: true });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const notification = sendNotification.mock.calls[0]![0];
+    expect(notification.id).toBe("vortex-update-available");
+    expect(notification.message).toBe("Vortex will update the next time you restart");
+    expect(notification.actions).toHaveLength(1);
+    expect(notification.actions![0]!.title).toBe("Restart Now");
+
+    notification.actions![0]!.action(() => undefined);
+    expect(updater.restartAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a one-time 'was updated' notice on the first launch after an update", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
+    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
+
+    const updated = sendNotification.mock.calls.filter(
+      ([notification]) => notification.id === "vortex-updated",
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]![0].message).toContain("was updated to 2.6.0-beta.1");
+    expect(updated[0]![0].actions![0]!.title).toBe("View changes");
   });
 
   it("syncs the initial status via getStatus for checks that finished early", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -17,6 +17,7 @@ interface FakeNotification {
   id: string;
   type?: string;
   message?: string;
+  progress?: number;
   actions?: Array<{ title: string; action: (dismiss: () => void) => void }>;
 }
 
@@ -395,6 +396,64 @@ describe("updater status handling", () => {
     pushStatus({ available: false, downloaded: false, checking: false, manual: false });
 
     expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  // Field report: hours of failing downloads were invisible outside the log.
+  it("surfaces update errors once and withdraws them on recovery", async () => {
+    const { sendNotification, notifications, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, error: "signature verification failed" });
+    pushStatus({ available: false, downloaded: false, error: "signature verification failed" });
+
+    const errors = sendNotification.mock.calls.filter(
+      ([notification]) => notification.id === "vortex-update-error",
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]![0].type).toBe("error");
+
+    // a later successful check clears the error and the notification
+    pushStatus({ available: false, downloaded: false });
+    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(false);
+  });
+
+  it("does not claim 'up to date' when a manual check failed", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, checking: true, manual: true });
+    pushStatus({ available: false, downloaded: false, manual: true, error: "network down" });
+
+    const ids = sendNotification.mock.calls.map(([notification]) => notification.id);
+    expect(ids).not.toContain("vortex-up-to-date");
+    expect(ids).toContain("vortex-update-error");
+  });
+
+  it("shows live download progress without re-toasting each tick", async () => {
+    const { sendNotification, dismissNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    dismissNotification.mockClear();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 41 });
+    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 42 });
+
+    // progress ticks update in place: no dismiss (which would re-toast)
+    expect(dismissNotification).not.toHaveBeenCalled();
+    const last = sendNotification.mock.calls.at(-1)![0];
+    expect(last.message).toBe("Downloading Vortex 2.7.0");
+    expect(last.progress).toBe(42);
+    // no Download button mid-download
+    expect(last.actions!.map((action) => action.title)).toEqual(["What's New"]);
+  });
+
+  it("dismisses the 'was updated' notice when an update notification appears", async () => {
+    const { notifications, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
+    expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(true);
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(false);
+    expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
   });
 
   it("re-checks periodically so long sessions hear about updates", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -88,7 +88,8 @@ describe("updater status handling", () => {
     const notification = sendNotification.mock.calls[0]![0];
     expect(notification.id).toBe("vortex-update-available");
     expect(notification.message).toContain("2.7.0");
-    expect(notification.actions[1].title).toBe("Install");
+    // not downloaded yet: the action is a download, and must say so
+    expect(notification.actions[1].title).toBe("Download");
   });
 
   // Regression pin #22826: a later "downloaded" status must update the same
@@ -103,7 +104,8 @@ describe("updater status handling", () => {
     const first = sendNotification.mock.calls[0]![0];
     const second = sendNotification.mock.calls[1]![0];
     expect(second.id).toBe(first.id);
-    expect(second.actions[1].title).toBe("Restart");
+    expect(first.actions[1].title).toBe("Download");
+    expect(second.actions[1].title).toBe("Restart & Install");
   });
 
   it("presents a downgrade status as an explicit downgrade offer, not an update", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -439,10 +439,34 @@ describe("updater status handling", () => {
     // progress ticks update in place: no dismiss (which would re-toast)
     expect(dismissNotification).not.toHaveBeenCalled();
     const last = sendNotification.mock.calls.at(-1)![0];
-    expect(last.message).toBe("Downloading Vortex 2.7.0");
+    // the percent lives in the text: the theme's bar overlay is too subtle
+    expect(last.message).toBe("Downloading Vortex 2.7.0 (42%)");
     expect(last.progress).toBe(42);
-    // no Download button mid-download
-    expect(last.actions!.map((action) => action.title)).toEqual(["What's New"]);
+    // no buttons at all while downloading
+    expect(last.actions).toBeUndefined();
+  });
+
+  // Field-tested: killing the feed mid-download left "Downloading…" frozen
+  // with no retry. A failed download (error set, progress cleared by main)
+  // must recover to a retryable notification alongside the error one.
+  it("recovers a failed download to a retryable notification", async () => {
+    const { sendNotification, notifications, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 40 });
+
+    pushStatus({
+      available: true,
+      downloaded: false,
+      version: "2.7.0",
+      error: "net::ERR_CONNECTION_REFUSED",
+    });
+
+    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(true);
+    const last = sendNotification.mock.calls.at(-1)![0];
+    expect(last.id).toBe("vortex-update-available");
+    expect(last.message).toBe("Vortex 2.7.0 is available to download");
+    expect(last.actions!.map((action) => action.title)).toEqual(["What's New", "Download"]);
   });
 
   it("dismisses the 'was updated' notice when an update notification appears", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,4 +1,4 @@
-import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
+import type { UpdaterSnapshot, UpdaterState, UpdaterStatusResponse } from "@vortex/shared/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IExtensionContext } from "../../types/IExtensionContext";
@@ -8,6 +8,7 @@ vi.mock("../../util/application", () => ({
 }));
 
 import init from "./index";
+import { getUpdaterStatus } from "./updaterStatus";
 
 interface FakeNotification {
   id: string;
@@ -65,10 +66,23 @@ function makeContext() {
   };
 }
 
+// A stand-in for main's updater:get-status: numbered snapshots replayed since
+// a sequence number, which is what the renderer's poller consumes.
 function makeUpdaterApi(initialSnapshot: UpdaterSnapshot) {
-  let listener: ((snapshot: UpdaterSnapshot) => void) | undefined;
+  let seq = 0;
+  let latest = initialSnapshot;
+  const history: Array<{ seq: number; snapshot: UpdaterSnapshot }> = [];
   const updater = {
-    getStatus: vi.fn().mockResolvedValue(initialSnapshot),
+    getStatus: vi.fn(
+      async (since?: number): Promise<UpdaterStatusResponse> => ({
+        seq,
+        snapshot: latest,
+        changes:
+          since == null
+            ? []
+            : history.filter((entry) => entry.seq > since).map((entry) => entry.snapshot),
+      }),
+    ),
     getUpdateChangelog: vi.fn().mockResolvedValue(null),
     setChannel: vi.fn(),
     checkForUpdates: vi.fn(),
@@ -76,15 +90,18 @@ function makeUpdaterApi(initialSnapshot: UpdaterSnapshot) {
     downloadDowngrade: vi.fn(),
     declineDowngrade: vi.fn(),
     restartAndInstall: vi.fn(),
-    onStatusChanged: vi.fn((cb: (snapshot: UpdaterSnapshot) => void) => {
-      listener = cb;
-      return () => undefined;
-    }),
   };
   return {
     updater,
-    pushState: (state: UpdaterState, justUpdatedFrom?: string) =>
-      listener?.({ state, justUpdatedFrom }),
+    // main moved to a new state; wake the poller (as any renderer request
+    // would) and let the poll deliver it
+    pushState: async (state: UpdaterState, justUpdatedFrom?: string) => {
+      seq += 1;
+      latest = { state, justUpdatedFrom };
+      history.push({ seq, snapshot: latest });
+      getUpdaterStatus()?.wake();
+      await vi.advanceTimersByTimeAsync(0);
+    },
   };
 }
 
@@ -107,7 +124,7 @@ async function setup(initialSnapshot: UpdaterSnapshot = idle) {
   vi.stubGlobal("window", { api: { updater } });
   init(context);
   runOnce();
-  // let the initial getStatus sync settle
+  // let the poller's first poll deliver the initial snapshot
   await vi.advanceTimersByTimeAsync(0);
   return { sendNotification, dismissNotification, showDialog, notifications, updater, pushState };
 }
@@ -122,7 +139,7 @@ describe("updater state rendering", () => {
   it("shows the update notification for an available state", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
 
     const updates = sent(sendNotification, "vortex-update-available");
     expect(updates).toHaveLength(1);
@@ -135,8 +152,8 @@ describe("updater state rendering", () => {
   it("updates the same notification when the download completes", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
-    pushState({ type: "staged", version: "2.7.0", kind: "update" });
+    await pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "staged", version: "2.7.0", kind: "update" });
 
     const updates = sent(sendNotification, "vortex-update-available");
     expect(updates).toHaveLength(2);
@@ -150,7 +167,7 @@ describe("updater state rendering", () => {
   it("presents a downgrade offer as exactly that, never as an update", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    await pushState({ type: "downgrade-offered", version: "2.5.0" });
 
     const offers = sent(sendNotification, "vortex-downgrade-offer");
     expect(offers).toHaveLength(1);
@@ -172,13 +189,13 @@ describe("updater state rendering", () => {
   it("re-creates the notification on transitions but not on identical pushes", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
     // identical push (e.g. re-broadcast) must not churn the notification
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(1);
 
     // a transition (download finished) re-creates it so the toast re-shows
-    pushState({ type: "staged", version: "2.7.0", kind: "update" });
+    await pushState({ type: "staged", version: "2.7.0", kind: "update" });
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
   });
 
@@ -187,13 +204,13 @@ describe("updater state rendering", () => {
   it("resurrects a dismissed notification on the next identical state", async () => {
     const { sendNotification, notifications, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(1);
 
     // user dismisses it (or an action did)
     notifications.length = 0;
 
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
     expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
   });
@@ -203,7 +220,7 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("shows 'Checking...' the moment a manual check starts", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "checking", manual: true });
+    await pushState({ type: "checking", manual: true });
 
     const checking = sent(sendNotification, "vortex-update-checking");
     expect(checking).toHaveLength(1);
@@ -213,8 +230,8 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("stays silent while a background check runs", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "checking", manual: false });
-    pushState({ type: "idle" });
+    await pushState({ type: "checking", manual: false });
+    await pushState({ type: "idle" });
 
     expect(sendNotification).not.toHaveBeenCalled();
   });
@@ -222,8 +239,8 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("shows an up-to-date toast when a manual check finds nothing", async () => {
     const { sendNotification, notifications, pushState } = await setup();
 
-    pushState({ type: "checking", manual: true });
-    pushState({ type: "idle" });
+    await pushState({ type: "checking", manual: true });
+    await pushState({ type: "idle" });
 
     const toasts = sent(sendNotification, "vortex-up-to-date");
     expect(toasts).toHaveLength(1);
@@ -235,9 +252,9 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("re-toasts the unchanged update notification after a manual check", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
-    pushState({ type: "checking", manual: true });
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "checking", manual: true });
+    await pushState({ type: "available", version: "2.7.0" });
 
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
   });
@@ -248,9 +265,15 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("shows a manual check's patch download as a visible download", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "checking", manual: true });
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: true });
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: true, percent: 30 });
+    await pushState({ type: "checking", manual: true });
+    await pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: true });
+    await pushState({
+      type: "downloading",
+      version: "2.6.1",
+      kind: "patch",
+      manual: true,
+      percent: 30,
+    });
 
     const updates = sent(sendNotification, "vortex-update-available");
     const last = updates.at(-1)!;
@@ -262,8 +285,8 @@ describe("manual check feedback (a pressed button always answers)", () => {
   it("does not claim 'up to date' when a manual check failed", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "checking", manual: true });
-    pushState({ type: "error", message: "network down", manual: true });
+    await pushState({ type: "checking", manual: true });
+    await pushState({ type: "error", message: "network down", manual: true });
 
     expect(sent(sendNotification, "vortex-up-to-date")).toHaveLength(0);
     expect(sent(sendNotification, "vortex-update-error")).toHaveLength(1);
@@ -274,11 +297,23 @@ describe("downloads", () => {
   it("shows live progress in the message without re-toasting each tick", async () => {
     const { sendNotification, dismissNotification, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
+    await pushState({ type: "available", version: "2.7.0" });
     dismissNotification.mockClear();
 
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 41 });
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 42 });
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 41,
+    });
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 42,
+    });
 
     // progress ticks update in place: no dismiss (which would re-toast)
     expect(dismissNotification).not.toHaveBeenCalledWith("vortex-update-available");
@@ -296,11 +331,17 @@ describe("downloads", () => {
     const { sendNotification, updater, pushState } = await setup();
 
     // auto-downloading: nothing to decide, no notification churn
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: false });
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: false, percent: 50 });
+    await pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: false });
+    await pushState({
+      type: "downloading",
+      version: "2.6.1",
+      kind: "patch",
+      manual: false,
+      percent: 50,
+    });
     expect(sendNotification).not.toHaveBeenCalled();
 
-    pushState({ type: "staged", version: "2.6.1", kind: "patch" });
+    await pushState({ type: "staged", version: "2.6.1", kind: "patch" });
     const updates = sent(sendNotification, "vortex-update-available");
     expect(updates).toHaveLength(1);
     expect(updates[0]!.message).toBe("Vortex will update on restart");
@@ -316,9 +357,15 @@ describe("downloads", () => {
   it("recovers a failed download to a retryable notification", async () => {
     const { sendNotification, notifications, pushState } = await setup();
 
-    pushState({ type: "available", version: "2.7.0" });
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 40 });
-    pushState({
+    await pushState({ type: "available", version: "2.7.0" });
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 40,
+    });
+    await pushState({
       type: "error",
       message: "net::ERR_CONNECTION_REFUSED",
       manual: true,
@@ -335,14 +382,14 @@ describe("downloads", () => {
   it("surfaces update errors once and withdraws them on recovery", async () => {
     const { sendNotification, notifications, pushState } = await setup();
 
-    pushState({ type: "error", message: "signature verification failed", manual: true });
-    pushState({ type: "error", message: "signature verification failed", manual: true });
+    await pushState({ type: "error", message: "signature verification failed", manual: true });
+    await pushState({ type: "error", message: "signature verification failed", manual: true });
 
     expect(sent(sendNotification, "vortex-update-error")).toHaveLength(1);
     expect(sent(sendNotification, "vortex-update-error")[0]!.type).toBe("error");
 
     // a later clean state clears the error notification
-    pushState({ type: "idle" });
+    await pushState({ type: "idle" });
     expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(false);
   });
 });
@@ -351,7 +398,7 @@ describe("downgrades", () => {
   it("declining the downgrade dismisses the notification and tells main", async () => {
     const { sendNotification, dismissNotification, showDialog, updater, pushState } = await setup();
 
-    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    await pushState({ type: "downgrade-offered", version: "2.5.0" });
     const offer = sent(sendNotification, "vortex-downgrade-offer")[0]!;
 
     // open the downgrade dialog via the notification's More action
@@ -374,7 +421,7 @@ describe("downgrades", () => {
   it("confirming the downgrade downloads without an automatic restart", async () => {
     const { sendNotification, showDialog, updater, pushState } = await setup();
 
-    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    await pushState({ type: "downgrade-offered", version: "2.5.0" });
     sent(sendNotification, "vortex-downgrade-offer")[0]!.actions![0]!.action(() => undefined);
     await vi.advanceTimersByTimeAsync(0);
 
@@ -390,7 +437,7 @@ describe("downgrades", () => {
   it("presents a confirmed downgrade as a downgrade, then as ready on restart", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({
+    await pushState({
       type: "downloading",
       version: "2.5.0",
       kind: "downgrade",
@@ -403,7 +450,7 @@ describe("downgrades", () => {
     expect(updates[0]!.actions).toBeUndefined();
 
     // once staged it installs on quit, like a patch, and says so
-    pushState({ type: "staged", version: "2.5.0", kind: "downgrade" });
+    await pushState({ type: "staged", version: "2.5.0", kind: "downgrade" });
     updates = sent(sendNotification, "vortex-update-available");
     const last = updates.at(-1)!;
     expect(last.message).toBe("Vortex will update on restart");
@@ -415,14 +462,14 @@ describe("downgrades", () => {
   it("withdraws standing notifications when nothing is on offer any more", async () => {
     const { notifications, pushState } = await setup();
 
-    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    await pushState({ type: "downgrade-offered", version: "2.5.0" });
     expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
 
-    pushState({ type: "idle" });
+    await pushState({ type: "idle" });
     expect(notifications).toHaveLength(0);
 
     // and the next offer still shows
-    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    await pushState({ type: "downgrade-offered", version: "2.5.0" });
     expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
   });
 });
@@ -431,8 +478,8 @@ describe("post-update notice", () => {
   it("shows a one-time 'was updated' notice on the first launch after an update", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "idle" }, "2.5.9");
-    pushState({ type: "idle" }, "2.5.9");
+    await pushState({ type: "idle" }, "2.5.9");
+    await pushState({ type: "idle" }, "2.5.9");
 
     const updated = sent(sendNotification, "vortex-updated");
     expect(updated).toHaveLength(1);
@@ -443,10 +490,10 @@ describe("post-update notice", () => {
   it("dismisses the 'was updated' notice when an update notification appears", async () => {
     const { notifications, pushState } = await setup();
 
-    pushState({ type: "idle" }, "2.5.9");
+    await pushState({ type: "idle" }, "2.5.9");
     expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(true);
 
-    pushState({ type: "available", version: "2.7.0" }, "2.5.9");
+    await pushState({ type: "available", version: "2.7.0" }, "2.5.9");
     expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(false);
     expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
   });

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -137,6 +137,8 @@ describe("updater status handling", () => {
     expect(second.id).toBe(first.id);
     expect(first.actions[1].title).toBe("Download");
     expect(second.actions[1].title).toBe("Restart & Install");
+    // install-on-quit is disclosed once the download is staged
+    expect(second.message).toContain("will install when you close Vortex");
   });
 
   it("presents a downgrade status as an explicit downgrade offer, not an update", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -131,6 +131,19 @@ describe("updater status handling", () => {
     expect(sendNotification.mock.calls[0]![0].message).toContain("2.8.0");
   });
 
+  it("re-creates the notification on transitions but not on identical pushes", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    // identical push (e.g. re-broadcast) must not churn the notification
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+
+    // a transition (download finished) re-creates it so the toast re-shows
+    pushStatus({ available: true, downloaded: true, version: "2.7.0" });
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+
   it("re-checks periodically so long sessions hear about updates", async () => {
     const { updater } = await setup();
     updater.checkForUpdates.mockClear();

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -46,6 +46,7 @@ function makeContext() {
     session: { notifications: { notifications } },
   };
   const showDialog = vi.fn().mockResolvedValue({ action: "Close" });
+  const dispatch = vi.fn();
   const context = {
     registerReducer: vi.fn(),
     registerSettings: vi.fn(),
@@ -56,7 +57,7 @@ function makeContext() {
       dismissNotification,
       showDialog,
       onStateChange: vi.fn(),
-      store: { getState: () => state },
+      store: { getState: () => state, dispatch },
     },
   } as unknown as IExtensionContext;
   return {
@@ -64,6 +65,7 @@ function makeContext() {
     sendNotification,
     dismissNotification,
     showDialog,
+    dispatch,
     notifications,
     runOnce: () => onceCallbacks.forEach((cb) => cb()),
   };
@@ -122,15 +124,30 @@ afterEach(() => {
 });
 
 async function setup(initialSnapshot: UpdaterSnapshot = idle) {
-  const { context, sendNotification, dismissNotification, showDialog, notifications, runOnce } =
-    makeContext();
+  const {
+    context,
+    sendNotification,
+    dismissNotification,
+    showDialog,
+    dispatch,
+    notifications,
+    runOnce,
+  } = makeContext();
   const { updater, pushState } = makeUpdaterApi(initialSnapshot);
   vi.stubGlobal("window", { api: { updater } });
   init(context);
   runOnce();
   // let the poller's first poll deliver the initial snapshot
   await vi.advanceTimersByTimeAsync(0);
-  return { sendNotification, dismissNotification, showDialog, notifications, updater, pushState };
+  return {
+    sendNotification,
+    dismissNotification,
+    showDialog,
+    dispatch,
+    notifications,
+    updater,
+    pushState,
+  };
 }
 
 function sent(sendNotification: ReturnType<typeof vi.fn>, id: string): FakeNotification[] {
@@ -140,6 +157,21 @@ function sent(sendNotification: ReturnType<typeof vi.fn>, id: string): FakeNotif
 }
 
 describe("updater state rendering", () => {
+  // Components (the Settings page) read the updater's state from redux so it
+  // survives leaving and re-entering the page.
+  it("puts every polled snapshot into session.updater", async () => {
+    const { dispatch, pushState } = await setup();
+
+    await pushState({ type: "checking", manual: true });
+    await pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true });
+
+    const snapshots = dispatch.mock.calls
+      .map(([action]) => action as { type: string; payload: UpdaterSnapshot })
+      .filter((action) => action.type === "SET_UPDATER_SNAPSHOT")
+      .map((action) => action.payload.state.type);
+    expect(snapshots).toEqual(["idle", "checking", "downloading"]);
+  });
+
   it("shows the update notification for an available state", async () => {
     const { sendNotification, pushState } = await setup();
 

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -15,6 +15,7 @@ interface FakeStatus {
   releaseNotes?: string;
   downgrade?: boolean;
   checking?: boolean;
+  manual?: boolean;
 }
 
 interface FakeNotification {
@@ -188,6 +189,53 @@ describe("updater status handling", () => {
     pushStatus({ available: true, downloaded: false, version: "2.7.0" });
     expect(sendNotification).toHaveBeenCalledTimes(2);
     expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
+  });
+
+  it("shows an up-to-date toast when a manual check finds nothing", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, checking: true, manual: true });
+    pushStatus({ available: false, downloaded: false, checking: false, manual: true });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const toast = sendNotification.mock.calls[0]![0];
+    expect(toast.id).toBe("vortex-up-to-date");
+    expect(toast.message).toContain("up to date");
+  });
+
+  it("re-toasts the unchanged update notification after a manual check", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+
+    // manual re-check resolves the same version: user still expects feedback
+    pushStatus({
+      available: true,
+      downloaded: false,
+      version: "2.7.0",
+      checking: true,
+      manual: true,
+    });
+    pushStatus({
+      available: true,
+      downloaded: false,
+      version: "2.7.0",
+      checking: false,
+      manual: true,
+    });
+
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    expect(sendNotification.mock.calls[1]![0].id).toBe("vortex-update-available");
+  });
+
+  it("stays quiet when a background check finds nothing", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, checking: true, manual: false });
+    pushStatus({ available: false, downloaded: false, checking: false, manual: false });
+
+    expect(sendNotification).not.toHaveBeenCalled();
   });
 
   it("re-checks periodically so long sessions hear about updates", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -242,15 +242,20 @@ describe("manual check feedback (a pressed button always answers)", () => {
     expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
   });
 
-  it("answers a manual check that lands on an in-flight patch download", async () => {
+  // Field report: a manual check that found a patch gave only a transient
+  // toast while the download ran on invisibly — anything the user's press
+  // set in motion downloads visibly, like the downgrade route.
+  it("shows a manual check's patch download as a visible download", async () => {
     const { sendNotification, pushState } = await setup();
 
     pushState({ type: "checking", manual: true });
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch" });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: true });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: true, percent: 30 });
 
-    const toasts = sent(sendNotification, "vortex-up-to-date");
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0]!.message).toContain("2.6.1 is downloading");
+    const updates = sent(sendNotification, "vortex-update-available");
+    const last = updates.at(-1)!;
+    expect(last.message).toBe("Downloading Vortex 2.6.1 (30%)");
+    expect(last.actions).toBeUndefined();
   });
 
   it("does not claim 'up to date' when a manual check failed", async () => {
@@ -271,8 +276,8 @@ describe("downloads", () => {
     pushState({ type: "available", version: "2.7.0" });
     dismissNotification.mockClear();
 
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 41 });
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 42 });
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 41 });
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 42 });
 
     // progress ticks update in place: no dismiss (which would re-toast)
     expect(dismissNotification).not.toHaveBeenCalledWith("vortex-update-available");
@@ -288,8 +293,8 @@ describe("downloads", () => {
     const { sendNotification, updater, pushState } = await setup();
 
     // auto-downloading: nothing to decide, no notification churn
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch" });
-    pushState({ type: "downloading", version: "2.6.1", kind: "patch", percent: 50 });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: false });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch", manual: false, percent: 50 });
     expect(sendNotification).not.toHaveBeenCalled();
 
     pushState({ type: "staged", version: "2.6.1", kind: "patch" });
@@ -309,7 +314,7 @@ describe("downloads", () => {
     const { sendNotification, notifications, pushState } = await setup();
 
     pushState({ type: "available", version: "2.7.0" });
-    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 40 });
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", manual: true, percent: 40 });
     pushState({
       type: "error",
       message: "net::ERR_CONNECTION_REFUSED",
@@ -382,7 +387,13 @@ describe("downgrades", () => {
   it("presents a confirmed downgrade as a downgrade, then as ready on restart", async () => {
     const { sendNotification, pushState } = await setup();
 
-    pushState({ type: "downloading", version: "2.5.0", kind: "downgrade", percent: 12 });
+    pushState({
+      type: "downloading",
+      version: "2.5.0",
+      kind: "downgrade",
+      manual: true,
+      percent: 12,
+    });
 
     let updates = sent(sendNotification, "vortex-update-available");
     expect(updates[0]!.message).toBe("Downgrading to Vortex 2.5.0 (12%)");

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -131,7 +131,7 @@ describe("updater state rendering", () => {
   });
 
   // Regression pin #22826: a later "staged" state must update the same
-  // notification (same id — upsert), flipping the action to Restart Now.
+  // notification (same id, upsert), flipping the action to Restart Now.
   it("updates the same notification when the download completes", async () => {
     const { sendNotification, pushState } = await setup();
 
@@ -243,7 +243,7 @@ describe("manual check feedback (a pressed button always answers)", () => {
   });
 
   // Field report: a manual check that found a patch gave only a transient
-  // toast while the download ran on invisibly — anything the user's press
+  // toast while the download ran on invisibly, anything the user's press
   // set in motion downloads visibly, like the downgrade route.
   it("shows a manual check's patch download as a visible download", async () => {
     const { sendNotification, pushState } = await setup();
@@ -402,7 +402,7 @@ describe("downgrades", () => {
     expect(updates[0]!.message).toBe("Downgrading to Vortex 2.5.0 (12%)");
     expect(updates[0]!.actions).toBeUndefined();
 
-    // once staged it installs on quit, like a patch — and says so
+    // once staged it installs on quit, like a patch, and says so
     pushState({ type: "staged", version: "2.5.0", kind: "downgrade" });
     updates = sent(sendNotification, "vortex-update-available");
     const last = updates.at(-1)!;

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,3 +1,4 @@
+import type { UpdateStatus } from "@vortex/shared/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IExtensionContext } from "../../types/IExtensionContext";
@@ -8,18 +9,9 @@ vi.mock("../../util/application", () => ({
 
 import init from "./index";
 
-interface FakeStatus {
-  available: boolean;
-  downloaded: boolean;
-  version?: string;
-  releaseNotes?: string;
-  downgrade?: boolean;
-  downgrading?: boolean;
-  checking?: boolean;
-  manual?: boolean;
-  patch?: boolean;
-  justUpdatedFrom?: string;
-}
+// the real IPC shape, so a field rename in @vortex/shared breaks these tests
+// instead of silently passing against a stale local copy
+type FakeStatus = Pick<UpdateStatus, "available" | "downloaded"> & Partial<UpdateStatus>;
 
 interface FakeNotification {
   id: string;
@@ -218,12 +210,12 @@ describe("updater status handling", () => {
     // committed flow: nothing for the user to click while it downloads
     expect(downloading.actions).toBeUndefined();
 
-    // once staged it reads like any other staged update, same buttons
+    // once staged it installs on quit, like a patch — and says so
     pushStatus({ available: true, downloaded: true, version: "2.5.0", downgrading: true });
     const downloaded = sendNotification.mock.calls[1]![0];
-    expect(downloaded.message).toContain("2.5.0 is ready to install");
-    expect(downloaded.actions![0]!.title).toBe("What's New");
-    expect(downloaded.actions![1]!.title).toBe("Restart Now");
+    expect(downloaded.message).toBe("Vortex will update on restart");
+    expect(downloaded.actions).toHaveLength(1);
+    expect(downloaded.actions![0]!.title).toBe("Restart Now");
   });
 
   it("keeps a patch update quiet until staged, then offers a restart", async () => {
@@ -237,12 +229,71 @@ describe("updater status handling", () => {
     expect(sendNotification).toHaveBeenCalledTimes(1);
     const notification = sendNotification.mock.calls[0]![0];
     expect(notification.id).toBe("vortex-update-available");
-    expect(notification.message).toBe("Vortex will update the next time you restart");
+    expect(notification.message).toBe("Vortex will update on restart");
     expect(notification.actions).toHaveLength(1);
     expect(notification.actions![0]!.title).toBe("Restart Now");
 
     notification.actions![0]!.action(() => undefined);
     expect(updater.restartAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  // Review finding: every check broadcasts checking:true statuses that have
+  // the patch/downgrade labels cleared while available/version survive —
+  // acting on them briefly presented a downloading patch as a loud regular
+  // update with a live Download button.
+  it("ignores transient mid-check statuses", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    // e.g. the periodic re-check firing while a patch auto-downloads
+    pushStatus({ available: true, downloaded: false, version: "2.6.1", checking: true });
+    expect(sendNotification).not.toHaveBeenCalled();
+
+    // the settled status carries the real labels again
+    pushStatus({ available: true, downloaded: false, version: "2.6.1", patch: true });
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("answers a manual check during a patch download with a downloading toast", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({
+      available: true,
+      downloaded: false,
+      version: "2.6.1",
+      patch: true,
+      checking: true,
+      manual: true,
+    });
+    pushStatus({
+      available: true,
+      downloaded: false,
+      version: "2.6.1",
+      patch: true,
+      checking: false,
+      manual: true,
+    });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const toast = sendNotification.mock.calls[0]![0];
+    expect(toast.message).toContain("2.6.1 is downloading");
+  });
+
+  // Review finding: when main retracts an offer (failed downgrade download,
+  // release pulled from the feed), the standing notification kept dead
+  // buttons on screen.
+  it("withdraws standing notifications when nothing is available any more", async () => {
+    const { sendNotification, notifications, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
+
+    pushStatus({ available: false, downloaded: false });
+    expect(notifications).toHaveLength(0);
+
+    // and the next offer still shows (lastShown was reset)
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
   });
 
   it("shows a one-time 'was updated' notice on the first launch after an update", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -17,6 +17,7 @@ interface FakeNotification {
   progress?: number;
   displayMS?: number;
   actions?: Array<{ title: string; action: (dismiss: () => void) => void }>;
+  onDismiss?: () => void;
 }
 
 function makeContext() {
@@ -31,10 +32,12 @@ function makeContext() {
       notifications.push(notification);
     }
   });
+  // like the real dismissNotification thunk: remove, then fire onDismiss
   const dismissNotification = vi.fn((id: string) => {
     const existing = notifications.findIndex((entry) => entry.id === id);
     if (existing >= 0) {
-      notifications.splice(existing, 1);
+      const [removed] = notifications.splice(existing, 1);
+      removed?.onDismiss?.();
     }
   });
   const state = {
@@ -89,6 +92,7 @@ function makeUpdaterApi(initialSnapshot: UpdaterSnapshot) {
     downloadUpdate: vi.fn(),
     downloadDowngrade: vi.fn(),
     declineDowngrade: vi.fn(),
+    cancelDownload: vi.fn(),
     restartAndInstall: vi.fn(),
   };
   return {
@@ -294,6 +298,50 @@ describe("manual check feedback (a pressed button always answers)", () => {
 });
 
 describe("downloads", () => {
+  // Ruling: closing the download notification is the one control it has, and
+  // it means "stop". Our own dismissals (the state moved on) must not cancel.
+  it("cancels the download when the user closes its notification", async () => {
+    const { dismissNotification, updater, pushState } = await setup();
+
+    await pushState({ type: "available", version: "2.7.0" });
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 12,
+    });
+
+    // the user clicks the X
+    dismissNotification("vortex-update-available");
+
+    expect(updater.cancelDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel when the notification is replaced or dismissed by a transition", async () => {
+    const { updater, pushState } = await setup();
+
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 12,
+    });
+    // progress ticks replace the notification in place
+    await pushState({
+      type: "downloading",
+      version: "2.7.0",
+      kind: "update",
+      manual: true,
+      percent: 40,
+    });
+    // the download finished: the renderer dismisses and re-sends as "ready to install"
+    await pushState({ type: "staged", version: "2.7.0", kind: "update" });
+
+    expect(updater.cancelDownload).not.toHaveBeenCalled();
+  });
+
   it("shows live progress in the message without re-toasting each tick", async () => {
     const { sendNotification, dismissNotification, pushState } = await setup();
 

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IExtensionContext } from "../../types/IExtensionContext";
+
+vi.mock("../../util/application", () => ({
+  getApplication: () => ({ version: "2.6.0-beta.1" }),
+}));
+
 import init from "./index";
 
 interface FakeStatus {
@@ -101,12 +106,16 @@ describe("updater status handling", () => {
     expect(second.actions[1].title).toBe("Restart");
   });
 
-  it("never presents a downgrade status as a regular update", async () => {
+  it("presents a downgrade status as an explicit downgrade offer, not an update", async () => {
     const { sendNotification, pushStatus } = await setup();
 
     pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
 
-    expect(sendNotification).not.toHaveBeenCalled();
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const notification = sendNotification.mock.calls[0]![0];
+    expect(notification.id).toBe("vortex-downgrade-offer");
+    expect(notification.type).toBe("warning");
+    expect(notification.message).toContain("older");
   });
 
   it("syncs the initial status via getStatus for checks that finished early", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -131,6 +131,17 @@ describe("updater status handling", () => {
     expect(sendNotification.mock.calls[0]![0].message).toContain("2.8.0");
   });
 
+  it("re-checks periodically so long sessions hear about updates", async () => {
+    const { updater } = await setup();
+    updater.checkForUpdates.mockClear();
+
+    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
+    expect(updater.checkForUpdates).toHaveBeenCalledWith("stable", false);
+
+    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
   it("ignores non-available statuses (checking, progress)", async () => {
     const { sendNotification, pushStatus } = await setup();
 

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -17,11 +17,18 @@ interface FakeStatus {
   checking?: boolean;
 }
 
+interface FakeNotification {
+  id: string;
+  type?: string;
+  message?: string;
+  actions?: Array<{ title: string; action: (dismiss: () => void) => void }>;
+}
+
 function makeContext() {
   const onceCallbacks: Array<() => void> = [];
   // mirror the notifications reducer: same-id send replaces, dismiss removes
-  const notifications: Array<{ id: string }> = [];
-  const sendNotification = vi.fn((notification: { id: string }) => {
+  const notifications: FakeNotification[] = [];
+  const sendNotification = vi.fn((notification: FakeNotification) => {
     const existing = notifications.findIndex((entry) => entry.id === notification.id);
     if (existing >= 0) {
       notifications.splice(existing, 1, notification);

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -19,10 +19,26 @@ interface FakeStatus {
 
 function makeContext() {
   const onceCallbacks: Array<() => void> = [];
-  const sendNotification = vi.fn();
+  // mirror the notifications reducer: same-id send replaces, dismiss removes
+  const notifications: Array<{ id: string }> = [];
+  const sendNotification = vi.fn((notification: { id: string }) => {
+    const existing = notifications.findIndex((entry) => entry.id === notification.id);
+    if (existing >= 0) {
+      notifications.splice(existing, 1, notification);
+    } else {
+      notifications.push(notification);
+    }
+  });
+  const dismissNotification = vi.fn((id: string) => {
+    const existing = notifications.findIndex((entry) => entry.id === id);
+    if (existing >= 0) {
+      notifications.splice(existing, 1);
+    }
+  });
   const state = {
     app: { installType: "regular" },
     settings: { update: { channel: "stable" } },
+    session: { notifications: { notifications } },
   };
   const context = {
     registerReducer: vi.fn(),
@@ -31,12 +47,19 @@ function makeContext() {
     api: {
       getState: () => state,
       sendNotification,
+      dismissNotification,
       showDialog: vi.fn().mockResolvedValue({ action: "Close" }),
       onStateChange: vi.fn(),
       store: { getState: () => state },
     },
   } as unknown as IExtensionContext;
-  return { context, sendNotification, runOnce: () => onceCallbacks.forEach((cb) => cb()) };
+  return {
+    context,
+    sendNotification,
+    dismissNotification,
+    notifications,
+    runOnce: () => onceCallbacks.forEach((cb) => cb()),
+  };
 }
 
 function makeUpdaterApi(initialStatus: FakeStatus) {
@@ -68,14 +91,14 @@ afterEach(() => {
 });
 
 async function setup(initialStatus: FakeStatus = idleStatus) {
-  const { context, sendNotification, runOnce } = makeContext();
+  const { context, sendNotification, dismissNotification, notifications, runOnce } = makeContext();
   const { updater, pushStatus } = makeUpdaterApi(initialStatus);
   vi.stubGlobal("window", { api: { updater } });
   init(context);
   runOnce();
   // let the initial getStatus sync settle
   await vi.advanceTimersByTimeAsync(0);
-  return { sendNotification, updater, pushStatus };
+  return { sendNotification, dismissNotification, notifications, updater, pushStatus };
 }
 
 describe("updater status handling", () => {
@@ -142,6 +165,22 @@ describe("updater status handling", () => {
     // a transition (download finished) re-creates it so the toast re-shows
     pushStatus({ available: true, downloaded: true, version: "2.7.0" });
     expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+
+  // Field report: after a dismissed notification (e.g. clicking Restart &
+  // Install in dev), a manual re-check of the same version showed nothing.
+  it("resurrects a dismissed notification on the next identical status", async () => {
+    const { sendNotification, notifications, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+
+    // user dismisses it (or an action did)
+    notifications.length = 0;
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
   });
 
   it("re-checks periodically so long sessions hear about updates", async () => {

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IExtensionContext } from "../../types/IExtensionContext";
+import init from "./index";
+
+interface FakeStatus {
+  available: boolean;
+  downloaded: boolean;
+  version?: string;
+  releaseNotes?: string;
+  downgrade?: boolean;
+  checking?: boolean;
+}
+
+function makeContext() {
+  const onceCallbacks: Array<() => void> = [];
+  const sendNotification = vi.fn();
+  const state = {
+    app: { installType: "regular" },
+    settings: { update: { channel: "stable" } },
+  };
+  const context = {
+    registerReducer: vi.fn(),
+    registerSettings: vi.fn(),
+    once: (cb: () => void) => onceCallbacks.push(cb),
+    api: {
+      getState: () => state,
+      sendNotification,
+      showDialog: vi.fn().mockResolvedValue({ action: "Close" }),
+      onStateChange: vi.fn(),
+      store: { getState: () => state },
+    },
+  } as unknown as IExtensionContext;
+  return { context, sendNotification, runOnce: () => onceCallbacks.forEach((cb) => cb()) };
+}
+
+function makeUpdaterApi(initialStatus: FakeStatus) {
+  let statusListener: ((status: FakeStatus) => void) | undefined;
+  const updater = {
+    getStatus: vi.fn().mockResolvedValue(initialStatus),
+    setChannel: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    restartAndInstall: vi.fn(),
+    onStatusChanged: vi.fn((cb: (status: FakeStatus) => void) => {
+      statusListener = cb;
+      return () => undefined;
+    }),
+  };
+  return { updater, pushStatus: (status: FakeStatus) => statusListener?.(status) };
+}
+
+const idleStatus: FakeStatus = { available: false, downloaded: false };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+async function setup(initialStatus: FakeStatus = idleStatus) {
+  const { context, sendNotification, runOnce } = makeContext();
+  const { updater, pushStatus } = makeUpdaterApi(initialStatus);
+  vi.stubGlobal("window", { api: { updater } });
+  init(context);
+  runOnce();
+  // let the initial getStatus sync settle
+  await vi.advanceTimersByTimeAsync(0);
+  return { sendNotification, updater, pushStatus };
+}
+
+describe("updater status handling", () => {
+  it("shows the update notification when a pushed status is available", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const notification = sendNotification.mock.calls[0]![0];
+    expect(notification.id).toBe("vortex-update-available");
+    expect(notification.message).toContain("2.7.0");
+    expect(notification.actions[1].title).toBe("Install");
+  });
+
+  // Regression pin #22826: a later "downloaded" status must update the same
+  // notification (same id — upsert), flipping the action to Restart.
+  it("updates the same notification when the download completes", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    pushStatus({ available: true, downloaded: true, version: "2.7.0" });
+
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    const first = sendNotification.mock.calls[0]![0];
+    const second = sendNotification.mock.calls[1]![0];
+    expect(second.id).toBe(first.id);
+    expect(second.actions[1].title).toBe("Restart");
+  });
+
+  it("never presents a downgrade status as a regular update", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("syncs the initial status via getStatus for checks that finished early", async () => {
+    const { sendNotification } = await setup({
+      available: true,
+      downloaded: false,
+      version: "2.8.0",
+    });
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification.mock.calls[0]![0].message).toContain("2.8.0");
+  });
+
+  it("ignores non-available statuses (checking, progress)", async () => {
+    const { sendNotification, pushStatus } = await setup();
+
+    pushStatus({ available: false, downloaded: false, checking: true });
+    pushStatus({ available: false, downloaded: false });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -255,6 +255,7 @@ describe("manual check feedback (a pressed button always answers)", () => {
     const updates = sent(sendNotification, "vortex-update-available");
     const last = updates.at(-1)!;
     expect(last.message).toBe("Downloading Vortex 2.6.1 (30%)");
+    expect(last.type).toBe("activity");
     expect(last.actions).toBeUndefined();
   });
 
@@ -285,6 +286,8 @@ describe("downloads", () => {
     const last = updates.at(-1)!;
     expect(last.message).toBe("Downloading Vortex 2.7.0 (42%)");
     expect(last.progress).toBe(42);
+    // "activity" is what makes the notifications panel render the bar
+    expect(last.type).toBe("activity");
     // no buttons at all while downloading
     expect(last.actions).toBeUndefined();
   });

--- a/src/renderer/src/extensions/updater/index.test.ts
+++ b/src/renderer/src/extensions/updater/index.test.ts
@@ -1,4 +1,4 @@
-import type { UpdateStatus } from "@vortex/shared/ipc";
+import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IExtensionContext } from "../../types/IExtensionContext";
@@ -9,15 +9,12 @@ vi.mock("../../util/application", () => ({
 
 import init from "./index";
 
-// the real IPC shape, so a field rename in @vortex/shared breaks these tests
-// instead of silently passing against a stale local copy
-type FakeStatus = Pick<UpdateStatus, "available" | "downloaded"> & Partial<UpdateStatus>;
-
 interface FakeNotification {
   id: string;
   type?: string;
   message?: string;
   progress?: number;
+  displayMS?: number;
   actions?: Array<{ title: string; action: (dismiss: () => void) => void }>;
 }
 
@@ -68,10 +65,10 @@ function makeContext() {
   };
 }
 
-function makeUpdaterApi(initialStatus: FakeStatus) {
-  let statusListener: ((status: FakeStatus) => void) | undefined;
+function makeUpdaterApi(initialSnapshot: UpdaterSnapshot) {
+  let listener: ((snapshot: UpdaterSnapshot) => void) | undefined;
   const updater = {
-    getStatus: vi.fn().mockResolvedValue(initialStatus),
+    getStatus: vi.fn().mockResolvedValue(initialSnapshot),
     getUpdateChangelog: vi.fn().mockResolvedValue(null),
     setChannel: vi.fn(),
     checkForUpdates: vi.fn(),
@@ -79,15 +76,19 @@ function makeUpdaterApi(initialStatus: FakeStatus) {
     downloadDowngrade: vi.fn(),
     declineDowngrade: vi.fn(),
     restartAndInstall: vi.fn(),
-    onStatusChanged: vi.fn((cb: (status: FakeStatus) => void) => {
-      statusListener = cb;
+    onStatusChanged: vi.fn((cb: (snapshot: UpdaterSnapshot) => void) => {
+      listener = cb;
       return () => undefined;
     }),
   };
-  return { updater, pushStatus: (status: FakeStatus) => statusListener?.(status) };
+  return {
+    updater,
+    pushState: (state: UpdaterState, justUpdatedFrom?: string) =>
+      listener?.({ state, justUpdatedFrom }),
+  };
 }
 
-const idleStatus: FakeStatus = { available: false, downloaded: false };
+const idle: UpdaterSnapshot = { state: { type: "idle" } };
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -99,70 +100,251 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function setup(initialStatus: FakeStatus = idleStatus) {
+async function setup(initialSnapshot: UpdaterSnapshot = idle) {
   const { context, sendNotification, dismissNotification, showDialog, notifications, runOnce } =
     makeContext();
-  const { updater, pushStatus } = makeUpdaterApi(initialStatus);
+  const { updater, pushState } = makeUpdaterApi(initialSnapshot);
   vi.stubGlobal("window", { api: { updater } });
   init(context);
   runOnce();
   // let the initial getStatus sync settle
   await vi.advanceTimersByTimeAsync(0);
-  return { sendNotification, dismissNotification, showDialog, notifications, updater, pushStatus };
+  return { sendNotification, dismissNotification, showDialog, notifications, updater, pushState };
 }
 
-describe("updater status handling", () => {
-  it("shows the update notification when a pushed status is available", async () => {
-    const { sendNotification, pushStatus } = await setup();
+function sent(sendNotification: ReturnType<typeof vi.fn>, id: string): FakeNotification[] {
+  return sendNotification.mock.calls
+    .map(([notification]) => notification as FakeNotification)
+    .filter((notification) => notification.id === id);
+}
 
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+describe("updater state rendering", () => {
+  it("shows the update notification for an available state", async () => {
+    const { sendNotification, pushState } = await setup();
 
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const notification = sendNotification.mock.calls[0]![0];
-    expect(notification.id).toBe("vortex-update-available");
-    expect(notification.message).toContain("2.7.0");
-    // not downloaded yet: the action is a download, and must say so
-    expect(notification.actions[1].title).toBe("Download");
+    pushState({ type: "available", version: "2.7.0" });
+
+    const updates = sent(sendNotification, "vortex-update-available");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.message).toBe("Vortex 2.7.0 is available to download");
+    expect(updates[0]!.actions!.map((action) => action.title)).toEqual(["What's New", "Download"]);
   });
 
-  // Regression pin #22826: a later "downloaded" status must update the same
-  // notification (same id — upsert), flipping the action to Restart.
+  // Regression pin #22826: a later "staged" state must update the same
+  // notification (same id — upsert), flipping the action to Restart Now.
   it("updates the same notification when the download completes", async () => {
-    const { sendNotification, pushStatus } = await setup();
+    const { sendNotification, pushState } = await setup();
 
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    pushStatus({ available: true, downloaded: true, version: "2.7.0" });
+    pushState({ type: "available", version: "2.7.0" });
+    pushState({ type: "staged", version: "2.7.0", kind: "update" });
 
-    expect(sendNotification).toHaveBeenCalledTimes(2);
-    const first = sendNotification.mock.calls[0]![0];
-    const second = sendNotification.mock.calls[1]![0];
-    expect(second.id).toBe(first.id);
-    expect(first.actions[1].title).toBe("Download");
-    expect(first.message).toContain("available to download");
-    expect(second.actions[1].title).toBe("Restart Now");
-    expect(second.message).toContain("ready to install");
+    const updates = sent(sendNotification, "vortex-update-available");
+    expect(updates).toHaveLength(2);
+    expect(updates[1]!.message).toBe("Vortex 2.7.0 is ready to install");
+    expect(updates[1]!.actions!.map((action) => action.title)).toEqual([
+      "What's New",
+      "Restart Now",
+    ]);
   });
 
-  it("presents a downgrade status as an explicit downgrade offer, not an update", async () => {
-    const { sendNotification, pushStatus } = await setup();
+  it("presents a downgrade offer as exactly that, never as an update", async () => {
+    const { sendNotification, pushState } = await setup();
 
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    pushState({ type: "downgrade-offered", version: "2.5.0" });
 
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const notification = sendNotification.mock.calls[0]![0];
-    expect(notification.id).toBe("vortex-downgrade-offer");
-    expect(notification.type).toBe("warning");
-    expect(notification.message).toContain("older");
+    const offers = sent(sendNotification, "vortex-downgrade-offer");
+    expect(offers).toHaveLength(1);
+    expect(offers[0]!.type).toBe("warning");
+    expect(offers[0]!.message).toContain("downgrade and older");
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(0);
   });
 
-  // Field report: declining left the warning notification up and the offer
-  // armed in main — "Stay on current version" must actually reset both.
+  it("syncs the initial state via getStatus for checks that settled early", async () => {
+    const { sendNotification } = await setup({
+      state: { type: "available", version: "2.8.0" },
+    });
+
+    const updates = sent(sendNotification, "vortex-update-available");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.message).toContain("2.8.0");
+  });
+
+  it("re-creates the notification on transitions but not on identical pushes", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "available", version: "2.7.0" });
+    // identical push (e.g. re-broadcast) must not churn the notification
+    pushState({ type: "available", version: "2.7.0" });
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(1);
+
+    // a transition (download finished) re-creates it so the toast re-shows
+    pushState({ type: "staged", version: "2.7.0", kind: "update" });
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
+  });
+
+  // Field report: after a dismissed notification, a re-check of the same
+  // version showed nothing.
+  it("resurrects a dismissed notification on the next identical state", async () => {
+    const { sendNotification, notifications, pushState } = await setup();
+
+    pushState({ type: "available", version: "2.7.0" });
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(1);
+
+    // user dismisses it (or an action did)
+    notifications.length = 0;
+
+    pushState({ type: "available", version: "2.7.0" });
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
+    expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
+  });
+});
+
+describe("manual check feedback (a pressed button always answers)", () => {
+  it("shows 'Checking...' the moment a manual check starts", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "checking", manual: true });
+
+    const checking = sent(sendNotification, "vortex-update-checking");
+    expect(checking).toHaveLength(1);
+    expect(checking[0]!.type).toBe("activity");
+  });
+
+  it("stays silent while a background check runs", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "checking", manual: false });
+    pushState({ type: "idle" });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("shows an up-to-date toast when a manual check finds nothing", async () => {
+    const { sendNotification, notifications, pushState } = await setup();
+
+    pushState({ type: "checking", manual: true });
+    pushState({ type: "idle" });
+
+    const toasts = sent(sendNotification, "vortex-up-to-date");
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]!.message).toContain("up to date");
+    // the Checking... feedback settled with the check
+    expect(notifications.some((entry) => entry.id === "vortex-update-checking")).toBe(false);
+  });
+
+  it("re-toasts the unchanged update notification after a manual check", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "available", version: "2.7.0" });
+    pushState({ type: "checking", manual: true });
+    pushState({ type: "available", version: "2.7.0" });
+
+    expect(sent(sendNotification, "vortex-update-available")).toHaveLength(2);
+  });
+
+  it("answers a manual check that lands on an in-flight patch download", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "checking", manual: true });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch" });
+
+    const toasts = sent(sendNotification, "vortex-up-to-date");
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]!.message).toContain("2.6.1 is downloading");
+  });
+
+  it("does not claim 'up to date' when a manual check failed", async () => {
+    const { sendNotification, pushState } = await setup();
+
+    pushState({ type: "checking", manual: true });
+    pushState({ type: "error", message: "network down", manual: true });
+
+    expect(sent(sendNotification, "vortex-up-to-date")).toHaveLength(0);
+    expect(sent(sendNotification, "vortex-update-error")).toHaveLength(1);
+  });
+});
+
+describe("downloads", () => {
+  it("shows live progress in the message without re-toasting each tick", async () => {
+    const { sendNotification, dismissNotification, pushState } = await setup();
+
+    pushState({ type: "available", version: "2.7.0" });
+    dismissNotification.mockClear();
+
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 41 });
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 42 });
+
+    // progress ticks update in place: no dismiss (which would re-toast)
+    expect(dismissNotification).not.toHaveBeenCalledWith("vortex-update-available");
+    const updates = sent(sendNotification, "vortex-update-available");
+    const last = updates.at(-1)!;
+    expect(last.message).toBe("Downloading Vortex 2.7.0 (42%)");
+    expect(last.progress).toBe(42);
+    // no buttons at all while downloading
+    expect(last.actions).toBeUndefined();
+  });
+
+  it("keeps a patch download quiet until staged, then offers a restart", async () => {
+    const { sendNotification, updater, pushState } = await setup();
+
+    // auto-downloading: nothing to decide, no notification churn
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch" });
+    pushState({ type: "downloading", version: "2.6.1", kind: "patch", percent: 50 });
+    expect(sendNotification).not.toHaveBeenCalled();
+
+    pushState({ type: "staged", version: "2.6.1", kind: "patch" });
+    const updates = sent(sendNotification, "vortex-update-available");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.message).toBe("Vortex will update on restart");
+    expect(updates[0]!.actions!.map((action) => action.title)).toEqual(["Restart Now"]);
+
+    updates[0]!.actions![0]!.action(() => undefined);
+    expect(updater.restartAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  // Field-tested: killing the feed mid-download left "Downloading..." frozen
+  // with no retry. A failed download must recover to a retryable notification
+  // alongside the error one.
+  it("recovers a failed download to a retryable notification", async () => {
+    const { sendNotification, notifications, pushState } = await setup();
+
+    pushState({ type: "available", version: "2.7.0" });
+    pushState({ type: "downloading", version: "2.7.0", kind: "update", percent: 40 });
+    pushState({
+      type: "error",
+      message: "net::ERR_CONNECTION_REFUSED",
+      manual: true,
+      retry: { version: "2.7.0" },
+    });
+
+    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(true);
+    const updates = sent(sendNotification, "vortex-update-available");
+    const last = updates.at(-1)!;
+    expect(last.message).toBe("Vortex 2.7.0 is available to download");
+    expect(last.actions!.map((action) => action.title)).toEqual(["What's New", "Download"]);
+  });
+
+  it("surfaces update errors once and withdraws them on recovery", async () => {
+    const { sendNotification, notifications, pushState } = await setup();
+
+    pushState({ type: "error", message: "signature verification failed", manual: true });
+    pushState({ type: "error", message: "signature verification failed", manual: true });
+
+    expect(sent(sendNotification, "vortex-update-error")).toHaveLength(1);
+    expect(sent(sendNotification, "vortex-update-error")[0]!.type).toBe("error");
+
+    // a later clean state clears the error notification
+    pushState({ type: "idle" });
+    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(false);
+  });
+});
+
+describe("downgrades", () => {
   it("declining the downgrade dismisses the notification and tells main", async () => {
-    const { sendNotification, dismissNotification, showDialog, updater, pushStatus } =
-      await setup();
+    const { sendNotification, dismissNotification, showDialog, updater, pushState } = await setup();
 
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
-    const offer = sendNotification.mock.calls[0]![0];
+    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    const offer = sent(sendNotification, "vortex-downgrade-offer")[0]!;
 
     // open the downgrade dialog via the notification's More action
     offer.actions![0]!.action(() => undefined);
@@ -182,10 +364,10 @@ describe("updater status handling", () => {
   });
 
   it("confirming the downgrade downloads without an automatic restart", async () => {
-    const { sendNotification, showDialog, updater, pushStatus } = await setup();
+    const { sendNotification, showDialog, updater, pushState } = await setup();
 
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
-    sendNotification.mock.calls[0]![0].actions![0]!.action(() => undefined);
+    pushState({ type: "downgrade-offered", version: "2.5.0" });
+    sent(sendNotification, "vortex-downgrade-offer")[0]!.actions![0]!.action(() => undefined);
     await vi.advanceTimersByTimeAsync(0);
 
     const buttons = showDialog.mock.calls[0]![3] as Array<{
@@ -197,289 +379,66 @@ describe("updater status handling", () => {
     expect(updater.downloadDowngrade).toHaveBeenCalledWith(false);
   });
 
-  // Field report: a confirmed downgrade was narrated as a regular update
-  // ("9.0.0 is available" with a Download button) while it was downloading.
-  it("presents a confirmed downgrade as a downgrade, then as ready to install", async () => {
-    const { sendNotification, pushStatus } = await setup();
+  it("presents a confirmed downgrade as a downgrade, then as ready on restart", async () => {
+    const { sendNotification, pushState } = await setup();
 
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrading: true });
+    pushState({ type: "downloading", version: "2.5.0", kind: "downgrade", percent: 12 });
 
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const downloading = sendNotification.mock.calls[0]![0];
-    expect(downloading.id).toBe("vortex-update-available");
-    expect(downloading.message).toContain("Downgrading to Vortex 2.5.0");
-    // committed flow: nothing for the user to click while it downloads
-    expect(downloading.actions).toBeUndefined();
+    let updates = sent(sendNotification, "vortex-update-available");
+    expect(updates[0]!.message).toBe("Downgrading to Vortex 2.5.0 (12%)");
+    expect(updates[0]!.actions).toBeUndefined();
 
     // once staged it installs on quit, like a patch — and says so
-    pushStatus({ available: true, downloaded: true, version: "2.5.0", downgrading: true });
-    const downloaded = sendNotification.mock.calls[1]![0];
-    expect(downloaded.message).toBe("Vortex will update on restart");
-    expect(downloaded.actions).toHaveLength(1);
-    expect(downloaded.actions![0]!.title).toBe("Restart Now");
+    pushState({ type: "staged", version: "2.5.0", kind: "downgrade" });
+    updates = sent(sendNotification, "vortex-update-available");
+    const last = updates.at(-1)!;
+    expect(last.message).toBe("Vortex will update on restart");
+    expect(last.actions!.map((action) => action.title)).toEqual(["Restart Now"]);
   });
 
-  it("keeps a patch update quiet until staged, then offers a restart", async () => {
-    const { sendNotification, updater, pushStatus } = await setup();
+  // Review finding: when main retracts an offer (failed downgrade, release
+  // pulled from the feed), the standing notification kept dead buttons.
+  it("withdraws standing notifications when nothing is on offer any more", async () => {
+    const { notifications, pushState } = await setup();
 
-    // auto-downloading: nothing to decide, no notification churn
-    pushStatus({ available: true, downloaded: false, version: "2.6.1", patch: true });
-    expect(sendNotification).not.toHaveBeenCalled();
-
-    pushStatus({ available: true, downloaded: true, version: "2.6.1", patch: true });
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const notification = sendNotification.mock.calls[0]![0];
-    expect(notification.id).toBe("vortex-update-available");
-    expect(notification.message).toBe("Vortex will update on restart");
-    expect(notification.actions).toHaveLength(1);
-    expect(notification.actions![0]!.title).toBe("Restart Now");
-
-    notification.actions![0]!.action(() => undefined);
-    expect(updater.restartAndInstall).toHaveBeenCalledTimes(1);
-  });
-
-  // Review finding: every check broadcasts checking:true statuses that have
-  // the patch/downgrade labels cleared while available/version survive —
-  // acting on them briefly presented a downloading patch as a loud regular
-  // update with a live Download button.
-  it("ignores transient mid-check statuses", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    // e.g. the periodic re-check firing while a patch auto-downloads
-    pushStatus({ available: true, downloaded: false, version: "2.6.1", checking: true });
-    expect(sendNotification).not.toHaveBeenCalled();
-
-    // the settled status carries the real labels again
-    pushStatus({ available: true, downloaded: false, version: "2.6.1", patch: true });
-    expect(sendNotification).not.toHaveBeenCalled();
-  });
-
-  it("answers a manual check during a patch download with a downloading toast", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({
-      available: true,
-      downloaded: false,
-      version: "2.6.1",
-      patch: true,
-      checking: true,
-      manual: true,
-    });
-    pushStatus({
-      available: true,
-      downloaded: false,
-      version: "2.6.1",
-      patch: true,
-      checking: false,
-      manual: true,
-    });
-
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const toast = sendNotification.mock.calls[0]![0];
-    expect(toast.message).toContain("2.6.1 is downloading");
-  });
-
-  // Review finding: when main retracts an offer (failed downgrade download,
-  // release pulled from the feed), the standing notification kept dead
-  // buttons on screen.
-  it("withdraws standing notifications when nothing is available any more", async () => {
-    const { sendNotification, notifications, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
-    expect(sendNotification).toHaveBeenCalledTimes(1);
+    pushState({ type: "downgrade-offered", version: "2.5.0" });
     expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
 
-    pushStatus({ available: false, downloaded: false });
+    pushState({ type: "idle" });
     expect(notifications).toHaveLength(0);
 
-    // and the next offer still shows (lastShown was reset)
-    pushStatus({ available: true, downloaded: false, version: "2.5.0", downgrade: true });
+    // and the next offer still shows
+    pushState({ type: "downgrade-offered", version: "2.5.0" });
     expect(notifications.some((entry) => entry.id === "vortex-downgrade-offer")).toBe(true);
   });
+});
 
+describe("post-update notice", () => {
   it("shows a one-time 'was updated' notice on the first launch after an update", async () => {
-    const { sendNotification, pushStatus } = await setup();
+    const { sendNotification, pushState } = await setup();
 
-    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
-    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
+    pushState({ type: "idle" }, "2.5.9");
+    pushState({ type: "idle" }, "2.5.9");
 
-    const updated = sendNotification.mock.calls.filter(
-      ([notification]) => notification.id === "vortex-updated",
-    );
+    const updated = sent(sendNotification, "vortex-updated");
     expect(updated).toHaveLength(1);
-    expect(updated[0]![0].message).toContain("was updated to 2.6.0-beta.1");
-    expect(updated[0]![0].actions![0]!.title).toBe("View changes");
-  });
-
-  it("syncs the initial status via getStatus for checks that finished early", async () => {
-    const { sendNotification } = await setup({
-      available: true,
-      downloaded: false,
-      version: "2.8.0",
-    });
-
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    expect(sendNotification.mock.calls[0]![0].message).toContain("2.8.0");
-  });
-
-  it("re-creates the notification on transitions but not on identical pushes", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    // identical push (e.g. re-broadcast) must not churn the notification
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-
-    // a transition (download finished) re-creates it so the toast re-shows
-    pushStatus({ available: true, downloaded: true, version: "2.7.0" });
-    expect(sendNotification).toHaveBeenCalledTimes(2);
-  });
-
-  // Field report: after a dismissed notification (e.g. clicking Restart &
-  // Install in dev), a manual re-check of the same version showed nothing.
-  it("resurrects a dismissed notification on the next identical status", async () => {
-    const { sendNotification, notifications, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-
-    // user dismisses it (or an action did)
-    notifications.length = 0;
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    expect(sendNotification).toHaveBeenCalledTimes(2);
-    expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
-  });
-
-  it("shows an up-to-date toast when a manual check finds nothing", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: false, downloaded: false, checking: true, manual: true });
-    pushStatus({ available: false, downloaded: false, checking: false, manual: true });
-
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-    const toast = sendNotification.mock.calls[0]![0];
-    expect(toast.id).toBe("vortex-up-to-date");
-    expect(toast.message).toContain("up to date");
-  });
-
-  it("re-toasts the unchanged update notification after a manual check", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    expect(sendNotification).toHaveBeenCalledTimes(1);
-
-    // manual re-check resolves the same version: user still expects feedback
-    pushStatus({
-      available: true,
-      downloaded: false,
-      version: "2.7.0",
-      checking: true,
-      manual: true,
-    });
-    pushStatus({
-      available: true,
-      downloaded: false,
-      version: "2.7.0",
-      checking: false,
-      manual: true,
-    });
-
-    expect(sendNotification).toHaveBeenCalledTimes(2);
-    expect(sendNotification.mock.calls[1]![0].id).toBe("vortex-update-available");
-  });
-
-  it("stays quiet when a background check finds nothing", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: false, downloaded: false, checking: true, manual: false });
-    pushStatus({ available: false, downloaded: false, checking: false, manual: false });
-
-    expect(sendNotification).not.toHaveBeenCalled();
-  });
-
-  // Field report: hours of failing downloads were invisible outside the log.
-  it("surfaces update errors once and withdraws them on recovery", async () => {
-    const { sendNotification, notifications, pushStatus } = await setup();
-
-    pushStatus({ available: false, downloaded: false, error: "signature verification failed" });
-    pushStatus({ available: false, downloaded: false, error: "signature verification failed" });
-
-    const errors = sendNotification.mock.calls.filter(
-      ([notification]) => notification.id === "vortex-update-error",
-    );
-    expect(errors).toHaveLength(1);
-    expect(errors[0]![0].type).toBe("error");
-
-    // a later successful check clears the error and the notification
-    pushStatus({ available: false, downloaded: false });
-    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(false);
-  });
-
-  it("does not claim 'up to date' when a manual check failed", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: false, downloaded: false, checking: true, manual: true });
-    pushStatus({ available: false, downloaded: false, manual: true, error: "network down" });
-
-    const ids = sendNotification.mock.calls.map(([notification]) => notification.id);
-    expect(ids).not.toContain("vortex-up-to-date");
-    expect(ids).toContain("vortex-update-error");
-  });
-
-  it("shows live download progress without re-toasting each tick", async () => {
-    const { sendNotification, dismissNotification, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    dismissNotification.mockClear();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 41 });
-    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 42 });
-
-    // progress ticks update in place: no dismiss (which would re-toast)
-    expect(dismissNotification).not.toHaveBeenCalled();
-    const last = sendNotification.mock.calls.at(-1)![0];
-    // the percent lives in the text: the theme's bar overlay is too subtle
-    expect(last.message).toBe("Downloading Vortex 2.7.0 (42%)");
-    expect(last.progress).toBe(42);
-    // no buttons at all while downloading
-    expect(last.actions).toBeUndefined();
-  });
-
-  // Field-tested: killing the feed mid-download left "Downloading…" frozen
-  // with no retry. A failed download (error set, progress cleared by main)
-  // must recover to a retryable notification alongside the error one.
-  it("recovers a failed download to a retryable notification", async () => {
-    const { sendNotification, notifications, pushStatus } = await setup();
-
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
-    pushStatus({ available: true, downloaded: false, version: "2.7.0", downloadProgress: 40 });
-
-    pushStatus({
-      available: true,
-      downloaded: false,
-      version: "2.7.0",
-      error: "net::ERR_CONNECTION_REFUSED",
-    });
-
-    expect(notifications.some((entry) => entry.id === "vortex-update-error")).toBe(true);
-    const last = sendNotification.mock.calls.at(-1)![0];
-    expect(last.id).toBe("vortex-update-available");
-    expect(last.message).toBe("Vortex 2.7.0 is available to download");
-    expect(last.actions!.map((action) => action.title)).toEqual(["What's New", "Download"]);
+    expect(updated[0]!.message).toContain("was updated to 2.6.0-beta.1");
+    expect(updated[0]!.actions![0]!.title).toBe("View changes");
   });
 
   it("dismisses the 'was updated' notice when an update notification appears", async () => {
-    const { notifications, pushStatus } = await setup();
+    const { notifications, pushState } = await setup();
 
-    pushStatus({ available: false, downloaded: false, justUpdatedFrom: "2.5.9" });
+    pushState({ type: "idle" }, "2.5.9");
     expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(true);
 
-    pushStatus({ available: true, downloaded: false, version: "2.7.0" });
+    pushState({ type: "available", version: "2.7.0" }, "2.5.9");
     expect(notifications.some((entry) => entry.id === "vortex-updated")).toBe(false);
     expect(notifications.some((entry) => entry.id === "vortex-update-available")).toBe(true);
   });
+});
 
+describe("periodic checks", () => {
   it("re-checks periodically so long sessions hear about updates", async () => {
     const { updater } = await setup();
     updater.checkForUpdates.mockClear();
@@ -489,14 +448,5 @@ describe("updater status handling", () => {
 
     await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
     expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
-  });
-
-  it("ignores non-available statuses (checking, progress)", async () => {
-    const { sendNotification, pushStatus } = await setup();
-
-    pushStatus({ available: false, downloaded: false, checking: true });
-    pushStatus({ available: false, downloaded: false });
-
-    expect(sendNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -59,7 +59,17 @@ function init(context: IExtensionContext): boolean {
 
     const channelNow = () => context.api.store.getState().settings.update.channel;
 
-    const dismiss = (id: string) => context.api.dismissNotification?.(id);
+    // Our own dismissals (a state moved on) must not read as the user closing
+    // a notification, which for a running download means "cancel it".
+    let dismissingOurselves = false;
+    const dismiss = (id: string) => {
+      dismissingOurselves = true;
+      try {
+        context.api.dismissNotification?.(id);
+      } finally {
+        dismissingOurselves = false;
+      }
+    };
 
     const notificationExists = (id: string): boolean =>
       context.api
@@ -317,7 +327,14 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                 ? `${verb} Vortex ${state.version} (${state.percent}%)`
                 : `${verb} Vortex ${state.version}`,
             progress: state.percent,
-            // no buttons while the download runs, nothing sensible to click
+            // no buttons while the download runs; closing the notification is
+            // the one control, and it cancels the download
+            onDismiss: () => {
+              if (dismissingOurselves) {
+                return;
+              }
+              act(() => window.api.updater.cancelDownload());
+            },
           });
           return;
         }

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -109,7 +109,28 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         .getState()
         .session.notifications.notifications.some((notification) => notification.id === id);
 
+    let prevStatus: UpdateStatus | null = null;
+
     const handleUpdateStatus = (status: UpdateStatus) => {
+      // A user-initiated check deserves visible feedback either way: re-toast
+      // the update notification even if nothing changed, or say "up to date".
+      const manualCheckCompleted =
+        prevStatus?.checking === true && prevStatus.manual === true && status.checking !== true;
+      prevStatus = status;
+      if (manualCheckCompleted) {
+        if (status.available) {
+          lastShown = null; // bypass the dedupe so the toast re-shows
+        } else {
+          context.api.sendNotification({
+            id: "vortex-up-to-date",
+            type: "success",
+            message: `Vortex ${getApplication().version} is up to date`,
+            displayMS: 5000,
+          });
+          return;
+        }
+      }
+
       const shown = {
         version: status.version,
         downloaded: status.downloaded,

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -77,7 +77,7 @@ function init(context: IExtensionContext): boolean {
 
 Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.
 
-If you downgrade, Vortex will download ${status.version}; once the download completes you can restart to install it.`,
+If you downgrade, Vortex will download ${status.version} and update on restart.`,
                 },
                 [
                   {
@@ -93,8 +93,8 @@ If you downgrade, Vortex will download ${status.version}; once the download comp
                     label: `Downgrade to ${status.version}`,
                     action: () => {
                       context.api.dismissNotification?.("vortex-downgrade-offer");
-                      // download only: the user restarts when ready, via the
-                      // same ready-to-install notification as regular updates
+                      // download without forcing a restart: once staged it
+                      // installs on quit, or via the notification's Restart Now
                       window.api.updater.downloadDowngrade(false);
                     },
                   },
@@ -132,7 +132,8 @@ If you downgrade, Vortex will download ${status.version}; once the download comp
     let shownUpdatedNotice = false;
     const showPostUpdateChanges = async () => {
       const version = getApplication().version;
-      const notes = await window.api.updater.getUpdateChangelog().catch(() => null);
+      const channel = context.api.store.getState().settings.update.channel;
+      const notes = await window.api.updater.getUpdateChangelog(channel).catch(() => null);
       await context.api.showDialog(
         "info",
         `What's New in ${version}`,
@@ -169,14 +170,43 @@ If you downgrade, Vortex will download ${status.version}; once the download comp
       const manualCheckCompleted =
         prevStatus?.checking === true && prevStatus.manual === true && status.checking !== true;
       prevStatus = status;
-      if (manualCheckCompleted) {
-        if (status.available) {
-          lastShown = null; // bypass the dedupe so the toast re-shows
-        } else {
+
+      // Mid-check pushes are transient: every check clears the downgrade and
+      // patch labels before re-resolving, so acting on a checking status
+      // renders the previous offer stripped of its identity (a patch would
+      // briefly show the loud Download notification). Only settled statuses
+      // drive notifications.
+      if (status.checking === true) {
+        return;
+      }
+
+      // The resolver settled on "nothing available": withdraw any standing
+      // notification (a retracted downgrade offer, a failed downgrade, a
+      // release pulled from the feed) so dead buttons don't linger.
+      if (!status.available) {
+        context.api.dismissNotification?.("vortex-update-available");
+        context.api.dismissNotification?.("vortex-downgrade-offer");
+        lastShown = null;
+        if (manualCheckCompleted) {
           context.api.sendNotification({
             id: "vortex-up-to-date",
             type: "success",
             message: `Vortex ${getApplication().version} is up to date`,
+            displayMS: 5000,
+          });
+        }
+        return;
+      }
+
+      if (manualCheckCompleted) {
+        lastShown = null; // bypass the dedupe so the toast re-shows
+        // A patch mid-download shows no standing notification, but a manual
+        // check still owes the user an answer.
+        if (status.patch && !status.downloaded && status.version) {
+          context.api.sendNotification({
+            id: "vortex-up-to-date",
+            type: "info",
+            message: `Vortex ${status.version} is downloading and will update on restart`,
             displayMS: 5000,
           });
           return;
@@ -202,8 +232,8 @@ If you downgrade, Vortex will download ${status.version}; once the download comp
 
       // A confirmed downgrade downloading is exactly that — describing it as
       // an available update misstates what is happening. Once downloaded it
-      // falls through to the ordinary ready-to-install notification below,
-      // same buttons and all.
+      // reads like a staged patch below: it installs on quit, Restart Now
+      // does it straight away.
       if (status.downgrading && !status.downloaded) {
         if (status.version) {
           lastShown = shown;
@@ -235,11 +265,13 @@ If you downgrade, Vortex will download ${status.version}; once the download comp
         }
         lastShown = shown;
         context.api.dismissNotification?.("vortex-update-available");
-        if (status.patch) {
+        // Staged patches and confirmed downgrades install when Vortex closes;
+        // the wording says so, and Restart Now does it straight away.
+        if (status.patch || status.downgrading) {
           context.api.sendNotification({
             id: "vortex-update-available",
             type: "info",
-            message: "Vortex will update the next time you restart",
+            message: "Vortex will update on restart",
             actions: [
               {
                 title: "Restart Now",

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -288,17 +288,10 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
           dismiss(NOTIF_OFFER);
           dismiss(NOTIF_ERROR);
           dismiss(NOTIF_UPDATED);
-          // patches download silently — but a manual check that found one
-          // still owes the user an answer
-          if (state.kind === "patch") {
-            if (manualCheckSettled) {
-              context.api.sendNotification({
-                id: NOTIF_TOAST,
-                type: "info",
-                message: `Vortex ${state.version} is downloading and will update on restart`,
-                displayMS: 5000,
-              });
-            }
+          // only BACKGROUND patch downloads are silent; anything the user's
+          // own press set in motion (Download, a confirmed downgrade, a
+          // manual check that found a patch) downloads visibly
+          if (state.kind === "patch" && !state.manual) {
             return;
           }
           // the percent lives in the text: the theme's progress overlay is

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -37,7 +37,8 @@ function init(context: IExtensionContext): boolean {
         [
           { label: "Close" },
           {
-            label: status.downloaded ? "Restart & Install" : "Download",
+            // matches the notification's action button
+            label: status.downloaded ? "Restart Now" : "Download",
             default: true,
             action: () => {
               if (status.downloaded) {
@@ -63,7 +64,7 @@ function init(context: IExtensionContext): boolean {
       context.api.sendNotification({
         id: "vortex-downgrade-offer",
         type: "warning",
-        message: `Stable version ${status.version} is older than your current version`,
+        message: `Vortex ${status.version} is a downgrade and older than your current version`,
         actions: [
           {
             title: "More",
@@ -76,15 +77,25 @@ function init(context: IExtensionContext): boolean {
 
 Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.
 
-If you downgrade, Vortex will restart and install ${status.version} as soon as the download completes.`,
+If you downgrade, Vortex will download ${status.version}; once the download completes you can restart to install it.`,
                 },
                 [
-                  { label: "Stay on current version" },
+                  {
+                    label: "Stay on current version",
+                    action: () => {
+                      // declining forgets the offer (notification included)
+                      // until the next check raises it again
+                      context.api.dismissNotification?.("vortex-downgrade-offer");
+                      window.api.updater.declineDowngrade();
+                    },
+                  },
                   {
                     label: `Downgrade to ${status.version}`,
                     action: () => {
                       context.api.dismissNotification?.("vortex-downgrade-offer");
-                      window.api.updater.downloadDowngrade(true);
+                      // download only: the user restarts when ready, via the
+                      // same ready-to-install notification as regular updates
+                      window.api.updater.downloadDowngrade(false);
                     },
                   },
                 ],
@@ -102,7 +113,12 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
     // so the toast re-appears; skip pushes that change nothing the user sees
     // (e.g. download progress) — unless the notification was dismissed in the
     // meantime, in which case a fresh check resurrects it.
-    let lastShown: { version?: string; downloaded: boolean; downgrade: boolean } | null = null;
+    let lastShown: {
+      version?: string;
+      downloaded: boolean;
+      downgrade: boolean;
+      downgrading: boolean;
+    } | null = null;
 
     const notificationExists = (id: string): boolean =>
       context.api
@@ -111,7 +127,43 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
 
     let prevStatus: UpdateStatus | null = null;
 
+    // One-time notice on the first launch after an update; "View changes"
+    // fetches the notes covering the versions the update went through.
+    let shownUpdatedNotice = false;
+    const showPostUpdateChanges = async () => {
+      const version = getApplication().version;
+      const notes = await window.api.updater.getUpdateChangelog().catch(() => null);
+      await context.api.showDialog(
+        "info",
+        `What's New in ${version}`,
+        {
+          htmlText: notes
+            ? `<div class="changelog-dialog-release">${notes}</div>`
+            : "<p>No release notes are available for this update.</p>",
+        },
+        [{ label: "Close" }],
+        "new-update-changelog-dialog",
+      );
+    };
+
     const handleUpdateStatus = (status: UpdateStatus) => {
+      if (!shownUpdatedNotice && status.justUpdatedFrom != null) {
+        shownUpdatedNotice = true;
+        context.api.sendNotification({
+          id: "vortex-updated",
+          type: "success",
+          message: `Vortex was updated to ${getApplication().version}`,
+          actions: [
+            {
+              title: "View changes",
+              action: () => {
+                void showPostUpdateChanges();
+              },
+            },
+          ],
+        });
+      }
+
       // A user-initiated check deserves visible feedback either way: re-toast
       // the update notification even if nothing changed, or say "up to date".
       const manualCheckCompleted =
@@ -135,14 +187,33 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         version: status.version,
         downloaded: status.downloaded,
         downgrade: status.downgrade === true,
+        downgrading: status.downgrading === true,
       };
       if (
         lastShown != null &&
         lastShown.version === shown.version &&
         lastShown.downloaded === shown.downloaded &&
         lastShown.downgrade === shown.downgrade &&
+        lastShown.downgrading === shown.downgrading &&
         notificationExists(shown.downgrade ? "vortex-downgrade-offer" : "vortex-update-available")
       ) {
+        return;
+      }
+
+      // A confirmed downgrade downloading is exactly that — describing it as
+      // an available update misstates what is happening. Once downloaded it
+      // falls through to the ordinary ready-to-install notification below,
+      // same buttons and all.
+      if (status.downgrading && !status.downloaded) {
+        if (status.version) {
+          lastShown = shown;
+          context.api.dismissNotification?.("vortex-update-available");
+          context.api.sendNotification({
+            id: "vortex-update-available",
+            type: "info",
+            message: `Downgrading to Vortex ${status.version}`,
+          });
+        }
         return;
       }
 
@@ -157,19 +228,38 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         return;
       }
       if (status.available && status.version) {
+        // Patch updates download themselves: stay quiet until the download
+        // is staged, then say what actually happens next (install on quit).
+        if (status.patch && !status.downloaded) {
+          return;
+        }
         lastShown = shown;
         context.api.dismissNotification?.("vortex-update-available");
+        if (status.patch) {
+          context.api.sendNotification({
+            id: "vortex-update-available",
+            type: "info",
+            message: "Vortex will update the next time you restart",
+            actions: [
+              {
+                title: "Restart Now",
+                // no dismiss: a packaged app quits here anyway, and if the
+                // install fails (or is skipped in dev) the button must stay
+                action: () => window.api.updater.restartAndInstall(),
+              },
+            ],
+          });
+          return;
+        }
         context.api.sendNotification({
           id: "vortex-update-available",
           type: "info",
-          // once staged, the update installs on quit — say so rather than
-          // surprising the user when they close Vortex
           message: status.downloaded
-            ? `Vortex ${status.version} will install when you close Vortex`
-            : `Vortex ${status.version} is available`,
+            ? `Vortex ${status.version} is ready to install`
+            : `Vortex ${status.version} is available to download`,
           actions: [
             {
-              title: "More",
+              title: "What's New",
               action: () => {
                 void showUpdateDialog(status.version!, status.releaseNotes);
               },
@@ -177,9 +267,8 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
             {
               // Not downloaded yet (minor/major updates wait for the user):
               // the button downloads, and the pushed "downloaded" status then
-              // flips this same notification to Restart & Install. Patch
-              // updates arrive already downloaded, so they start there.
-              title: status.downloaded ? "Restart & Install" : "Download",
+              // flips this same notification to Restart Now.
+              title: status.downloaded ? "Restart Now" : "Download",
               action: () => {
                 if (status.downloaded) {
                   // no dismiss: a packaged app quits here anyway, and if the
@@ -189,7 +278,7 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
                   const channel = context.api.store.getState().settings.update.channel;
                   window.api.updater.downloadUpdate(channel, false);
                   // keep the notification: it live-updates to show the
-                  // Restart & Install action once the download completes
+                  // Restart Now action once the download completes
                 }
               },
             },

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -158,6 +158,17 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
       }
     }, 5000);
 
+    // Vortex sessions stay open for days; without a periodic re-check a
+    // long-running instance never hears about updates (including hotfix
+    // patches, which auto-download) until the next launch.
+    const PERIODIC_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+    setInterval(() => {
+      const channel = context.api.store.getState().settings.update.channel;
+      if (channel !== "none") {
+        window.api.updater.checkForUpdates(channel, false);
+      }
+    }, PERIODIC_CHECK_INTERVAL_MS);
+
     // Main pushes every status change; the one-time getStatus covers a check
     // that finished before this subscription existed (e.g. window reload).
     window.api.updater.onStatusChanged(handleUpdateStatus);

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -118,7 +118,9 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
       downloaded: boolean;
       downgrade: boolean;
       downgrading: boolean;
+      progress?: number;
     } | null = null;
+    let lastErrorShown: string | null = null;
 
     const notificationExists = (id: string): boolean =>
       context.api
@@ -180,6 +182,38 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
         return;
       }
 
+      // Failures were invisible outside the log: a download that dies (bad
+      // signature, network) or a failed check now says so. Shown once per
+      // distinct error, withdrawn when a later attempt clears it.
+      if (status.error != null) {
+        if (status.error !== lastErrorShown) {
+          lastErrorShown = status.error;
+          const detail = status.error;
+          context.api.sendNotification({
+            id: "vortex-update-error",
+            type: "error",
+            message: "Vortex update failed",
+            actions: [
+              {
+                title: "More",
+                action: () => {
+                  void context.api.showDialog(
+                    "error",
+                    "Vortex update failed",
+                    { text: detail },
+                    [{ label: "Close" }],
+                    "update-error-dialog",
+                  );
+                },
+              },
+            ],
+          });
+        }
+      } else if (lastErrorShown != null) {
+        lastErrorShown = null;
+        context.api.dismissNotification?.("vortex-update-error");
+      }
+
       // The resolver settled on "nothing available": withdraw any standing
       // notification (a retracted downgrade offer, a failed downgrade, a
       // release pulled from the feed) so dead buttons don't linger.
@@ -188,12 +222,15 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
         context.api.dismissNotification?.("vortex-downgrade-offer");
         lastShown = null;
         if (manualCheckCompleted) {
-          context.api.sendNotification({
-            id: "vortex-up-to-date",
-            type: "success",
-            message: `Vortex ${getApplication().version} is up to date`,
-            displayMS: 5000,
-          });
+          // a failed check must not masquerade as "up to date"
+          if (status.error == null) {
+            context.api.sendNotification({
+              id: "vortex-up-to-date",
+              type: "success",
+              message: `Vortex ${getApplication().version} is up to date`,
+              displayMS: 5000,
+            });
+          }
         }
         return;
       }
@@ -218,17 +255,30 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
         downloaded: status.downloaded,
         downgrade: status.downgrade === true,
         downgrading: status.downgrading === true,
+        // whole percent while a download is in flight — so the notification
+        // can show a live bar (a frozen bar is also the only honest signal
+        // for a stalled download)
+        progress:
+          !status.downloaded && typeof status.downloadProgress === "number"
+            ? Math.floor(status.downloadProgress)
+            : undefined,
       };
-      if (
+      const sameOffer =
         lastShown != null &&
         lastShown.version === shown.version &&
         lastShown.downloaded === shown.downloaded &&
         lastShown.downgrade === shown.downgrade &&
-        lastShown.downgrading === shown.downgrading &&
+        lastShown.downgrading === shown.downgrading;
+      if (
+        sameOffer &&
+        lastShown!.progress === shown.progress &&
         notificationExists(shown.downgrade ? "vortex-downgrade-offer" : "vortex-update-available")
       ) {
         return;
       }
+      // Progress ticks update the notification in place; dismiss-and-resend
+      // (which re-toasts) is reserved for user-meaningful transitions.
+      const progressOnly = sameOffer && lastShown!.progress !== shown.progress;
 
       // A confirmed downgrade downloading is exactly that — describing it as
       // an available update misstates what is happening. Once downloaded it
@@ -237,11 +287,15 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
       if (status.downgrading && !status.downloaded) {
         if (status.version) {
           lastShown = shown;
-          context.api.dismissNotification?.("vortex-update-available");
+          if (!progressOnly) {
+            context.api.dismissNotification?.("vortex-update-available");
+            context.api.dismissNotification?.("vortex-updated");
+          }
           context.api.sendNotification({
             id: "vortex-update-available",
             type: "info",
             message: `Downgrading to Vortex ${status.version}`,
+            progress: shown.progress,
           });
         }
         return;
@@ -251,6 +305,7 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
         if (status.version) {
           lastShown = shown;
           context.api.dismissNotification?.("vortex-downgrade-offer");
+          context.api.dismissNotification?.("vortex-updated");
           showDowngradeOffer(status);
         } else {
           log("warn", "downgrade status without a version", status);
@@ -264,7 +319,12 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
           return;
         }
         lastShown = shown;
-        context.api.dismissNotification?.("vortex-update-available");
+        if (!progressOnly) {
+          context.api.dismissNotification?.("vortex-update-available");
+          // an actionable update supersedes the "was updated" notice — two
+          // update notifications at once reads as a glitch
+          context.api.dismissNotification?.("vortex-updated");
+        }
         // Staged patches and confirmed downgrades install when Vortex closes;
         // the wording says so, and Restart Now does it straight away.
         if (status.patch || status.downgrading) {
@@ -288,7 +348,10 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
           type: "info",
           message: status.downloaded
             ? `Vortex ${status.version} is ready to install`
-            : `Vortex ${status.version} is available to download`,
+            : shown.progress != null
+              ? `Downloading Vortex ${status.version}`
+              : `Vortex ${status.version} is available to download`,
+          progress: shown.progress,
           actions: [
             {
               title: "What's New",
@@ -296,24 +359,30 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
                 void showUpdateDialog(status.version!, status.releaseNotes);
               },
             },
-            {
-              // Not downloaded yet (minor/major updates wait for the user):
-              // the button downloads, and the pushed "downloaded" status then
-              // flips this same notification to Restart Now.
-              title: status.downloaded ? "Restart Now" : "Download",
-              action: () => {
-                if (status.downloaded) {
-                  // no dismiss: a packaged app quits here anyway, and if the
-                  // install fails (or is skipped in dev) the button must stay
-                  window.api.updater.restartAndInstall();
-                } else {
-                  const channel = context.api.store.getState().settings.update.channel;
-                  window.api.updater.downloadUpdate(channel, false);
-                  // keep the notification: it live-updates to show the
-                  // Restart Now action once the download completes
-                }
-              },
-            },
+            // no Download button while the download is running
+            ...(shown.progress != null
+              ? []
+              : [
+                  {
+                    // Not downloaded yet (minor/major updates wait for the
+                    // user): the button downloads, and the pushed "downloaded"
+                    // status then flips this same notification to Restart Now.
+                    title: status.downloaded ? "Restart Now" : "Download",
+                    action: () => {
+                      if (status.downloaded) {
+                        // no dismiss: a packaged app quits here anyway, and if
+                        // the install fails (or is skipped in dev) the button
+                        // must stay
+                        window.api.updater.restartAndInstall();
+                      } else {
+                        const channel = context.api.store.getState().settings.update.channel;
+                        window.api.updater.downloadUpdate(channel, false);
+                        // keep the notification: it live-updates to show the
+                        // Restart Now action once the download completes
+                      }
+                    },
+                  },
+                ]),
           ],
         });
       }

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -1,8 +1,38 @@
+import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
+
 import type { IExtensionContext } from "../../types/IExtensionContext";
 import { getApplication } from "../../util/application";
-import { log } from "../../util/log";
 import settingsReducer from "./reducers";
 import SettingsUpdate from "./SettingsUpdate";
+
+// Notification surfaces. UPDATE is the single slot for "what the updater is
+// doing with a version" (available/downloading/staged); the others are
+// auxiliary and mutually independent.
+const NOTIF_UPDATE = "vortex-update-available";
+const NOTIF_OFFER = "vortex-downgrade-offer";
+const NOTIF_ERROR = "vortex-update-error";
+const NOTIF_TOAST = "vortex-up-to-date";
+const NOTIF_CHECKING = "vortex-update-checking";
+const NOTIF_UPDATED = "vortex-updated";
+
+// The identity of a state for notification purposes: states with the same key
+// upsert the standing notification in place (no re-toast); a key change is a
+// user-meaningful transition and re-toasts. Progress percent is deliberately
+// not part of the key.
+function stateKey(state: UpdaterState): string {
+  switch (state.type) {
+    case "available":
+    case "downgrade-offered":
+      return `${state.type}:${state.version}`;
+    case "downloading":
+    case "staged":
+      return `${state.type}:${state.kind}:${state.version}`;
+    case "error":
+      return `error:${state.message}`;
+    default:
+      return state.type;
+  }
+}
 
 function init(context: IExtensionContext): boolean {
   context.registerReducer(["settings", "update"], settingsReducer);
@@ -18,14 +48,23 @@ function init(context: IExtensionContext): boolean {
 
     let haveSetChannel = false;
 
-    type UpdateStatus = Awaited<ReturnType<typeof window.api.updater.getStatus>>;
+    const channelNow = () => context.api.store.getState().settings.update.channel;
 
-    // Show update details dialog with HTML release notes. Buttons act via
-    // their own callbacks rather than label matching, so a renamed or
-    // translated label can't silently break the action.
+    const dismiss = (id: string) => context.api.dismissNotification?.(id);
+
+    const notificationExists = (id: string): boolean =>
+      context.api
+        .getState()
+        .session.notifications.notifications.some((notification) => notification.id === id);
+
+    // ---- dialogs -----------------------------------------------------------
+
+    // What's New dialog with HTML release notes. Buttons act via their own
+    // callbacks rather than label matching, so a renamed or translated label
+    // can't silently break the action.
     const showUpdateDialog = async (version: string, releaseNotes?: string) => {
-      const status = await window.api.updater.getStatus();
-
+      const { state } = await window.api.updater.getStatus();
+      const staged = state.type === "staged";
       await context.api.showDialog(
         "info",
         `What's New in ${version}`,
@@ -38,14 +77,13 @@ function init(context: IExtensionContext): boolean {
           { label: "Close" },
           {
             // matches the notification's action button
-            label: status.downloaded ? "Restart Now" : "Download",
+            label: staged ? "Restart Now" : "Download",
             default: true,
             action: () => {
-              if (status.downloaded) {
+              if (staged) {
                 window.api.updater.restartAndInstall();
               } else {
-                const channel = context.api.store.getState().settings.update.channel;
-                window.api.updater.downloadUpdate(channel);
+                window.api.updater.downloadUpdate(channelNow(), false);
               }
             },
           },
@@ -54,17 +92,33 @@ function init(context: IExtensionContext): boolean {
       );
     };
 
-    // React to a status pushed from main (or fetched for the initial sync):
-    // upsert the update notification — same id, so repeated statuses update
-    // it in place rather than stacking.
-    // A downgrade offer only ever follows an explicit switch to the stable
+    // One-time notice on the first launch after an update; "View changes"
+    // fetches the notes covering the versions the update went through.
+    let shownUpdatedNotice = false;
+    const showPostUpdateChanges = async () => {
+      const version = getApplication().version;
+      const notes = await window.api.updater.getUpdateChangelog(channelNow()).catch(() => null);
+      await context.api.showDialog(
+        "info",
+        `What's New in ${version}`,
+        {
+          htmlText: notes
+            ? `<div class="changelog-dialog-release">${notes}</div>`
+            : "<p>No release notes are available for this update.</p>",
+        },
+        [{ label: "Close" }],
+        "new-update-changelog-dialog",
+      );
+    };
+
+    // A downgrade offer only ever follows a purposeful switch to the stable
     // channel; it is presented as exactly what it is, never as an update.
-    const showDowngradeOffer = (status: UpdateStatus) => {
+    const showDowngradeOffer = (version: string) => {
       const currentVersion = getApplication().version;
       context.api.sendNotification({
-        id: "vortex-downgrade-offer",
+        id: NOTIF_OFFER,
         type: "warning",
-        message: `Vortex ${status.version} is a downgrade and older than your current version`,
+        message: `Vortex ${version} is a downgrade and older than your current version`,
         actions: [
           {
             title: "More",
@@ -73,26 +127,26 @@ function init(context: IExtensionContext): boolean {
                 "question",
                 "Downgrade to stable?",
                 {
-                  text: `Switching to the Stable channel would install Vortex ${status.version}, which is older than the version you are running (${currentVersion}).
+                  text: `Switching to the Stable channel would install Vortex ${version}, which is older than the version you are running (${currentVersion}).
 
 Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.
 
-If you downgrade, Vortex will download ${status.version} and update on restart.`,
+If you downgrade, Vortex will download ${version} and update on restart.`,
                 },
                 [
                   {
                     label: "Stay on current version",
                     action: () => {
                       // declining forgets the offer (notification included)
-                      // until the next check raises it again
-                      context.api.dismissNotification?.("vortex-downgrade-offer");
+                      // until the next purposeful switch to stable
+                      dismiss(NOTIF_OFFER);
                       window.api.updater.declineDowngrade();
                     },
                   },
                   {
-                    label: `Downgrade to ${status.version}`,
+                    label: `Downgrade to ${version}`,
                     action: () => {
-                      context.api.dismissNotification?.("vortex-downgrade-offer");
+                      dismiss(NOTIF_OFFER);
                       // download without forcing a restart: once staged it
                       // installs on quit, or via the notification's Restart Now
                       window.api.updater.downloadDowngrade(false);
@@ -107,53 +161,30 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
       });
     };
 
-    // The toast only shows when a notification is created — same-id updates
-    // keep their createdTime and stay collapsed in the tray. Dismiss and
-    // re-send on user-meaningful transitions (new version, download finished)
-    // so the toast re-appears; skip pushes that change nothing the user sees
-    // (e.g. download progress) — unless the notification was dismissed in the
-    // meantime, in which case a fresh check resurrects it.
-    let lastShown: {
-      version?: string;
-      downloaded: boolean;
-      downgrade: boolean;
-      downgrading: boolean;
-      progress?: number;
-    } | null = null;
-    let lastErrorShown: string | null = null;
+    // ---- state → notifications --------------------------------------------
 
-    const notificationExists = (id: string): boolean =>
-      context.api
-        .getState()
-        .session.notifications.notifications.some((notification) => notification.id === id);
+    // The updater is a state machine (see UpdaterState); this is the single
+    // mapping from states to Vortex notifications. Everything the user sees
+    // derives from the current state plus two rules:
+    //   - background work is silent unless it changed something the user can
+    //     see; button-pressed work is visible from press to settle
+    //   - one update notification at a time (an actionable state supersedes
+    //     the "was updated" notice)
+    let prevState: UpdaterState | null = null;
 
-    let prevStatus: UpdateStatus | null = null;
+    // the "Checking for updates..." feedback settles with the check
+    const settleCheckToast = () => dismiss(NOTIF_CHECKING);
 
-    // One-time notice on the first launch after an update; "View changes"
-    // fetches the notes covering the versions the update went through.
-    let shownUpdatedNotice = false;
-    const showPostUpdateChanges = async () => {
-      const version = getApplication().version;
-      const channel = context.api.store.getState().settings.update.channel;
-      const notes = await window.api.updater.getUpdateChangelog(channel).catch(() => null);
-      await context.api.showDialog(
-        "info",
-        `What's New in ${version}`,
-        {
-          htmlText: notes
-            ? `<div class="changelog-dialog-release">${notes}</div>`
-            : "<p>No release notes are available for this update.</p>",
-        },
-        [{ label: "Close" }],
-        "new-update-changelog-dialog",
-      );
-    };
+    const render = (snapshot: UpdaterSnapshot) => {
+      const state = snapshot.state;
+      const prev = prevState;
+      prevState = state;
 
-    const handleUpdateStatus = (status: UpdateStatus) => {
-      if (!shownUpdatedNotice && status.justUpdatedFrom != null) {
+      // one-time "was updated" notice; any actionable state below supersedes it
+      if (!shownUpdatedNotice && snapshot.justUpdatedFrom != null) {
         shownUpdatedNotice = true;
         context.api.sendNotification({
-          id: "vortex-updated",
+          id: NOTIF_UPDATED,
           type: "success",
           message: `Vortex was updated to ${getApplication().version}`,
           actions: [
@@ -167,231 +198,234 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
         });
       }
 
-      // A user-initiated check deserves visible feedback either way: re-toast
-      // the update notification even if nothing changed, or say "up to date".
-      const manualCheckCompleted =
-        prevStatus?.checking === true && prevStatus.manual === true && status.checking !== true;
-      prevStatus = status;
+      // a settled manual check always answers, even when nothing changed
+      const manualCheckSettled =
+        prev?.type === "checking" && prev.manual && state.type !== "checking";
 
-      // Mid-check pushes are transient: every check clears the downgrade and
-      // patch labels before re-resolving, so acting on a checking status
-      // renders the previous offer stripped of its identity (a patch would
-      // briefly show the loud Download notification). Only settled statuses
-      // drive notifications.
-      if (status.checking === true) {
-        return;
-      }
+      const key = stateKey(state);
+      const sameAsPrev = prev != null && stateKey(prev) === key;
 
-      // Failures were invisible outside the log: a download that dies (bad
-      // signature, network) or a failed check now says so. Shown once per
-      // distinct error, withdrawn when a later attempt clears it.
-      if (status.error != null) {
-        if (status.error !== lastErrorShown) {
-          lastErrorShown = status.error;
-          const detail = status.error;
-          context.api.sendNotification({
-            id: "vortex-update-error",
-            type: "error",
-            message: "Vortex update failed",
-            actions: [
-              {
-                title: "More",
-                action: () => {
-                  void context.api.showDialog(
-                    "error",
-                    "Vortex update failed",
-                    { text: detail },
-                    [{ label: "Close" }],
-                    "update-error-dialog",
-                  );
-                },
-              },
-            ],
-          });
-        }
-      } else if (lastErrorShown != null) {
-        lastErrorShown = null;
-        context.api.dismissNotification?.("vortex-update-error");
-      }
-
-      // The resolver settled on "nothing available": withdraw any standing
-      // notification (a retracted downgrade offer, a failed downgrade, a
-      // release pulled from the feed) so dead buttons don't linger.
-      if (!status.available) {
-        context.api.dismissNotification?.("vortex-update-available");
-        context.api.dismissNotification?.("vortex-downgrade-offer");
-        lastShown = null;
-        if (manualCheckCompleted) {
-          // a failed check must not masquerade as "up to date"
-          if (status.error == null) {
+      switch (state.type) {
+        case "disabled":
+        case "idle": {
+          // nothing on offer: withdraw everything actionable
+          settleCheckToast();
+          dismiss(NOTIF_UPDATE);
+          dismiss(NOTIF_OFFER);
+          dismiss(NOTIF_ERROR);
+          if (manualCheckSettled && state.type === "idle") {
             context.api.sendNotification({
-              id: "vortex-up-to-date",
+              id: NOTIF_TOAST,
               type: "success",
               message: `Vortex ${getApplication().version} is up to date`,
               displayMS: 5000,
             });
           }
-        }
-        return;
-      }
-
-      if (manualCheckCompleted) {
-        lastShown = null; // bypass the dedupe so the toast re-shows
-        // A patch mid-download shows no standing notification, but a manual
-        // check still owes the user an answer.
-        if (status.patch && !status.downloaded && status.version) {
-          context.api.sendNotification({
-            id: "vortex-up-to-date",
-            type: "info",
-            message: `Vortex ${status.version} is downloading and will update on restart`,
-            displayMS: 5000,
-          });
           return;
         }
-      }
 
-      const shown = {
-        version: status.version,
-        downloaded: status.downloaded,
-        downgrade: status.downgrade === true,
-        downgrading: status.downgrading === true,
-        // whole percent while a download is in flight — so the notification
-        // can show a live bar (a frozen bar is also the only honest signal
-        // for a stalled download)
-        progress:
-          !status.downloaded && typeof status.downloadProgress === "number"
-            ? Math.floor(status.downloadProgress)
-            : undefined,
-      };
-      const sameOffer =
-        lastShown != null &&
-        lastShown.version === shown.version &&
-        lastShown.downloaded === shown.downloaded &&
-        lastShown.downgrade === shown.downgrade &&
-        lastShown.downgrading === shown.downgrading;
-      if (
-        sameOffer &&
-        lastShown!.progress === shown.progress &&
-        notificationExists(shown.downgrade ? "vortex-downgrade-offer" : "vortex-update-available")
-      ) {
-        return;
-      }
-      // Progress ticks update the notification in place; dismiss-and-resend
-      // (which re-toasts) is reserved for user-meaningful transitions.
-      const progressOnly = sameOffer && lastShown!.progress !== shown.progress;
-
-      // A confirmed downgrade downloading is exactly that — describing it as
-      // an available update misstates what is happening. Once downloaded it
-      // reads like a staged patch below: it installs on quit, Restart Now
-      // does it straight away.
-      if (status.downgrading && !status.downloaded) {
-        if (status.version) {
-          lastShown = shown;
-          if (!progressOnly) {
-            context.api.dismissNotification?.("vortex-update-available");
-            context.api.dismissNotification?.("vortex-updated");
+        case "checking": {
+          // manual checks are visible from the moment of the press;
+          // background checks change nothing until they settle
+          if (state.manual) {
+            context.api.sendNotification({
+              id: NOTIF_CHECKING,
+              type: "activity",
+              message: "Checking for updates...",
+            });
           }
-          context.api.sendNotification({
-            id: "vortex-update-available",
-            type: "info",
-            // the percent lives in the text: the theme's progress overlay is
-            // too subtle to read, and the collapsed tray shows only the text
-            message:
-              shown.progress != null
-                ? `Downgrading to Vortex ${status.version} (${shown.progress}%)`
-                : `Downgrading to Vortex ${status.version}`,
-            progress: shown.progress,
-          });
-        }
-        return;
-      }
-
-      if (status.downgrade) {
-        if (status.version) {
-          lastShown = shown;
-          context.api.dismissNotification?.("vortex-downgrade-offer");
-          context.api.dismissNotification?.("vortex-updated");
-          showDowngradeOffer(status);
-        } else {
-          log("warn", "downgrade status without a version", status);
-        }
-        return;
-      }
-      if (status.available && status.version) {
-        // Patch updates download themselves: stay quiet until the download
-        // is staged, then say what actually happens next (install on quit).
-        if (status.patch && !status.downloaded) {
           return;
         }
-        lastShown = shown;
-        if (!progressOnly) {
-          context.api.dismissNotification?.("vortex-update-available");
-          // an actionable update supersedes the "was updated" notice — two
-          // update notifications at once reads as a glitch
-          context.api.dismissNotification?.("vortex-updated");
-        }
-        // Staged patches and confirmed downgrades install when Vortex closes;
-        // the wording says so, and Restart Now does it straight away.
-        if (status.patch || status.downgrading) {
+
+        case "available": {
+          settleCheckToast();
+          dismiss(NOTIF_OFFER);
+          dismiss(NOTIF_ERROR);
+          dismiss(NOTIF_UPDATED);
+          if (sameAsPrev && !manualCheckSettled && notificationExists(NOTIF_UPDATE)) {
+            return; // unchanged and still on screen
+          }
+          dismiss(NOTIF_UPDATE); // re-create so the toast re-shows
           context.api.sendNotification({
-            id: "vortex-update-available",
+            id: NOTIF_UPDATE,
             type: "info",
-            message: "Vortex will update on restart",
+            message: `Vortex ${state.version} is available to download`,
             actions: [
               {
-                title: "Restart Now",
-                // no dismiss: a packaged app quits here anyway, and if the
-                // install fails (or is skipped in dev) the button must stay
-                action: () => window.api.updater.restartAndInstall(),
+                title: "What's New",
+                action: () => {
+                  void showUpdateDialog(state.version, state.releaseNotes);
+                },
+              },
+              {
+                title: "Download",
+                action: () => {
+                  window.api.updater.downloadUpdate(channelNow(), false);
+                  // keep the notification: it live-updates through
+                  // downloading to staged
+                },
               },
             ],
           });
           return;
         }
-        context.api.sendNotification({
-          id: "vortex-update-available",
-          type: "info",
-          message: status.downloaded
-            ? `Vortex ${status.version} is ready to install`
-            : shown.progress != null
-              ? `Downloading Vortex ${status.version} (${shown.progress}%)`
-              : `Vortex ${status.version} is available to download`,
-          progress: shown.progress,
-          // no buttons at all while the download is running — there is
-          // nothing sensible to click until it settles
-          actions:
-            shown.progress != null
-              ? undefined
-              : [
-                  {
-                    title: "What's New",
-                    action: () => {
-                      void showUpdateDialog(status.version!, status.releaseNotes);
-                    },
+
+        case "downgrade-offered": {
+          settleCheckToast();
+          dismiss(NOTIF_UPDATE);
+          dismiss(NOTIF_ERROR);
+          dismiss(NOTIF_UPDATED);
+          if (sameAsPrev && !manualCheckSettled && notificationExists(NOTIF_OFFER)) {
+            return;
+          }
+          dismiss(NOTIF_OFFER);
+          showDowngradeOffer(state.version);
+          return;
+        }
+
+        case "downloading": {
+          settleCheckToast();
+          dismiss(NOTIF_OFFER);
+          dismiss(NOTIF_ERROR);
+          dismiss(NOTIF_UPDATED);
+          // patches download silently — but a manual check that found one
+          // still owes the user an answer
+          if (state.kind === "patch") {
+            if (manualCheckSettled) {
+              context.api.sendNotification({
+                id: NOTIF_TOAST,
+                type: "info",
+                message: `Vortex ${state.version} is downloading and will update on restart`,
+                displayMS: 5000,
+              });
+            }
+            return;
+          }
+          // the percent lives in the text: the theme's progress overlay is
+          // too subtle to read, and the collapsed tray shows only the text
+          const verb = state.kind === "downgrade" ? "Downgrading to" : "Downloading";
+          context.api.sendNotification({
+            id: NOTIF_UPDATE,
+            type: "info",
+            message:
+              state.percent != null
+                ? `${verb} Vortex ${state.version} (${state.percent}%)`
+                : `${verb} Vortex ${state.version}`,
+            progress: state.percent,
+            // no buttons while the download runs — nothing sensible to click
+          });
+          return;
+        }
+
+        case "staged": {
+          settleCheckToast();
+          dismiss(NOTIF_OFFER);
+          dismiss(NOTIF_ERROR);
+          dismiss(NOTIF_UPDATED);
+          if (sameAsPrev && !manualCheckSettled && notificationExists(NOTIF_UPDATE)) {
+            return;
+          }
+          dismiss(NOTIF_UPDATE);
+          if (state.kind === "update") {
+            context.api.sendNotification({
+              id: NOTIF_UPDATE,
+              type: "info",
+              message: `Vortex ${state.version} is ready to install`,
+              actions: [
+                {
+                  title: "What's New",
+                  action: () => {
+                    void showUpdateDialog(state.version, state.releaseNotes);
                   },
-                  {
-                    // Not downloaded yet (minor/major updates wait for the
-                    // user): the button downloads, and the pushed "downloaded"
-                    // status then flips this same notification to Restart Now.
-                    title: status.downloaded ? "Restart Now" : "Download",
-                    action: () => {
-                      if (status.downloaded) {
-                        // no dismiss: a packaged app quits here anyway, and if
-                        // the install fails (or is skipped in dev) the button
-                        // must stay
-                        window.api.updater.restartAndInstall();
-                      } else {
-                        const channel = context.api.store.getState().settings.update.channel;
-                        window.api.updater.downloadUpdate(channel, false);
-                        // keep the notification: it live-updates to show the
-                        // Restart Now action once the download completes
-                      }
-                    },
+                },
+                {
+                  // no dismiss: a packaged app quits here anyway, and if the
+                  // install fails (or is skipped in dev) the button must stay
+                  title: "Restart Now",
+                  action: () => window.api.updater.restartAndInstall(),
+                },
+              ],
+            });
+          } else {
+            // staged patches and confirmed downgrades install when Vortex
+            // closes; the wording says so, Restart Now does it straight away
+            context.api.sendNotification({
+              id: NOTIF_UPDATE,
+              type: "info",
+              message: "Vortex will update on restart",
+              actions: [
+                {
+                  title: "Restart Now",
+                  action: () => window.api.updater.restartAndInstall(),
+                },
+              ],
+            });
+          }
+          return;
+        }
+
+        case "error": {
+          settleCheckToast();
+          dismiss(NOTIF_OFFER);
+          if (!sameAsPrev || !notificationExists(NOTIF_ERROR)) {
+            dismiss(NOTIF_ERROR);
+            const detail = state.message;
+            context.api.sendNotification({
+              id: NOTIF_ERROR,
+              type: "error",
+              message: "Vortex update failed",
+              actions: [
+                {
+                  title: "More",
+                  action: () => {
+                    void context.api.showDialog(
+                      "error",
+                      "Vortex update failed",
+                      { text: detail },
+                      [{ label: "Close" }],
+                      "update-error-dialog",
+                    );
                   },
-                ],
-        });
+                },
+              ],
+            });
+          }
+          // keep a working Download next to the error when the update is
+          // still known; otherwise the update notification is stale
+          if (state.retry != null) {
+            const retry = state.retry;
+            if (sameAsPrev && notificationExists(NOTIF_UPDATE)) {
+              return; // identical error re-broadcast: don't churn the retry
+            }
+            dismiss(NOTIF_UPDATE);
+            context.api.sendNotification({
+              id: NOTIF_UPDATE,
+              type: "info",
+              message: `Vortex ${retry.version} is available to download`,
+              actions: [
+                {
+                  title: "What's New",
+                  action: () => {
+                    void showUpdateDialog(retry.version, retry.releaseNotes);
+                  },
+                },
+                {
+                  title: "Download",
+                  action: () => {
+                    window.api.updater.downloadUpdate(channelNow(), false);
+                  },
+                },
+              ],
+            });
+          } else {
+            dismiss(NOTIF_UPDATE);
+          }
+          return;
+        }
       }
     };
+
+    // ---- wiring -------------------------------------------------------------
 
     // check for update when the user changes the update channel
     context.api.onStateChange(
@@ -406,8 +440,7 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
     // check for update in 5 seconds
     setTimeout(() => {
       if (!haveSetChannel) {
-        const channel = context.api.store.getState().settings.update.channel;
-        window.api.updater.setChannel(channel, false);
+        window.api.updater.setChannel(channelNow(), false);
       }
     }, 5000);
 
@@ -416,18 +449,18 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
     // patches, which auto-download) until the next launch.
     const PERIODIC_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
     setInterval(() => {
-      const channel = context.api.store.getState().settings.update.channel;
+      const channel = channelNow();
       if (channel !== "none") {
         window.api.updater.checkForUpdates(channel, false);
       }
     }, PERIODIC_CHECK_INTERVAL_MS);
 
-    // Main pushes every status change; the one-time getStatus covers a check
-    // that finished before this subscription existed (e.g. window reload).
-    window.api.updater.onStatusChanged(handleUpdateStatus);
+    // Main pushes every state change; the one-time getStatus covers a check
+    // that settled before this subscription existed (e.g. window reload).
+    window.api.updater.onStatusChanged(render);
     window.api.updater
       .getStatus()
-      .then(handleUpdateStatus)
+      .then(render)
       .catch(() => undefined);
   });
 

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -1,5 +1,6 @@
 import type { IExtensionContext } from "../../types/IExtensionContext";
 import { getApplication } from "../../util/application";
+import { log } from "../../util/log";
 import settingsReducer from "./reducers";
 import SettingsUpdate from "./SettingsUpdate";
 
@@ -80,6 +81,7 @@ Downgrading can damage your application state. Alternatively, stay on your curre
                   {
                     label: `Downgrade to ${status.version}`,
                     action: () => {
+                      context.api.dismissNotification?.("vortex-downgrade-offer");
                       window.api.updater.downloadDowngrade(true);
                     },
                   },
@@ -96,6 +98,8 @@ Downgrading can damage your application state. Alternatively, stay on your curre
       if (status.downgrade) {
         if (status.version) {
           showDowngradeOffer(status);
+        } else {
+          log("warn", "downgrade status without a version", status);
         }
         return;
       }

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -1,4 +1,5 @@
 import type { IExtensionContext } from "../../types/IExtensionContext";
+import { getApplication } from "../../util/application";
 import settingsReducer from "./reducers";
 import SettingsUpdate from "./SettingsUpdate";
 
@@ -54,10 +55,48 @@ function init(context: IExtensionContext): boolean {
     // React to a status pushed from main (or fetched for the initial sync):
     // upsert the update notification — same id, so repeated statuses update
     // it in place rather than stacking.
+    // A downgrade offer only ever follows an explicit switch to the stable
+    // channel; it is presented as exactly what it is, never as an update.
+    const showDowngradeOffer = (status: UpdateStatus) => {
+      const currentVersion = getApplication().version;
+      context.api.sendNotification({
+        id: "vortex-downgrade-offer",
+        type: "warning",
+        message: `Stable version ${status.version} is older than your current version`,
+        actions: [
+          {
+            title: "More",
+            action: () => {
+              void context.api.showDialog(
+                "question",
+                "Downgrade to stable?",
+                {
+                  text: `Switching to the Stable channel would install Vortex ${status.version}, which is older than the version you are running (${currentVersion}).
+
+Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.`,
+                },
+                [
+                  { label: "Stay on current version" },
+                  {
+                    label: `Downgrade to ${status.version}`,
+                    action: () => {
+                      window.api.updater.downloadDowngrade(true);
+                    },
+                  },
+                ],
+                "downgrade-offer-dialog",
+              );
+            },
+          },
+        ],
+      });
+    };
+
     const handleUpdateStatus = (status: UpdateStatus) => {
       if (status.downgrade) {
-        // downgrade offers get their own flow when the channel-switch UX
-        // ships; never present one as a regular update
+        if (status.version) {
+          showDowngradeOffer(status);
+        }
         return;
       }
       if (status.available && status.version) {

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -74,7 +74,9 @@ function init(context: IExtensionContext): boolean {
                 {
                   text: `Switching to the Stable channel would install Vortex ${status.version}, which is older than the version you are running (${currentVersion}).
 
-Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.`,
+Downgrading can damage your application state. Alternatively, stay on your current version and you will be offered the next stable release once it is newer than ${currentVersion}.
+
+If you downgrade, Vortex will restart and install ${status.version} as soon as the download completes.`,
                 },
                 [
                   { label: "Stay on current version" },
@@ -116,15 +118,21 @@ Downgrading can damage your application state. Alternatively, stay on your curre
               },
             },
             {
-              title: status.downloaded ? "Restart" : "Install",
+              // Not downloaded yet (minor/major updates wait for the user):
+              // the button downloads, and the pushed "downloaded" status then
+              // flips this same notification to Restart & Install. Patch
+              // updates arrive already downloaded, so they start there.
+              title: status.downloaded ? "Restart & Install" : "Download",
               action: (dismiss) => {
                 if (status.downloaded) {
                   window.api.updater.restartAndInstall();
+                  dismiss();
                 } else {
                   const channel = context.api.store.getState().settings.update.channel;
-                  window.api.updater.downloadUpdate(channel, true);
+                  window.api.updater.downloadUpdate(channel, false);
+                  // keep the notification: it live-updates to show the
+                  // Restart & Install action once the download completes
                 }
-                dismiss();
               },
             },
           ],

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -2,7 +2,8 @@ import type { UpdaterSnapshot, UpdaterState } from "@vortex/shared/ipc";
 
 import type { IExtensionContext } from "../../types/IExtensionContext";
 import { getApplication } from "../../util/application";
-import settingsReducer from "./reducers";
+import { setUpdaterSnapshot } from "./actions";
+import settingsReducer, { sessionReducer } from "./reducers";
 import SettingsUpdate from "./SettingsUpdate";
 import { initUpdaterStatus } from "./updaterStatus";
 
@@ -37,6 +38,7 @@ function stateKey(state: UpdaterState): string {
 
 function init(context: IExtensionContext): boolean {
   context.registerReducer(["settings", "update"], settingsReducer);
+  context.registerReducer(["session", "updater"], sessionReducer);
   context.registerSettings("Vortex", SettingsUpdate);
 
   context.once(() => {
@@ -480,6 +482,11 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
     // The renderer polls main for status (see updaterStatus.ts); the first
     // poll doubles as the initial sync for a check that settled before this
     // window existed (e.g. a reload).
+    // every snapshot goes into session.updater first (so components read it
+    // like any other state, across navigation), then drives the notifications
+    poller.subscribe((snapshot) => {
+      context.api.store.dispatch(setUpdaterSnapshot(snapshot));
+    });
     poller.subscribe(render);
   });
 

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -162,7 +162,11 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         context.api.sendNotification({
           id: "vortex-update-available",
           type: "info",
-          message: `Vortex ${status.version} is available`,
+          // once staged, the update installs on quit — say so rather than
+          // surprising the user when they close Vortex
+          message: status.downloaded
+            ? `Vortex ${status.version} will install when you close Vortex`
+            : `Vortex ${status.version} is available`,
           actions: [
             {
               title: "More",

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -100,8 +100,14 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
     // keep their createdTime and stay collapsed in the tray. Dismiss and
     // re-send on user-meaningful transitions (new version, download finished)
     // so the toast re-appears; skip pushes that change nothing the user sees
-    // (e.g. download progress).
+    // (e.g. download progress) — unless the notification was dismissed in the
+    // meantime, in which case a fresh check resurrects it.
     let lastShown: { version?: string; downloaded: boolean; downgrade: boolean } | null = null;
+
+    const notificationExists = (id: string): boolean =>
+      context.api
+        .getState()
+        .session.notifications.notifications.some((notification) => notification.id === id);
 
     const handleUpdateStatus = (status: UpdateStatus) => {
       const shown = {
@@ -113,7 +119,8 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         lastShown != null &&
         lastShown.version === shown.version &&
         lastShown.downloaded === shown.downloaded &&
-        lastShown.downgrade === shown.downgrade
+        lastShown.downgrade === shown.downgrade &&
+        notificationExists(shown.downgrade ? "vortex-downgrade-offer" : "vortex-update-available")
       ) {
         return;
       }
@@ -148,10 +155,11 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
               // flips this same notification to Restart & Install. Patch
               // updates arrive already downloaded, so they start there.
               title: status.downloaded ? "Restart & Install" : "Download",
-              action: (dismiss) => {
+              action: () => {
                 if (status.downloaded) {
+                  // no dismiss: a packaged app quits here anyway, and if the
+                  // install fails (or is skipped in dev) the button must stay
                   window.api.updater.restartAndInstall();
-                  dismiss();
                 } else {
                   const channel = context.api.store.getState().settings.update.channel;
                   window.api.updater.downloadUpdate(channel, false);

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -294,7 +294,12 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
           context.api.sendNotification({
             id: "vortex-update-available",
             type: "info",
-            message: `Downgrading to Vortex ${status.version}`,
+            // the percent lives in the text: the theme's progress overlay is
+            // too subtle to read, and the collapsed tray shows only the text
+            message:
+              shown.progress != null
+                ? `Downgrading to Vortex ${status.version} (${shown.progress}%)`
+                : `Downgrading to Vortex ${status.version}`,
             progress: shown.progress,
           });
         }
@@ -349,20 +354,21 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
           message: status.downloaded
             ? `Vortex ${status.version} is ready to install`
             : shown.progress != null
-              ? `Downloading Vortex ${status.version}`
+              ? `Downloading Vortex ${status.version} (${shown.progress}%)`
               : `Vortex ${status.version} is available to download`,
           progress: shown.progress,
-          actions: [
-            {
-              title: "What's New",
-              action: () => {
-                void showUpdateDialog(status.version!, status.releaseNotes);
-              },
-            },
-            // no Download button while the download is running
-            ...(shown.progress != null
-              ? []
+          // no buttons at all while the download is running — there is
+          // nothing sensible to click until it settles
+          actions:
+            shown.progress != null
+              ? undefined
               : [
+                  {
+                    title: "What's New",
+                    action: () => {
+                      void showUpdateDialog(status.version!, status.releaseNotes);
+                    },
+                  },
                   {
                     // Not downloaded yet (minor/major updates wait for the
                     // user): the button downloads, and the pushed "downloaded"
@@ -382,8 +388,7 @@ If you downgrade, Vortex will download ${status.version} and update on restart.`
                       }
                     },
                   },
-                ]),
-          ],
+                ],
         });
       }
     };

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -96,9 +96,32 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
       });
     };
 
+    // The toast only shows when a notification is created — same-id updates
+    // keep their createdTime and stay collapsed in the tray. Dismiss and
+    // re-send on user-meaningful transitions (new version, download finished)
+    // so the toast re-appears; skip pushes that change nothing the user sees
+    // (e.g. download progress).
+    let lastShown: { version?: string; downloaded: boolean; downgrade: boolean } | null = null;
+
     const handleUpdateStatus = (status: UpdateStatus) => {
+      const shown = {
+        version: status.version,
+        downloaded: status.downloaded,
+        downgrade: status.downgrade === true,
+      };
+      if (
+        lastShown != null &&
+        lastShown.version === shown.version &&
+        lastShown.downloaded === shown.downloaded &&
+        lastShown.downgrade === shown.downgrade
+      ) {
+        return;
+      }
+
       if (status.downgrade) {
         if (status.version) {
+          lastShown = shown;
+          context.api.dismissNotification?.("vortex-downgrade-offer");
           showDowngradeOffer(status);
         } else {
           log("warn", "downgrade status without a version", status);
@@ -106,6 +129,8 @@ If you downgrade, Vortex will restart and install ${status.version} as soon as t
         return;
       }
       if (status.available && status.version) {
+        lastShown = shown;
+        context.api.dismissNotification?.("vortex-update-available");
         context.api.sendNotification({
           id: "vortex-update-available",
           type: "info",

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -161,7 +161,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
       });
     };
 
-    // ---- state → notifications --------------------------------------------
+    // ---- state -> notifications -------------------------------------------
 
     // The updater is a state machine (see UpdaterState); this is the single
     // mapping from states to Vortex notifications. Everything the user sees
@@ -306,7 +306,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                 ? `${verb} Vortex ${state.version} (${state.percent}%)`
                 : `${verb} Vortex ${state.version}`,
             progress: state.percent,
-            // no buttons while the download runs — nothing sensible to click
+            // no buttons while the download runs, nothing sensible to click
           });
           return;
         }

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -4,6 +4,7 @@ import type { IExtensionContext } from "../../types/IExtensionContext";
 import { getApplication } from "../../util/application";
 import settingsReducer from "./reducers";
 import SettingsUpdate from "./SettingsUpdate";
+import { initUpdaterStatus } from "./updaterStatus";
 
 // Notification surfaces. UPDATE is the single slot for "what the updater is
 // doing with a version" (available/downloading/staged); the others are
@@ -48,6 +49,14 @@ function init(context: IExtensionContext): boolean {
 
     let haveSetChannel = false;
 
+    const poller = initUpdaterStatus((since) => window.api.updater.getStatus(since));
+    // every request to main is followed by a poll, so its outcome is seen at
+    // once instead of after an idle interval
+    const act = (request: () => void) => {
+      request();
+      poller.wake();
+    };
+
     const channelNow = () => context.api.store.getState().settings.update.channel;
 
     const dismiss = (id: string) => context.api.dismissNotification?.(id);
@@ -63,7 +72,9 @@ function init(context: IExtensionContext): boolean {
     // callbacks rather than label matching, so a renamed or translated label
     // can't silently break the action.
     const showUpdateDialog = async (version: string, releaseNotes?: string) => {
-      const { state } = await window.api.updater.getStatus();
+      const {
+        snapshot: { state },
+      } = await window.api.updater.getStatus();
       const staged = state.type === "staged";
       await context.api.showDialog(
         "info",
@@ -81,9 +92,9 @@ function init(context: IExtensionContext): boolean {
             default: true,
             action: () => {
               if (staged) {
-                window.api.updater.restartAndInstall();
+                act(() => window.api.updater.restartAndInstall());
               } else {
-                window.api.updater.downloadUpdate(channelNow(), false);
+                act(() => window.api.updater.downloadUpdate(channelNow(), false));
               }
             },
           },
@@ -140,7 +151,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                       // declining forgets the offer (notification included)
                       // until the next purposeful switch to stable
                       dismiss(NOTIF_OFFER);
-                      window.api.updater.declineDowngrade();
+                      act(() => window.api.updater.declineDowngrade());
                     },
                   },
                   {
@@ -149,7 +160,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                       dismiss(NOTIF_OFFER);
                       // download without forcing a restart: once staged it
                       // installs on quit, or via the notification's Restart Now
-                      window.api.updater.downloadDowngrade(false);
+                      act(() => window.api.updater.downloadDowngrade(false));
                     },
                   },
                 ],
@@ -260,7 +271,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
               {
                 title: "Download",
                 action: () => {
-                  window.api.updater.downloadUpdate(channelNow(), false);
+                  act(() => window.api.updater.downloadUpdate(channelNow(), false));
                   // keep the notification: it live-updates through
                   // downloading to staged
                 },
@@ -336,7 +347,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                   // no dismiss: a packaged app quits here anyway, and if the
                   // install fails (or is skipped in dev) the button must stay
                   title: "Restart Now",
-                  action: () => window.api.updater.restartAndInstall(),
+                  action: () => act(() => window.api.updater.restartAndInstall()),
                 },
               ],
             });
@@ -350,7 +361,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
               actions: [
                 {
                   title: "Restart Now",
-                  action: () => window.api.updater.restartAndInstall(),
+                  action: () => act(() => window.api.updater.restartAndInstall()),
                 },
               ],
             });
@@ -406,7 +417,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                 {
                   title: "Download",
                   action: () => {
-                    window.api.updater.downloadUpdate(channelNow(), false);
+                    act(() => window.api.updater.downloadUpdate(channelNow(), false));
                   },
                 },
               ],
@@ -425,7 +436,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
     context.api.onStateChange(
       ["settings", "update", "channel"],
       (_oldChannel: string, newChannel: string) => {
-        window.api.updater.setChannel(newChannel, true);
+        act(() => window.api.updater.setChannel(newChannel, true));
         haveSetChannel = true;
       },
     );
@@ -434,7 +445,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
     // check for update in 5 seconds
     setTimeout(() => {
       if (!haveSetChannel) {
-        window.api.updater.setChannel(channelNow(), false);
+        act(() => window.api.updater.setChannel(channelNow(), false));
       }
     }, 5000);
 
@@ -445,17 +456,14 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
     setInterval(() => {
       const channel = channelNow();
       if (channel !== "none") {
-        window.api.updater.checkForUpdates(channel, false);
+        act(() => window.api.updater.checkForUpdates(channel, false));
       }
     }, PERIODIC_CHECK_INTERVAL_MS);
 
-    // Main pushes every state change; the one-time getStatus covers a check
-    // that settled before this subscription existed (e.g. window reload).
-    window.api.updater.onStatusChanged(render);
-    window.api.updater
-      .getStatus()
-      .then(render)
-      .catch(() => undefined);
+    // The renderer polls main for status (see updaterStatus.ts); the first
+    // poll doubles as the initial sync for a check that settled before this
+    // window existed (e.g. a reload).
+    poller.subscribe(render);
   });
 
   return true;

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -294,12 +294,13 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
           if (state.kind === "patch" && !state.manual) {
             return;
           }
-          // the percent lives in the text: the theme's progress overlay is
-          // too subtle to read, and the collapsed tray shows only the text
+          // "activity" + progress makes the notifications panel draw a real
+          // bar (and a spinner icon); the percent also lives in the text
+          // because the toast and the collapsed tray only show the message
           const verb = state.kind === "downgrade" ? "Downgrading to" : "Downloading";
           context.api.sendNotification({
             id: NOTIF_UPDATE,
-            type: "info",
+            type: "activity",
             message:
               state.percent != null
                 ? `${verb} Vortex ${state.version} (${state.percent}%)`

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -16,11 +16,15 @@ function init(context: IExtensionContext): boolean {
 
     let haveSetChannel = false;
 
-    // Show update details dialog with HTML release notes
+    type UpdateStatus = Awaited<ReturnType<typeof window.api.updater.getStatus>>;
+
+    // Show update details dialog with HTML release notes. Buttons act via
+    // their own callbacks rather than label matching, so a renamed or
+    // translated label can't silently break the action.
     const showUpdateDialog = async (version: string, releaseNotes?: string) => {
       const status = await window.api.updater.getStatus();
 
-      const result = await context.api.showDialog(
+      await context.api.showDialog(
         "info",
         `What's New in ${version}`,
         {
@@ -33,52 +37,55 @@ function init(context: IExtensionContext): boolean {
           {
             label: status.downloaded ? "Restart & Install" : "Download",
             default: true,
+            action: () => {
+              if (status.downloaded) {
+                window.api.updater.restartAndInstall();
+              } else {
+                const channel = context.api.store.getState().settings.update.channel;
+                window.api.updater.downloadUpdate(channel);
+              }
+            },
           },
         ],
         "new-update-changelog-dialog",
       );
-
-      if (result.action === "Restart & Install") {
-        window.api.updater.restartAndInstall();
-      } else if (result.action === "Download" && !status.downloaded) {
-        const channel = context.api.store.getState().settings.update.channel;
-        window.api.updater.downloadUpdate(channel);
-      }
     };
 
-    // Query update status and show notification if update is available
-    const checkUpdateStatus = async () => {
-      try {
-        const status = await window.api.updater.getStatus();
-        if (status.available && status.version) {
-          context.api.sendNotification({
-            id: "vortex-update-available",
-            type: "info",
-            message: `Vortex ${status.version} is available`,
-            actions: [
-              {
-                title: "More",
-                action: () => {
-                  void showUpdateDialog(status.version!, status.releaseNotes);
-                },
+    // React to a status pushed from main (or fetched for the initial sync):
+    // upsert the update notification — same id, so repeated statuses update
+    // it in place rather than stacking.
+    const handleUpdateStatus = (status: UpdateStatus) => {
+      if (status.downgrade) {
+        // downgrade offers get their own flow when the channel-switch UX
+        // ships; never present one as a regular update
+        return;
+      }
+      if (status.available && status.version) {
+        context.api.sendNotification({
+          id: "vortex-update-available",
+          type: "info",
+          message: `Vortex ${status.version} is available`,
+          actions: [
+            {
+              title: "More",
+              action: () => {
+                void showUpdateDialog(status.version!, status.releaseNotes);
               },
-              {
-                title: status.downloaded ? "Restart" : "Install",
-                action: (dismiss) => {
-                  if (status.downloaded) {
-                    window.api.updater.restartAndInstall();
-                  } else {
-                    const channel = context.api.store.getState().settings.update.channel;
-                    window.api.updater.downloadUpdate(channel, true);
-                  }
-                  dismiss();
-                },
+            },
+            {
+              title: status.downloaded ? "Restart" : "Install",
+              action: (dismiss) => {
+                if (status.downloaded) {
+                  window.api.updater.restartAndInstall();
+                } else {
+                  const channel = context.api.store.getState().settings.update.channel;
+                  window.api.updater.downloadUpdate(channel, true);
+                }
+                dismiss();
               },
-            ],
-          });
-        }
-      } catch {
-        // Silently ignore status check errors
+            },
+          ],
+        });
       }
     };
 
@@ -100,10 +107,13 @@ function init(context: IExtensionContext): boolean {
       }
     }, 5000);
 
-    // Check update status once after update check completes (give it time)
-    setTimeout(() => {
-      void checkUpdateStatus();
-    }, 15000);
+    // Main pushes every status change; the one-time getStatus covers a check
+    // that finished before this subscription existed (e.g. window reload).
+    window.api.updater.onStatusChanged(handleUpdateStatus);
+    window.api.updater
+      .getStatus()
+      .then(handleUpdateStatus)
+      .catch(() => undefined);
   });
 
   return true;

--- a/src/renderer/src/extensions/updater/reducers.test.ts
+++ b/src/renderer/src/extensions/updater/reducers.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect } from "vitest";
 
-import reducer from "./reducers";
+import reducer, { sessionReducer } from "./reducers";
 
 describe("setUpdateChannel", () => {
   it("sets the Update Channel", () => {
     const input = { channel: "value" };
     const result = reducer.reducers.SET_UPDATE_CHANNEL(input, "new value");
     expect(result).toEqual({ channel: "new value" });
+  });
+});
+
+describe("setUpdaterSnapshot", () => {
+  it("stores the latest polled snapshot in session state", () => {
+    const snapshot = {
+      state: { type: "downloading", version: "2.7.0", kind: "update", manual: true },
+    };
+    const result = sessionReducer.reducers.SET_UPDATER_SNAPSHOT({}, snapshot);
+    expect(result).toEqual({ snapshot });
   });
 });

--- a/src/renderer/src/extensions/updater/reducers.ts
+++ b/src/renderer/src/extensions/updater/reducers.ts
@@ -1,7 +1,20 @@
+import type { UpdaterSnapshot } from "@vortex/shared/ipc";
 import update from "immutability-helper";
 
 import type { IReducerSpec } from "../../types/IExtensionContext";
-import { setUpdateChannel } from "./actions";
+import { setUpdateChannel, setUpdaterSnapshot } from "./actions";
+
+/** session.updater: what the updater is doing, as last polled from main */
+export interface IUpdaterSessionState {
+  snapshot?: UpdaterSnapshot;
+}
+
+export const sessionReducer: IReducerSpec = {
+  reducers: {
+    [setUpdaterSnapshot as any]: (state, payload) => update(state, { snapshot: { $set: payload } }),
+  },
+  defaults: {} satisfies IUpdaterSessionState,
+};
 
 /**
  * reducer for changes to interface settings

--- a/src/renderer/src/extensions/updater/updaterStatus.test.ts
+++ b/src/renderer/src/extensions/updater/updaterStatus.test.ts
@@ -1,0 +1,186 @@
+import type { UpdaterSnapshot, UpdaterStatusResponse } from "@vortex/shared/ipc";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../util/log", () => ({ log: vi.fn() }));
+
+import { createUpdaterStatusPoller, POLL_MS, WAKE_WINDOW_MS } from "./updaterStatus";
+
+// A stand-in for main: numbered snapshots, replayed since a sequence number,
+// exactly like the updater:get-status handler.
+function fakeMain(initial: UpdaterSnapshot = { state: { type: "idle" } }) {
+  let seq = 0;
+  let latest = initial;
+  const history: Array<{ seq: number; snapshot: UpdaterSnapshot }> = [];
+  const getStatus = vi.fn(
+    async (since?: number): Promise<UpdaterStatusResponse> => ({
+      seq,
+      snapshot: latest,
+      changes:
+        since == null
+          ? []
+          : history.filter((entry) => entry.seq > since).map((entry) => entry.snapshot),
+    }),
+  );
+  return {
+    getStatus,
+    push(snapshot: UpdaterSnapshot) {
+      seq += 1;
+      latest = snapshot;
+      history.push({ seq, snapshot });
+    },
+  };
+}
+
+const downloading: UpdaterSnapshot = {
+  state: { type: "downloading", version: "2.7.0", kind: "update", manual: true },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("updater status poller", () => {
+  it("delivers the latest snapshot on the first poll", async () => {
+    const main = fakeMain({ state: { type: "available", version: "2.7.0" } });
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    const seen: UpdaterSnapshot[] = [];
+    poller.subscribe((snapshot) => seen.push(snapshot));
+
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.state).toMatchObject({ type: "available", version: "2.7.0" });
+    expect(poller.current()).toBe(seen[0]);
+    poller.stop();
+  });
+
+  // An idle Vortex makes no updater IPC: every updater activity starts in the
+  // renderer, so the loop is woken before anything can happen.
+  it("stops polling once the state is settled", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+    main.getStatus.mockClear();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(main.getStatus).not.toHaveBeenCalled();
+    poller.stop();
+  });
+
+  // The reason polls carry a sequence number: a manual check that finds
+  // nothing is `checking` for a few hundred ms then `idle`; the UI needs to
+  // have seen the `checking` to answer "up to date".
+  it("wake() polls at once and delivers every transition since, in order", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    const seen: string[] = [];
+    poller.subscribe((snapshot) => seen.push(snapshot.state.type));
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // the renderer sent check-for-updates; main went through both states
+    // before the next poll landed
+    main.push({ state: { type: "checking", manual: true } });
+    main.push({ state: { type: "idle" } });
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(seen).toEqual(["idle", "checking", "idle"]);
+    poller.stop();
+  });
+
+  it("keeps polling at the download cadence while busy, then stops when settled", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    main.push(downloading);
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(poller.current()?.state.type).toBe("downloading");
+
+    // well past the wake window: still polling because the state is busy
+    await vi.advanceTimersByTimeAsync(WAKE_WINDOW_MS * 2);
+    main.getStatus.mockClear();
+    await vi.advanceTimersByTimeAsync(POLL_MS * 5);
+    expect(main.getStatus.mock.calls.length).toBeGreaterThanOrEqual(4);
+
+    // settled: the next poll sees it and the loop exits
+    main.push({ state: { type: "staged", version: "2.7.0", kind: "update" } });
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(poller.current()?.state.type).toBe("staged");
+    main.getStatus.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(main.getStatus).not.toHaveBeenCalled();
+    poller.stop();
+  });
+
+  it("keeps polling for the wake window even if the state is not busy yet", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // a request was sent but main has not transitioned yet
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(0);
+    main.getStatus.mockClear();
+    await vi.advanceTimersByTimeAsync(WAKE_WINDOW_MS - POLL_MS);
+    expect(main.getStatus.mock.calls.length).toBeGreaterThanOrEqual(5);
+
+    // a late transition inside the window is still picked up
+    main.push({ state: { type: "available", version: "2.7.0" } });
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(poller.current()?.state.type).toBe("available");
+    poller.stop();
+  });
+
+  it("survives a failed poll", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    const seen: string[] = [];
+    poller.subscribe((snapshot) => seen.push(snapshot.state.type));
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    main.getStatus.mockRejectedValueOnce(new Error("ipc down"));
+    main.push({ state: { type: "available", version: "2.7.0" } });
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(seen).toEqual(["idle"]);
+    // the wake window is still open, so the next poll catches up
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+
+    expect(seen).toEqual(["idle", "available"]);
+    poller.stop();
+  });
+
+  it("stops delivering after unsubscribe and after stop", async () => {
+    const main = fakeMain();
+    const poller = createUpdaterStatusPoller(main.getStatus);
+    const seen: string[] = [];
+    const unsubscribe = poller.subscribe((snapshot) => seen.push(snapshot.state.type));
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    unsubscribe();
+    main.push({ state: { type: "available", version: "2.7.0" } });
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(seen).toEqual(["idle"]);
+
+    poller.stop();
+    main.getStatus.mockClear();
+    poller.wake();
+    await vi.advanceTimersByTimeAsync(WAKE_WINDOW_MS);
+    expect(main.getStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/extensions/updater/updaterStatus.ts
+++ b/src/renderer/src/extensions/updater/updaterStatus.ts
@@ -1,0 +1,162 @@
+import { getErrorMessageOrDefault } from "@vortex/shared";
+import type { UpdaterSnapshot, UpdaterStatusResponse } from "@vortex/shared/ipc";
+
+import { log } from "../../util/log";
+
+/**
+ * Pull, not push, like the downloader (IPCDownloadAdapter.ts) and uploader
+ * (uploadV3.ts): main keeps the state, the renderer reads it at its own pace.
+ *
+ * Shaped like the uploader's loop: it runs only while something is happening.
+ * Every updater activity starts in this process (launch check, periodic timer,
+ * button presses), so the loop is woken just before and stops once the state
+ * settles. An idle Vortex makes no updater IPC.
+ *
+ * Unlike a transfer, the UI reacts to transitions: a manual check that finds
+ * nothing is `checking` for ~300 ms then `idle`, and the "up to date" toast
+ * needs to have seen the `checking`. So main numbers snapshots and each poll
+ * asks for everything since the last one it saw.
+ */
+
+/** Poll cadence while the updater is busy; the downloader's figure. */
+export const POLL_MS = 200;
+/** How long after a renderer request polling continues if the state stays settled. */
+export const WAKE_WINDOW_MS = 2000;
+
+export type StatusListener = (snapshot: UpdaterSnapshot) => void;
+
+export interface UpdaterStatusPoller {
+  /** Called with every snapshot in order; returns an unsubscribe function. */
+  subscribe(listener: StatusListener): () => void;
+  /** The most recent snapshot seen, if any. */
+  current(): UpdaterSnapshot | undefined;
+  /**
+   * Poll now and keep polling for a moment. Called right after every
+   * renderer -> main updater request so the resulting transition is seen.
+   */
+  wake(): void;
+  /** Poll once for the initial state (and keep going if it is busy). */
+  start(): void;
+  stop(): void;
+}
+
+function isBusy(snapshot: UpdaterSnapshot | undefined): boolean {
+  return snapshot?.state.type === "checking" || snapshot?.state.type === "downloading";
+}
+
+export function createUpdaterStatusPoller(
+  getStatus: (since?: number) => Promise<UpdaterStatusResponse>,
+): UpdaterStatusPoller {
+  const listeners = new Set<StatusListener>();
+  let latest: UpdaterSnapshot | undefined;
+  let lastSeq: number | undefined;
+  let enabled = false;
+  let looping = false;
+  let wakeUntil = 0;
+  let wakeEarly: (() => void) | undefined;
+
+  const deliver = (snapshot: UpdaterSnapshot) => {
+    latest = snapshot;
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+  };
+
+  const tick = async () => {
+    try {
+      const response = await getStatus(lastSeq);
+      // first poll: just the latest; afterwards: everything since the last seen
+      const snapshots = lastSeq === undefined ? [response.snapshot] : response.changes;
+      lastSeq = response.seq;
+      for (const snapshot of snapshots) {
+        deliver(snapshot);
+      }
+    } catch (err) {
+      // a dropped sample is not worth killing the loop over
+      log("debug", "updater status poll failed", { error: getErrorMessageOrDefault(err) });
+    }
+  };
+
+  const shouldKeepPolling = () => isBusy(latest) || Date.now() < wakeUntil;
+
+  // interruptible, so wake() does not have to wait out an interval
+  const sleep = () =>
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, POLL_MS);
+      wakeEarly = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+    });
+
+  // Runs until the state has settled and the wake window has passed, then
+  // exits; wake() starts it again.
+  const loop = async () => {
+    looping = true;
+    try {
+      while (enabled) {
+        await tick();
+        if (!enabled || !shouldKeepPolling()) {
+          return;
+        }
+        await sleep();
+        wakeEarly = undefined;
+      }
+    } finally {
+      looping = false;
+    }
+  };
+
+  const ensureLooping = () => {
+    if (!enabled) {
+      return;
+    }
+    if (looping) {
+      wakeEarly?.();
+    } else {
+      void loop();
+    }
+  };
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    current: () => latest,
+    wake() {
+      wakeUntil = Date.now() + WAKE_WINDOW_MS;
+      ensureLooping();
+    },
+    start() {
+      if (enabled) {
+        return;
+      }
+      enabled = true;
+      ensureLooping();
+    },
+    stop() {
+      enabled = false;
+      wakeEarly?.();
+    },
+  };
+}
+
+// The extension creates one poller per window at init; the settings page
+// reads from the same one rather than running a second loop.
+let instance: UpdaterStatusPoller | undefined;
+
+export function initUpdaterStatus(
+  getStatus: (since?: number) => Promise<UpdaterStatusResponse>,
+): UpdaterStatusPoller {
+  instance?.stop();
+  instance = createUpdaterStatusPoller(getStatus);
+  instance.start();
+  return instance;
+}
+
+export function getUpdaterStatus(): UpdaterStatusPoller | undefined {
+  return instance;
+}

--- a/src/renderer/src/types/IState.ts
+++ b/src/renderer/src/types/IState.ts
@@ -11,6 +11,7 @@ import type { IHealthCheckSessionState } from "../extensions/health_check/reduce
 import type { IHistoryPersistent, IHistoryState } from "../extensions/history_management/reducers";
 import type { IMod } from "../extensions/mod_management/types/IMod";
 import type { IProfile } from "../extensions/profile_management/types/IProfile";
+import type { IUpdaterSessionState } from "../extensions/updater/reducers";
 import type { ICollectionInstallState } from "./collections/ICollectionInstallSession";
 import type { ExtensionType, IAvailableExtension, IExtension } from "./extensions";
 import type { IAttributeState } from "./IAttributeState";
@@ -409,6 +410,7 @@ export interface ISessionState {
   history: IHistoryState;
   overlays: IOverlaysState;
   healthCheck: IHealthCheckSessionState;
+  updater: IUpdaterSessionState;
 }
 
 export interface IState {

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -254,6 +254,10 @@ export interface RendererChannels extends RendererCallbackChannels {
   // Updater: Download the available update (installAfterDownload triggers auto-restart when done)
   "updater:download": (channel: string, installAfterDownload: boolean) => void;
 
+  // Updater: Download the downgrade offered after an explicit switch to stable.
+  // Ignored unless a downgrade offer is outstanding.
+  "updater:download-downgrade": (installAfterDownload: boolean) => void;
+
   // Updater: Restart and install update
   "updater:restart-and-install": () => void;
 

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -308,6 +308,9 @@ export interface MainChannels extends MainCallbackChannels {
 
   // Feature flags: main pushes updated flags after each successful poll
   "flags:synchronize": (flags: FeatureFlag[]) => void;
+
+  // Auto-updater: main pushes the full status snapshot on every change
+  "updater:status-changed": (status: UpdateStatus) => void;
 }
 
 /** Context data the renderer can push to refine feature flag evaluation */

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -72,6 +72,8 @@ export interface UpdateStatus {
   downgrade?: boolean;
   /** An update check is in flight */
   checking?: boolean;
+  /** Whether the most recent check was user-initiated (Check now / channel switch) */
+  manual?: boolean;
 }
 
 /** Vortex application paths */

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -51,45 +51,56 @@ export interface AppInitMetadata {
   warnedAdmin?: number;
 }
 
-/** Status of the auto-updater in main process */
-export interface UpdateStatus {
-  /** Whether an update is available */
-  available: boolean;
-  /** Whether update is downloaded and ready to install */
-  downloaded: boolean;
-  /** Version of the available update */
-  version?: string;
-  /** Release notes/changelog for the update */
-  releaseNotes?: string;
-  /** Download progress (0-100) if downloading */
-  downloadProgress?: number;
-  /** Error message if update check failed */
-  error?: string;
+/**
+ * What kind of update a download/staged installer represents. Patches
+ * auto-download and install on restart; regular updates wait for the user;
+ * downgrades only ever follow an explicit confirmation.
+ */
+export type UpdateKind = "patch" | "update" | "downgrade";
+
+/**
+ * The auto-updater as an explicit state machine (modeled on VS Code's
+ * updater): exactly one state at a time, each carrying only the data valid
+ * for it, so contradictory combinations (stale progress on an error, a patch
+ * flag on a minor update) are unrepresentable. The UI renders purely from
+ * the current state.
+ */
+export type UpdaterState =
+  /** updates turned off (channel "none") */
+  | { type: "disabled" }
+  /** nothing on offer */
+  | { type: "idle" }
+  /** a check is in flight; manual checks always render visible feedback */
+  | { type: "checking"; manual: boolean }
+  /** a newer version needs a user decision to download */
+  | { type: "available"; version: string; releaseNotes?: string }
   /**
-   * The offered version is lower than the running one. Only ever set after
-   * a purposeful switch to the stable channel, never for background checks,
-   * and never presented as a regular update.
+   * the stable channel's latest is older than the running version; only ever
+   * entered on a purposeful switch to stable, awaiting confirm/decline
    */
-  downgrade?: boolean;
+  | { type: "downgrade-offered"; version: string }
+  /** a download is running; percent is absent until the first progress event */
+  | { type: "downloading"; version: string; kind: UpdateKind; percent?: number }
+  /** downloaded and verified; installs on quit, or immediately via Restart Now */
+  | { type: "staged"; version: string; kind: UpdateKind; releaseNotes?: string }
   /**
-   * A user-confirmed downgrade is downloading/installing. Distinct from
-   * `downgrade` (the offer): once confirmed the flow runs to completion and
-   * must not be presented as a regular update download.
+   * a check or download failed in a way the user should hear about; retry
+   * carries the still-known update so a working Download can be offered
    */
-  downgrading?: boolean;
-  /** An update check is in flight */
-  checking?: boolean;
-  /** Whether the most recent check was user-initiated (Check now / channel switch) */
-  manual?: boolean;
-  /**
-   * The available update is a patch-level update that auto-downloads and
-   * installs on restart; the renderer presents these more quietly than
-   * updates that need a user decision.
-   */
-  patch?: boolean;
+  | {
+      type: "error";
+      message: string;
+      manual: boolean;
+      retry?: { version: string; releaseNotes?: string };
+    };
+
+/** The full updater snapshot pushed to (and queried by) the renderer */
+export interface UpdaterSnapshot {
+  state: UpdaterState;
   /**
    * Set on the first launch after an update: the version that was running
-   * before. Drives the one-time "Vortex was updated" notice.
+   * before. Drives the one-time "Vortex was updated" notice; orthogonal to
+   * the state machine.
    */
   justUpdatedFrom?: string;
 }
@@ -338,7 +349,7 @@ export interface MainChannels extends MainCallbackChannels {
   "flags:synchronize": (flags: FeatureFlag[]) => void;
 
   // Auto-updater: main pushes the full status snapshot on every change
-  "updater:status-changed": (status: UpdateStatus) => void;
+  "updater:status-changed": (snapshot: UpdaterSnapshot) => void;
 }
 
 /** Context data the renderer can push to refine feature flag evaluation */
@@ -380,7 +391,7 @@ export interface InvokeChannels {
   "persist:get-hydration": () => Promise<Partial<PersistedState>>;
 
   // Updater: Query current update status from main process
-  "updater:get-status": () => Promise<UpdateStatus>;
+  "updater:get-status": () => Promise<UpdaterSnapshot>;
   // Updater: Release notes covering the update the app just went through
   // (null when the launch did not follow an update or notes are unavailable).
   // The renderer passes its persisted channel — the handler can be invoked

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -79,8 +79,13 @@ export type UpdaterState =
    * entered on a purposeful switch to stable, awaiting confirm/decline
    */
   | { type: "downgrade-offered"; version: string }
-  /** a download is running; percent is absent until the first progress event */
-  | { type: "downloading"; version: string; kind: UpdateKind; percent?: number }
+  /**
+   * a download is running; percent is absent until the first progress event.
+   * manual marks a download the user's own action set in motion (Download,
+   * a confirmed downgrade, a manual check that found a patch) — those render
+   * visibly; only background-initiated patch downloads stay silent.
+   */
+  | { type: "downloading"; version: string; kind: UpdateKind; manual: boolean; percent?: number }
   /** downloaded and verified; installs on quit, or immediately via Restart Now */
   | { type: "staged"; version: string; kind: UpdateKind; releaseNotes?: string }
   /**

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -82,7 +82,7 @@ export type UpdaterState =
   /**
    * a download is running; percent is absent until the first progress event.
    * manual marks a download the user's own action set in motion (Download,
-   * a confirmed downgrade, a manual check that found a patch) — those render
+   * a confirmed downgrade, a manual check that found a patch), those render
    * visibly; only background-initiated patch downloads stay silent.
    */
   | { type: "downloading"; version: string; kind: UpdateKind; manual: boolean; percent?: number }
@@ -399,7 +399,7 @@ export interface InvokeChannels {
   "updater:get-status": () => Promise<UpdaterSnapshot>;
   // Updater: Release notes covering the update the app just went through
   // (null when the launch did not follow an update or notes are unavailable).
-  // The renderer passes its persisted channel — the handler can be invoked
+  // The renderer passes its persisted channel, the handler can be invoked
   // before the first check has established one in main.
   "updater:get-update-changelog": (channel: string) => Promise<string | null>;
   // Dialog channels

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -66,14 +66,32 @@ export interface UpdateStatus {
   /** Error message if update check failed */
   error?: string;
   /**
-   * The offered version is lower than the running one. Only ever set after
-   * an explicit switch to the stable channel, never for background checks.
+   * The offered version is lower than the running one. Only ever set for
+   * checks on the stable channel (a prerelease build whose user chose
+   * stable), never presented as a regular update.
    */
   downgrade?: boolean;
+  /**
+   * A user-confirmed downgrade is downloading/installing. Distinct from
+   * `downgrade` (the offer): once confirmed the flow runs to completion and
+   * must not be presented as a regular update download.
+   */
+  downgrading?: boolean;
   /** An update check is in flight */
   checking?: boolean;
   /** Whether the most recent check was user-initiated (Check now / channel switch) */
   manual?: boolean;
+  /**
+   * The available update is a patch-level update that auto-downloads and
+   * installs on restart; the renderer presents these more quietly than
+   * updates that need a user decision.
+   */
+  patch?: boolean;
+  /**
+   * Set on the first launch after an update: the version that was running
+   * before. Drives the one-time "Vortex was updated" notice.
+   */
+  justUpdatedFrom?: string;
 }
 
 /** Vortex application paths */
@@ -256,9 +274,13 @@ export interface RendererChannels extends RendererCallbackChannels {
   // Updater: Download the available update (installAfterDownload triggers auto-restart when done)
   "updater:download": (channel: string, installAfterDownload: boolean) => void;
 
-  // Updater: Download the downgrade offered after an explicit switch to stable.
+  // Updater: Download the downgrade offered on the stable channel.
   // Ignored unless a downgrade offer is outstanding.
   "updater:download-downgrade": (installAfterDownload: boolean) => void;
+
+  // Updater: Decline the outstanding downgrade offer. Clears the offer until
+  // the next check (manual, periodic, or next launch) raises it again.
+  "updater:decline-downgrade": () => void;
 
   // Updater: Restart and install update
   "updater:restart-and-install": () => void;
@@ -359,6 +381,9 @@ export interface InvokeChannels {
 
   // Updater: Query current update status from main process
   "updater:get-status": () => Promise<UpdateStatus>;
+  // Updater: Release notes covering the update the app just went through
+  // (null when the launch did not follow an update or notes are unavailable)
+  "updater:get-update-changelog": () => Promise<string | null>;
   // Dialog channels
   "dialog:showOpen": (options: OpenDialogOptions) => Promise<OpenDialogReturnValue>;
   "dialog:showSave": (options: SaveDialogOptions) => Promise<SaveDialogReturnValue>;

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -382,8 +382,10 @@ export interface InvokeChannels {
   // Updater: Query current update status from main process
   "updater:get-status": () => Promise<UpdateStatus>;
   // Updater: Release notes covering the update the app just went through
-  // (null when the launch did not follow an update or notes are unavailable)
-  "updater:get-update-changelog": () => Promise<string | null>;
+  // (null when the launch did not follow an update or notes are unavailable).
+  // The renderer passes its persisted channel — the handler can be invoked
+  // before the first check has established one in main.
+  "updater:get-update-changelog": (channel: string) => Promise<string | null>;
   // Dialog channels
   "dialog:showOpen": (options: OpenDialogOptions) => Promise<OpenDialogReturnValue>;
   "dialog:showSave": (options: SaveDialogOptions) => Promise<SaveDialogReturnValue>;

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -66,9 +66,9 @@ export interface UpdateStatus {
   /** Error message if update check failed */
   error?: string;
   /**
-   * The offered version is lower than the running one. Only ever set for
-   * checks on the stable channel (a prerelease build whose user chose
-   * stable), never presented as a regular update.
+   * The offered version is lower than the running one. Only ever set after
+   * a purposeful switch to the stable channel, never for background checks,
+   * and never presented as a regular update.
    */
   downgrade?: boolean;
   /**
@@ -274,12 +274,12 @@ export interface RendererChannels extends RendererCallbackChannels {
   // Updater: Download the available update (installAfterDownload triggers auto-restart when done)
   "updater:download": (channel: string, installAfterDownload: boolean) => void;
 
-  // Updater: Download the downgrade offered on the stable channel.
-  // Ignored unless a downgrade offer is outstanding.
+  // Updater: Download the downgrade offered after an explicit switch to
+  // stable. Ignored unless a downgrade offer is outstanding.
   "updater:download-downgrade": (installAfterDownload: boolean) => void;
 
-  // Updater: Decline the outstanding downgrade offer. Clears the offer until
-  // the next check (manual, periodic, or next launch) raises it again.
+  // Updater: Decline the outstanding downgrade offer. Clears the offer;
+  // only another purposeful switch to stable raises it again.
   "updater:decline-downgrade": () => void;
 
   // Updater: Restart and install update

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -310,6 +310,8 @@ export interface RendererChannels extends RendererCallbackChannels {
   // Updater: Decline the outstanding downgrade offer. Clears the offer;
   // only another purposeful switch to stable raises it again.
   "updater:decline-downgrade": () => void;
+  // Updater: stop the running download (the user dismissed its notification)
+  "updater:cancel-download": () => void;
 
   // Updater: Restart and install update
   "updater:restart-and-install": () => void;

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -110,6 +110,19 @@ export interface UpdaterSnapshot {
   justUpdatedFrom?: string;
 }
 
+/**
+ * Reply to `updater:get-status`. The renderer polls rather than being pushed
+ * (the same model as downloads and uploads). `seq` counts snapshots recorded
+ * so far; passing it back as `since` on the next poll returns every snapshot
+ * after it in `changes`, so a state that lasted 300 ms is still delivered.
+ * `snapshot` is always the latest.
+ */
+export interface UpdaterStatusResponse {
+  seq: number;
+  snapshot: UpdaterSnapshot;
+  changes: UpdaterSnapshot[];
+}
+
 /** Vortex application paths */
 export type VortexPaths = {
   base: string;
@@ -352,9 +365,6 @@ export interface MainChannels extends MainCallbackChannels {
 
   // Feature flags: main pushes updated flags after each successful poll
   "flags:synchronize": (flags: FeatureFlag[]) => void;
-
-  // Auto-updater: main pushes the full status snapshot on every change
-  "updater:status-changed": (snapshot: UpdaterSnapshot) => void;
 }
 
 /** Context data the renderer can push to refine feature flag evaluation */
@@ -395,8 +405,10 @@ export interface InvokeChannels {
   // Persistence: Get all hydration data at startup (called once during init)
   "persist:get-hydration": () => Promise<Partial<PersistedState>>;
 
-  // Updater: Query current update status from main process
-  "updater:get-status": () => Promise<UpdaterSnapshot>;
+  // Updater: the renderer polls this (pull, like downloads and uploads). With
+  // `since`, the reply also lists every snapshot recorded after that sequence
+  // number, so short-lived states are seen and not sampled past.
+  "updater:get-status": (since?: number) => Promise<UpdaterStatusResponse>;
   // Updater: Release notes covering the update the app just went through
   // (null when the launch did not follow an update or notes are unavailable).
   // The renderer passes its persisted channel, the handler can be invoked

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -476,6 +476,12 @@ export interface UpdaterApi {
    * Trigger restart and install of the downloaded update.
    */
   restartAndInstall(): void;
+
+  /**
+   * Subscribe to update-status changes pushed from the main process.
+   * Returns an unsubscribe function.
+   */
+  onStatusChanged(callback: (status: UpdateStatus) => void): () => void;
 }
 
 /** API for interacting with the DownloadManager in main */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -459,8 +459,9 @@ export interface UpdaterApi {
   /**
    * Release notes covering the update the app just went through. Null when
    * this launch did not follow an update or the notes are unavailable.
+   * Takes the renderer's persisted update channel.
    */
-  getUpdateChangelog(): Promise<string | null>;
+  getUpdateChangelog(channel: string): Promise<string | null>;
 
   /**
    * Set the update channel and trigger an update check.

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -23,7 +23,7 @@ import type {
   AppInitMetadata,
   HashAlgorithm,
   Serializable,
-  UpdaterSnapshot,
+  UpdaterStatusResponse,
   VortexPaths,
   WireDownloadCheckpoint,
   WireDownloadState,
@@ -452,9 +452,11 @@ export interface AdaptorsApi {
 /** API for querying update status from main process */
 export interface UpdaterApi {
   /**
-   * Get current update status from main process.
+   * Read the updater's status from main. The renderer polls this; with
+   * `since` (the last seen sequence number) the reply includes every
+   * snapshot recorded after it, in order.
    */
-  getStatus(): Promise<UpdaterSnapshot>;
+  getStatus(since?: number): Promise<UpdaterStatusResponse>;
 
   /**
    * Release notes covering the update the app just went through. Null when
@@ -495,12 +497,6 @@ export interface UpdaterApi {
    * purposeful switch to stable raises it again.
    */
   declineDowngrade(): void;
-
-  /**
-   * Subscribe to update-status changes pushed from the main process.
-   * Returns an unsubscribe function.
-   */
-  onStatusChanged(callback: (snapshot: UpdaterSnapshot) => void): () => void;
 }
 
 /** API for interacting with the DownloadManager in main */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -457,6 +457,12 @@ export interface UpdaterApi {
   getStatus(): Promise<UpdateStatus>;
 
   /**
+   * Release notes covering the update the app just went through. Null when
+   * this launch did not follow an update or the notes are unavailable.
+   */
+  getUpdateChangelog(): Promise<string | null>;
+
+  /**
    * Set the update channel and trigger an update check.
    */
   setChannel(channel: string, manual: boolean): void;
@@ -478,10 +484,16 @@ export interface UpdaterApi {
   restartAndInstall(): void;
 
   /**
-   * Download the downgrade offered after an explicit switch to stable.
+   * Download the downgrade offered on the stable channel.
    * Ignored by main unless a downgrade offer is outstanding.
    */
   downloadDowngrade(installAfterDownload?: boolean): void;
+
+  /**
+   * Decline the outstanding downgrade offer. Clears it until the next check
+   * (manual, periodic, or next launch) raises it again.
+   */
+  declineDowngrade(): void;
 
   /**
    * Subscribe to update-status changes pushed from the main process.

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -484,14 +484,14 @@ export interface UpdaterApi {
   restartAndInstall(): void;
 
   /**
-   * Download the downgrade offered on the stable channel.
+   * Download the downgrade offered after an explicit switch to stable.
    * Ignored by main unless a downgrade offer is outstanding.
    */
   downloadDowngrade(installAfterDownload?: boolean): void;
 
   /**
-   * Decline the outstanding downgrade offer. Clears it until the next check
-   * (manual, periodic, or next launch) raises it again.
+   * Decline the outstanding downgrade offer. Clears it; only another
+   * purposeful switch to stable raises it again.
    */
   declineDowngrade(): void;
 

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -478,6 +478,12 @@ export interface UpdaterApi {
   restartAndInstall(): void;
 
   /**
+   * Download the downgrade offered after an explicit switch to stable.
+   * Ignored by main unless a downgrade offer is outstanding.
+   */
+  downloadDowngrade(installAfterDownload?: boolean): void;
+
+  /**
    * Subscribe to update-status changes pushed from the main process.
    * Returns an unsubscribe function.
    */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -23,7 +23,7 @@ import type {
   AppInitMetadata,
   HashAlgorithm,
   Serializable,
-  UpdateStatus,
+  UpdaterSnapshot,
   VortexPaths,
   WireDownloadCheckpoint,
   WireDownloadState,
@@ -454,7 +454,7 @@ export interface UpdaterApi {
   /**
    * Get current update status from main process.
    */
-  getStatus(): Promise<UpdateStatus>;
+  getStatus(): Promise<UpdaterSnapshot>;
 
   /**
    * Release notes covering the update the app just went through. Null when
@@ -500,7 +500,7 @@ export interface UpdaterApi {
    * Subscribe to update-status changes pushed from the main process.
    * Returns an unsubscribe function.
    */
-  onStatusChanged(callback: (status: UpdateStatus) => void): () => void;
+  onStatusChanged(callback: (snapshot: UpdaterSnapshot) => void): () => void;
 }
 
 /** API for interacting with the DownloadManager in main */

--- a/src/shared/src/types/preload.ts
+++ b/src/shared/src/types/preload.ts
@@ -497,6 +497,11 @@ export interface UpdaterApi {
    * purposeful switch to stable raises it again.
    */
   declineDowngrade(): void;
+
+  /**
+   * Cancel the download in progress. Ignored by main unless one is running.
+   */
+  cancelDownload(): void;
 }
 
 /** API for interacting with the DownloadManager in main */


### PR DESCRIPTION
Merges after #23992.

The big one. Downgrades are never presented as updates. The only way to get one is purposefully switching to Stable while running something newer, and it's offered as exactly what it is, with decline/confirm and a marker that stops the "Downgrade detected" scare on the next launch. The updater is now an explicit state machine (modeled on VS Code's): one state at a time, transitions logged, notifications rendered purely from state. Patches download silently and install on restart. Bigger updates ask first and show live progress. Installs always run the visible wizard, including on quit. Failures tell the user instead of dying in the log. Tested through the full matrix on packaged local builds and on real GitHub with CI-signed builds. Flow and testing docs are in #23995.

Status reaches the renderer by polling, the same model as downloads and uploads. The renderer used to poll once, 15 seconds after startup, and missed anything that resolved later; now it polls `updater:get-status` at 200ms while something is happening and stops when the state settles (nothing polls while Vortex is idle), and main numbers snapshots so a poll gets every transition since the last one it saw. See `updaterStatus.ts` and the `get-status` handler.

Review history: this PR absorbed #23993 (status transport). Florian's review there, asking for pull instead of push, is what shaped the transport: https://github.com/Nexus-Mods/Vortex/pull/23993#pullrequestreview-5016409470
