### PR TITLE
Keep persistence alive past a single fault

### DIFF
--- a/src/renderer/src/store/persistDiffMiddleware.test.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.test.ts
@@ -255,3 +255,56 @@ describe("flushPendingDiffsSync (GH#23363 quit flush)", () => {
     expect(sendDiff).not.toHaveBeenCalled();
   });
 });
+
+/** The only path state takes to disk, so one fault must cost at most one flush window. */
+describe("fault tolerance", () => {
+  const deliveredValues = (sendDiff: ReturnType<typeof vi.fn>) =>
+    sendDiff.mock.calls
+      .flatMap((call) => call[1] as DiffOperation[])
+      .filter((op) => op.type === "set")
+      .map((op) => op.value);
+
+  it("keeps flushing after a send failure", () => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn().mockImplementationOnce(() => {
+      throw new Error("ipc send failed");
+    });
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff }));
+    const store = createStore(reducer, applyMiddleware(mw));
+    store.dispatch({ type: "INIT" });
+
+    store.dispatch({ type: "SET_PERSISTENT", payload: { marker: 1 } });
+    // the failing flush is contained by the middleware, not re-thrown out of the timer
+    expect(() => vi.runAllTimers()).not.toThrow();
+
+    store.dispatch({ type: "SET_PERSISTENT", payload: { marker: 2 } });
+    vi.runAllTimers();
+
+    expect(deliveredValues(sendDiff)).toContain(2);
+  });
+
+  it("keeps persisting after a change whose diff computation fails", () => {
+    vi.useFakeTimers();
+    const sendDiff = vi.fn();
+    const mw = createPersistDiffMiddleware(() => ({ sendDiff }));
+    const store = createStore(reducer, applyMiddleware(mw));
+    store.dispatch({ type: "INIT" });
+
+    // collecting this subtree recurses once per nesting level, so the diff dies on stack depth
+    let bomb: unknown = 1;
+    for (let i = 0; i < 100_000; i++) {
+      bomb = { d: bomb };
+    }
+    expect(() =>
+      store.dispatch({ type: "SET_PERSISTENT", payload: { marker: 1, bomb } }),
+    ).not.toThrow();
+
+    store.dispatch({ type: "SET_PERSISTENT", payload: { marker: 1, second: 2 } });
+    vi.runAllTimers();
+
+    const values = deliveredValues(sendDiff);
+    expect(values).toContain(2);
+    // the change from the failed window rides the next successful diff
+    expect(values).toContain(1);
+  });
+});

