### PR TITLE
Stop the updater analytics reporting offers that never happened

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -96,18 +96,18 @@ Every step of the funnel is a Mixpanel event, emitted by
 `src/renderer/src/extensions/updater/updaterAnalytics.ts` from the state
 transitions and the buttons, and carrying `update_channel`:
 
-| event                             | when                                                                                                                                                 |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `app_update_check_completed`      | a check settled; `outcome` is `up_to_date`, `offered` or `failed`. Manual checks always, background checks only when the outcome is not `up_to_date` |
-| `app_update_offered`              | a version was offered (`kind`: `patch`, `update`, `downgrade`)                                                                                       |
-| `app_update_download_started`     | a download began                                                                                                                                     |
-| `app_update_download_completed`   | downloaded and verified, with `duration_ms`                                                                                                          |
-| `app_update_download_failed`      | with `error_message` and whether a retry was offered                                                                                                 |
-| `app_update_install_started`      | Restart Now, from the notification or the dialog                                                                                                     |
-| `app_update_downgrade_decided`    | the downgrade dialog was answered (`accepted`)                                                                                                       |
-| `app_update_channel_changed`      | a confirmed channel change                                                                                                                           |
-| `app_update_release_notes_viewed` | What's New or View changes opened; `source` says which (`offer`, `staged`, `error_retry`, `post_update`)                                             |
-| `app_updated`                     | first launch after an update, `from_version` and `to_version`                                                                                        |
+| event                             | when                                                                                                                                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app_update_check_completed`      | a check settled; `outcome` is `up_to_date`, `offered`, `failed` or `already_staged` (the update was in hand before the check). Manual checks always, background checks only when something changed |
+| `app_update_offered`              | a version was offered (`kind`: `patch`, `update`, `downgrade`)                                                                                                                                     |
+| `app_update_download_started`     | a download began                                                                                                                                                                                   |
+| `app_update_download_completed`   | downloaded and verified, with `duration_ms`                                                                                                                                                        |
+| `app_update_download_failed`      | with `error_message` and whether a retry was offered                                                                                                                                               |
+| `app_update_install_started`      | Restart Now, from the notification or the dialog                                                                                                                                                   |
+| `app_update_downgrade_decided`    | the downgrade dialog was answered (`accepted`)                                                                                                                                                     |
+| `app_update_channel_changed`      | a confirmed channel change                                                                                                                                                                         |
+| `app_update_release_notes_viewed` | What's New or View changes opened; `source` says which (`offer`, `staged`, `error_retry`, `post_update`)                                                                                           |
+| `app_updated`                     | first launch after an update, `from_version` and `to_version`                                                                                                                                      |
 
 `app_launched` carries `update_channel` too, as the population these events are
 measured against. Events emitted before analytics has started (the launch

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -106,7 +106,7 @@ transitions and the buttons, and carrying `update_channel`:
 | `app_update_install_started`      | Restart Now, from the notification or the dialog                                                                                                     |
 | `app_update_downgrade_decided`    | the downgrade dialog was answered (`accepted`)                                                                                                       |
 | `app_update_channel_changed`      | a confirmed channel change                                                                                                                           |
-| `app_update_release_notes_viewed` | What's New or View changes opened                                                                                                                    |
+| `app_update_release_notes_viewed` | What's New or View changes opened; `source` says which (`offer`, `staged`, `error_retry`, `post_update`)                                             |
 | `app_updated`                     | first launch after an update, `from_version` and `to_version`                                                                                        |
 
 `app_launched` carries `update_channel` too, as the population these events are

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -139,6 +139,16 @@ export class AppUpdateDownloadCompletedEvent implements MixpanelEvent {
   }
 }
 
+/**
+ * Error messages can be arbitrarily long (stack traces, upstream HTTP bodies). Truncated in the
+ * event constructors rather than at the call sites, so a new caller cannot forget to do it.
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+
+function truncateErrorMessage(message: string | undefined): string | undefined {
+  return message?.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
 export interface AppUpdateDownloadFailedProps {
   to_version: string;
   kind: UpdateKindProp;
@@ -152,7 +162,7 @@ export class AppUpdateDownloadFailedEvent implements MixpanelEvent {
   readonly eventName = "app_update_download_failed";
   readonly properties: Record<string, unknown>;
   constructor(props: AppUpdateDownloadFailedProps) {
-    this.properties = { ...props };
+    this.properties = { ...props, error_message: truncateErrorMessage(props.error_message) };
   }
 }
 
@@ -175,7 +185,7 @@ export class AppUpdateCheckCompletedEvent implements MixpanelEvent {
   readonly eventName = "app_update_check_completed";
   readonly properties: Record<string, unknown>;
   constructor(props: AppUpdateCheckCompletedProps) {
-    this.properties = { ...props };
+    this.properties = { ...props, error_message: truncateErrorMessage(props.error_message) };
   }
 }
 

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -156,7 +156,8 @@ export class AppUpdateDownloadFailedEvent implements MixpanelEvent {
   }
 }
 
-export type UpdateCheckOutcome = "up_to_date" | "offered" | "failed";
+/** `already_staged` is a re-confirmation of an update the user already has, not a new offer. */
+export type UpdateCheckOutcome = "up_to_date" | "offered" | "failed" | "already_staged";
 
 export interface AppUpdateCheckCompletedProps {
   manual: boolean;

--- a/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
+++ b/src/renderer/src/extensions/analytics/mixpanel/MixpanelEvents.ts
@@ -227,7 +227,8 @@ export class AppUpdateChannelChangedEvent implements MixpanelEvent {
   }
 }
 
-export type UpdateReleaseNotesSource = "notification" | "post_update";
+/** Which button: the three What's New sites are distinct funnel moments, counted apart. */
+export type UpdateReleaseNotesSource = "offer" | "staged" | "error_retry" | "post_update";
 
 export interface AppUpdateReleaseNotesViewedProps {
   to_version: string;

--- a/src/renderer/src/extensions/updater/index.ts
+++ b/src/renderer/src/extensions/updater/index.ts
@@ -296,7 +296,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
               {
                 title: "What's New",
                 action: () => {
-                  analytics.releaseNotesViewed(state.version, "notification");
+                  analytics.releaseNotesViewed(state.version, "offer");
                   void showUpdateDialog(state.version, state.releaseNotes);
                 },
               },
@@ -379,7 +379,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                 {
                   title: "What's New",
                   action: () => {
-                    analytics.releaseNotesViewed(state.version, "notification");
+                    analytics.releaseNotesViewed(state.version, "staged");
                     void showUpdateDialog(state.version, state.releaseNotes);
                   },
                 },
@@ -457,7 +457,7 @@ If you downgrade, Vortex will download ${version} and update on restart.`,
                 {
                   title: "What's New",
                   action: () => {
-                    analytics.releaseNotesViewed(retry.version, "notification");
+                    analytics.releaseNotesViewed(retry.version, "error_retry");
                     void showUpdateDialog(retry.version, retry.releaseNotes);
                   },
                 },

