### PR TITLE
Fix bullets and release grouping in the What's New dialog

### DIFF
--- a/src/main/src/extensions/autoupdater/releaseResolver.test.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.test.ts
@@ -174,6 +174,37 @@ describe("resolveUpdate fetching", () => {
     expect(resolved?.notesHtml).not.toContain("2.4.1");
   });
 
+  it("wraps each release's notes in its own section under a version heading", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(fixture)));
+
+    const notes = (await resolveUpdate("beta", "2.5.0-beta.1"))?.notesHtml ?? "";
+
+    // the What's New dialog groups by these; without them the bodies of every
+    // release the update spans run together as one blob
+    expect(notes).toContain(
+      '<h4 class="changelog-release-version">2.6.0-beta.1<span class="changelog-release-date">',
+    );
+    expect(notes).toContain(
+      '<div class="changelog-release-body"><p>2.6.0-beta.1: new collections workflow</p></div>',
+    );
+    // 2.5.0-beta.2, 2.5.0 and 2.6.0-beta.1 all fall in the range
+    expect(notes.match(/<section class="changelog-release">/g)).toHaveLength(3);
+    // newest first, and each body stays inside its own section
+    expect(notes.indexOf("2.6.0-beta.1")).toBeLessThan(notes.indexOf("2.5.0: stable rollup"));
+  });
+
+  it("omits the date for a release with no publish timestamp", async () => {
+    const undated = fixture.map((entry) =>
+      entry.tag_name === "v2.5.0" ? { ...entry, published_at: undefined } : entry,
+    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(undated)));
+
+    const notes = (await resolveUpdate("stable", "2.4.2"))?.notesHtml ?? "";
+
+    expect(notes).toContain('<h4 class="changelog-release-version">2.5.0</h4>');
+    expect(notes).not.toContain("changelog-release-date");
+  });
+
   it("serves the cached body on 304 and sends if-none-match", async () => {
     const fetchMock = vi
       .fn()

--- a/src/main/src/extensions/autoupdater/releaseResolver.ts
+++ b/src/main/src/extensions/autoupdater/releaseResolver.ts
@@ -294,6 +294,28 @@ async function fetchReleases(repo: string): Promise<GithubReleaseLite[]> {
   return releases;
 }
 
+// The What's New dialog shows the notes of every release the update spans, so
+// each body needs a version heading of its own; without one the bodies run
+// together and the reader can't tell which change came in which release. The
+// version is validated semver and the date is ours, so neither can inject
+// markup into the dialog's innerHTML.
+function releaseSection(version: string, body: string, publishedAt?: string): string {
+  const published =
+    publishedAt != null && !Number.isNaN(Date.parse(publishedAt))
+      ? `<span class="changelog-release-date">${formatReleaseDate(publishedAt)}</span>`
+      : "";
+  return [
+    `<section class="changelog-release">`,
+    `<h4 class="changelog-release-version">${version}${published}</h4>`,
+    `<div class="changelog-release-body">${body}</div>`,
+    `</section>`,
+  ].join("");
+}
+
+function formatReleaseDate(publishedAt: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "long" }).format(new Date(publishedAt));
+}
+
 /**
  * Resolve the update target for a channel. Returns null when no eligible
  * release exists. Network and rate-limit errors propagate, the caller logs
@@ -319,8 +341,11 @@ export async function resolveUpdate(
         current != null && semver.gt(version, current) && semver.lte(version, pickedVersion),
     )
     .sort((lhs, rhs) => semver.rcompare(lhs.version, rhs.version))
-    .map(({ release }) => release.body_html)
-    .filter((body): body is string => body != null && body.trim().length > 0);
+    .flatMap(({ release, version }) =>
+      release.body_html != null && release.body_html.trim().length > 0
+        ? [releaseSection(version, release.body_html, release.published_at)]
+        : [],
+    );
 
   return {
     tag: picked.tag_name,

--- a/src/stylesheets/vortex/dialogs.scss
+++ b/src/stylesheets/vortex/dialogs.scss
@@ -176,43 +176,98 @@
 
         .dialog-container {
             .dialog-content-html {
-                gap: 8px;
                 padding-right: 16px;
 
-                // need different sizes in case github releases markdown come in as h1's and h2's etc
-                // when really they should h4s, h5s for their level of importance and consistency
-
                 .changelog-dialog-release {
+                    // the release notes are real markup from the GitHub API, so
+                    // the pre-wrap that .dialog-content-html applies for plain
+                    // text would turn every newline between tags into a blank
+                    // line and every indent into leading spaces
+                    white-space: normal;
+                    display: flex;
+                    flex-direction: column;
                     gap: 12px;
 
-                    h1 {
-                        font-size: 1.3em;
+                    // one section per release, emitted by releaseResolver.ts;
+                    // the h4 is the version, everything below it is that
+                    // release's own notes
+                    .changelog-release {
+                        display: flex;
+                        flex-direction: column;
+                        gap: 8px;
+
+                        + .changelog-release {
+                            border-top: 1px solid $border-color;
+                            padding-top: 16px;
+                        }
                     }
 
-                    h2 {
-                        font-size: 1.2em;
-                    }
-
-                    h3 {
-                        font-size: 1.1em;
-                    }
-
-                    // these are going to be set in code as each release heading
-
-                    h4 {
+                    .changelog-release-version {
+                        display: flex;
+                        align-items: baseline;
+                        justify-content: space-between;
+                        gap: 8px;
                         font-size: 1.6em;
                         line-height: 1;
-                        margin: 10px 0 0 0;
+                        margin: 0;
                     }
 
-                    ul {
+                    .changelog-release-date {
+                        font-size: 0.55em;
+                        font-weight: normal;
+                        color: $text-color-disabled;
+                    }
+
+                    // block flow rather than a flex column: the body is
+                    // arbitrary markup from a release author, and as flex items
+                    // a small image would be stretched to the dialog width
+                    .changelog-release-body {
+                        > * + * {
+                            margin-top: 8px;
+                        }
+
+                        // release authors reach for h1 and h2 freely; clamp
+                        // every level so a release body can't outshout the
+                        // version heading above it
+                        h1,
+                        h2,
+                        h3,
+                        h4,
+                        h5,
+                        h6 {
+                            font-size: 1.15em;
+                            margin: 12px 0 0 0;
+                        }
+                    }
+
+                    ul,
+                    ol {
                         padding-inline-start: 32px;
-                        line-height: 1;
                         margin: 0;
 
                         li {
                             line-height: 1.5;
                         }
+                    }
+
+                    // tailwind's preflight resets list-style globally, which
+                    // leaves GitHub's plain <ul> bullets invisible
+                    ul {
+                        list-style: disc;
+                    }
+
+                    ul ul {
+                        list-style: circle;
+                    }
+
+                    ol {
+                        list-style: decimal;
+                    }
+
+                    // GitHub task lists ship their own checkbox
+                    ul.contains-task-list {
+                        list-style: none;
+                        padding-inline-start: 0;
                     }
 
                     p {


### PR DESCRIPTION
FINALLY FIXED THIS

Release notes had no bullets, blank lines where the markup had newlines, and nothing separating one release from the next. Tailwind's preflight resets `list-style` globally, and the container's `pre-wrap` was meant for plain text. The resolver now gives each release its own section with a version heading.

Before

<img width="627" height="762" alt="Screenshot 2026-09-01 230704" src="https://github.com/user-attachments/assets/930acddb-6034-45a2-8566-dbef287d6adb" />

After 

<img width="704" height="817" alt="image" src="https://github.com/user-attachments/assets/0100a40f-67a9-4711-97fc-d91b17d0125f" />