--- a/src/renderer/src/store/persistDiffMiddleware.ts
+++ b/src/renderer/src/store/persistDiffMiddleware.ts
@@ -164,9 +164,10 @@ export function createPersistDiffMiddleware(
   let flushTimeout: ReturnType<typeof setTimeout> | null = null;
 
   /**
-   * Flush all pending diffs to main process
+   * Flush all pending diffs to main process.
    */
   const flushDiffs = () => {
+    flushTimeout = null;
     const persistApi = getApi();
     if (persistApi == null) {
       return;
@@ -176,14 +177,20 @@ export function createPersistDiffMiddleware(
       PersistedHive,
       PendingHiveDiffs,
     ][]) {
-      if (operations.size > 0) {
-        // Serialize operations to ensure IPC compatibility
-        const serializedOps = Array.from(operations.values(), serializeOperation);
+      // Serialize operations to ensure IPC compatibility
+      const serializedOps = Array.from(operations.values(), serializeOperation);
+      try {
         persistApi.sendDiff(hive, serializedOps);
+        // cleared only once the send succeeded, so a failure keeps the queue for the next flush
+        delete pendingDiffs[hive];
+      } catch (err) {
+        log("error", "failed to send state diff for persistence", {
+          hive,
+          operationCount: serializedOps.length,
+          error: getErrorMessageOrDefault(err),
+        });
       }
     }
-    pendingDiffs = {};
-    flushTimeout = null;
   };
 
   /**
@@ -283,24 +290,30 @@ export function createPersistDiffMiddleware(
       }
 
       // Compute and queue diffs for each persisted hive
-      for (const hive of persistedHives) {
-        const oldHive = previousState[hive as keyof IState];
-        const newHive = newState[hive as keyof IState];
+      try {
+        for (const hive of persistedHives) {
+          const oldHive = previousState[hive as keyof IState];
+          const newHive = newState[hive as keyof IState];
 
-        // Skip if hive hasn't changed (reference equality)
-        if (oldHive === newHive) {
-          continue;
+          // Skip if hive hasn't changed (reference equality)
+          if (oldHive === newHive) {
+            continue;
+          }
+
+          // Compute diff for this hive
+          const operations = computeStateDiff(oldHive, newHive);
+          if (operations.length > 0) {
+            queueDiffs(hive as PersistedHive, operations);
+          }
         }
 
-        // Compute diff for this hive
-        const operations = computeStateDiff(oldHive, newHive);
-        if (operations.length > 0) {
-          queueDiffs(hive as PersistedHive, operations);
-        }
+        // Update previous state for next comparison
+        previousState = newState;
+      } catch (err) {
+        log("error", "failed to compute state diff, changes held for the next attempt", {
+          error: getErrorMessageOrDefault(err),
+        });
       }
-
-      // Update previous state for next comparison
-      previousState = newState;
 
       return result;
     };

--- a/src/renderer/src/store/stateDiff.test.ts
+++ b/src/renderer/src/store/stateDiff.test.ts
@@ -159,4 +159,20 @@ describe("computeStateDiff", () => {
     expect(ops[0].type).toBe("set");
     expect(ops[0].path).toEqual(["attributes", "installTime"]);
   });
+
+  // one dispatch can change a whole game's mod table, past the engine's argument-spread limit
+  it("diffs a subtree with more leaves than the engine spread limit", () => {
+    const LEAVES = 200_000;
+    // keyed by synthetic leaf id
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < LEAVES; i++) {
+      wide[`leaf-${i}`] = i;
+    }
+    const oldState = { mods: {} as Record<string, number> };
+    const newState = { mods: wide };
+
+    const ops = computeStateDiff(oldState, newState);
+
+    expect(ops).toHaveLength(LEAVES);
+  });
 });

--- a/src/renderer/src/store/stateDiff.ts
+++ b/src/renderer/src/store/stateDiff.ts
@@ -19,24 +19,24 @@ function isObject(state: unknown): state is Record<string, unknown> {
 /**
  * Compute the diff operations needed to transform oldState into newState.
  * Returns an array of DiffOperation objects that can be sent over IPC
- * for persistence in the main process.
+ * for persistence in the main process. Recursively append.
  *
  * @param oldState - The previous state
  * @param newState - The new state
  * @param path - Current path in the state tree (used for recursion)
+ * @param operations - Accumulator the recursion appends to
  * @returns Array of diff operations (set/remove)
  */
 export function computeStateDiff<T>(
   oldState: T,
   newState: T,
   path: string[] = [],
+  operations: DiffOperation[] = [],
 ): DiffOperation[] {
   // No change - no operations needed
   if (oldState === newState) {
-    return [];
+    return operations;
   }
-
-  const operations: DiffOperation[] = [];
 
   if (isObject(oldState) && isObject(newState)) {
     // Both are objects - compare keys recursively
@@ -61,11 +61,11 @@ export function computeStateDiff<T>(
         // the old rows. For primitives the container-path remove covers it.
         operations.push({ type: "remove", path: currentPath });
         if (isObject(oldState[key])) {
-          operations.push(...collectRemoveOperations(currentPath, oldState[key]));
+          collectRemoveOperations(currentPath, oldState[key], operations);
         }
       } else if (oldState[key] !== newState[key]) {
         // Key exists in both but value changed - recurse
-        operations.push(...computeStateDiff(oldState[key], newState[key], currentPath));
+        computeStateDiff(oldState[key], newState[key], currentPath, operations);
       }
       // If oldState[key] === newState[key], no operation needed
     }
@@ -75,7 +75,7 @@ export function computeStateDiff<T>(
       if (oldState[key] === undefined && newState[key] !== undefined) {
         const currentPath = [...path, key];
         // Key was added - collect all set operations for this subtree
-        operations.push(...collectSetOperations(currentPath, newState[key]));
+        collectSetOperations(currentPath, newState[key], operations);
       }
     }
   } else {
@@ -84,7 +84,7 @@ export function computeStateDiff<T>(
       // Value changed or added
       if (isObject(newState)) {
         // New value is an object - add all its leaf values
-        operations.push(...collectSetOperations(path, newState));
+        collectSetOperations(path, newState, operations);
       } else {
         // New value is a primitive
         operations.push({ type: "set", path, value: newState });
@@ -95,7 +95,7 @@ export function computeStateDiff<T>(
       // matters under prefix-delete and why the leaf removes are required).
       operations.push({ type: "remove", path });
       if (isObject(oldState)) {
-        operations.push(...collectRemoveOperations(path, oldState));
+        collectRemoveOperations(path, oldState, operations);
       }
     }
   }
@@ -105,40 +105,48 @@ export function computeStateDiff<T>(
 
 /**
  * Collect all set operations needed to persist an entire state subtree.
- * Recursively traverses objects to find all leaf values.
+ * Recursively traverses objects to find all leaf values, appending to `operations`.
  */
-function collectSetOperations(path: string[], state: unknown): DiffOperation[] {
+function collectSetOperations(
+  path: string[],
+  state: unknown,
+  operations: DiffOperation[] = [],
+): DiffOperation[] {
   if (state === undefined) {
-    return [];
+    return operations;
   }
 
   if (isObject(state)) {
-    const operations: DiffOperation[] = [];
     for (const key of Object.keys(state)) {
-      operations.push(...collectSetOperations([...path, key], state[key]));
+      collectSetOperations([...path, key], state[key], operations);
     }
     return operations;
   }
 
   // Leaf value - create set operation
-  return [{ type: "set", path, value: state }];
+  operations.push({ type: "set", path, value: state });
+  return operations;
 }
 
 /**
  * Collect all remove operations needed to clear an entire state subtree.
- * Recursively traverses objects to find all leaf values.
+ * Recursively traverses objects to find all leaf values, appending to `operations`.
  */
-function collectRemoveOperations(path: string[], state: unknown): DiffOperation[] {
+function collectRemoveOperations(
+  path: string[],
+  state: unknown,
+  operations: DiffOperation[] = [],
+): DiffOperation[] {
   if (isObject(state)) {
-    const operations: DiffOperation[] = [];
     for (const key of Object.keys(state)) {
-      operations.push(...collectRemoveOperations([...path, key], state[key]));
+      collectRemoveOperations([...path, key], state[key], operations);
     }
     return operations;
   }
 
   // Leaf value - create remove operation
-  return [{ type: "remove", path }];
+  operations.push({ type: "remove", path });
+  return operations;
 }
 
 /**


### PR DESCRIPTION
One fault in the diff pipeline cost the rest of the session, silently: a diff past the engine's argument-spread limit threw out of computeStateDiff, the throw escaped dispatch and froze previousState so every later diff grew from the same stale snapshot, and a send failure left the flush timer handle set so no flush was ever scheduled again.

Diff operations are now appended without spread, a diff-computation fault is caught and logged with previousState held so the changes ride the next diff, and a hive's queue is only cleared once its send succeeded.

fixes LAZ-1007