### PR TITLE
fix(ui): let the classic notifications popover be closed

### DIFF
--- a/src/renderer/src/views/NotificationButton.test.tsx
+++ b/src/renderer/src/views/NotificationButton.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type * as ReactReduxTypes from "react-redux";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { INotification } from "../types/INotification";
+
+const { dispatch, emit } = vi.hoisted(() => ({ dispatch: vi.fn(), emit: vi.fn() }));
+
+vi.mock("../ExtensionProvider", () => ({
+  useExtensionContext: () => ({ getApi: () => ({ events: { emit } }) }),
+}));
+
+// Icon loads its font set into an `#icon-sets` element the real document has and this
+// one doesn't. Nothing here turns on which glyph is drawn.
+vi.mock("../controls/Icon", () => ({ default: () => null }));
+
+/** Rewritten per test, then read by the real selector through the mocked hook. */
+const store = vi.hoisted(() => ({ state: {} as Record<string, unknown> }));
+
+vi.mock("react-redux", async () => {
+  const actual = await vi.importActual<typeof ReactReduxTypes>("react-redux");
+
+  return {
+    ...actual,
+    useDispatch: () => dispatch,
+    useSelector: (selector: (state: unknown) => unknown) => selector(store.state),
+  };
+});
+
+import { NotificationButton } from "./NotificationButton";
+
+const withNotifications = (notifications: INotification[]) => {
+  store.state = { session: { notifications: { notifications } } };
+};
+
+/**
+ * A notification offering the user a choice. `displayTime` returns null for these, so
+ * nothing ever filters it out — which is what made the popover unclosable.
+ */
+const choice = (id: string): INotification => ({
+  id,
+  type: "info",
+  message: "needs an answer",
+  createdTime: Date.now(),
+  updatedTime: Date.now(),
+  actions: [{ title: "Fix", action: () => undefined }],
+});
+
+/** A plain notification, which does expire on its own. */
+const transient = (id: string): INotification => ({
+  id,
+  type: "info",
+  message: "for information",
+  createdTime: Date.now(),
+  updatedTime: Date.now(),
+});
+
+const popover = () => screen.queryByTestId("notifications-popover");
+
+const renderButton = () => render(<NotificationButton hide={false} id="notification-button" />);
+
+describe("NotificationButton", () => {
+  beforeEach(() => {
+    dispatch.mockClear();
+    emit.mockClear();
+  });
+
+  it("shows the popover by itself when there is a notification", async () => {
+    withNotifications([transient("a")]);
+    renderButton();
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+  });
+
+  // The bug: `open` only governed whether expired notifications stay listed, so a
+  // notification that never expires left the popover with nothing to close it.
+  it("closes on the button even when the notification never expires", async () => {
+    withNotifications([choice("a")]);
+    renderButton();
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("notifications-button"));
+
+    await waitFor(() => expect(popover()).not.toBeInTheDocument());
+  });
+
+  it("reports the close to analytics as a close", async () => {
+    withNotifications([choice("a")]);
+    renderButton();
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("notifications-button"));
+
+    expect(emit).toHaveBeenCalledWith(
+      "analytics-track-click-event",
+      "Notifications",
+      "Close Notifications",
+    );
+  });
+
+  it("comes back when a notification the user has not seen arrives", async () => {
+    withNotifications([choice("a")]);
+    const { rerender } = renderButton();
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("notifications-button"));
+    await waitFor(() => expect(popover()).not.toBeInTheDocument());
+
+    withNotifications([choice("a"), transient("b")]);
+    rerender(<NotificationButton hide={false} id="notification-button" />);
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+  });
+
+  // Otherwise a download reporting progress would reopen what the user just closed.
+  it("stays closed while a notification it already knows about changes", async () => {
+    const activity: INotification = {
+      id: "a",
+      type: "activity",
+      message: "working",
+      progress: 10,
+      createdTime: Date.now(),
+      updatedTime: Date.now(),
+    };
+
+    withNotifications([activity]);
+    const { rerender } = renderButton();
+
+    await waitFor(() => expect(popover()).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("notifications-button"));
+    await waitFor(() => expect(popover()).not.toBeInTheDocument());
+
+    withNotifications([{ ...activity, progress: 60, updatedTime: Date.now() }]);
+    rerender(<NotificationButton hide={false} id="notification-button" />);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(popover()).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/views/NotificationButton.tsx
+++ b/src/renderer/src/views/NotificationButton.tsx
@@ -68,6 +68,11 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
   // Local state
   const [expand, setExpand] = React.useState<string | undefined>(undefined);
   const [open, setOpen] = React.useState(false);
+  // Whether the user has closed the popover on what it was showing. `open` can't do
+  // this on its own: it says whether to keep notifications whose display time has run
+  // out, so a popover the user shut on a notification that never expires — an ongoing
+  // activity, or one waiting on a choice -- had nothing to shut it.
+  const [closed, setClosed] = React.useState(false);
   const [resizing, setResizing] = React.useState(false);
   const [filtered, setFiltered] = React.useState<INotification[]>([]);
 
@@ -76,10 +81,11 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
   const updateTimerRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
   const mountedRef = React.useRef(false);
   const prevNotificationsRef = React.useRef(notifications);
+  const prevIdsRef = React.useRef<Set<string>>(new Set());
 
   // Store latest values for callbacks
-  const stateRef = React.useRef({ notifications, open, expand, filtered });
-  stateRef.current = { notifications, open, expand, filtered };
+  const stateRef = React.useRef({ notifications, open, closed, expand, filtered });
+  stateRef.current = { notifications, open, closed, expand, filtered };
 
   // Dispatch callbacks
   const onDismiss = React.useCallback(
@@ -217,16 +223,18 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
   const toggle = React.useCallback(
     (evt: React.MouseEvent<unknown>) => {
       evt.preventDefault();
-      const { open: isOpen } = stateRef.current;
+      // Grouping only ever merges notifications, so anything in `filtered` is on screen.
+      const { closed: isClosed, filtered: filt } = stateRef.current;
+      const isShowing = !isClosed && filt.length > 0;
+
       api.events.emit(
         "analytics-track-click-event",
         "Notifications",
-        `${isOpen ? "Close" : "Open"} Notifications`,
+        `${isShowing ? "Close" : "Open"} Notifications`,
       );
-      setOpen(!isOpen);
-      setTimeout(() => {
-        updateDebouncer.current.runNow(() => null);
-      }, 0);
+
+      setClosed(isShowing);
+      setOpen(!isShowing);
     },
     [api],
   );
@@ -372,6 +380,27 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
     };
   }, [onResize, updateFiltered]);
 
