### PR TITLE
Fixed table reducer crash on persisted state without `attributes` (cherry-pick #23975 to release/v2.6)

### DIFF
--- a/src/renderer/src/reducers/tables.test.ts
+++ b/src/renderer/src/reducers/tables.test.ts
@@ -25,6 +25,17 @@ describe("setAttributeVisible", () => {
       test: { attributes: { attr1: { enabled: false } } },
     });
   });
+  it("handles persisted table state without attributes", () => {
+    const input = { test: { filter: { attr1: "x" } } };
+    const result = tableReducer.reducers.SET_ATTRIBUTE_VISIBLE(input, {
+      tableId: "test",
+      attributeId: "attr1",
+      visible: true,
+    });
+    expect(result).toEqual({
+      test: { filter: { attr1: "x" }, attributes: { attr1: { enabled: true } } },
+    });
+  });
 });
 
 describe("setAttributeSort", () => {
@@ -37,6 +48,35 @@ describe("setAttributeSort", () => {
     });
     expect(result).toEqual({
       test: { attributes: { attr1: { sortDirection: "asc" } } },
+    });
+  });
+  it("resets sort direction on other attributes", () => {
+    const input = {
+      test: { attributes: { attr1: { enabled: true, sortDirection: "asc" as const } } },
+    };
+    const result = tableReducer.reducers.SET_ATTRIBUTE_SORT(input, {
+      tableId: "test",
+      attributeId: "attr2",
+      direction: "desc",
+    });
+    expect(result).toEqual({
+      test: {
+        attributes: {
+          attr1: { enabled: true, sortDirection: "none" },
+          attr2: { sortDirection: "desc" },
+        },
+      },
+    });
+  });
+  it("handles persisted table state without attributes", () => {
+    const input = { test: { groupBy: "attr2" } };
+    const result = tableReducer.reducers.SET_ATTRIBUTE_SORT(input, {
+      tableId: "test",
+      attributeId: "attr1",
+      direction: "asc",
+    });
+    expect(result).toEqual({
+      test: { groupBy: "attr2", attributes: { attr1: { sortDirection: "asc" } } },
     });
   });
 });

--- a/src/renderer/src/reducers/tables.ts
+++ b/src/renderer/src/reducers/tables.ts
@@ -8,7 +8,8 @@ interface TableAttributeState {
 }
 
 interface TableState {
-  attributes: Record<string, TableAttributeState>;
+  // optional: pre-2.6.0 persisted entries may only contain filter/groupBy/collapsedGroups
+  attributes?: Record<string, TableAttributeState>;
   filter?: Record<string, unknown>;
   groupBy?: string;
   collapsedGroups?: string[];
@@ -22,13 +23,16 @@ export const tableReducer = actionsToReducerSpec(defaultState, actions, {
   setAttributeVisible: (state, payload) => {
     const { tableId, attributeId, visible } = payload;
     const table = state[tableId] ?? defaultTableState;
+    // persisted pre-2.6.0 table entries may lack `attributes` (old setSafe reducers
+    // only created the paths they wrote)
+    const tableAttributes = table.attributes ?? {};
     return {
       ...state,
       [tableId]: {
         ...table,
         attributes: {
-          ...table.attributes,
-          [attributeId]: { ...table.attributes[attributeId], enabled: visible },
+          ...tableAttributes,
+          [attributeId]: { ...tableAttributes[attributeId], enabled: visible },
         },
       },
     };
@@ -53,10 +57,12 @@ export const tableReducer = actionsToReducerSpec(defaultState, actions, {
     // ensure sorting for other columns is reset because we don't support sorting by multiple
     // attributes atm
     const attributes: Record<string, TableAttributeState> = Object.fromEntries(
-      Object.entries(table.attributes).map(([iter, attribute]): [string, TableAttributeState] => [
-        iter,
-        { ...attribute, sortDirection: "none" },
-      ]),
+      Object.entries(table.attributes ?? {}).map(
+        ([iter, attribute]): [string, TableAttributeState] => [
+          iter,
+          { ...attribute, sortDirection: "none" },
+        ],
+      ),
     );
     return {
       ...state,


### PR DESCRIPTION
Cherry-pick of #23975 (3a1141b81) to `release/v2.6

Fixes fingerprints d9d41370 d4c620e5, 48665945 0d2487ca
Refs LAZ-974