### PR TITLE
fix copyFileAtomic closing recycled file descriptors (LAZ-1001)

### DIFF
--- a/src/renderer/src/util/fsAtomic.test.ts
+++ b/src/renderer/src/util/fsAtomic.test.ts
@@ -2,7 +2,20 @@ import * as nodeFs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmpSpy = vi.hoisted((): { lastFileOpts?: Record<string, unknown> } => ({}));
+
+vi.mock("tmp", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    file: (opts: Record<string, unknown>, cb: unknown) => {
+      tmpSpy.lastFileOpts = opts;
+      return (actual.file as (o: unknown, c: unknown) => void)(opts, cb);
+    },
+  };
+});
 
 import { copyFileAtomic } from "./fsAtomic";
 
@@ -36,6 +49,19 @@ describe("copyFileAtomic", () => {
     await copyFileAtomic(src, dest);
 
     expect(nodeFs.readFileSync(dest, "utf8")).toBe("new content");
+  });
+
+  it("holds no descriptor on its temp file", async () => {
+    // the copy works on the temp PATH, so keeping tmp's descriptor open only creates
+    // close bookkeeping; a stray close on a recycled descriptor number can hit an
+    // unrelated file (observed: the parallel profile-sync copy's own temp)
+    const src = path.join(dir, "src.txt");
+    const dest = path.join(dir, "dest.txt");
+    nodeFs.writeFileSync(src, "new content");
+
+    await copyFileAtomic(src, dest);
+
+    expect(tmpSpy.lastFileOpts).toMatchObject({ discardDescriptor: true });
   });
 
   it("keeps the destination intact when the source does not exist", async () => {

--- a/src/renderer/src/util/fsAtomic.ts
+++ b/src/renderer/src/util/fsAtomic.ts
@@ -96,22 +96,23 @@ function writeFileAtomicImpl(
  * @returns {PromiseBB<void>}
  */
 export function copyFileAtomic(srcPath: string, destPath: string): PromiseBB<void> {
-  let cleanup: () => void;
+  let cleanup: (next?: (err?: Error) => void) => void;
   let tmpPath: string;
-  return new PromiseBB((resolve, reject) => {
+  return new PromiseBB<void>((resolve, reject) => {
+    // the copy only ever works on the temp PATH; discardDescriptor makes tmp close its
+    // descriptor immediately, so no descriptor is held (or ever double-closed) here
     file(
-      { template: `${destPath}.XXXXXX.tmp` },
-      (err: any, genPath: string, fd: number, cleanupCB: () => void) => {
+      { template: `${destPath}.XXXXXX.tmp`, discardDescriptor: true },
+      (err: any, genPath: string, _fd: number, cleanupCB: () => void) => {
         if (err) {
           return reject(err);
         }
         cleanup = cleanupCB;
         tmpPath = genPath;
-        resolve(fd);
+        resolve();
       },
     );
   })
-    .then((fd: number) => fs.closeAsync(fd))
     .then(() => fs.copyAsync(srcPath, tmpPath))
     .then(() =>
       fs.unlinkAsync(destPath).catch((err) => {
@@ -133,17 +134,11 @@ export function copyFileAtomic(srcPath: string, destPath: string): PromiseBB<voi
     .catch((unknownErr) => {
       const err = unknownToError(unknownErr);
       log("info", "failed to copy", { srcPath, destPath, err: err.stack });
-      if (cleanup !== undefined) {
-        try {
-          cleanup();
-        } catch (cleanupErr) {
-          log("error", "failed to clean up temporary file", cleanupErr);
-        }
-      }
-      // the tmp cleanup callback fails on the already-closed fd, leaving the file behind
+      // with the descriptor discarded, tmp's cleanup only unlinks; awaiting it keeps
+      // the temp file from outliving the rejection
       const removeTmp =
-        tmpPath !== undefined
-          ? fs.removeAsync(tmpPath).catch(() => PromiseBB.resolve())
+        cleanup !== undefined
+          ? new PromiseBB<void>((removed) => cleanup(() => removed()))
           : PromiseBB.resolve();
       return removeTmp.then(() => PromiseBB.reject(err));
     });


### PR DESCRIPTION
`copyFileAtomic` held a descriptor from `tmp.file()` that it never used (closed as its first act since the function's introduction), and its failure path called tmp's cleanup callback, closing the same descriptor number a second time. When the OS recycles that number onto another open file, the stray close hits an unrelated descriptor - observed in a 2.6.2 field log as the parallel profile-sync copy losing its temp descriptor, its own close then failing EBADF, and the fs layer's retry dialog stalling a fresh-profile switch for 38 seconds until the user cancelled.

- `discardDescriptor: true` has tmp close its own descriptor at creation, so the copy never holds one and no path can double-close; tmp's cleanup callback becomes unlink-only
- the failure path awaits that cleanup callback instead of removing the temp through the interactive fs wrapper, so a copy failure can no longer raise UI
- new test pins the no-descriptor contract via a tmp module spy; the existing ENOENT-contract tests (destination untouched, no lingering temp) are unchanged

closes LAZ-1001