### PR TITLE
Fix the display options picker and the header title truncating

### DIFF
--- a/src/renderer/src/ui/components/popover/PopoverPanel.tsx
+++ b/src/renderer/src/ui/components/popover/PopoverPanel.tsx
@@ -1,7 +1,22 @@
 import { PopoverPanel as HeadlessPopoverPanel } from "@headlessui/react";
-import React, { type ComponentProps } from "react";
+import React, {
+  type ComponentProps,
+  type ForwardRefExoticComponent,
+  forwardRef,
+  type RefAttributes,
+} from "react";
 
 import { joinClasses } from "@/ui/utils/joinClasses";
+
+type IPopoverPanelProps = ComponentProps<typeof HeadlessPopoverPanel>;
+
+/**
+ * Spelled out so the declaration build has a name for it. Left to infer, the forwarded
+ * ref makes a type that can only be named by reaching into Headless UI's internals.
+ */
+type IPopoverPanel = ForwardRefExoticComponent<
+  Omit<IPopoverPanelProps, "ref"> & RefAttributes<HTMLElement>
+>;
 
 /**
  * Floating panel for a Popover. Unlike a Dropdown's menu, this holds arbitrary
@@ -11,14 +26,20 @@ import { joinClasses } from "@/ui/utils/joinClasses";
  * `anchor` hands positioning to Headless UI's Floating UI integration, which also
  * portals the panel — so it escapes any clipping ancestor and flips itself when
  * there's no room below. Pass `anchor` to place it elsewhere.
+ *
+ * The ref reaches the panel element, for a caller that has to focus it. Headless UI's
+ * own `focus` prop does that too, but it couples the focus to the panel's lifetime and
+ * closes as soon as focus leaves.
  */
-export const PopoverPanel = ({
-  className,
-  ...props
-}: ComponentProps<typeof HeadlessPopoverPanel>) => (
-  <HeadlessPopoverPanel
-    anchor={{ gap: 4, to: "bottom end" }}
-    className={joinClasses(["nxm-popover-panel", className])}
-    {...props}
-  />
+export const PopoverPanel: IPopoverPanel = forwardRef<HTMLElement, IPopoverPanelProps>(
+  ({ className, ...props }, ref) => (
+    <HeadlessPopoverPanel
+      anchor={{ gap: 4, to: "bottom end" }}
+      className={joinClasses(["nxm-popover-panel", className])}
+      ref={ref}
+      {...props}
+    />
+  ),
 );
+
+PopoverPanel.displayName = "PopoverPanel";

--- a/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.test.tsx
@@ -1,0 +1,81 @@
+import { mdiTune, mdiViewGrid, mdiViewList } from "@mdi/js";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { Picker } from "@/ui/components/picker/Picker";
+import { PopoverPanelGroup } from "@/ui/components/popover/PopoverPanelGroup";
+import { PopoverPanelGroupItem } from "@/ui/components/popover/PopoverPanelGroupItem";
+
+import { ToolbarPanelButton } from "./ToolbarPanelButton";
+
+// --- Helpers ---
+
+/** The display options panel, whose "Display as" row holds a nested picker. */
+const displayOptions = () => (
+  <PopoverPanelGroup>
+    <PopoverPanelGroupItem label="Display as">
+      <Picker<string>
+        button={{ leftIconPath: mdiViewGrid, size: "sm" }}
+        options={[
+          { label: "Grid", value: "small", iconPath: mdiViewGrid },
+          { label: "List", value: "list", iconPath: mdiViewList },
+        ]}
+        value="small"
+        onChange={() => {}}
+      />
+    </PopoverPanelGroupItem>
+  </PopoverPanelGroup>
+);
+
+const openPanel = async () => {
+  render(
+    <ToolbarPanelButton label="Display options" leftIconPath={mdiTune} panel={displayOptions} />,
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Display options" }));
+  await waitFor(() => expect(screen.getByText("Display as")).toBeInTheDocument());
+};
+
+const panelRow = () => screen.queryByText("Display as");
+
+/** The picker's own trigger, which sits inside the panel and shows the selection. */
+const picker = () => screen.getByRole("button", { name: /Grid/ });
+
+// --- Tests ---
+
+describe("ToolbarPanelButton", () => {
+  it("opens its panel", async () => {
+    await openPanel();
+
+    expect(panelRow()).toBeInTheDocument();
+  });
+
+  // The panel used to close on any focus leaving it, which is what a nested control
+  // opening its own floating list looks like.
+  it("stays open when a control inside it opens its own list", async () => {
+    await openPanel();
+
+    await userEvent.click(picker());
+
+    expect(panelRow()).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("option", { name: /List/ })).toBeInTheDocument());
+  });
+
+  it("takes focus as it opens, so the keyboard lands in the panel", async () => {
+    await openPanel();
+
+    await waitFor(() =>
+      expect(document.activeElement).toHaveClass("nxm-popover-panel-controls", { exact: false }),
+    );
+  });
+
+  it("still closes on Escape", async () => {
+    await openPanel();
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => expect(panelRow()).not.toBeInTheDocument());
+  });
+});

