### PR TITLE
fix plugin state lost after switching to a new profile (LAZ-993)

### DIFF
--- a/extensions/gamebryo-plugin-management/src/util/PluginPersistor.test.ts
+++ b/extensions/gamebryo-plugin-management/src/util/PluginPersistor.test.ts
@@ -226,6 +226,41 @@ describe("PluginPersistor", () => {
       expect(onExternalChange).not.toHaveBeenCalled();
     });
 
+    it("re-asserts the plugin files from the known set after loading", async () => {
+      // on a profile switch the known-plugins refresh lands while the persistor is
+      // disabled, so its serialize is dropped; loading must then write the files back
+      // from the refreshed known set or they keep the previous profile's entries
+      await persistor.disable();
+      persistor.setKnownPlugins({ "new.esp": "New.esp" });
+
+      await persistor.loadFiles("skyrimse");
+
+      await vi.waitFor(() => {
+        const written = nodeFs.readFileSync(path.join(paths.pluginDir, "plugins.txt"), "latin1");
+        expect(written).toContain("New.esp");
+        expect(written).not.toContain("Old.esp");
+      });
+    });
+
+    it("stays writable after the initial load finds an empty plugins file", async () => {
+      const freshDir = nodeFs.mkdtempSync(path.join(os.tmpdir(), "plugin-empty-"));
+      paths.pluginDir = freshDir;
+      nodeFs.writeFileSync(path.join(freshDir, "plugins.txt"), "", { encoding: "latin1" });
+      const fresh = new PluginPersistor(vi.fn(), () => false);
+      fresh.setResetCallback(vi.fn(async () => undefined));
+      await fresh.loadFiles("skyrimse");
+
+      fresh.setKnownPlugins({ "new.esp": "New.esp" });
+      await fresh.setItem(["new.esp"], JSON.stringify({ enabled: true, loadOrder: 0 }));
+
+      await vi.waitFor(() => {
+        const written = nodeFs.readFileSync(path.join(freshDir, "plugins.txt"), "latin1");
+        expect(written).toContain("*New.esp");
+      });
+      await fresh.disable();
+      nodeFs.rmSync(freshDir, { recursive: true, force: true });
+    });
+
     it("clears a pending choice when the persistor is disabled", async () => {
       // the prompt can outlive the game it was raised for; left pending it blocks the
       // next game's initial read and the hive is never populated

--- a/extensions/gamebryo-plugin-management/src/util/PluginPersistor.ts
+++ b/extensions/gamebryo-plugin-management/src/util/PluginPersistor.ts
@@ -115,6 +115,7 @@ class PluginPersistor implements types.IPersistor {
           // start watching for external changes
           .then(() => {
             this.startWatch();
+            this.serialize();
             return Promise.resolve();
           })
       );
@@ -542,8 +543,12 @@ class PluginPersistor implements types.IPersistor {
         if (data.length === 0) {
           // not even a header? I don't trust this. Read once more in case we caught a write
           // mid-flight, then leave the current state alone: a truncated file is not a
-          // statement that every plugin is gone, and adopting it would discard the lot
-          return retry ? Promise.resolve() : this.deserialize(true, adoptForeign);
+          if (retry) {
+            // The persistor must still count as loaded, or serialize() drops every write
+            this.mLoaded = true;
+            return Promise.resolve();
+          }
+          return this.deserialize(true, adoptForeign);
         }
         const keys: string[] = this.filterFileData(data.toString("latin1"), true, foreign);
         this.initFromKeyList(newPlugins, keys, true, offset);

--- a/src/renderer/src/extensions/profile_management/sync.ts
+++ b/src/renderer/src/extensions/profile_management/sync.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 
+import { getErrorCode } from "@vortex/shared";
 import PromiseBB from "bluebird";
 
 import { UserCanceled } from "../../util/CustomErrors";
@@ -24,8 +25,8 @@ export function syncToProfile(
           })
           .catch((err) => {
             log("warn", "failed to copy to profile", { filePath, destPath });
-            if (err.code !== "EBADF") {
-              // EBADF would indicate the file doesn't exist, which isn't a problem,
+            if (!["EBADF", "ENOENT"].includes(getErrorCode(err))) {
+              // both indicate the file doesn't exist, which isn't a problem,
               // it's as if the file was empty
               onError("failed to sync to profile: " + filePath, err);
             }

--- a/src/renderer/src/util/fsAtomic.test.ts
+++ b/src/renderer/src/util/fsAtomic.test.ts
@@ -1,0 +1,52 @@
+import * as nodeFs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { copyFileAtomic } from "./fsAtomic";
+
+describe("copyFileAtomic", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = nodeFs.mkdtempSync(path.join(os.tmpdir(), "fs-atomic-"));
+  });
+
+  afterEach(() => {
+    nodeFs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("replaces the destination with the source content", async () => {
+    const src = path.join(dir, "src.txt");
+    const dest = path.join(dir, "dest.txt");
+    nodeFs.writeFileSync(src, "new content");
+    nodeFs.writeFileSync(dest, "old content");
+
+    await copyFileAtomic(src, dest);
+
+    expect(nodeFs.readFileSync(dest, "utf8")).toBe("new content");
+  });
+
+  it("creates the destination when it does not exist yet", async () => {
+    const src = path.join(dir, "src.txt");
+    const dest = path.join(dir, "dest.txt");
+    nodeFs.writeFileSync(src, "new content");
+
+    await copyFileAtomic(src, dest);
+
+    expect(nodeFs.readFileSync(dest, "utf8")).toBe("new content");
+  });
+
+  it("keeps the destination intact when the source does not exist", async () => {
+    const src = path.join(dir, "missing.txt");
+    const dest = path.join(dir, "dest.txt");
+    nodeFs.writeFileSync(dest, "old content");
+
+    await expect(copyFileAtomic(src, dest)).rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(nodeFs.readFileSync(dest, "utf8")).toBe("old content");
+    // the temp file must not linger next to the destination either
+    expect(nodeFs.readdirSync(dir)).toEqual(["dest.txt"]);
+  });
+});

--- a/src/renderer/src/util/fsAtomic.ts
+++ b/src/renderer/src/util/fsAtomic.ts
@@ -129,7 +129,6 @@ export function copyFileAtomic(srcPath: string, destPath: string): PromiseBB<voi
         }
       }),
     )