--- a/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
+++ b/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
@@ -161,7 +161,7 @@ describe("updater analytics: decisions", () => {
     const { analytics, events } = harness("beta");
     analytics.downgradeDecided("2.5.0", false);
     analytics.channelChanged("beta", "stable");
-    analytics.releaseNotesViewed("2.7.0", "notification");
+    analytics.releaseNotesViewed("2.7.0", "offer");
     analytics.appUpdated("2.5.9");
 
     expect(names(events)).toEqual([
@@ -183,6 +183,22 @@ describe("updater analytics: decisions", () => {
       update_channel: "stable",
     });
     expect(events[3]!.properties).toMatchObject({ from_version: "2.5.9", to_version: "2.6.0" });
+  });
+
+  // collapsing these would lose whether notes are read before downloading or before restarting
+  it("keeps the release notes sources apart", () => {
+    const { analytics, events } = harness("stable");
+    analytics.releaseNotesViewed("2.7.0", "offer");
+    analytics.releaseNotesViewed("2.7.0", "staged");
+    analytics.releaseNotesViewed("2.7.0", "error_retry");
+    analytics.releaseNotesViewed("2.6.0", "post_update");
+
+    expect(events.map((event) => event.properties["source"])).toEqual([
+      "offer",
+      "staged",
+      "error_retry",
+      "post_update",
+    ]);
   });
 });
 

--- a/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
+++ b/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
@@ -139,6 +139,8 @@ describe("updater analytics: checks", () => {
     expect(events[0]!.properties).toMatchObject({ manual: true, outcome: "already_staged" });
   });
 