+  // Whether a notification whose display time has run out belongs in `filtered` turns
+  // on `open`, so the filter has to run again when it changes.
+  React.useEffect(() => {
+    updateDebouncer.current.runNow(() => null);
+  }, [open]);
+
+  // A notification arriving is how the popover comes up unasked, so it also undoes a
+  // close — otherwise the first one the user shut the popover on would be the last
+  // they ever saw. Only a notification we haven't seen counts: an activity reporting
+  // progress must not reopen what the user just closed. Silent ones never show at all.
+  React.useEffect(() => {
+    const hasNew = notifications.some(
+      (item) => !prevIdsRef.current.has(item.id) && item.type !== "silent",
+    );
+    prevIdsRef.current = new Set(notifications.map((item) => item.id));
+
+    if (hasNew) {
+      setClosed(false);
+    }
+  }, [notifications]);
+
   // Handle notifications changes
   React.useEffect(() => {
     if (prevNotificationsRef.current !== notifications) {
@@ -401,6 +430,7 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
   const popover = (
     <Popover
       arrowOffsetLeft={64}
+      data-testid="notifications-popover"
       id="notifications-popover"
       style={{ display: hide ? "none" : "block" }}
     >
@@ -427,7 +457,12 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
 
   return (
     <div style={{ display: "inline-block" }}>
-      <Button id="notifications-button" ref={buttonRef} onClick={toggle}>
+      <Button
+        data-testid="notifications-button"
+        id="notifications-button"
+        ref={buttonRef}
+        onClick={toggle}
+      >
         <Icon name="notifications" />
 
         <RadialProgress
@@ -445,7 +480,7 @@ export const NotificationButton: React.FC<React.PropsWithChildren<IBaseProps>> =
         placement="bottom"
         rootClose={false}
         shouldUpdatePosition={resizing}
-        show={items.length > 0}
+        show={!closed && items.length > 0}
         target={buttonRef.current}
         onExit={unExpand}
       >


### PR DESCRIPTION
The popover's visibility was `items.length > 0` — whether it had anything to show — so the button under it only ever chose whether notifications past their display time stayed listed. Closing worked by accident: the list emptied as things expired. A notification that never expires therefore had nothing to close it, and since APP-468 (#23226) taught `displayTime` that a notification offering the user a choice must not auto-hide, any of those pinned the popover open for good.

The user's close is now its own state, apart from `open`, which keeps its meaning of whether the expired are still listed. A notification arriving clears it, that being how the popover shows itself unasked and the alternative being that the first thing the user closes is the last they see. Only an id we haven't seen counts, so an activity reporting progress won't reopen what they just shut.

The modern header's popover was never affected: it gates its panel on the Headless UI open state and opens itself by clicking its own button, which is the arrangement arrived at here.