-    .catch((err) => (getErrorCode(err) === "ENOENT" ? PromiseBB.resolve() : PromiseBB.reject(err)))
     .then(() => (tmpPath !== undefined ? fs.renameAsync(tmpPath, destPath) : PromiseBB.resolve()))
     .catch((unknownErr) => {
       const err = unknownToError(unknownErr);
@@ -141,6 +140,11 @@ export function copyFileAtomic(srcPath: string, destPath: string): PromiseBB<voi
           log("error", "failed to clean up temporary file", cleanupErr);
         }
       }
-      return PromiseBB.reject(err);
+      // the tmp cleanup callback fails on the already-closed fd, leaving the file behind
+      const removeTmp =
+        tmpPath !== undefined
+          ? fs.removeAsync(tmpPath).catch(() => PromiseBB.resolve())
+          : PromiseBB.resolve();
+      return removeTmp.then(() => PromiseBB.reject(err));
     });
 }


### PR DESCRIPTION
- copyFileAtomic rejects with ENOENT when the source is missing instead of renaming its empty temp over the destination; profile sync treats the missing file as nothing-to-copy. Switching to a profile without saved plugin files previously truncated the live plugins.txt to zero bytes.
- the plugin persistor counts as loaded after reading an empty plugins.txt (still without adopting it), so plugin enables keep reaching the file instead of being dropped for the rest of the session.
- loadFiles re-asserts the plugin files from the known-plugin set, healing an already-truncated file on the next start.

fixes LAZ-993
fixes #24024
fixes #24023