+  // the emitter passes the message through untouched: truncation is the event constructors' job,
+  // so a caller cannot forget it
   it("truncates long error messages on both failure events", () => {
     const { analytics, events } = harness();
     const long = "x".repeat(500);

--- a/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
+++ b/src/renderer/src/extensions/updater/updaterAnalytics.test.ts
@@ -105,8 +105,7 @@ describe("updater analytics: the funnel", () => {
   it("a staged update restored by a check (no download watched) is not a completion", () => {
     const { analytics, events } = harness();
     analytics.onTransition(checkingBackground, staged);
-    expect(names(events)).toEqual(["app_update_check_completed"]);
-    expect(events[0]!.properties).toMatchObject({ outcome: "offered", manual: false });
+    expect(events).toHaveLength(0);
   });
 });
 
@@ -129,6 +128,26 @@ describe("updater analytics: checks", () => {
     const { analytics, events } = harness();
     analytics.onTransition(checkingBackground, { type: "idle" });
     expect(events).toHaveLength(0);
+  });
+
+  // landing back on an update the user already has is not an offer: counting it as one would
+  // inflate the offer rate by 6 a day for anyone who leaves an update staged
+  it("reports a manual check that lands on an already-staged update as such", () => {
+    const { analytics, events } = harness();
+    analytics.onTransition(checkingManual, staged);
+    expect(names(events)).toEqual(["app_update_check_completed"]);
+    expect(events[0]!.properties).toMatchObject({ manual: true, outcome: "already_staged" });
+  });
+
+  it("truncates long error messages on both failure events", () => {
+    const { analytics, events } = harness();
+    const long = "x".repeat(500);
+    analytics.onTransition(checkingManual, { type: "error", message: long, manual: true });
+    analytics.onTransition(downloading, { type: "error", message: long, manual: true });
+
+    expect(names(events)).toEqual(["app_update_check_completed", "app_update_download_failed"]);
+    expect(events[0]!.properties["error_message"]).toHaveLength(200);
+    expect(events[1]!.properties["error_message"]).toHaveLength(200);
   });
 
   it("reports a background check that fails or offers", () => {

--- a/src/renderer/src/extensions/updater/updaterAnalytics.ts
+++ b/src/renderer/src/extensions/updater/updaterAnalytics.ts
@@ -58,20 +58,25 @@ export function createUpdaterAnalytics(deps: UpdaterAnalyticsDeps): UpdaterAnaly
 
   const onTransition = (prev: UpdaterState | null, next: UpdaterState) => {
     // a check settled: report every manual outcome, and background failures
-    // and offers; the background "nothing new" is left out on purpose
+    // and offers; the background "nothing new" is left out on purpose, which
+    // covers landing back on an already-staged update as well as finding
+    // nothing (checks run 4-hourly, so neither is worth repeating forever)
     if (prev?.type === "checking" && next.type !== "checking") {
       const outcome =
         next.type === "error"
           ? "failed"
           : next.type === "idle" || next.type === "disabled"
             ? "up_to_date"
-            : "offered";
-      if (prev.manual || outcome !== "up_to_date") {
+            : next.type === "staged"
+              ? "already_staged"
+              : "offered";
+      const nothingNew = outcome === "up_to_date" || outcome === "already_staged";
+      if (prev.manual || !nothingNew) {
         emit(
           new AppUpdateCheckCompletedEvent({
             manual: prev.manual,
             outcome,
-            error_message: next.type === "error" ? next.message : undefined,
+            error_message: next.type === "error" ? next.message.slice(0, 200) : undefined,
             ...base(),
           }),
         );

--- a/src/renderer/src/extensions/updater/updaterAnalytics.ts
+++ b/src/renderer/src/extensions/updater/updaterAnalytics.ts
@@ -76,7 +76,7 @@ export function createUpdaterAnalytics(deps: UpdaterAnalyticsDeps): UpdaterAnaly
           new AppUpdateCheckCompletedEvent({
             manual: prev.manual,
             outcome,
-            error_message: next.type === "error" ? next.message.slice(0, 200) : undefined,
+            error_message: next.type === "error" ? next.message : undefined,
             ...base(),
           }),
         );
@@ -145,7 +145,7 @@ export function createUpdaterAnalytics(deps: UpdaterAnalyticsDeps): UpdaterAnaly
             new AppUpdateDownloadFailedEvent({
               to_version: prev.version,
               kind: prev.kind,
-              error_message: next.message.slice(0, 200),
+              error_message: next.message,
               retry_offered: next.retry != null,
               ...base(),
             }),


### PR DESCRIPTION
Two corrections to the updater funnel, both to events added on this branch and not yet released.

All three What's New buttons reported the same source, so there was no telling whether people read the notes before downloading or before restarting. They are now offer, staged and error_retry.

The check outcome was worked out by elimination, so a check landing back on an already staged update counted as a new offer, and background checks were not suppressed either. Anyone leaving an update staged emitted a false offer every four hours. It now reports already_staged, and background checks stay quiet for it as they do for up_to_date.

Tested by driving the updater against a local mock feed and watching the dev log. The events are confirmed arriving in the dev Mixpanel project.

Checked live:

- all four check outcomes, including the new already_staged on a manual check against a staged update
- offered, download_started, download_completed and install_started across all three kinds (patch, update, downgrade)
- both the manual and background branches of every event carrying that flag
- download_failed with retry_offered set, and a check failure reported separately from a download failure
- cancelling a download mid transfer emits nothing, so cancels do not inflate the failure rate
- a background check that finds nothing emits nothing
- events emitted before login are queued and flushed in order once analytics starts

The three new release notes sources are covered by unit tests but were not clicked through after the rename. app_updated and the post_update source still need a packaged install, since justUpdatedFrom is compiled out of dev builds.