### PR TITLE
Track the mods toolbar's clicks and pins (LAZ-666, LAZ-953)

### DIFF
--- a/src/renderer/src/actions/toolbars.ts
+++ b/src/renderer/src/actions/toolbars.ts
@@ -1,5 +1,12 @@
 import { createAction } from "redux-act";
 
+/** One decision about whether an action sits on a toolbar. */
+interface IPinDecision {
+  toolbarId: string;
+  actionId: string;
+  pinned: boolean;
+}
+
 /**
  * Pins an action to a toolbar, or takes it off. Only an action the user has decided
  * about is recorded — see the reducer — so a default we change later still reaches
@@ -7,17 +14,11 @@ import { createAction } from "redux-act";
  */
 export const setActionPinned = createAction(
   "SET_TOOLBAR_ACTION_PINNED",
-  (toolbarId: string, actionId: string, pinned: boolean) => ({
-    toolbarId,
-    actionId,
-    pinned,
-  }),
+  (decision: IPinDecision) => decision,
 );
 
 /** Forgets every decision the user made about one toolbar, restoring its defaults. */
 export const resetPinnedActions = createAction(
   "RESET_TOOLBAR_PINNED_ACTIONS",
-  (toolbarId: string) => ({
-    toolbarId,
-  }),
+  (target: Pick<IPinDecision, "toolbarId">) => target,
 );

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -14,8 +14,14 @@ app_ui_mode_changed { is_legacy_ui } // the mode switched to, from Settings > Th
 Toolbar
 
 toolbar_action_clicked { toolbar, action, extension, surface } // mods page only for now
-// action = stable id, never the translated label; extension = absent for the page's own
+toolbar_pin_changed { toolbar, action, extension, pinned } // pinned = the state moved to
+toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no action
+// action = the same stable id pinning stores against, never the translated label
+// extension = absent for an action the page owns rather than one registered into it
 // surface = bar | overflow | menu (reached directly, via the kebab, or inside Open.../Import...)
+// where pinning is on the kebab holds every action, so `overflow` means "reached through
+// the menu" rather than "did not fit" — and a menu interaction reports twice, the Open...
+// parent on `bar` and then the row on `menu`
 
 Mods
 

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -11,6 +11,12 @@ App
 app_launched { is_legacy_ui } // true = legacy/classic UI, false = modern
 app_ui_mode_changed { is_legacy_ui } // the mode switched to, from Settings > Theme
 
+Toolbar
+
+toolbar_action_clicked { toolbar, action, extension, surface } // mods page only for now
+// action = stable id, never the translated label; extension = absent for the page's own
+// surface = bar | overflow | menu (reached directly, via the kebab, or inside Open.../Import...)
+
 Mods
 
 mods_download_started

