### PR TITLE
Add WinGet release workflow

### DIFF
--- a/.github/winget/installer.overlay.yaml
+++ b/.github/winget/installer.overlay.yaml
@@ -1,0 +1,19 @@
+# Fields Vortex owns in the winget installer manifest (NexusMods.Vortex.installer.yaml).
+# Merged over komac's output by winget-release.yml; keys here win, arrays are
+# replaced, anything absent is carried forward from the previous version.
+# Dependencies are not listed here: they come from runtime-dependencies.json at the repo root.
+Protocols:
+  - nxm
+# installer.nsh preInit aborts below Windows 10
+MinimumOSVersion: 10.0.0.0
+# perMachine NSIS -> RequestExecutionLevel admin
+ElevationRequirement: elevationRequired
+# Matches the Apps & Features entry electron-builder writes; ProductCode is derived from appId
+AppsAndFeaturesEntries:
+  - DisplayName: Vortex
+    Publisher: Black Tree Gaming Ltd.
+    ProductCode: 57979c68-f490-55b8-8fed-8b017a5af2fe
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Vortex'
+  Files:
+    - RelativeFilePath: Vortex.exe

--- a/.github/winget/locale.overlay.yaml
+++ b/.github/winget/locale.overlay.yaml
@@ -21,9 +21,9 @@ Tags:
   - nexus-mods
 Documentations:
   - DocumentLabel: Vortex Wiki
-    DocumentUrl: https://modding.wiki/en/vortextest/vortex
+    DocumentUrl: https://modding.wiki/en/vortex
   - DocumentLabel: How to report Vortex bugs
-    DocumentUrl: https://modding.wiki/en/vortextest/vortex/bug-reports
+    DocumentUrl: https://modding.wiki/en/vortex/bug-reports
   - DocumentLabel: Vortex Discord
     DocumentUrl: https://discord.gg/nexusmods
 InstallationNotes: Vortex registers itself as the handler for nxm:// links on first launch so downloads from nexusmods.com open in Vortex.

--- a/.github/winget/locale.overlay.yaml
+++ b/.github/winget/locale.overlay.yaml
@@ -1,0 +1,30 @@
+# Fields Vortex owns in the winget locale manifest (NexusMods.Vortex.locale.en-US.yaml).
+# Merged over komac's output by winget-release.yml; keys here win, arrays are
+# replaced, anything absent is carried forward from the previous version.
+Publisher: Black Tree Gaming Ltd.
+PublisherUrl: https://www.nexusmods.com
+PublisherSupportUrl: https://forums.nexusmods.com/forum/4306-vortex-support/
+PrivacyUrl: https://help.nexusmods.com/article/20-privacy-policy
+Author: Nexus Mods
+PackageName: Vortex
+PackageUrl: https://www.nexusmods.com/about/vortex
+License: GPL-3.0
+LicenseUrl: https://github.com/Nexus-Mods/Vortex/blob/master/LICENSE.md
+Moniker: vortex
+ShortDescription: Vortex is the easiest way to manage your mods, so you can spend more time playing.
+Description: |-
+  Vortex is the Nexus Mods mod manager. It helps you download, install, organise, update, enable, disable, and remove mods while keeping track of the files and choices that affect each game.
+Tags:
+  - mod-manager
+  - modding
+  - mods
+  - nexus-mods
+Documentations:
+  - DocumentLabel: Vortex Wiki
+    DocumentUrl: https://modding.wiki/en/vortextest/vortex
+  - DocumentLabel: How to report Vortex bugs
+    DocumentUrl: https://modding.wiki/en/vortextest/vortex/bug-reports
+  - DocumentLabel: Vortex Discord
+    DocumentUrl: https://discord.gg/nexusmods
+InstallationNotes: Vortex registers itself as the handler for nxm:// links on first launch so downloads from nexusmods.com open in Vortex.
+# Icons are restricted to verified publishers in winget-pkgs; Microsoft populates them.

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,0 +1,34 @@
+name: Publish to WinGet
+
+# Opens a PR against microsoft/winget-pkgs for Vortex from the
+# Nexus-Mods/winget-pkgs fork whenever a stable release is published.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v2.6.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  winget:
+    name: Submit to winget-pkgs
+    # `released` never fires for pre-releases, but a beta could still be
+    # published as a full release by mistake; winget has no channels.
+    if: ${{ !contains(inputs.tag || github.event.release.tag_name, '-') }}
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: NexusMods.Vortex
+          installers-regex: '^vortex-setup-\d+\.\d+\.\d+\.exe$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          release-notes-url: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag || github.event.release.tag_name }}
+          fork-user: Nexus-Mods
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -2,6 +2,13 @@ name: Publish to WinGet
 
 # Opens a PR against microsoft/winget-pkgs for Vortex from the
 # Nexus-Mods/winget-pkgs fork whenever a stable release is published.
