### PR TITLE
Fixed Nexus Publishing

### DIFF
--- a/.github/workflows/publish-nexusmods-release.yml
+++ b/.github/workflows/publish-nexusmods-release.yml
@@ -75,7 +75,6 @@ jobs:
           filename: ${{ steps.prepare.outputs.installer-path }}
           version: ${{ steps.prepare.outputs.version }}
           display_name: Vortex ${{ steps.prepare.outputs.version }}
-          description: ${{ steps.prepare.outputs.body }}
           changelog: ${{ steps.prepare.outputs.changelog }}
           category: main
           archive_existing_version: false


### PR DESCRIPTION
Removed description to mimic what the site does. We also were getting 500 most likely because the release notes are way bigger than the description limit