--- a/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.tsx
@@ -11,6 +11,31 @@ import { TOOLBAR_CONTROL_ATTRIBUTE } from "./useToolbarOverflow.hook";
 export type IToolbarPanelButtonProps = IToolbarButtonProps & { panel: IToolbarPanel };
 
 /**
+ * Moves focus into the panel as it opens, so opening from the keyboard lands in the
+ * rows rather than leaving them to be tabbed to.
+ *
+ * `PopoverPanel`'s own `focus` prop does this, but it also closes the panel the moment
+ * focus leaves it — and a control inside the panel that opens its own floating list,
+ * as the display options picker does, reads as exactly that. Clicking the picker shut
+ * the panel it was in. Doing the focus here keeps the keyboard entry and leaves closing
+ * to an outside click or Escape.
+ *
+ * Declared out here so the ref keeps one identity: an inline callback would be a new
+ * ref every render, and refocus the panel each time — taking focus back off whatever
+ * the user had just opened inside it.
+ */
+const focusPanel = (element: HTMLElement | null) => {
+  if (element === null) {
+    return;
+  }
+
+  // Headless UI keeps `tabIndex` to itself as a prop, so it goes on the element. The
+  // panel is a plain div and won't take focus without it.
+  element.tabIndex = -1;
+  element.focus({ preventScroll: true });
+};
+
+/**
  * A toolbar control that opens a floating panel instead of running an action.
  *
  * The trigger is a {@link ToolbarButton} rendered as the popover's button, so the
@@ -25,7 +50,7 @@ export const ToolbarPanelButton = ({ panel, ...props }: IToolbarPanelButtonProps
       <>
         <ToolbarButton {...props} as={PopoverButton} tooltipDisabled={open} />
 
-        <PopoverPanel focus className="nxm-popover-panel-controls">
+        <PopoverPanel className="nxm-popover-panel-controls" ref={focusPanel}>
           {({ close }) => <>{panel({ close, dismiss: close })}</>}
         </PopoverPanel>
       </>

--- a/src/renderer/src/views/components/Header/Header.tsx
+++ b/src/renderer/src/views/components/Header/Header.tsx
@@ -54,7 +54,7 @@ export const Header: FC<React.PropsWithChildren<unknown>> = () => {
 
   return (
     <div
-      className="flex h-11 items-center justify-between pl-4.5"
+      className="flex h-11 items-center justify-between gap-x-6 pl-4.5"
       style={{ WebkitAppRegion: "drag" }}
     >
       <div className="flex min-w-0 flex-1 items-center gap-x-1">
@@ -71,12 +71,12 @@ export const Header: FC<React.PropsWithChildren<unknown>> = () => {
 
         <Typography
           brand="none"
-          className="flex min-w-0 items-center gap-x-2 truncate font-semibold"
+          className="flex grow items-center gap-x-2 overflow-hidden font-semibold whitespace-nowrap"
         >
-          <span className="shrink-0 text-neutral-strong">{title}</span>
+          <span className="truncate text-neutral-strong">{title}</span>
 
           {!!profileName && (
-            <span className="max-w-[33%] min-w-0 truncate text-neutral-subdued">{profileName}</span>
+            <span className="shrink-9999 truncate text-neutral-subdued">{profileName}</span>
           )}
         </Typography>
       </div>


### PR DESCRIPTION
### The display options panel closed on its own controls
  
Clicking "Display as" in a display options panel shut the panel, so the picker could never be opened — games page and extensions page both.

`ToolbarPanelButton` passed Headless UI's `focus` to `PopoverPanel`. That focuses the panel as it opens *and* closes it as soon as focus leaves — and a control that opens its own floating list, which Headless UI anchors and portals outside the panel, is indistinguishable from focus leaving. The two behaviours only come as a pair.

The panel now takes focus itself through a ref, and doesn't sign up for the close. Escape and an outside click still close it, which is what that component's own doc comment already claimed. `tabIndex` goes on the element rather than being passed, Headless UI keeping that prop to itself.

`PopoverPanel` forwards its ref for this, with its type written out rather than inferred — the api declaration build can't name what `forwardRef` infers here without reaching into Headless UI's internals. 

Nothing else passed `focus`, so this was the only affected panel: menu panels never had it, and a menu focuses its own first row.

<img width="335" height="211" alt="image" src="https://github.com/user-attachments/assets/a6aab36f-6841-4603-b551-f4d754684d1b" />


### The header title never truncated, and the profile name capped instead
  
The title had `shrink-0`, so it never gave up width and its `truncate` never fired — a long game name overflowed and was clipped with no ellipsis. The `truncate` on the row did nothing either: `text-overflow` needs inline content, and a flex container's children are blockified.

Both spans truncate now, with the profile name shrinking at 9999 against the title's 1, so the title's share of any shortfall stays sub-pixel until the profile name has collapsed to nothing. The game's name is the last thing to lose characters rather than the first. The `max-w-[33%]` cap on the profile name goes, the shrink order having replaced what it approximated.

**Truncating profile name**

<img width="1464" height="62" alt="image" src="https://github.com/user-attachments/assets/d6678a40-701b-4b16-ade5-f6806d5da47c" />

**Truncating game name**

<img width="617" height="68" alt="image" src="https://github.com/user-attachments/assets/5d8c704f-3722-47e8-b984-8571d1b88206" />