+#
+# komac carries the previous version's manifests forward and fills in the new
+# URL, hash and release notes; fields Vortex owns are then overlaid from
+# .github/winget/*.overlay.yaml before submitting.
+#
+# PERSONAL_ACCESS_TOKEN must be a classic PAT whose owner has Write access to
+# the fork; fine-grained and App tokens cannot open PRs on microsoft/winget-pkgs.
 
 on:
   release:
@@ -12,9 +19,19 @@ on:
         description: "Release tag (e.g. v2.6.2)"
         required: true
         type: string
+      dry-run:
+        description: "Generate manifests but don't submit"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+
+env:
+  PACKAGE_ID: NexusMods.Vortex
+  KOMAC_VERSION: 2.16.0
+  TAG: ${{ inputs.tag || github.event.release.tag_name }}
 
 jobs:
   winget:
@@ -22,13 +39,61 @@ jobs:
     # `released` never fires for pre-releases, but a beta could still be
     # published as a full release by mistake; winget has no channels.
     if: ${{ !contains(inputs.tag || github.event.release.tag_name, '-') }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      KOMAC_FORK_OWNER: Nexus-Mods
+      KOMAC_CREATED_WITH: Vortex Release Workflow
+      KOMAC_CREATED_WITH_URL: https://github.com/${{ github.repository }}/blob/master/.github/workflows/winget-release.yml
     steps:
-      - uses: vedantmgoyal9/winget-releaser@v2
+      - uses: actions/checkout@v7
         with:
-          identifier: NexusMods.Vortex
-          installers-regex: '^vortex-setup-\d+\.\d+\.\d+\.exe$'
-          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
-          release-notes-url: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag || github.event.release.tag_name }}
-          fork-user: Nexus-Mods
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          sparse-checkout: |
+            .github/winget
+            runtime-dependencies.json
+          sparse-checkout-cone-mode: false
+
+      - name: Install komac
+        run: |
+          curl -fsSL "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin komac
+          komac --version
+
+      - name: Generate manifests
+        id: generate
+        run: |
+          version="${TAG#v}"
+          url=$(gh release view "$TAG" -R "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[] | select(.name | test("^vortex-setup-[0-9]+\\.[0-9]+\\.[0-9]+\\.exe$")) | .url')
+          test -n "$url" || { echo "::error::no vortex-setup-*.exe asset on release $TAG"; exit 1; }
+          echo "Installer $url"
+
+          komac update "$PACKAGE_ID" --version "$version" --urls "$url" \
+            --release-notes-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG" \
+            --dry-run --output ./out
+          echo "dir=$(dirname "$(find ./out -name "$PACKAGE_ID.installer.yaml")")" >> "$GITHUB_OUTPUT"
+
+      - name: Apply Vortex-owned fields
+        env:
+          DIR: ${{ steps.generate.outputs.dir }}
+        run: |
+          merge() {
+            yq eval-all 'select(fileIndex == 0) * (select(fileIndex == 1) | ... comments="")' "$1" "$2" > "$1.tmp" && mv "$1.tmp" "$1"
+          }
+          merge "$DIR/$PACKAGE_ID.installer.yaml" .github/winget/installer.overlay.yaml
+          merge "$DIR/$PACKAGE_ID.locale.en-US.yaml" .github/winget/locale.overlay.yaml
+          export COPYRIGHT="Copyright © $(date -u +%Y) Black Tree Gaming Ltd."
+          yq -i '.Copyright = strenv(COPYRIGHT)' "$DIR/$PACKAGE_ID.locale.en-US.yaml"
+
+          # winget dependencies are the runtimes the installer bundles
+          yq -i '.Dependencies.PackageDependencies = (load("runtime-dependencies.json") | map({"PackageIdentifier": .winget}))' \
+            "$DIR/$PACKAGE_ID.installer.yaml"
+          for f in "$DIR"/*.yaml; do echo "::group::$(basename "$f")"; cat "$f"; echo "::endgroup::"; done
+
+      - name: Submit to winget-pkgs
+        env:
+          DIR: ${{ steps.generate.outputs.dir }}
+        run: |
+          komac sync-fork
+          komac submit --yes ${{ inputs.dry-run == true && '--dry-run' || '' }} "$DIR"
+          komac cleanup --only-merged

--- a/runtime-dependencies.json
+++ b/runtime-dependencies.json
@@ -1,0 +1,12 @@
+[
+  {
+    "file": "VC_redist.x64.exe",
+    "url": "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+    "winget": "Microsoft.VCRedist.2015+.x64"
+  },
+  {
+    "file": "windowsdesktop-runtime-win-x64.exe",
+    "url": "https://aka.ms/dotnet/9.0/windowsdesktop-runtime-win-x64.exe",
+    "winget": "Microsoft.DotNet.DesktopRuntime.9"
+  }
+]

--- a/src/main/prepare-dist-package.mjs
+++ b/src/main/prepare-dist-package.mjs
@@ -8,6 +8,8 @@ const MAIN_DIR = resolve(import.meta.dirname);
 const MAIN_PACKAGE_PATH = resolve(MAIN_DIR, "package.json");
 const DIST_DIR = resolve(MAIN_DIR, "build");
 const DIST_PACKAGE_PATH = resolve(DIST_DIR, "package.json");
+// Runtimes bundled into the installer; also declared as winget dependencies by winget-release.yml.
+const RUNTIME_DEPS_PATH = resolve(MAIN_DIR, "..", "..", "runtime-dependencies.json");
 
 async function resolveDepVersions(deps, nodeModulesDir) {
   if (!deps) return deps;
@@ -36,14 +38,10 @@ async function downloadFile(url, dest) {
 
 async function prepareWin() {
   const tempDir = resolve(MAIN_DIR, "temp");
-  await downloadFile(
-    "https://aka.ms/vs/17/release/vc_redist.x64.exe",
-    resolve(tempDir, "VC_redist.x64.exe"),
-  );
-  await downloadFile(
-    "https://aka.ms/dotnet/9.0/windowsdesktop-runtime-win-x64.exe",
-    resolve(tempDir, "windowsdesktop-runtime-win-x64.exe"),
-  );
+  const runtimeDeps = JSON.parse(await readFile(RUNTIME_DEPS_PATH, "utf8"));
+  for (const { file, url } of runtimeDeps) {
+    await downloadFile(url, resolve(tempDir, file));
+  }
 }
 
 async function main() {


### PR DESCRIPTION
Adds `winget-release.yml`, which submits new stable releases of `NexusMods.Vortex` to `microsoft/winget-pkgs` via [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser), pushing the manifest branch to the `Nexus-Mods/winget-pkgs` fork.

- Fires on `release: released` (stable only; pre-releases never trigger it, plus a guard against tags containing `-`)
- `workflow_dispatch` with a `tag` input for backfills / re-runs
- Installer regex anchored to `vortex-setup-X.Y.Z.exe` so `.blockmap` / `latest.yml` can't match
- Uses `WINGET_GITHUB_PAT` (classic PAT with Write on the fork); `GITHUB_TOKEN` / App tokens can't open PRs on `microsoft/winget-pkgs`

First real run after merge: `gh workflow run winget-release.yml -f tag=v2.6.2`, which backfills 2.6.2 (winget-pkgs is currently at 2.6.1).

We can't set the icon atm, we'll need the Verified Developer status first
> The WinGet community repository has a set of policies restricting the use of certain manifest fields in PRs. These policies primarily affect optional metadata fields restricted to verified developers. Some fields are automatically populated during our validation process like the fields for icons.
>
> Note: The verified developer workflow is still in progress.

[The end result PR](https://github.com/microsoft/winget-pkgs/pull/425304/changes)

<img width="1836" height="802" alt="image" src="https://github.com/user-attachments/assets/eba2e620-384c-4e8e-9023-53d7b3fb4451" />

<img width="987" height="708" alt="image" src="https://github.com/user-attachments/assets/585e264b-453e-44a8-89d2-44a884ba29e4" />