--- a/src/renderer/src/extensions/mod_management/components/ModsToolbar.test.tsx
+++ b/src/renderer/src/extensions/mod_management/components/ModsToolbar.test.tsx
@@ -1,0 +1,83 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * The mods toolbar is the one toolbar whose use is counted, so what is checked here is
+ * the opt-in itself: that a click on it reaches Mixpanel as `toolbar_action_clicked`, and
+ * that the classic bar this page still renders alongside it stays unmeasured.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type * as ReactReduxTypes from "react-redux";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
+import type { IToolbarAction } from "@/ui/components/toolbar/ToolbarGroup";
+
+const { actions, emit } = vi.hoisted(() => ({
+  actions: { current: [] as IToolbarAction[] },
+  emit: vi.fn(),
+}));
+
+vi.mock("@/contexts", () => ({ useMainContext: () => ({ api: { events: { emit } } }) }));
+
+/**
+ * The mods toolbar offers pinning, so the group takes the path that reads the store.
+ * Nothing here is about what the user pinned, so an empty slice will do.
+ */
+vi.mock("react-redux", async () => ({
+  ...(await vi.importActual<typeof ReactReduxTypes>("react-redux")),
+  useDispatch: () => vi.fn(),
+  useSelector: (selector: (state: unknown) => unknown) => selector({ settings: { toolbars: {} } }),
+}));
+
+vi.mock("../hooks/useModToolbarActions.hook", () => ({
+  useModToolbarActions: () => actions.current,
+}));
+
+import { ModsToolbar } from "./ModsToolbar";
+
+const t = ((key: string) => key) as never;
+
+/** The event the toolbar handed to the generic Mixpanel funnel, if it handed one over. */
+const trackedEvent = (): MixpanelEvent | undefined =>
+  emit.mock.calls.find(([name]) => name === "analytics-track-mixpanel-event")?.[1];
+
+describe("ModsToolbar", () => {
+  it("reports a click on one of its buttons as use of the mods toolbar", async () => {
+    // Pinned, because the mods toolbar offers pinning and only pinned actions reach
+    // the bar — an unpinned one lives in the kebab and would report `overflow`.
+    actions.current = [{ label: "Deploy Mods", id: "deploy", pinned: true, onClick: vi.fn() }];
+    render(<ModsToolbar t={t} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Deploy Mods" }));
+
+    expect(trackedEvent()?.eventName).toBe("toolbar_action_clicked");
+    expect(trackedEvent()?.properties).toEqual({
+      action: "deploy",
+      surface: "bar",
+      toolbar: "mods",
+    });
+  });
+});
+
+/**
+ * The mods page renders the new toolbar or the classic `IconBar` depending on the UI
+ * mode, and only the new one is instrumented — deliberately, so the numbers describe the
+ * toolbar being redesigned rather than a mixture of the two.
+ *
+ * Asserted against the source because there is nothing to observe: the guarantee is that
+ * no tracking reaches this file at all, and a test that renders it can only show that
+ * none fired on the paths it happened to exercise.
+ */
+describe("the classic toolbar", () => {
+  it("has no tracking of its own", () => {
+    const iconBar = fs.readFileSync(
+      path.resolve(__dirname, "../../../controls/IconBar.tsx"),
+      "utf8",
+    );
+
+    expect(iconBar).not.toMatch(/analytics|ToolbarActionClicked|onActionClick/i);
+  });
+});

--- a/src/renderer/src/extensions/mod_management/components/ModsToolbar.tsx
+++ b/src/renderer/src/extensions/mod_management/components/ModsToolbar.tsx
@@ -15,12 +15,12 @@ import { useModToolbarActions } from "../hooks/useModToolbarActions.hook";
  * these buttons earn their place, and nothing on the classic bar is measured at all.
  */
 export const ModsToolbar = ({ t }: { t: TFunction }) => {
-  const onActionClick = useToolbarAnalytics("mods");
-  const actions = useModToolbarActions(t, onActionClick);
+  const tracking = useToolbarAnalytics("mods");
+  const actions = useModToolbarActions(t, tracking.onActionClick);
 
   return (
     // without `flex-1` the toolbar keeps every action and runs over the page title
-    <Toolbar className="flex-1 justify-end" pinningId="mods" onActionClick={onActionClick}>
+    <Toolbar className="flex-1 justify-end" pinningId="mods" tracking={tracking}>
       <ToolbarGroup actions={actions} />
     </Toolbar>
   );

--- a/src/renderer/src/extensions/mod_management/components/ModsToolbar.tsx
+++ b/src/renderer/src/extensions/mod_management/components/ModsToolbar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { Toolbar } from "@/ui/components/toolbar/Toolbar";
 import { ToolbarGroup } from "@/ui/components/toolbar/ToolbarGroup";
+import { useToolbarAnalytics } from "@/ui/components/toolbar/useToolbarAnalytics.hook";
 import type { TFunction } from "@/util/i18n";
 
 import { useModToolbarActions } from "../hooks/useModToolbarActions.hook";
@@ -9,13 +10,17 @@ import { useModToolbarActions } from "../hooks/useModToolbarActions.hook";
 /**
  * The mods page toolbar. See {@link useModToolbarActions} for how the page's own
  * actions and the ones extensions register into `mod-icons` are combined.
+ *
+ * The only toolbar whose clicks are counted, for now: the redesign has to decide which of
+ * these buttons earn their place, and nothing on the classic bar is measured at all.
  */
 export const ModsToolbar = ({ t }: { t: TFunction }) => {
-  const actions = useModToolbarActions(t);
+  const onActionClick = useToolbarAnalytics("mods");
+  const actions = useModToolbarActions(t, onActionClick);
 
   return (
     // without `flex-1` the toolbar keeps every action and runs over the page title
-    <Toolbar className="flex-1 justify-end" pinningId="mods">
+    <Toolbar className="flex-1 justify-end" pinningId="mods" onActionClick={onActionClick}>
       <ToolbarGroup actions={actions} />
     </Toolbar>
   );

--- a/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.test.tsx
+++ b/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { fireEvent, render, renderHook, screen } from "@testing-library/react";
 import React from "react";
 import type * as ReactReduxTypes from "react-redux";
 import { describe, expect, it, vi } from "vitest";
@@ -24,10 +24,16 @@ vi.mock("@/contexts", () => ({
 /**
  * The registrations under test. `useRegisteredActions` reads the group through this;
  * the rest of the module has to stay, `ActionControl` taking `extend` from it.
+ *
+ * Group-aware, because the real thing is: an extension registers into `mod-icons`, and
+ * anything that reaches the "Open ..." or "Import ..." menus does so by its icon rather
+ * than by registering into their groups. Answering every group with the same list puts
+ * each action in a menu *and* on the bar.
  */
 vi.mock("@/ExtensionProvider", async (importOriginal) => ({
   ...(await importOriginal<object>()),
-  useExtensionObjects: () => objects.current,
+  useExtensionObjects: (_registerFunc: unknown, _static: unknown, group: string) =>
+    group === "mod-icons" ? objects.current : [],
 }));
 
 const state = {
@@ -62,12 +68,27 @@ import { useModToolbarActions } from "./useModToolbarActions.hook";
 
 const t = ((key: string) => key) as never;
 
-const labels = (definitions: IActionDefinition[]): string[] => {
+const actionsFor = (definitions: IActionDefinition[], onActionClick?: () => void) => {
   objects.current = definitions;
-  const { result } = renderHook(() => useModToolbarActions(t));
+  const { result } = renderHook(() => useModToolbarActions(t, onActionClick));
 
-  return result.current.map((action) => action.label);
+  return result.current;
 };
+
+const labels = (definitions: IActionDefinition[]): string[] =>
+  actionsFor(definitions).map((action) => action.label);
+
+const byLabel = (definitions: IActionDefinition[], label: string, onActionClick?: () => void) =>
+  actionsFor(definitions, onActionClick).find((action) => action.label === label);
+
+/** Two registrations sharing the "open-ext" icon, which is what folds them into a menu. */
+const opener = (title: string, namespace: string): IActionDefinition => ({
+  icon: "open-ext",
+  title,
+  position: 90,
+  options: { namespace },
+  action: () => undefined,
+});
 
 const plain = (title: string, options: IActionDefinition["options"] = {}): IActionDefinition => ({
   icon: "rules",
@@ -104,5 +125,76 @@ describe("useModToolbarActions", () => {
     } as unknown as IActionDefinition;
 
     expect(labels([asComponent])).toHaveLength(4);
+  });
+});
+
+describe("useModToolbarActions tracking identity", () => {
+  it("identifies a registered action by its bare title and its extension", () => {
+    const action = byLabel(
+      [plain("Manage Rules", { namespace: "mod-dependency-manager" })],
+      "Manage Rules",
+    );
+
+    expect(action?.id).toBe("Manage Rules");
+    expect(action?.extension).toBe("mod-dependency-manager");
+  });
+
+  // A notice follows state, so folding it into the label the way the bar does would
+  // split one button across as many ids as it has things to say.
+  it("keeps the notice out of the identity, though the label shows it", () => {
+    const withNotice = plain("Manage Rules", {
+      namespace: "mod-dependency-manager",
+      notice: () => "2 unresolved",
+    });
+    const action = byLabel([withNotice], "Manage Rules (2 unresolved)");
+
+    expect(action?.id).toBe("Manage Rules");
+  });
+
+  // "Open..." is built from a translated word, so the menu's own stable id is what
+  // both a pin and a click are recorded against.
+  it("identifies the Open menu by its own id", () => {
+    const menu = byLabel(
+      [opener("Open Mod Folder", "open-directory"), opener("Open Game Folder", "open-directory")],
+      "Open...",
+    );
+
+    expect(menu?.id).toBe("open");
+  });
+
+  it("counts a row inside that menu against the menu, not the bar", () => {
+    const onActionClick = vi.fn();
+    const menu = byLabel(
+      [opener("Open Mod Folder", "open-directory"), opener("Open Game Folder", "open-directory")],
+      "Open...",
+      onActionClick,
+    );
+
+    const { getByRole } = render(
+      <>{menu?.panel?.({ close: () => undefined, dismiss: () => undefined })}</>,
+    );
+    fireEvent.click(getByRole("menuitem", { name: "Open Mod Folder" }));
+
+    expect(onActionClick).toHaveBeenCalledWith(
+      { id: "Open Mod Folder", extension: "open-directory" },
+      "menu",
+    );
+  });
+
+  // Collapsed to a single entry it goes on the bar, where the group counts it like any
+  // other action — counting it here as well would report every use twice.
+  it("leaves a one-entry menu to the bar", () => {
+    const onActionClick = vi.fn();
+    const only = byLabel(
+      [opener("Open Mod Folder", "open-directory")],
+      "Open Mod Folder",
+      onActionClick,
+    );
+
+    only?.onClick?.();
+
+    expect(onActionClick).not.toHaveBeenCalled();
+    expect(only?.id).toBe("Open Mod Folder");
+    expect(only?.extension).toBe("open-directory");
   });
 });

--- a/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
+++ b/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
@@ -12,7 +12,7 @@ import { log } from "@/logging";
 import type { IActionDefinition } from "@/types/IActionDefinition";
 import type { IState } from "@/types/IState";
 import { PopoverMenu } from "@/ui/components/popover/PopoverMenu";
-import type { IToolbarContext } from "@/ui/components/toolbar/Toolbar.context";
+import type { IToolbarAnalytics } from "@/ui/components/toolbar/Toolbar.context";
 import type { IToolbarAction } from "@/ui/components/toolbar/ToolbarGroup";
 import { trackedActions } from "@/ui/components/toolbar/ToolbarGroup";
 import { fileMD5 } from "@/util/checksum";
@@ -631,7 +631,7 @@ const useActionMenu = (
   t: TFunction,
   menu: IActionMenu,
   adopted: IPositionedAction[],
-  onActionClick: IToolbarContext["onActionClick"],
+  onActionClick: IToolbarAnalytics["onActionClick"] | undefined,
 ): IPositionedAction | undefined => {
   const registered = useRegisteredActions(menu.group);
 
@@ -679,7 +679,7 @@ const useActionMenu = (
  */
 export const useModToolbarActions = (
   t: TFunction,
-  onActionClick?: IToolbarContext["onActionClick"],
+  onActionClick?: IToolbarAnalytics["onActionClick"],
 ): IToolbarAction[] => {
   const installFromFile = useInstallFromFileAction(t);
   const checkVersions = useCheckVersionsAction(t);

--- a/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
+++ b/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
@@ -12,7 +12,9 @@ import { log } from "@/logging";
 import type { IActionDefinition } from "@/types/IActionDefinition";
 import type { IState } from "@/types/IState";
 import { PopoverMenu } from "@/ui/components/popover/PopoverMenu";
+import type { IToolbarContext } from "@/ui/components/toolbar/Toolbar.context";
 import type { IToolbarAction } from "@/ui/components/toolbar/ToolbarGroup";
+import { trackedActions } from "@/ui/components/toolbar/ToolbarGroup";
 import { fileMD5 } from "@/util/checksum";
 import { TemporaryError, UserCanceled } from "@/util/CustomErrors";
 import * as fs from "@/util/fs";
@@ -604,6 +606,7 @@ const useRegisteredActions = (group: string): IPositionedAction[] => {
         iconPath: getIconPath(definition.icon, mdiPuzzleOutline),
         pinned: definition.options?.pinned ?? false,
         disabled: typeof condition === "string",
+        extension: definition.options?.namespace,
         onClick: () => definition.action?.(instanceIds),
       },
     });
@@ -628,6 +631,7 @@ const useActionMenu = (
   t: TFunction,
   menu: IActionMenu,
   adopted: IPositionedAction[],
+  onActionClick: IToolbarContext["onActionClick"],
 ): IPositionedAction | undefined => {
   const registered = useRegisteredActions(menu.group);
 
@@ -643,7 +647,12 @@ const useActionMenu = (
     }
 
     const label = t(menu.label);
-    const actions = entries.map((entry) => entry.action);
+
+    const actions = trackedActions(
+      entries.map((entry) => entry.action),
+      "menu",
+      onActionClick,
+    );
 
     return {
       position: menu.position,
@@ -658,7 +667,7 @@ const useActionMenu = (
         ),
       },
     };
-  }, [adopted, menu, registered, t]);
+  }, [adopted, menu, onActionClick, registered, t]);
 };
 
 /**
@@ -668,7 +677,10 @@ const useActionMenu = (
  * see `useToolbarPinning` — and anything that doesn't fit is collapsed into the
  * overflow menu by {@link ToolbarGroup}, so this is a flat list.
  */
-export const useModToolbarActions = (t: TFunction): IToolbarAction[] => {
+export const useModToolbarActions = (
+  t: TFunction,
+  onActionClick?: IToolbarContext["onActionClick"],
+): IToolbarAction[] => {
   const installFromFile = useInstallFromFileAction(t);
   const checkVersions = useCheckVersionsAction(t);
   const deploy = useDeployAction(t);
@@ -681,8 +693,13 @@ export const useModToolbarActions = (t: TFunction): IToolbarAction[] => {
     [registered],
   );
 
-  const open = useActionMenu(t, OPEN_MENU, byIcon[OPEN_MENU.icon] ?? NO_ACTIONS);
-  const importFrom = useActionMenu(t, IMPORT_MENU, byIcon[IMPORT_MENU.icon] ?? NO_ACTIONS);
+  const open = useActionMenu(t, OPEN_MENU, byIcon[OPEN_MENU.icon] ?? NO_ACTIONS, onActionClick);
+  const importFrom = useActionMenu(
+    t,
+    IMPORT_MENU,
+    byIcon[IMPORT_MENU.icon] ?? NO_ACTIONS,
+    onActionClick,
+  );
 
   return useMemo(
     () =>

--- a/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
@@ -1,5 +1,19 @@
 import { createContext, useContext } from "react";
 
+/**
+ * What identifies a toolbar action to whoever is counting its clicks, independent of the
+ * label on screen. Labels are translated, so nothing may derive identity from one.
+ */
+export interface IToolbarActionIdentity {
+  /** Stable id — a test id, or the untranslated title an extension registered under. */
+  id: string;
+  /** Namespace of the extension that registered the action, absent for a page's own. */
+  extension?: string;
+}
+
+/** Where in a toolbar an action was reached from. */
+export type ToolbarSurface = "bar" | "overflow" | "menu";
+
 /** Layout facts a `Toolbar` publishes to the groups rendered inside it. */
 export interface IToolbarContext {
   /** The toolbar row, or `null` for a group rendered without a `Toolbar`. */
@@ -21,6 +35,13 @@ export interface IToolbarContext {
    * earlier group collapses and frees space.
    */
   signature: string;
+  /**
+   * Called when an action in this toolbar is clicked, for a page that opts into click
+   * tracking. Absent on a toolbar nobody is counting, which leaves its controls
+   * untouched. Identity is passed through rather than read, so nothing here needs to
+   * know what becomes of it — see `useToolbarAnalytics` for the mods page's.
+   */
+  onActionClick?: (action: IToolbarActionIdentity, surface: ToolbarSurface) => void;
 }
 
 export const ToolbarContext = createContext<IToolbarContext>({

--- a/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.context.ts
@@ -1,18 +1,51 @@
 import { createContext, useContext } from "react";
 
+import type { IToolbarAction } from "./ToolbarGroup";
+
 /**
- * What identifies a toolbar action to whoever is counting its clicks, independent of the
- * label on screen. Labels are translated, so nothing may derive identity from one.
+ * What identifies a toolbar action to whoever is counting what happens to it,
+ * independent of the label on screen. Labels are translated, so nothing may derive
+ * identity from one.
  */
 export interface IToolbarActionIdentity {
-  /** Stable id — a test id, or the untranslated title an extension registered under. */
+  /** The same stable id a decision to pin the action is stored against. */
   id: string;
   /** Namespace of the extension that registered the action, absent for a page's own. */
   extension?: string;
 }
 
+/**
+ * What an action calls itself when its clicks and pins are counted: the `id` that
+ * pinning already requires to survive a change of language or release.
+ *
+ * An action without one says nothing about itself, so what happens to it goes
+ * unrecorded rather than recorded wrongly. It cannot be pinned either, and
+ * `useToolbarPinning` says so.
+ *
+ * Lives here rather than beside either caller so that clicks and pins can never come
+ * to disagree about what a button is called.
+ */
+export const identityOf = (action: IToolbarAction): IToolbarActionIdentity | undefined =>
+  action.id ? { id: action.id, extension: action.extension } : undefined;
+
 /** Where in a toolbar an action was reached from. */
 export type ToolbarSurface = "bar" | "overflow" | "menu";
+
+/**
+ * What a page hands a toolbar to have its use counted. Identity is passed through
+ * rather than read, so nothing under `ui/` needs to know what becomes of it.
+ */
+export interface IToolbarAnalytics {
+  /** An action was clicked, and where in the toolbar it was reached from. */
+  onActionClick: (action: IToolbarActionIdentity, surface: ToolbarSurface) => void;
+  /**
+   * The user pinned or unpinned an action, with `pinned` the state being moved *to*.
+   * Only ever fires on a toolbar that offers pinning.
+   */
+  onPinChange: (action: IToolbarActionIdentity, pinned: boolean) => void;
+  /** The user put every pin on this toolbar back to its default. */
+  onPinsReset: () => void;
+}
 
 /** Layout facts a `Toolbar` publishes to the groups rendered inside it. */
 export interface IToolbarContext {
@@ -36,12 +69,10 @@ export interface IToolbarContext {
    */
   signature: string;
   /**
-   * Called when an action in this toolbar is clicked, for a page that opts into click
-   * tracking. Absent on a toolbar nobody is counting, which leaves its controls
-   * untouched. Identity is passed through rather than read, so nothing here needs to
-   * know what becomes of it — see `useToolbarAnalytics` for the mods page's.
+   * How what happens to this toolbar is counted, or absent on one nobody is counting —
+   * which leaves its controls untouched. See `useToolbarAnalytics`.
    */
-  onActionClick?: (action: IToolbarActionIdentity, surface: ToolbarSurface) => void;
+  tracking?: IToolbarAnalytics;
 }
 
 export const ToolbarContext = createContext<IToolbarContext>({

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -8,6 +8,7 @@ import { toolbarReducer } from "@/reducers/toolbars";
 import type { IToolbarStates } from "@/types/IState";
 
 import { Toolbar } from "./Toolbar";
+import type { IToolbarAnalytics } from "./Toolbar.context";
 import { ToolbarGroup, type IToolbarAction } from "./ToolbarGroup";
 import { fitVisibleActions, type IToolbarGroupMetrics } from "./useToolbarOverflow.hook";
 
@@ -54,6 +55,13 @@ const makeActions = (count: number): IToolbarAction[] =>
 const KEBAB_TEST_ID = "toolbar-overflow";
 
 const getKebab = () => screen.getByTestId(KEBAB_TEST_ID);
+
+/** Tracking whose every callback is a spy, for a test that cares about only one. */
+const silentTracking = (): IToolbarAnalytics => ({
+  onActionClick: vi.fn(),
+  onPinChange: vi.fn(),
+  onPinsReset: vi.fn(),
+});
 
 const queryKebab = () => screen.queryByTestId(KEBAB_TEST_ID);
 
@@ -578,17 +586,19 @@ describe("ToolbarGroup", () => {
       actions,
       decisions = {},
       width = 1000,
+      tracking,
     }: {
       actions: IToolbarAction[];
       decisions?: { [actionId: string]: boolean };
       width?: number;
+      tracking?: Partial<IToolbarAnalytics>;
     }) => {
       stubLayout(width);
       const store = makeStore({ mods: { pinned: decisions } });
 
       render(
         <Provider store={store as never}>
-          <Toolbar pinningId="mods">
+          <Toolbar pinningId="mods" tracking={tracking && { ...silentTracking(), ...tracking }}>
             <ToolbarGroup actions={actions} />
           </Toolbar>
         </Provider>,
@@ -773,6 +783,45 @@ describe("ToolbarGroup", () => {
         expect(queryResetLink()).not.toBeInTheDocument();
       });
     });
+
+    describe("tracking", () => {
+      it("reports a pin, and the unpin that undoes it", async () => {
+        const onPinChange = vi.fn();
+        renderToolbar({ actions: pinnable([["Deploy", false]]), tracking: { onPinChange } });
+
+        await openMenu();
+        await userEvent.click(pinOf("Deploy"));
+
+        expect(onPinChange).toHaveBeenLastCalledWith({ id: "deploy", extension: undefined }, true);
+
+        await userEvent.click(pinOf("Deploy"));
+
+        expect(onPinChange).toHaveBeenLastCalledWith({ id: "deploy", extension: undefined }, false);
+      });
+
+      it("reports a reset to defaults", async () => {
+        const onPinsReset = vi.fn();
+        renderToolbar({
+          actions: pinnable([["Deploy", false]]),
+          decisions: { deploy: true },
+          tracking: { onPinsReset },
+        });
+
+        await openMenu();
+        await userEvent.click(resetLink());
+
+        expect(onPinsReset).toHaveBeenCalledOnce();
+      });
+
+      it("says nothing on a toolbar that isn't tracked", async () => {
+        renderToolbar({ actions: pinnable([["Deploy", false]]) });
+
+        await openMenu();
+        await userEvent.click(pinOf("Deploy"));
+
+        expect(screen.getByRole("toolbar")).toBeInTheDocument();
+      });
+    });
   });
 });
 
@@ -870,7 +919,7 @@ describe("fitVisibleActions", () => {
 describe("click tracking", () => {
   const trackedToolbar = (actions: IToolbarAction[], onActionClick: () => void, max?: number) =>
     render(
-      <Toolbar onActionClick={onActionClick}>
+      <Toolbar tracking={{ ...silentTracking(), onActionClick }}>
         <ToolbarGroup actions={actions} maxVisible={max} />
       </Toolbar>,
     );

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -827,3 +827,131 @@ describe("fitVisibleActions", () => {
     });
   });
 });
+
+describe("click tracking", () => {
+  const trackedToolbar = (actions: IToolbarAction[], onActionClick: () => void, max?: number) =>
+    render(
+      <Toolbar onActionClick={onActionClick}>
+        <ToolbarGroup actions={actions} maxVisible={max} />
+      </Toolbar>,
+    );
+
+  it("reports a visible action's click, and still runs it exactly once", async () => {
+    const onActionClick = vi.fn();
+    const onClick = vi.fn();
+    trackedToolbar([{ label: "Deploy", id: "deploy", onClick }], onActionClick);
+
+    await userEvent.click(screen.getByRole("button", { name: "Deploy" }));
+
+    expect(onActionClick).toHaveBeenCalledWith({ id: "deploy", extension: undefined }, "bar");
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("reports an overflowed action against the overflow, not the bar", async () => {
+    const onActionClick = vi.fn();
+    const onClick = vi.fn();
+    const actions = [...makeActions(7), { label: "Overflowed", id: "overflowed", onClick }];
+    trackedToolbar(actions, onActionClick, 7);
+
+    await userEvent.click(getKebab());
+    await userEvent.click(screen.getByText("Overflowed"));
+
+    expect(onActionClick).toHaveBeenCalledWith(
+      { id: "overflowed", extension: undefined },
+      "overflow",
+    );
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("names the extension an action came from", async () => {
+    const onActionClick = vi.fn();
+    trackedToolbar(
+      [
+        {
+          label: "Manage Rules",
+          id: "Manage Rules",
+          extension: "mod-dependency-manager",
+          onClick: vi.fn(),
+        },
+      ],
+      onActionClick,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage Rules" }));
+
+    expect(onActionClick).toHaveBeenCalledWith(
+      { id: "Manage Rules", extension: "mod-dependency-manager" },
+      "bar",
+    );
+  });
+
+  // The label is the only other thing to hand, and it is translated. Reporting an action
+  // under a name that changes with the language would split one button across as many
+  // ids as there are locales, which is worse than not reporting it at all. An action
+  // without an id cannot be pinned either — see `useToolbarPinning`.
+  it("says nothing about an action that has no id, but still runs it", async () => {
+    const onActionClick = vi.fn();
+    const onClick = vi.fn();
+    trackedToolbar([{ label: "Nameless", onClick }], onActionClick);
+
+    await userEvent.click(screen.getByRole("button", { name: "Nameless" }));
+
+    expect(onActionClick).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  // An empty id is no identity at all — reporting it would put `action: ""` in the
+  // dashboard, which reads as a real button nobody can name.
+  it("treats an empty id as no identity", async () => {
+    const onActionClick = vi.fn();
+    const onClick = vi.fn();
+    trackedToolbar([{ label: "Blank", id: "", onClick }], onActionClick);
+
+    await userEvent.click(screen.getByRole("button", { name: "Blank" }));
+
+    expect(onActionClick).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("leaves an untracked toolbar's actions alone", async () => {
+    const onClick = vi.fn();
+    render(
+      <Toolbar>
+        <ToolbarGroup actions={[{ label: "Deploy", id: "deploy", onClick }]} />
+      </Toolbar>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Deploy" }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  describe("panel actions", () => {
+    const panelAction: IToolbarAction = {
+      label: "Open",
+      id: "open",
+      panel: () => <span>Panel content</span>,
+    };
+
+    it("counts opening the panel as a click on the control", async () => {
+      const onActionClick = vi.fn();
+      trackedToolbar([panelAction], onActionClick);
+
+      await userEvent.click(screen.getByRole("button", { name: "Open" }));
+
+      expect(screen.getByText("Panel content")).toBeInTheDocument();
+      expect(onActionClick).toHaveBeenCalledWith({ id: "open", extension: undefined }, "bar");
+    });
+
+    it("does not count closing it again as a second click", async () => {
+      const onActionClick = vi.fn();
+      trackedToolbar([panelAction], onActionClick);
+
+      const trigger = screen.getByRole("button", { name: "Open" });
+      await userEvent.click(trigger);
+      await userEvent.click(trigger);
+
+      expect(onActionClick).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.test.tsx
@@ -630,6 +630,14 @@ describe("ToolbarGroup", () => {
      */
     const pinOf = (label: string) => within(rowFor(label)).getByRole("button");
 
+    /**
+     * The reset link, which sits below the menu rather than in it — the same shape the
+     * display options panel ends in.
+     */
+    const queryResetLink = () => screen.queryByRole("button", { name: "Reset pins to default" });
+
+    const resetLink = () => screen.getByRole("button", { name: "Reset pins to default" });
+
     it("puts the pinned actions on the bar, and every action in the menu", async () => {
       renderToolbar({
         actions: pinnable([
@@ -733,6 +741,37 @@ describe("ToolbarGroup", () => {
       await openMenu();
       expect(within(rowFor("Nameless")).queryByRole("button")).not.toBeInTheDocument();
       expect(pinOf("Deploy")).toBeInTheDocument();
+    });
+
+    describe("resetting to defaults", () => {
+      it("offers no reset until the user has decided something", async () => {
+        renderToolbar({ actions: pinnable([["Deploy", true]]) });
+
+        await openMenu();
+        expect(queryResetLink()).not.toBeInTheDocument();
+      });
+
+      it("offers one once a decision has been made", async () => {
+        renderToolbar({ actions: pinnable([["Deploy", true]]), decisions: { deploy: false } });
+
+        await openMenu();
+        expect(resetLink()).toBeInTheDocument();
+      });
+
+      // The pins above move back, which is the confirmation — and with nothing left to
+      // undo the link takes itself away.
+      it("puts the bar back, leaves the menu open, and removes itself", async () => {
+        renderToolbar({ actions: pinnable([["Deploy", true]]), decisions: { deploy: false } });
+
+        await openMenu();
+        expect(barLabels()).toEqual([]);
+
+        await userEvent.click(resetLink());
+
+        expect(barLabels()).toEqual(["Deploy"]);
+        expect(screen.getByRole("menu")).toBeInTheDocument();
+        expect(queryResetLink()).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/renderer/src/ui/components/toolbar/Toolbar.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.tsx
@@ -15,6 +15,11 @@ interface IToolbarProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   /** Lets the user choose which actions sit on the bar, stored under this id. */
   pinningId?: string;
+  /**
+   * Opts this toolbar into click tracking. Omitted, its controls report nothing —
+   * see {@link IToolbarContext.onActionClick}.
+   */
+  onActionClick?: IToolbarContext["onActionClick"];
 }
 
 /**
@@ -37,7 +42,9 @@ const rowWidthFrom = (signature: string): number | null => {
  * rather than an effect means the measurement reaches a render without being
  * copied into state first, and React does the change detection.
  */
-const useRowLayout = (row: HTMLElement | null): Omit<IToolbarContext, "pinningId"> => {
+const useRowLayout = (
+  row: HTMLElement | null,
+): Omit<IToolbarContext, "onActionClick" | "pinningId"> => {
   const subscribe = useCallback(
     (onSizeChange: () => void) => {
       if (!row || typeof ResizeObserver === "undefined") {
@@ -99,13 +106,19 @@ const useRowLayout = (row: HTMLElement | null): Omit<IToolbarContext, "pinningId
  * because a toolbar sized by its content can't tell how much room it actually
  * has. Add a `flex-1` (or `shrink`) class to opt such a toolbar into collapsing.
  */
-export const Toolbar = ({ children, className, pinningId, ...props }: IToolbarProps) => {
+export const Toolbar = ({
+  children,
+  className,
+  pinningId,
+  onActionClick,
+  ...props
+}: IToolbarProps) => {
   const [row, setRow] = useState<HTMLDivElement | null>(null);
   const layout = useRowLayout(row);
 
   const context = useMemo<IToolbarContext>(
-    () => ({ ...layout, pinningId: pinningId ?? null }),
-    [layout, pinningId],
+    () => ({ ...layout, pinningId: pinningId ?? null, onActionClick }),
+    [layout, onActionClick, pinningId],
   );
 
   return (

--- a/src/renderer/src/ui/components/toolbar/Toolbar.tsx
+++ b/src/renderer/src/ui/components/toolbar/Toolbar.tsx
@@ -16,10 +16,10 @@ interface IToolbarProps extends HTMLAttributes<HTMLDivElement> {
   /** Lets the user choose which actions sit on the bar, stored under this id. */
   pinningId?: string;
   /**
-   * Opts this toolbar into click tracking. Omitted, its controls report nothing —
-   * see {@link IToolbarContext.onActionClick}.
+   * Opts this toolbar into tracking. Omitted, its controls report nothing —
+   * see {@link IToolbarContext.tracking}.
    */
-  onActionClick?: IToolbarContext["onActionClick"];
+  tracking?: IToolbarContext["tracking"];
 }
 
 /**
@@ -42,9 +42,7 @@ const rowWidthFrom = (signature: string): number | null => {
  * rather than an effect means the measurement reaches a render without being
  * copied into state first, and React does the change detection.
  */
-const useRowLayout = (
-  row: HTMLElement | null,
-): Omit<IToolbarContext, "onActionClick" | "pinningId"> => {
+const useRowLayout = (row: HTMLElement | null): Omit<IToolbarContext, "pinningId" | "tracking"> => {
   const subscribe = useCallback(
     (onSizeChange: () => void) => {
       if (!row || typeof ResizeObserver === "undefined") {
@@ -106,19 +104,13 @@ const useRowLayout = (
  * because a toolbar sized by its content can't tell how much room it actually
  * has. Add a `flex-1` (or `shrink`) class to opt such a toolbar into collapsing.
  */
-export const Toolbar = ({
-  children,
-  className,
-  pinningId,
-  onActionClick,
-  ...props
-}: IToolbarProps) => {
+export const Toolbar = ({ children, className, pinningId, tracking, ...props }: IToolbarProps) => {
   const [row, setRow] = useState<HTMLDivElement | null>(null);
   const layout = useRowLayout(row);
 
   const context = useMemo<IToolbarContext>(
-    () => ({ ...layout, pinningId: pinningId ?? null, onActionClick }),
-    [layout, onActionClick, pinningId],
+    () => ({ ...layout, pinningId: pinningId ?? null, tracking }),
+    [layout, pinningId, tracking],
   );
 
   return (

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -4,6 +4,7 @@ import type { IMenuAction, IPopoverPanel } from "@/ui/components/popover/Popover
 import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
+import type { IToolbarActionIdentity, IToolbarContext, ToolbarSurface } from "./Toolbar.context";
 import { useToolbarContext } from "./Toolbar.context";
 import { ToolbarButton } from "./ToolbarButton";
 import { ToolbarOverflow } from "./ToolbarOverflow";
@@ -33,6 +34,11 @@ export type IToolbarAction = IMenuAction & {
    * that doesn't offer pinning, which shows every action it was given.
    */
   pinned?: boolean;
+  /**
+   * The extension that registered this action, for a toolbar counting where its
+   * buttons come from. Absent for an action the page owns.
+   */
+  extension?: string;
 };
 
 type IToolbarGroupProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
@@ -70,15 +76,97 @@ const controlProps = (action: IToolbarAction) => ({
 });
 
 /**
+ * What an action calls itself when its clicks are counted: the same `id` a decision to
+ * pin it is stored against, which is already required to survive a change of language
+ * or release. Never its label — that is translated, and an identity derived from one
+ * splits a single button across as many ids as there are languages.
+ *
+ * An action without one says nothing about itself, so its clicks go unrecorded rather
+ * than recorded wrongly. It cannot be pinned either, and `useToolbarPinning` says so.
+ */
+const identityOf = (action: IToolbarAction): IToolbarActionIdentity | undefined =>
+  action.id ? { id: action.id, extension: action.extension } : undefined;
+
+/**
+ * The half of {@link IToolbarAction} that runs something when activated, as one type
+ * rather than the either-or. Copying an action means spreading it, and spreading the
+ * either-or gives back an either-or that no longer knows which half it came from.
+ */
+type IToolbarClickAction = Extract<IToolbarAction, { panel?: never }>;
+
+const runsSomething = (action: IToolbarAction): action is IToolbarClickAction =>
+  action.panel === undefined;
+
+/**
+ * The actions as the row will run them: each reports its own click first, if the toolbar
+ * is being tracked and the action can say who it is.
+ *
+ * A panel action is left alone here — opening a panel is a click its control sees but
+ * its `onClick` doesn't, so {@link ToolbarControl} reports that one instead. In the
+ * overflow menu there is no such click to catch, and the rows inside the panel carry
+ * their own identity anyway.
+ *
+ * Exported because a page that folds several actions into a menu of its own has rows the
+ * group never sees, and they have to be counted by the same rule — identity resolves in
+ * one place or it drifts.
+ */
+export const trackedActions = (
+  actions: IToolbarAction[],
+  surface: ToolbarSurface,
+  onActionClick: IToolbarContext["onActionClick"],
+): IToolbarAction[] => {
+  if (onActionClick === undefined) {
+    return actions;
+  }
+
+  return actions.map((action): IToolbarAction => {
+    const identity = identityOf(action);
+
+    if (identity === undefined || !runsSomething(action)) {
+      return action;
+    }
+
+    const { onClick } = action;
+
+    return {
+      ...action,
+      onClick: () => {
+        onActionClick(identity, surface);
+        onClick?.();
+      },
+    };
+  });
+};
+
+/**
+ * Reports the click on a panel action: the one that opens it, which is the only moment
+ * a control that runs nothing can be said to have been clicked.
+ *
+ * Always from the bar, because a panel action that collapsed into the overflow is opened
+ * from a menu row instead, where there is no such click to hang this on.
+ */
+const panelClickReporter = (
+  action: IToolbarAction,
+  onActionClick: IToolbarContext["onActionClick"],
+): (() => void) | undefined => {
+  const identity = runsSomething(action) ? undefined : identityOf(action);
+
+  return onActionClick === undefined || identity === undefined
+    ? undefined
+    : () => onActionClick(identity, "bar");
+};
+
+/**
  * A panel action marks itself, because there the group's child is the popover
  * wrapper rather than the button — see {@link TOOLBAR_CONTROL_ATTRIBUTE}.
  */
-const ToolbarControl = ({ action }: { action: IToolbarAction }) =>
+const ToolbarControl = ({ action, onClick }: { action: IToolbarAction; onClick?: () => void }) =>
   action.panel ? (
     <ToolbarPanelButton
       {...controlProps(action)}
       panel={action.panel}
       panelRole={action.panelRole}
+      onClick={onClick}
     />
   ) : (
     <ToolbarButton
@@ -106,6 +194,7 @@ const ToolbarGroupBody = ({
   pinningEnabled,
   ...props
 }: IGroupBodyProps) => {
+  const { onActionClick } = useToolbarContext();
   const { groupRef, isMeasuring, visible } = useToolbarOverflow({
     actionCount: barActions.length,
     alwaysReserveOverflow: pinningEnabled,
@@ -113,9 +202,22 @@ const ToolbarGroupBody = ({
     signature: widthSignature(barActions),
   });
 
-  const visibleActions = barActions.filter((_, index) => visible.has(index));
+  const visibleActions = trackedActions(
+    barActions.filter((_, index) => visible.has(index)),
+    "bar",
+    onActionClick,
+  );
   const hiddenActions = barActions.filter((_, index) => !visible.has(index));
-  const menuActions = pinningEnabled ? actions : hiddenActions;
+
+  // Where pinning is on the menu is the full list rather than the leftovers, so
+  // `overflow` records that a button was reached through the kebab, not that it
+  // failed to fit.
+  const menuActions = trackedActions(
+    pinningEnabled ? actions : hiddenActions,
+    "overflow",
+    onActionClick,
+  );
+
   return (
     <TooltipDelayGroup
       as="div"
@@ -124,7 +226,11 @@ const ToolbarGroupBody = ({
       {...props}
     >
       {visibleActions.map((action) => (
-        <ToolbarControl action={action} key={action.label} />
+        <ToolbarControl
+          action={action}
+          key={action.label}
+          onClick={panelClickReporter(action, onActionClick)}
+        />
       ))}
 
       {/* Kept mounted through the measuring pass so its width is measured too. */}

--- a/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarGroup.tsx
@@ -4,8 +4,8 @@ import type { IMenuAction, IPopoverPanel } from "@/ui/components/popover/Popover
 import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
-import type { IToolbarActionIdentity, IToolbarContext, ToolbarSurface } from "./Toolbar.context";
-import { useToolbarContext } from "./Toolbar.context";
+import type { IToolbarAnalytics, ToolbarSurface } from "./Toolbar.context";
+import { identityOf, useToolbarContext } from "./Toolbar.context";
 import { ToolbarButton } from "./ToolbarButton";
 import { ToolbarOverflow } from "./ToolbarOverflow";
 import { ToolbarPanelButton } from "./ToolbarPanelButton";
@@ -76,18 +76,6 @@ const controlProps = (action: IToolbarAction) => ({
 });
 
 /**
- * What an action calls itself when its clicks are counted: the same `id` a decision to
- * pin it is stored against, which is already required to survive a change of language
- * or release. Never its label — that is translated, and an identity derived from one
- * splits a single button across as many ids as there are languages.
- *
- * An action without one says nothing about itself, so its clicks go unrecorded rather
- * than recorded wrongly. It cannot be pinned either, and `useToolbarPinning` says so.
- */
-const identityOf = (action: IToolbarAction): IToolbarActionIdentity | undefined =>
-  action.id ? { id: action.id, extension: action.extension } : undefined;
-
-/**
  * The half of {@link IToolbarAction} that runs something when activated, as one type
  * rather than the either-or. Copying an action means spreading it, and spreading the
  * either-or gives back an either-or that no longer knows which half it came from.
@@ -113,7 +101,7 @@ const runsSomething = (action: IToolbarAction): action is IToolbarClickAction =>
 export const trackedActions = (
   actions: IToolbarAction[],
   surface: ToolbarSurface,
-  onActionClick: IToolbarContext["onActionClick"],
+  onActionClick: IToolbarAnalytics["onActionClick"] | undefined,
 ): IToolbarAction[] => {
   if (onActionClick === undefined) {
     return actions;
@@ -147,7 +135,7 @@ export const trackedActions = (
  */
 const panelClickReporter = (
   action: IToolbarAction,
-  onActionClick: IToolbarContext["onActionClick"],
+  onActionClick: IToolbarAnalytics["onActionClick"] | undefined,
 ): (() => void) | undefined => {
   const identity = runsSomething(action) ? undefined : identityOf(action);
 
@@ -194,7 +182,7 @@ const ToolbarGroupBody = ({
   pinningEnabled,
   ...props
 }: IGroupBodyProps) => {
-  const { onActionClick } = useToolbarContext();
+  const { tracking } = useToolbarContext();
   const { groupRef, isMeasuring, visible } = useToolbarOverflow({
     actionCount: barActions.length,
     alwaysReserveOverflow: pinningEnabled,
@@ -205,7 +193,7 @@ const ToolbarGroupBody = ({
   const visibleActions = trackedActions(
     barActions.filter((_, index) => visible.has(index)),
     "bar",
-    onActionClick,
+    tracking?.onActionClick,
   );
   const hiddenActions = barActions.filter((_, index) => !visible.has(index));
 
@@ -215,7 +203,7 @@ const ToolbarGroupBody = ({
   const menuActions = trackedActions(
     pinningEnabled ? actions : hiddenActions,
     "overflow",
-    onActionClick,
+    tracking?.onActionClick,
   );
 
   return (
@@ -229,7 +217,7 @@ const ToolbarGroupBody = ({
         <ToolbarControl
           action={action}
           key={action.label}
-          onClick={panelClickReporter(action, onActionClick)}
+          onClick={panelClickReporter(action, tracking?.onActionClick)}
         />
       ))}
 

--- a/src/renderer/src/ui/components/toolbar/ToolbarOverflow.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarOverflow.tsx
@@ -2,10 +2,13 @@ import { mdiDotsHorizontal } from "@mdi/js";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import { DropdownDivider } from "@/ui/components/dropdown/DropdownDivider";
 import { Popover } from "@/ui/components/popover/Popover";
 import { PopoverButton } from "@/ui/components/popover/PopoverButton";
 import { PopoverMenu } from "@/ui/components/popover/PopoverMenu";
 import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
+import { PopoverPanelGroupItem } from "@/ui/components/popover/PopoverPanelGroupItem";
+import { TypographyLink } from "@/ui/components/typography/TypographyLink";
 
 import type { IToolbarAction } from "./ToolbarGroup";
 import { TOOLBAR_OVERFLOW_ATTRIBUTE } from "./useToolbarOverflow.hook";
@@ -16,12 +19,19 @@ interface IToolbarOverflowProps {
   pinning?: {
     isPinned: (action: IToolbarAction) => boolean;
     togglePin: (action: IToolbarAction) => void;
+    canReset: boolean;
+    reset: () => void;
   };
 }
 
 /**
  * The actions a group had no room for, as a menu hung off a kebab button. They
  * arrive already ordered and belong together, so they go in as a single group.
+ *
+ * Where pinning is offered the menu ends in a reset link, shown only once there is
+ * something to undo. Resetting leaves the menu open — the pins above visibly move
+ * back, which is the confirmation — and the link then removes itself, there being
+ * nothing left to reset.
  */
 export const ToolbarOverflow = ({ actions, pinning }: IToolbarOverflowProps) => {
   const { t } = useTranslation();
@@ -61,7 +71,28 @@ export const ToolbarOverflow = ({ actions, pinning }: IToolbarOverflowProps) => 
       />
 
       <PopoverPanel className="nxm-popover-panel-dropdown">
-        {({ close }) => <PopoverMenu actions={[rows]} label={label} onSelect={close} />}
+        {({ close }) => (
+          <>
+            <PopoverMenu actions={[rows]} label={label} onSelect={close} />
+
+            {!!pinning?.canReset && (
+              <>
+                <DropdownDivider />
+
+                <PopoverPanelGroupItem className="h-auto justify-end py-3">
+                  <TypographyLink
+                    brand="info"
+                    typographyType="body-sm"
+                    variant="secondary"
+                    onClick={pinning.reset}
+                  >
+                    {t("Reset pins to default")}
+                  </TypographyLink>
+                </PopoverPanelGroupItem>
+              </>
+            )}
+          </>
+        )}
       </PopoverPanel>
     </Popover>
   );

--- a/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.tsx
+++ b/src/renderer/src/ui/components/toolbar/ToolbarPanelButton.tsx
@@ -53,7 +53,12 @@ const focusPanel = (element: HTMLElement | null) => {
  * settings by default, or a menu, which is styled as a dropdown and left to focus
  * its own first row.
  */
-export const ToolbarPanelButton = ({ panel, panelRole, ...props }: IToolbarPanelButtonProps) => {
+export const ToolbarPanelButton = ({
+  panel,
+  panelRole,
+  onClick,
+  ...props
+}: IToolbarPanelButtonProps) => {
   const isMenu = panelRole === "menu";
 
   return (
@@ -66,6 +71,7 @@ export const ToolbarPanelButton = ({ panel, panelRole, ...props }: IToolbarPanel
             aria-haspopup={panelRole ?? "dialog"}
             as={PopoverButton}
             tooltipDisabled={open}
+            onClick={open ? undefined : onClick}
           />
 
           <PopoverPanel

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The shape of `toolbar_action_clicked` as it reaches the generic Mixpanel funnel. The event
+ * carries no game, version or user scope of its own — those are super properties
+ * registered elsewhere — so what is asserted here is the whole of what a toolbar
+ * contributes.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
+
+import type { IToolbarActionIdentity, ToolbarSurface } from "./Toolbar.context";
+
+const { emit } = vi.hoisted(() => ({ emit: vi.fn() }));
+
+vi.mock("@/contexts", () => ({ useMainContext: () => ({ api: { events: { emit } } }) }));
+
+import { useToolbarAnalytics } from "./useToolbarAnalytics.hook";
+
+/** Reports one use of the mods toolbar, and hands back what that put on the wire. */
+const report = (action: IToolbarActionIdentity, surface: ToolbarSurface): MixpanelEvent => {
+  const { result } = renderHook(() => useToolbarAnalytics("mods"));
+  result.current(action, surface);
+
+  const [name, event] = emit.mock.calls.at(-1) ?? [];
+  expect(name).toBe("analytics-track-mixpanel-event");
+
+  return event as MixpanelEvent;
+};
+
+beforeEach(() => {
+  emit.mockClear();
+});
+
+describe("useToolbarAnalytics", () => {
+  it("reports the action, its toolbar and where it was reached from", () => {
+    const event = report({ id: "deploy-mods" }, "bar");
+
+    expect(event.eventName).toBe("toolbar_action_clicked");
+    expect(event.properties).toEqual({ action: "deploy-mods", surface: "bar", toolbar: "mods" });
+  });
+
+  it("names the extension an action came from", () => {
+    const event = report({ id: "Manage Rules", extension: "mod-dependency-manager" }, "menu");
+
+    expect(event.properties.extension).toBe("mod-dependency-manager");
+  });
+
+  // Absent rather than empty, so that the property's presence is itself the answer to
+  // "did this button come from an extension?" without having to filter out blanks.
+  it("leaves the extension out entirely for a page's own action", () => {
+    const event = report({ id: "deploy-mods" }, "bar");
+
+    expect(Object.keys(event.properties)).not.toContain("extension");
+  });
+});

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
@@ -17,15 +17,28 @@ vi.mock("@/contexts", () => ({ useMainContext: () => ({ api: { events: { emit } 
 
 import { useToolbarAnalytics } from "./useToolbarAnalytics.hook";
 
-/** Reports one use of the mods toolbar, and hands back what that put on the wire. */
-const report = (action: IToolbarActionIdentity, surface: ToolbarSurface): MixpanelEvent => {
-  const { result } = renderHook(() => useToolbarAnalytics("mods"));
-  result.current(action, surface);
-
+/** What the last call put on the wire, having checked it went to the generic funnel. */
+const lastEvent = (): MixpanelEvent => {
   const [name, event] = emit.mock.calls.at(-1) ?? [];
   expect(name).toBe("analytics-track-mixpanel-event");
 
   return event as MixpanelEvent;
+};
+
+/** Reports one click on the mods toolbar. */
+const report = (action: IToolbarActionIdentity, surface: ToolbarSurface): MixpanelEvent => {
+  const { result } = renderHook(() => useToolbarAnalytics("mods"));
+  result.current.onActionClick(action, surface);
+
+  return lastEvent();
+};
+
+/** Reports one pin or unpin on the mods toolbar. */
+const reportPin = (action: IToolbarActionIdentity, pinned: boolean): MixpanelEvent => {
+  const { result } = renderHook(() => useToolbarAnalytics("mods"));
+  result.current.onPinChange(action, pinned);
+
+  return lastEvent();
 };
 
 beforeEach(() => {
@@ -52,5 +65,31 @@ describe("useToolbarAnalytics", () => {
     const event = report({ id: "deploy-mods" }, "bar");
 
     expect(Object.keys(event.properties)).not.toContain("extension");
+  });
+});
+
+describe("useToolbarAnalytics pin tracking", () => {
+  it.each([true, false])("reports the state a pin was moved to (pinned=%s)", (pinned) => {
+    const event = reportPin({ id: "deploy" }, pinned);
+
+    expect(event.eventName).toBe("toolbar_pin_changed");
+    expect(event.properties).toEqual({ action: "deploy", pinned, toolbar: "mods" });
+  });
+
+  it("names the extension a pinned action came from", () => {
+    const event = reportPin({ id: "Manage Rules", extension: "mod-dependency-manager" }, true);
+
+    expect(event.properties.extension).toBe("mod-dependency-manager");
+  });
+
+  // No action, because a reset is about the whole toolbar rather than one button.
+  it("reports a reset against the toolbar alone", () => {
+    const { result } = renderHook(() => useToolbarAnalytics("mods"));
+    result.current.onPinsReset();
+
+    const event = lastEvent();
+
+    expect(event.eventName).toBe("toolbar_pins_reset");
+    expect(event.properties).toEqual({ toolbar: "mods" });
   });
 });

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
@@ -1,54 +1,94 @@
-import { useCallback } from "react";
+import { useMemo } from "react";
 
 import { useMainContext } from "@/contexts";
 import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
 
-import type { IToolbarActionIdentity, IToolbarContext, ToolbarSurface } from "./Toolbar.context";
+import type { IToolbarActionIdentity, IToolbarAnalytics, ToolbarSurface } from "./Toolbar.context";
 
-/**
- * Says that an action on a page toolbar was clicked, so that a toolbar being redesigned can
- * be cut down on evidence rather than on guesswork — which buttons are clicked, how often,
- * and whether people reach them on the bar or dig them out of the overflow menu.
- *
- * Carries no game, version or user scope of its own: those are Mixpanel super properties
- * registered once at startup and kept current on game switch, so every event has them.
- */
-const toolbarActionClickedEvent = (
-  { extension, id }: IToolbarActionIdentity,
-  surface: ToolbarSurface,
-  toolbar: string,
-): MixpanelEvent => ({
-  eventName: "toolbar_action_clicked",
-  properties: {
-    action: id,
-    surface,
-    toolbar,
-    ...(extension === undefined ? {} : { extension }),
-  },
+/** What every toolbar event about a single button says: which one, on which toolbar. */
+interface IToolbarActionEvent {
+  action: IToolbarActionIdentity;
+  toolbar: string;
+}
+
+const actionProperties = ({ action: { extension, id }, toolbar }: IToolbarActionEvent) => ({
+  action: id,
+  toolbar,
+  // Left out entirely rather than sent empty, so the property's presence is itself
+  // the answer to "did this come from an extension?"
+  ...(extension === undefined ? {} : { extension }),
 });
 
 /**
- * Usage tracking for one page's toolbar, as the callback {@link Toolbar} takes.
- *
- * Opting a toolbar in is the single line that passes the result to it — a toolbar without
- * it reports nothing, which is every toolbar but the mods page's for now. That is also
- * what keeps the components themselves free of analytics: they are handed a callback and
- * forward identity through it, and this is the only part that knows where it goes.
- *
- * @param toolbar Names the toolbar in the event, e.g. `"mods"`.
+ * Says that an action on a page toolbar was clicked, so that a toolbar being redesigned
+ * can be cut down on evidence rather than on guesswork — which buttons are clicked, how
+ * often, and whether people reach them on the bar or through the kebab.
  */
-export const useToolbarAnalytics = (
-  toolbar: string,
-): NonNullable<IToolbarContext["onActionClick"]> => {
+const toolbarActionClickedEvent = ({
+  surface,
+  ...event
+}: IToolbarActionEvent & { surface: ToolbarSurface }): MixpanelEvent => ({
+  eventName: "toolbar_action_clicked",
+  properties: { ...actionProperties(event), surface },
+});
+
+/**
+ * Says that the user pinned or unpinned an action. Together with the click events this
+ * is what the toolbar redesign is asking about: which buttons people want in front of
+ * them, as opposed to which they merely end up pressing.
+ */
+const toolbarPinChangedEvent = ({
+  pinned,
+  ...event
+}: IToolbarActionEvent & { pinned: boolean }): MixpanelEvent => ({
+  eventName: "toolbar_pin_changed",
+  properties: { ...actionProperties(event), pinned },
+});
+
+/**
+ * Says that the user gave up on their own arrangement and took the toolbar back to
+ * its defaults — which says something about the defaults that the individual pins
+ * do not.
+ */
+const toolbarPinsResetEvent = ({ toolbar }: { toolbar: string }): MixpanelEvent => ({
+  eventName: "toolbar_pins_reset",
+  properties: { toolbar },
+});
+
+/**
+ * Usage tracking for one page's toolbar, as the callbacks {@link Toolbar} takes.
+ *
+ * Opting a toolbar in is the single line that hands the result to it — a toolbar without
+ * it reports nothing, which is every toolbar but the mods page's for now. That is also
+ * what keeps the components themselves free of analytics: they are handed callbacks and
+ * forward identity through them, and this is the only part that knows where it goes.
+ *
+ * None of the events carry game, version or user scope of their own: those are Mixpanel
+ * super properties registered once at startup and kept current on game switch.
+ *
+ * @param toolbar Names the toolbar in every event, e.g. `"mods"`.
+ */
+export const useToolbarAnalytics = (toolbar: string): IToolbarAnalytics => {
   const { api } = useMainContext();
 
-  return useCallback(
-    (action: IToolbarActionIdentity, surface: ToolbarSurface) => {
-      api.events.emit(
-        "analytics-track-mixpanel-event",
-        toolbarActionClickedEvent(action, surface, toolbar),
-      );
-    },
+  return useMemo(
+    () => ({
+      onActionClick: (action: IToolbarActionIdentity, surface: ToolbarSurface) => {
+        api.events.emit(
+          "analytics-track-mixpanel-event",
+          toolbarActionClickedEvent({ action, surface, toolbar }),
+        );
+      },
+      onPinChange: (action: IToolbarActionIdentity, pinned: boolean) => {
+        api.events.emit(
+          "analytics-track-mixpanel-event",
+          toolbarPinChangedEvent({ action, pinned, toolbar }),
+        );
+      },
+      onPinsReset: () => {
+        api.events.emit("analytics-track-mixpanel-event", toolbarPinsResetEvent({ toolbar }));
+      },
+    }),
     [api, toolbar],
   );
 };

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+
+import { useMainContext } from "@/contexts";
+import type { MixpanelEvent } from "@/extensions/analytics/mixpanel/MixpanelEvents";
+
+import type { IToolbarActionIdentity, IToolbarContext, ToolbarSurface } from "./Toolbar.context";
+
+/**
+ * Says that an action on a page toolbar was clicked, so that a toolbar being redesigned can
+ * be cut down on evidence rather than on guesswork — which buttons are clicked, how often,
+ * and whether people reach them on the bar or dig them out of the overflow menu.
+ *
+ * Carries no game, version or user scope of its own: those are Mixpanel super properties
+ * registered once at startup and kept current on game switch, so every event has them.
+ */
+const toolbarActionClickedEvent = (
+  { extension, id }: IToolbarActionIdentity,
+  surface: ToolbarSurface,
+  toolbar: string,
+): MixpanelEvent => ({
+  eventName: "toolbar_action_clicked",
+  properties: {
+    action: id,
+    surface,
+    toolbar,
+    ...(extension === undefined ? {} : { extension }),
+  },
+});
+
+/**
+ * Usage tracking for one page's toolbar, as the callback {@link Toolbar} takes.
+ *
+ * Opting a toolbar in is the single line that passes the result to it — a toolbar without
+ * it reports nothing, which is every toolbar but the mods page's for now. That is also
+ * what keeps the components themselves free of analytics: they are handed a callback and
+ * forward identity through it, and this is the only part that knows where it goes.
+ *
+ * @param toolbar Names the toolbar in the event, e.g. `"mods"`.
+ */
+export const useToolbarAnalytics = (
+  toolbar: string,
+): NonNullable<IToolbarContext["onActionClick"]> => {
+  const { api } = useMainContext();
+
+  return useCallback(
+    (action: IToolbarActionIdentity, surface: ToolbarSurface) => {
+      api.events.emit(
+        "analytics-track-mixpanel-event",
+        toolbarActionClickedEvent(action, surface, toolbar),
+      );
+    },
+    [api, toolbar],
+  );
+};

--- a/src/renderer/src/ui/components/toolbar/useToolbarPinning.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarPinning.hook.ts
@@ -5,7 +5,7 @@ import { resetPinnedActions, setActionPinned } from "@/actions/toolbars";
 import { log } from "@/logging";
 import type { IState } from "@/types/IState";
 
-import { useToolbarContext } from "./Toolbar.context";
+import { identityOf, useToolbarContext } from "./Toolbar.context";
 import type { IToolbarAction } from "./ToolbarGroup";
 
 const NO_DECISIONS: { [actionId: string]: boolean } = {};
@@ -32,7 +32,7 @@ export interface IToolbarPinning {
  * treated as pinned so that a toolbar offering pinning never silently drops it.
  */
 export const useToolbarPinning = (actions: IToolbarAction[]): IToolbarPinning => {
-  const { pinningId } = useToolbarContext();
+  const { pinningId, tracking } = useToolbarContext();
   const dispatch = useDispatch();
 
   const decisions = useSelector(
@@ -64,16 +64,26 @@ export const useToolbarPinning = (actions: IToolbarAction[]): IToolbarPinning =>
         return;
       }
 
-      dispatch(setActionPinned(pinningId, action.id, !isPinned(action)));
+      const pinned = !isPinned(action);
+      dispatch(setActionPinned({ toolbarId: pinningId, actionId: action.id, pinned }));
+
+      // Reported from here rather than from the menu row, so that every route to a
+      // pin change is counted and none has to remember to say so.
+      const identity = identityOf(action);
+
+      if (identity !== undefined) {
+        tracking?.onPinChange(identity, pinned);
+      }
     },
-    [dispatch, isPinned, pinningId],
+    [dispatch, isPinned, pinningId, tracking],
   );
 
   const reset = useCallback(() => {
     if (pinningId !== null) {
-      dispatch(resetPinnedActions(pinningId));
+      dispatch(resetPinnedActions({ toolbarId: pinningId }));
+      tracking?.onPinsReset();
     }
-  }, [dispatch, pinningId]);
+  }, [dispatch, pinningId, tracking]);
 
   const pinnedActions = useMemo(
     () => (pinningId === null ? actions : actions.filter((action) => isPinned(action))),


### PR DESCRIPTION
Stacked on #23941 — **base is `laz-915`, so merge that one first.** The diff here is only the three commits on top.

Closes [LAZ-666](https://linear.app/nexus-mods/issue/LAZ-666/add-tracking-for-toolbar-buttons) and [LAZ-953](https://linear.app/nexus-mods/issue/LAZ-953/track-toolbar-usage-and-pinning).

## What this adds

Three Mixpanel events, so the toolbar redesign can decide which buttons earn their place on evidence rather than guesswork:

| event | properties |
|---|---|
| `toolbar_action_clicked` | `toolbar`, `action`, `extension`, `surface` |
| `toolbar_pin_changed` | `toolbar`, `action`, `extension`, `pinned` |
| `toolbar_pins_reset` | `toolbar` |

Plus the UI that makes the last one reachable: the overflow menu now ends in a **Reset pins to default** link, in the shape the display options panel already uses.

Nothing on that bar had ever been measured — the `analytics-track-click-event` calls dotted around the renderer are Google-Analytics-era leftovers with no listener anywhere.

<img width="402" height="635" alt="image" src="https://github.com/user-attachments/assets/e2b91fea-23a1-46db-b558-f9d9d1ac0271" />


## Worth knowing when reading it

**Identity is `action.id`.** The pinning work already requires an id that survives a change of language or release, because a pin decision is stored against it. That is exactly the tracking contract, so the two share one `identityOf` rather than each deriving their own. A label is never used: it is translated, and an id derived from one splits a button across as many ids as there are languages.

**`surface` says how a button was reached, not whether it fit.** With pinning on, the kebab holds the *full* list rather than the leftovers, so `overflow` means the user went through the menu — and a pinned button on the bar can be clicked either way.

**Only the mods toolbar reports anything.** The capability lives in the shared `Toolbar` but is inert until a page passes `tracking`. The classic `IconBar` the mods page still renders in the legacy UI stays unmeasured, as LAZ-666 asks; there is a test pinning that down.

**Pins are counted in `useToolbarPinning`**, not in the menu row that offers the toggle, so any future pin affordance is counted without having to remember.
