### PR TITLE
Address Health Check install failure reports 

### DIFF
--- a/src/renderer/src/extensions/health_check/utils/shared/installTracking.ts
+++ b/src/renderer/src/extensions/health_check/utils/shared/installTracking.ts
@@ -1,5 +1,7 @@
 import { classifyErrorCode } from "@/extensions/analytics/mixpanel/error-code";
+import InstallManager from "@/extensions/mod_management/InstallManager";
 import type { IExtensionApi } from "@/types/IExtensionContext";
+import ConcurrencyLimiter from "@/util/ConcurrencyLimiter";
 
 import { createHealthCheckTracker } from "../../hooks/healthCheckTracker";
 import type { OptionalIssueAnalyticsIdentity } from "./tracking";
@@ -16,8 +18,15 @@ export type IInstallIdentity = OptionalIssueAnalyticsIdentity & {
 };
 
 /**
+ * Caps concurrent health-check-triggered installs. The "install all" bulk actions fire every
+ * download-then-install chain at once with no queue of their own, so this reuses InstallManager's
+ * own install budget (MAX_SIMULTANEOUS_INSTALLS) rather than picking an unrelated number.
+ */
+const installConcurrencyLimit = new ConcurrencyLimiter(InstallManager.MAX_SIMULTANEOUS_INSTALLS);
+
+/**
  * Bracket a health-check-initiated install with the install_started / install_completed /
- * install_failed funnel events (LAZ-551).
+ * install_failed funnel events (LAZ-551), queued behind the shared install concurrency limit.
  *
  * `run` should cover only the work that follows the user committing to the install — past
  * the premium gate and any id resolution — so a free user being routed to the website, or
@@ -29,25 +38,26 @@ export const trackedInstall = async (
   api: IExtensionApi,
   identity: IInstallIdentity,
   run: () => Promise<void>,
-): Promise<void> => {
-  const { trackInstallCompleted, trackInstallFailed, trackInstallStarted } =
-    createHealthCheckTracker(api);
-  const startedAt = Date.now();
+): Promise<void> =>
+  installConcurrencyLimit.do(async () => {
+    const { trackInstallCompleted, trackInstallFailed, trackInstallStarted } =
+      createHealthCheckTracker(api);
+    const startedAt = Date.now();
 
-  trackInstallStarted(identity);
+    trackInstallStarted(identity);
 
-  try {
-    await run();
-  } catch (err) {
-    trackInstallFailed({
-      issue_id: identity.issue_id,
-      check_id: identity.check_id,
-      mod_id: identity.mod_id,
-      error_reason: classifyErrorCode(err),
-    });
+    try {
+      await run();
+    } catch (err) {
+      trackInstallFailed({
+        issue_id: identity.issue_id,
+        check_id: identity.check_id,
+        mod_id: identity.mod_id,
+        error_reason: classifyErrorCode(err),
+      });
 
-    throw err;
-  }
+      throw err;
+    }
 
-  trackInstallCompleted({ ...identity, duration_ms: Date.now() - startedAt });
-};
+    trackInstallCompleted({ ...identity, duration_ms: Date.now() - startedAt });
+  });

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -534,7 +534,10 @@ async function mapWithConcurrency<T, R>(
  * @class InstallManager
  */
 class InstallManager {
-  private static readonly MAX_SIMULTANEOUS_INSTALLS = 5;
+  // Exported so other features that fire their own install fan-out (e.g. health check's bulk
+  // install actions) can size their own queue against the same, already-tuned budget instead of
+  // picking an unrelated number.
+  static readonly MAX_SIMULTANEOUS_INSTALLS = 5;
   private mApi: IExtensionApi;
   private mInstallers: IModInstaller[] = [];
   private mGetInstallPath: (gameId: string) => string;


### PR DESCRIPTION
- Addresses the post-GA spike in `data_invalid`/`aggregate_error` health-check install failures reported in mixpanel.
- Caps concurrency on the bulk "install all" actions, which previously fired every download+install at once unlike every other bulk-install path in the app. 
- Also stops discarding the real error behind a failed file-access check and reports enough extra detail on `health_check_install_failed` (underlying OS code, AggregateError sub-error codes/count) to diagnose what's left from real data instead of guessing.
