### PR TITLE
Restore active state for spine download button (LAZ-984)

### DIFF
--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.test.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.test.tsx
@@ -1,0 +1,212 @@
+import { render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type * as ReactRedux from "react-redux";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IState } from "@/types/IState";
+
+import type { SpineSelection } from "../SpineContext";
+
+// The component derives everything from the store via a selector, so useSelector is
+// run against a hand-built state rather than a real store — that keeps the progress
+// maths under test instead of stubbing it out.
+const mocks = vi.hoisted(() => ({
+  state: { persistent: { downloads: { files: {}, speed: 0 } } } as unknown as IState,
+  selectDownloads: vi.fn(),
+  selection: { type: "home" } as SpineSelection,
+}));
+
+vi.mock("react-redux", async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactRedux>()),
+  useSelector: (selector: (state: IState) => unknown) => selector(mocks.state),
+}));
+
+vi.mock("../SpineContext", () => ({
+  useSpineContext: () => ({
+    selection: mocks.selection,
+    selectDownloads: mocks.selectDownloads,
+  }),
+}));
+
+import { DownloadButton } from "./DownloadButton";
+
+// --- Helpers ---
+
+const MB = 1024 * 1024;
+
+/** Geometry mirrored from ProgressRing so offsets can be checked against real numbers. */
+const CIRCUMFERENCE = 2 * Math.PI * ((48 - 4) / 2);
+
+interface IDownloadFixture {
+  state: string;
+  size?: number;
+  received: number;
+}
+
+const setStore = (downloads: IDownloadFixture[], speedMBps = 0) => {
+  mocks.state = {
+    persistent: {
+      downloads: {
+        files: Object.fromEntries(downloads.map((dl, i) => [`dl${i}`, dl])),
+        speed: speedMBps * MB,
+      },
+    },
+  } as unknown as IState;
+};
+
+const setSelection = (type: SpineSelection["type"]) => {
+  mocks.selection = { type } as SpineSelection;
+};
+
+const renderComponent = () => {
+  const { container } = render(<DownloadButton />);
+  const circles = () => [...container.querySelectorAll("circle")];
+
+  return {
+    container,
+    button: within(container).getByRole("button", { name: "Downloads" }),
+    /** ProgressRing renders the track first, then the progress arc over it. */
+    track: () => circles()[0],
+    arc: () => circles()[1],
+    hasRing: () => circles().length > 0,
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setStore([]);
+  setSelection("home");
+});
+
+// --- Tests ---
+
+describe("DownloadButton", () => {
+  describe("idle", () => {
+    it("shows the download icon and no progress ring", () => {
+      const { container, hasRing } = renderComponent();
+      expect(hasRing()).toBe(false);
+      expect(container.querySelector("svg path")).toBeInTheDocument();
+    });
+
+    it("outlines itself when the downloads page is open", () => {
+      setSelection("downloads");
+      const { button } = renderComponent();
+      expect(button).toHaveClass("border-neutral-strong", "bg-surface-translucent-low");
+    });
+
+    it("stays subdued when another page is open", () => {
+      const { button } = renderComponent();
+      expect(button).toHaveClass("border-stroke-weak");
+      expect(button).not.toHaveClass("bg-surface-translucent-low");
+    });
+  });
+
+  describe("downloading", () => {
+    beforeEach(() => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+    });
+
+    it("reports the current speed in MB/s", () => {
+      const { button } = renderComponent();
+      expect(button).toHaveTextContent("8.6");
+      expect(button).toHaveTextContent("mb/s");
+    });
+
+    it("draws the arc in proportion to bytes received", () => {
+      const { arc } = renderComponent();
+      // 250 of 1000 bytes → a quarter sweep, so three quarters remain as offset.
+      expect(Number(arc().getAttribute("stroke-dashoffset"))).toBeCloseTo(CIRCUMFERENCE * 0.75, 3);
+    });
+
+    it("treats several downloads as one combined total", () => {
+      setStore(
+        [
+          { state: "started", size: 1000, received: 500 },
+          { state: "started", size: 1000, received: 250 },
+        ],
+        4,
+      );
+      const { arc } = renderComponent();
+      // 750 of 2000 → 37.5%.
+      expect(Number(arc().getAttribute("stroke-dashoffset"))).toBeCloseTo(CIRCUMFERENCE * 0.625, 3);
+    });
+  });
+
+  // LAZ-984: the ring is the button's only active affordance while a download is
+  // running — there's no border in that branch — so both of its strokes have to
+  // respond to selection.
+  describe("ring colours", () => {
+    it("keeps the track subdued while another page is open", () => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+      const { track } = renderComponent();
+      expect(track()).toHaveClass("stroke-stroke-weak");
+    });
+
+    it("lifts the track when the downloads page is open", () => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+      setSelection("downloads");
+      const { track } = renderComponent();
+      expect(track()).toHaveClass("stroke-stroke-moderate");
+    });
+
+    it("draws the arc in the accent colour while downloading", () => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+      const { arc } = renderComponent();
+      expect(arc()).toHaveClass("stroke-info-subdued");
+    });
+
+    it("draws the arc in the foreground colour when selected", () => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+      setSelection("downloads");
+      const { arc } = renderComponent();
+      expect(arc()).toHaveClass("stroke-neutral-strong");
+    });
+
+    it("mutes the arc while paused", () => {
+      setStore([{ state: "paused", size: 1000, received: 250 }]);
+      const { arc } = renderComponent();
+      expect(arc()).toHaveClass("stroke-stroke-moderate");
+    });
+
+    it("still marks a paused download as selected", () => {
+      setStore([{ state: "paused", size: 1000, received: 250 }]);
+      setSelection("downloads");
+      const { arc, track } = renderComponent();
+      expect(arc()).toHaveClass("stroke-neutral-strong");
+      expect(track()).toHaveClass("stroke-stroke-moderate");
+    });
+  });
+
+  describe("paused", () => {
+    it('labels itself "paused" instead of showing a speed', () => {
+      setStore([{ state: "paused", size: 1000, received: 250 }]);
+      const { button } = renderComponent();
+      expect(button).toHaveTextContent("paused");
+      expect(button).not.toHaveTextContent("mb/s");
+    });
+
+    it("is not paused while any download is still running", () => {
+      setStore(
+        [
+          { state: "paused", size: 1000, received: 250 },
+          { state: "started", size: 1000, received: 250 },
+        ],
+        2,
+      );
+      const { button } = renderComponent();
+      expect(button).toHaveTextContent("mb/s");
+      expect(button).not.toHaveTextContent("paused");
+    });
+  });
+
+  describe("interaction", () => {
+    it("opens the downloads page when clicked", async () => {
+      const { button } = renderComponent();
+
+      await userEvent.click(button);
+
+      expect(mocks.selectDownloads).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
@@ -1,5 +1,5 @@
 import { mdiDownload } from "@mdi/js";
-import React, { type FC } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 
 import type { DownloadState } from "@/extensions/download_management/types/IDownload";
@@ -9,7 +9,7 @@ import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-import { useSpineContext } from "./SpineContext";
+import { useSpineContext } from "../SpineContext";
 
 const ACTIVE_DOWNLOAD_STATES: DownloadState[] = ["init", "started", "finalizing"];
 
@@ -21,7 +21,7 @@ interface DownloadProgress {
   estimatedMins: number; // Estimated time remaining in minutes
 }
 
-function useDownloadProgress(): DownloadProgress {
+const useDownloadProgress = (): DownloadProgress => {
   return useSelector((state: IState) => {
     const files = state.persistent.downloads?.files ?? {};
     const speed = state.persistent.downloads?.speed ?? 0;
@@ -70,15 +70,17 @@ function useDownloadProgress(): DownloadProgress {
       estimatedMins,
     };
   });
-}
+};
 
-const ProgressRing: FC<
-  React.PropsWithChildren<{
-    isActive: boolean;
-    isPaused: boolean;
-    progress: number;
-  }>
-> = ({ isActive, isPaused, progress }) => {
+const ProgressRing = ({
+  isActive,
+  isPaused,
+  progress,
+}: {
+  isActive: boolean;
+  isPaused: boolean;
+  progress: number;
+}) => {
   const size = 48;
   const strokeWidth = 4;
   const radius = (size - strokeWidth) / 2;
@@ -89,7 +91,10 @@ const ProgressRing: FC<
     <svg className="pointer-events-none absolute inset-0 -rotate-90" height={size} width={size}>
       {/* Background circle */}
       <circle
-        className="stroke-stroke-weak"
+        className={joinClasses([
+          "transition-colors",
+          isActive ? "stroke-stroke-moderate" : "stroke-stroke-weak",
+        ])}
         cx={size / 2}
         cy={size / 2}
         fill="none"
@@ -104,7 +109,7 @@ const ProgressRing: FC<
           isActive
             ? "stroke-neutral-strong"
             : isPaused
-              ? "stroke-neutral-moderate"
+              ? "stroke-stroke-moderate"
               : "stroke-info-subdued group-hover/download:stroke-info-strong",
         ])}
         cx={size / 2}
@@ -119,7 +124,7 @@ const ProgressRing: FC<
   );
 };
 
-export const DownloadButton: FC<React.PropsWithChildren<unknown>> = () => {
+export const DownloadButton = () => {
   const { selection, selectDownloads } = useSpineContext();
 
   const isActive = selection.type === "downloads";

--- a/src/renderer/src/views/components/Spine/index.tsx
+++ b/src/renderer/src/views/components/Spine/index.tsx
@@ -9,7 +9,7 @@ import {
   knownGames as knownGamesSelector,
   profiles as profilesSelector,
 } from "../../../util/selectors";
-import { DownloadButton } from "./DownloadButton";
+import { DownloadButton } from "./download_button/DownloadButton";
 import { GameButton } from "./GameButton";
 import { SpineButton } from "./SpineButton";
 import { useSpineContext } from "./SpineContext";


### PR DESCRIPTION
https://linear.app/nexus-mods/issue/LAZ-984/restore-active-state-for-spine-download-button

The progress ring is the download button's only selection affordance while a download is running — that branch renders no border — but the track was pinned to `stroke-weak`, so the button looked the same whether or not the Downloads page was open. It now lifts to `stroke-moderate` when active.

The paused arc also used `neutral-moderate`, far lighter than the design; it moves to the same `stroke-moderate`. 
                                         
Moves the component into `download_button/` with a test covering the ring colours in each state, since a live download is awkward to stage by hand. Also tidies the file: `useDownloadProgress` becomes an arrow function, and `FC`/`PropsWithChildren` are dropped — they advertised a `children` prop the component never rendered.

### Testing                                         

15 new tests. Verified they bite by reverting the fix: exactly the three ring-colour assertions failed. Full workspace `build`, `lint`, `typecheck` and `test` pass.

<img width="98" height="117" alt="image" src="https://github.com/user-attachments/assets/be724ad4-d068-4e18-89ea-fbf91741ff83" />

<img width="98" height="117" alt="image" src="https://github.com/user-attachments/assets/e0e4351f-e663-4eeb-9caf-70bf8052ff23" />

