### PR TITLE
Count which of a table's columns people keep (LAZ-894)

### DIFF
--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -31,6 +31,12 @@ import { getSafe, setSafe } from "../util/storeHelper";
 import { makeUnique, sanitizeCSSId, truthy } from "../util/util";
 import { ComponentEx, connect, extend, translate } from "./ComponentEx";
 import IconBar from "./IconBar";
+import {
+  columnsOf,
+  emitTableColumnsViewed,
+  emitTableColumnToggled,
+  isColumn,
+} from "./table/columnAnalytics";
 import GroupingRow, { EMPTY_ID } from "./table/GroupingRow";
 import HeaderCell from "./table/HeaderCell";
 import { Table, TBody, TD, TH, THead, TR } from "./table/MyTable";
@@ -140,6 +146,11 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   // this improves scroll smoothness at the expense of memory
   private static SCROLL_DEBOUNCE = 5000;
 
+  // How long the set of columns has to hold still before it's reported. Attributes come
+  // from extensions and can be gated on state, so what a table shows in its first frame
+  // isn't yet what the user is looking at.
+  private static COLUMN_REPORT_DEBOUNCE = 2000;
+
   private mVisibleAttributes: ITableAttribute[];
   private mVisibleDetails: ITableAttribute[];
   private mVisibleInlines: ITableAttribute[];
@@ -162,6 +173,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   private mVisibleHeaderRef: HTMLElement;
   private mHeaderUpdateDebouncer: Debouncer;
   private mUpdateCalculatedDebouncer: Debouncer;
+  private mColumnReportDebouncer: Debouncer;
   private mLastScroll: number;
   private mWillSetVisibility: boolean = false;
   private mMounted: boolean = false;
@@ -217,6 +229,15 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
       200,
       true,
     );
+
+    this.mColumnReportDebouncer = new Debouncer(
+      () => {
+        this.reportColumns();
+        return PromiseBB.resolve();
+      },
+      SuperTable.COLUMN_REPORT_DEBOUNCE,
+      true,
+    );
   }
 
   public componentDidMount() {
@@ -233,12 +254,14 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     });
     this.mMounted = true;
     window.addEventListener("resize", this.onResize);
+    this.mColumnReportDebouncer.schedule();
   }
 
   public componentWillUnmount() {
     this.context.api.events.removeAllListeners(this.props.tableId + "-scroll-to");
     window.removeEventListener("resize", this.onResize);
     this.mMounted = false;
+    this.mColumnReportDebouncer.clear();
   }
 
   public UNSAFE_componentWillReceiveProps(newProps: IProps) {
@@ -252,6 +275,10 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
       this.mVisibleAttributes = table;
       this.mVisibleDetails = detail;
       this.mVisibleInlines = inline;
+
+      // The columns just changed, so give them longer to hold still before reporting
+      // them. Once reported, this is a no-op for the rest of the session.
+      this.mColumnReportDebouncer.schedule();
 
       if (
         Object.keys(newProps.attributeState).find(
@@ -739,7 +766,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
           prev[attr.placement === "inline" ? "inlines" : visible ? "columns" : "disabled"].push({
             icon: attributeState.enabled ? "checkbox-checked" : "checkbox-unchecked",
             title: attr.name,
-            action: (arg) => this.setAttributeVisible(attr.id, !attributeState.enabled),
+            action: (arg) => this.setAttributeVisible(attr, !attributeState.enabled),
           });
         }
         return prev;
@@ -1620,9 +1647,35 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     }, []);
   }
 
-  private setAttributeVisible = (attributeId: string, visible: boolean) => {
+  /**
+   * Says which of this table's columns the user has in front of them, so the case for
+   * dropping one can be made from how many installs still show it. See
+   * {@link emitTableColumnsViewed} for why this happens once a session.
+   */
+  private reportColumns() {
+    const { columnBlacklist, objects, tableId } = this.props;
+
+    emitTableColumnsViewed(
+      this.context.api,
+      tableId,
+      columnsOf({
+        attributes: objects,
+        visible: this.mVisibleAttributes ?? [],
+        blacklist: columnBlacklist,
+      }),
+    );
+  }
+
+  private setAttributeVisible = (attribute: ITableAttribute, visible: boolean) => {
     const { onSetAttributeVisible, tableId } = this.props;
-    onSetAttributeVisible(tableId, attributeId, visible);
+
+    // The same menu toggles attributes that are never columns, and hiding one of those
+    // says nothing about the columns this is counting.
+    if (isColumn(attribute)) {
+      emitTableColumnToggled(this.context.api, tableId, attribute.id, visible);
+    }
+
+    onSetAttributeVisible(tableId, attribute.id, visible);
   };
 
   private getClasses(element: HTMLElement): string {

--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -17,6 +17,7 @@ import {
   setCollapsedGroups,
   setGroupingAttribute,
 } from "../actions/tables";
+import { activeGameId } from "../extensions/profile_management/selectors";
 import smoothScroll from "../smoothScroll";
 import type { IActionDefinition } from "../types/IActionDefinition";
 import type { IAttributeState } from "../types/IAttributeState";
@@ -1652,7 +1653,10 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   /**
    * Says which of this table's columns the user has in front of them, so the case for
    * dropping one can be made from how many installs still show it. See
-   * {@link emitTableColumnsViewed} for why this happens once a session.
+   * {@link emitTableColumnsViewed} for why this happens once a game a session.
+   *
+   * The game is read here rather than taken from props so it is the one in effect when
+   * the debounce fires, which is what the columns being reported were built from.
    */
   private reportColumns() {
     const { analyticsId, columnBlacklist, objects, tableId } = this.props;
@@ -1660,6 +1664,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
     emitTableColumnsViewed(
       this.context.api,
       analyticsId ?? tableId,
+      activeGameId(this.context.api.getState()),
       columnsOf({
         attributes: objects,
         visible: this.mVisibleAttributes ?? [],

--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -56,6 +56,8 @@ export interface ITableRowAction extends IActionDefinition {
 
 export interface IBaseProps {
   tableId: string;
+  /** This table's id in the analytics. Defaults to `tableId`; set where two tables share one. */
+  analyticsId?: string;
   data: { [rowId: string]: any };
   // cheap-ass way to force the table to refresh its data cache. This will only affect
   // 'volatile' fields as normal data fields would prompt a table refresh anyway
@@ -1653,11 +1655,11 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
    * {@link emitTableColumnsViewed} for why this happens once a session.
    */
   private reportColumns() {
-    const { columnBlacklist, objects, tableId } = this.props;
+    const { analyticsId, columnBlacklist, objects, tableId } = this.props;
 
     emitTableColumnsViewed(
       this.context.api,
-      tableId,
+      analyticsId ?? tableId,
       columnsOf({
         attributes: objects,
         visible: this.mVisibleAttributes ?? [],
@@ -1667,14 +1669,15 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   }
 
   private setAttributeVisible = (attribute: ITableAttribute, visible: boolean) => {
-    const { onSetAttributeVisible, tableId } = this.props;
+    const { analyticsId, onSetAttributeVisible, tableId } = this.props;
 
     // The same menu toggles attributes that are never columns, and hiding one of those
     // says nothing about the columns this is counting.
     if (isColumn(attribute)) {
-      emitTableColumnToggled(this.context.api, tableId, attribute.id, visible);
+      emitTableColumnToggled(this.context.api, analyticsId ?? tableId, attribute.id, visible);
     }
 
+    // The layout is stored against `tableId`, so that stays whatever the numbers call it.
     onSetAttributeVisible(tableId, attribute.id, visible);
   };
 

--- a/src/renderer/src/controls/Table.tsx
+++ b/src/renderer/src/controls/Table.tsx
@@ -17,6 +17,7 @@ import {
   setCollapsedGroups,
   setGroupingAttribute,
 } from "../actions/tables";
+import { numericNexusGameId } from "../extensions/analytics/mixpanel/numericGameId";
 import { activeGameId } from "../extensions/profile_management/selectors";
 import smoothScroll from "../smoothScroll";
 import type { IActionDefinition } from "../types/IActionDefinition";
@@ -36,6 +37,7 @@ import {
   columnsOf,
   emitTableColumnsViewed,
   emitTableColumnToggled,
+  gameIdPending,
   isColumn,
 } from "./table/columnAnalytics";
 import GroupingRow, { EMPTY_ID } from "./table/GroupingRow";
@@ -154,6 +156,10 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   // isn't yet what the user is looking at.
   private static COLUMN_REPORT_DEBOUNCE = 2000;
 
+  // How many of those to wait through for the games list before reporting with no game
+  // rather than the wrong one. A cold start has been seen to take 21.6s.
+  private static COLUMN_REPORT_MAX_WAITS = 12;
+
   private mVisibleAttributes: ITableAttribute[];
   private mVisibleDetails: ITableAttribute[];
   private mVisibleInlines: ITableAttribute[];
@@ -177,6 +183,7 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   private mHeaderUpdateDebouncer: Debouncer;
   private mUpdateCalculatedDebouncer: Debouncer;
   private mColumnReportDebouncer: Debouncer;
+  private mColumnReportWaits: number = 0;
   private mLastScroll: number;
   private mWillSetVisibility: boolean = false;
   private mMounted: boolean = false;
@@ -1661,10 +1668,25 @@ class SuperTable extends ComponentEx<IProps, IComponentState> {
   private reportColumns() {
     const { analyticsId, columnBlacklist, objects, tableId } = this.props;
 
+    const activeGame = activeGameId(this.context.api.getState());
+    const game = activeGame === undefined ? null : numericNexusGameId(activeGame);
+
+    // Giving up reports under no game rather than staying silent: a row with no game can
+    // be filtered out, silence can't be seen. That also leaves the real game's slot
+    // unspent, so the table reports properly if its columns change once the list lands.
+    if (
+      gameIdPending(activeGame, game) &&
+      this.mColumnReportWaits < SuperTable.COLUMN_REPORT_MAX_WAITS
+    ) {
+      this.mColumnReportWaits += 1;
+      this.mColumnReportDebouncer.schedule();
+      return;
+    }
+
     emitTableColumnsViewed(
       this.context.api,
       analyticsId ?? tableId,
-      activeGameId(this.context.api.getState()),
+      game,
       columnsOf({
         attributes: objects,
         visible: this.mVisibleAttributes ?? [],

--- a/src/renderer/src/controls/table/columnAnalytics.test.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the table column analytics: what the snapshot counts as hidden as opposed to
+ * never offered, that it reports a table once per session, and that a toggle reports the
+ * state it moved to.
+ */
+import { EventEmitter } from "events";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { MixpanelEvent } from "../../extensions/analytics/mixpanel/MixpanelEvents";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import type { ITableAttribute, Placement } from "../../types/ITableAttribute";
+import {
+  columnsOf,
+  emitTableColumnsViewed,
+  emitTableColumnToggled,
+  isColumn,
+  resetReportedColumns,
+} from "./columnAnalytics";
+
+function harness() {
+  const emitter = new EventEmitter();
+  const events: MixpanelEvent[] = [];
+  emitter.on("analytics-track-mixpanel-event", (event: MixpanelEvent) => events.push(event));
+  return { api: { events: emitter } as unknown as IExtensionApi, events };
+}
+
+const attribute = (
+  id: string,
+  overrides: {
+    placement?: Placement;
+    isToggleable?: boolean;
+    condition?: () => boolean;
+  } = {},
+): ITableAttribute =>
+  ({
+    id,
+    name: id,
+    placement: "table",
+    isToggleable: true,
+    edit: {},
+    ...overrides,
+  }) as ITableAttribute;
+
+describe("table column analytics", () => {
+  beforeEach(() => {
+    resetReportedColumns();
+  });
+
+  describe("columnsOf", () => {
+    it("reports the visible columns in the order the table draws them", () => {
+      const name = attribute("name");
+      const version = attribute("version");
+
+      expect(
+        columnsOf({ attributes: [version, name], visible: [name, version] }).visible,
+      ).toStrictEqual(["name", "version"]);
+    });
+
+    it("counts a toggleable column that isn't showing as hidden", () => {
+      const name = attribute("name");
+      const author = attribute("author");
+
+      expect(columnsOf({ attributes: [name, author], visible: [name] }).hidden).toStrictEqual([
+        "author",
+      ]);
+    });
+
+    it("leaves out what the table never offered, so it doesn't read as switched off", () => {
+      const name = attribute("name");
+      const fixed = attribute("fixed", { isToggleable: false });
+      const unavailable = attribute("unavailable", { condition: () => false });
+      const detail = attribute("notes", { placement: "detail" });
+      const inline = attribute("flag", { placement: "inline" });
+
+      const { hidden } = columnsOf({
+        attributes: [name, fixed, unavailable, detail, inline],
+        visible: [name],
+      });
+
+      expect(hidden).toStrictEqual([]);
+    });
+
+    it("leaves out a blacklisted column, which the page took away rather than the user", () => {
+      const name = attribute("name");
+      const blacklisted = attribute("game");
+
+      const { hidden } = columnsOf({
+        attributes: [name, blacklisted],
+        visible: [name],
+        blacklist: ["game"],
+      });
+
+      expect(hidden).toStrictEqual([]);
+    });
+  });
+
+  describe("isColumn", () => {
+    it("counts attributes that can appear as a column, and nothing else", () => {
+      expect(isColumn(attribute("name"))).toBe(true);
+      expect(isColumn(attribute("name", { placement: "both" }))).toBe(true);
+      expect(isColumn(attribute("notes", { placement: "detail" }))).toBe(false);
+      expect(isColumn(attribute("flag", { placement: "inline" }))).toBe(false);
+    });
+  });
+
+  describe("emitTableColumnsViewed", () => {
+    it("says which columns are on show, which are off, and how many there are", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", { visible: ["name", "version"], hidden: ["author"] });
+
+      expect(h.events).toHaveLength(1);
+      expect(h.events[0].eventName).toBe("table_columns_viewed");
+      expect(h.events[0].properties).toStrictEqual({
+        table: "mods",
+        columns: ["name", "version"],
+        hidden_columns: ["author"],
+        column_count: 2,
+      });
+    });
+
+    it("reports a table once a session, however often the page is opened", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", { visible: ["name", "version"], hidden: [] });
+
+      expect(h.events).toHaveLength(1);
+    });
+
+    it("reports each table separately", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "downloads", { visible: ["filename"], hidden: [] });
+
+      expect(h.events.map((event) => event.properties.table)).toStrictEqual(["mods", "downloads"]);
+    });
+
+    it("says nothing about a table with no columns yet, and reports it once it has some", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", { visible: [], hidden: [] });
+      expect(h.events).toHaveLength(0);
+
+      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
+      expect(h.events).toHaveLength(1);
+    });
+  });
+
+  describe("emitTableColumnToggled", () => {
+    it("reports the state the column moved to", () => {
+      const h = harness();
+
+      emitTableColumnToggled(h.api, "mods", "author", false);
+
+      expect(h.events).toHaveLength(1);
+      expect(h.events[0].eventName).toBe("table_column_toggled");
+      expect(h.events[0].properties).toStrictEqual({
+        table: "mods",
+        column: "author",
+        visible: false,
+      });
+    });
+
+    it("reports every toggle, so a column switched on and off again says so twice", () => {
+      const h = harness();
+
+      emitTableColumnToggled(h.api, "mods", "author", true);
+      emitTableColumnToggled(h.api, "mods", "author", false);
+
+      expect(h.events.map((event) => event.properties.visible)).toStrictEqual([true, false]);
+    });
+  });
+});

--- a/src/renderer/src/controls/table/columnAnalytics.test.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.test.ts
@@ -25,6 +25,9 @@ function harness() {
   return { api: { events: emitter } as unknown as IExtensionApi, events };
 }
 
+/** The active game the plain cases report under; the per-game cases name their own. */
+const GAME = "skyrimse";
+
 const attribute = (
   id: string,
   overrides: {
@@ -108,7 +111,10 @@ describe("table column analytics", () => {
     it("says which columns are on show, which are off, and how many there are", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", { visible: ["name", "version"], hidden: ["author"] });
+      emitTableColumnsViewed(h.api, "mods", GAME, {
+        visible: ["name", "version"],
+        hidden: ["author"],
+      });
 
       expect(h.events).toHaveLength(1);
       expect(h.events[0].eventName).toBe("app_table_columns_viewed");
@@ -123,8 +129,8 @@ describe("table column analytics", () => {
     it("reports a table once a session, however often the page is opened", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
-      emitTableColumnsViewed(h.api, "mods", { visible: ["name", "version"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name", "version"], hidden: [] });
 
       expect(h.events).toHaveLength(1);
     });
@@ -132,8 +138,8 @@ describe("table column analytics", () => {
     it("reports each table separately", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
-      emitTableColumnsViewed(h.api, "downloads", { visible: ["filename"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "downloads", GAME, { visible: ["filename"], hidden: [] });
 
       expect(h.events.map((event) => event.properties.table)).toStrictEqual(["mods", "downloads"]);
     });
@@ -145,11 +151,11 @@ describe("table column analytics", () => {
     it("gates on the id it is handed, so tables sharing a layout id each report", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "collection-mods-edit", {
+      emitTableColumnsViewed(h.api, "collection-mods-edit", GAME, {
         visible: ["name", "phase"],
         hidden: ["category"],
       });
-      emitTableColumnsViewed(h.api, "collection-mods-view", {
+      emitTableColumnsViewed(h.api, "collection-mods-view", GAME, {
         visible: ["name", "uploader"],
         hidden: [],
       });
@@ -164,13 +170,47 @@ describe("table column analytics", () => {
       ]);
     });
 
+    // Game extensions contribute columns, and those are the ones that differ from one game
+    // to the next. Keyed on the table alone, a user who switched game mid-session reported
+    // nothing the second time and their only snapshot was stamped with the first game.
+    it("reports a table again for a game it hasn't been reported for", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name", "esp"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", "stardewvalley", { visible: ["name"], hidden: [] });
+
+      expect(h.events.map((event) => event.properties.visible_columns)).toStrictEqual([
+        ["name", "esp"],
+        ["name"],
+      ]);
+    });
+
+    it("still reports a table once for a game it has been reported for", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", "stardewvalley", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name", "esp"], hidden: [] });
+
+      expect(h.events).toHaveLength(2);
+    });
+
+    it("counts no active game as a game of its own", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "extensions", undefined, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "extensions", undefined, { visible: ["name"], hidden: [] });
+
+      expect(h.events).toHaveLength(1);
+    });
+
     it("says nothing about a table with no columns yet, and reports it once it has some", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", { visible: [], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: [], hidden: [] });
       expect(h.events).toHaveLength(0);
 
-      emitTableColumnsViewed(h.api, "mods", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name"], hidden: [] });
       expect(h.events).toHaveLength(1);
     });
   });

--- a/src/renderer/src/controls/table/columnAnalytics.test.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.test.ts
@@ -114,9 +114,9 @@ describe("table column analytics", () => {
       expect(h.events[0].eventName).toBe("app_table_columns_viewed");
       expect(h.events[0].properties).toStrictEqual({
         table: "mods",
-        columns: ["name", "version"],
+        visible_columns: ["name", "version"],
         hidden_columns: ["author"],
-        column_count: 2,
+        visible_column_count: 2,
       });
     });
 
@@ -136,6 +136,32 @@ describe("table column analytics", () => {
       emitTableColumnsViewed(h.api, "downloads", { visible: ["filename"], hidden: [] });
 
       expect(h.events.map((event) => event.properties.table)).toStrictEqual(["mods", "downloads"]);
+    });
+
+    // Two tables can share the `tableId` their layout is stored against — authoring a
+    // collection and viewing one are both `collection-mods` — so the gate keys on the id
+    // it is handed, not on the table. Handing it one id for two different sets of columns
+    // is what would report whichever came first and silently drop the other.
+    it("gates on the id it is handed, so tables sharing a layout id each report", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "collection-mods-edit", {
+        visible: ["name", "phase"],
+        hidden: ["category"],
+      });
+      emitTableColumnsViewed(h.api, "collection-mods-view", {
+        visible: ["name", "uploader"],
+        hidden: [],
+      });
+
+      expect(h.events.map((event) => event.properties.table)).toStrictEqual([
+        "collection-mods-edit",
+        "collection-mods-view",
+      ]);
+      expect(h.events.map((event) => event.properties.visible_columns)).toStrictEqual([
+        ["name", "phase"],
+        ["name", "uploader"],
+      ]);
     });
 
     it("says nothing about a table with no columns yet, and reports it once it has some", () => {

--- a/src/renderer/src/controls/table/columnAnalytics.test.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.test.ts
@@ -111,7 +111,7 @@ describe("table column analytics", () => {
       emitTableColumnsViewed(h.api, "mods", { visible: ["name", "version"], hidden: ["author"] });
 
       expect(h.events).toHaveLength(1);
-      expect(h.events[0].eventName).toBe("table_columns_viewed");
+      expect(h.events[0].eventName).toBe("app_table_columns_viewed");
       expect(h.events[0].properties).toStrictEqual({
         table: "mods",
         columns: ["name", "version"],
@@ -156,7 +156,7 @@ describe("table column analytics", () => {
       emitTableColumnToggled(h.api, "mods", "author", false);
 
       expect(h.events).toHaveLength(1);
-      expect(h.events[0].eventName).toBe("table_column_toggled");
+      expect(h.events[0].eventName).toBe("app_table_column_toggled");
       expect(h.events[0].properties).toStrictEqual({
         table: "mods",
         column: "author",

--- a/src/renderer/src/controls/table/columnAnalytics.test.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.test.ts
@@ -14,6 +14,7 @@ import {
   columnsOf,
   emitTableColumnsViewed,
   emitTableColumnToggled,
+  gameIdPending,
   isColumn,
   resetReportedColumns,
 } from "./columnAnalytics";
@@ -25,8 +26,13 @@ function harness() {
   return { api: { events: emitter } as unknown as IExtensionApi, events };
 }
 
-/** The active game the plain cases report under; the per-game cases name their own. */
-const GAME = "skyrimse";
+/**
+ * The active game the plain cases report under; the per-game cases name their own. The
+ * numeric Nexus id, because that is what the event is stamped with. Skyrim SE here, and
+ * Stardew Valley below.
+ */
+const GAME = 1704;
+const OTHER_GAME = 1303;
 
 const attribute = (
   id: string,
@@ -107,6 +113,24 @@ describe("table column analytics", () => {
     });
   });
 
+  describe("gameIdPending", () => {
+    // The internal id is in state from the first frame, the numeric one comes from the
+    // games list. Reporting in between would label the snapshot with whatever the
+    // previous session left registered and spend the game's only report on it.
+    it("holds while an active game has no numeric id yet", () => {
+      expect(gameIdPending("skyrimse", null)).toBe(true);
+    });
+
+    it("doesn't hold once the numeric id has arrived", () => {
+      expect(gameIdPending("skyrimse", GAME)).toBe(false);
+    });
+
+    // Not the same case: nothing is coming, so there is nothing to wait for.
+    it("doesn't hold when there is no active game at all", () => {
+      expect(gameIdPending(undefined, null)).toBe(false);
+    });
+  });
+
   describe("emitTableColumnsViewed", () => {
     it("says which columns are on show, which are off, and how many there are", () => {
       const h = harness();
@@ -176,8 +200,8 @@ describe("table column analytics", () => {
     it("reports a table again for a game it hasn't been reported for", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name", "esp"], hidden: [] });
-      emitTableColumnsViewed(h.api, "mods", "stardewvalley", { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name", "esp"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", OTHER_GAME, { visible: ["name"], hidden: [] });
 
       expect(h.events.map((event) => event.properties.visible_columns)).toStrictEqual([
         ["name", "esp"],
@@ -188,9 +212,9 @@ describe("table column analytics", () => {
     it("still reports a table once for a game it has been reported for", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name"], hidden: [] });
-      emitTableColumnsViewed(h.api, "mods", "stardewvalley", { visible: ["name"], hidden: [] });
-      emitTableColumnsViewed(h.api, "mods", "skyrimse", { visible: ["name", "esp"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", OTHER_GAME, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name", "esp"], hidden: [] });
 
       expect(h.events).toHaveLength(2);
     });
@@ -198,10 +222,25 @@ describe("table column analytics", () => {
     it("counts no active game as a game of its own", () => {
       const h = harness();
 
-      emitTableColumnsViewed(h.api, "extensions", undefined, { visible: ["name"], hidden: [] });
-      emitTableColumnsViewed(h.api, "extensions", undefined, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "extensions", null, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "extensions", null, { visible: ["name"], hidden: [] });
 
       expect(h.events).toHaveLength(1);
+    });
+
+    // The caller reports without a game rather than staying silent when the games list
+    // never arrives. That must not cost the game its own report, or an install that
+    // started up slowly would be counted as having no game for the rest of the session.
+    it("leaves a game's own report unspent after one made without a game", () => {
+      const h = harness();
+
+      emitTableColumnsViewed(h.api, "mods", null, { visible: ["name"], hidden: [] });
+      emitTableColumnsViewed(h.api, "mods", GAME, { visible: ["name", "esp"], hidden: [] });
+
+      expect(h.events.map((event) => event.properties.visible_columns)).toStrictEqual([
+        ["name"],
+        ["name", "esp"],
+      ]);
     });
 
     it("says nothing about a table with no columns yet, and reports it once it has some", () => {

--- a/src/renderer/src/controls/table/columnAnalytics.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.ts
@@ -56,9 +56,9 @@ export const columnsOf = ({
 
 /**
  * Says which columns a table is showing, so that a decision to drop one rests on how
- * many installs still have it rather than on guesswork. One event per table per session
- * keeps the answer per-install: the page can be left and come back to any number of
- * times without weighting one user's layout more than another's.
+ * many installs still have it rather than on guesswork. One event per table per game
+ * per session keeps the answer per-install: the page can be left and come back to any
+ * number of times without weighting one user's layout more than another's.
  */
 const columnsViewedEvent = (table: string, { visible, hidden }: ITableColumns): MixpanelEvent => ({
   eventName: "app_table_columns_viewed",
@@ -80,31 +80,47 @@ const columnToggledEvent = (table: string, column: string, visible: boolean): Mi
 });
 
 /**
- * Tables whose columns this session has already reported. Module scope, so it is the
+ * Table and game pairs this session has already reported. Module scope, so it is the
  * window's lifetime that bounds it: a reload is a new session and reports again, which
  * is the same thing every other per-session count here means.
  */
 const reported = new Set<string>();
 
+/**
+ * Keyed by game as well as table, because game extensions contribute columns and those
+ * are the ones that differ from one game to the next. Keyed on the table alone, a user
+ * who switched game mid-session reported nothing the second time and their only snapshot
+ * was stamped with whichever game they happened to open first.
+ *
+ * Neither a game id nor a table id contains a colon, so the two can't run together.
+ */
+const reportKey = (table: string, game: string | undefined): string => `${game ?? "none"}:${table}`;
+
 /** Forgets what this session reported. For tests; a session has no reason to. */
 export const resetReportedColumns = (): void => reported.clear();
 
 /**
- * Reports `table`'s columns, once per session. Silent on a table showing nothing yet:
- * attributes arrive from extensions and can be gated on state, so an empty list means
- * the set hasn't settled rather than that the user hid everything — and the table
- * refuses to hide its last column anyway.
+ * Reports `table`'s columns, once per game per session. Silent on a table showing nothing
+ * yet: attributes arrive from extensions and can be gated on state, so an empty list means
+ * the set hasn't settled rather than that the user hid everything — and the table refuses
+ * to hide its last column anyway.
+ *
+ * `game` bounds the gate only. What the event is stamped with is mixpanel's `game_id`
+ * super property, which the analytics layer keeps in step with the active game.
  */
 export const emitTableColumnsViewed = (
   api: IExtensionApi,
   table: string,
+  game: string | undefined,
   columns: ITableColumns,
 ): void => {
-  if (columns.visible.length === 0 || reported.has(table)) {
+  const key = reportKey(table, game);
+
+  if (columns.visible.length === 0 || reported.has(key)) {
     return;
   }
 
-  reported.add(table);
+  reported.add(key);
   api.events.emit("analytics-track-mixpanel-event", columnsViewedEvent(table, columns));
 };
 

--- a/src/renderer/src/controls/table/columnAnalytics.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.ts
@@ -64,9 +64,9 @@ const columnsViewedEvent = (table: string, { visible, hidden }: ITableColumns): 
   eventName: "app_table_columns_viewed",
   properties: {
     table,
-    columns: visible,
+    visible_columns: visible,
     hidden_columns: hidden,
-    column_count: visible.length,
+    visible_column_count: visible.length,
   },
 });
 

--- a/src/renderer/src/controls/table/columnAnalytics.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.ts
@@ -61,7 +61,7 @@ export const columnsOf = ({
  * times without weighting one user's layout more than another's.
  */
 const columnsViewedEvent = (table: string, { visible, hidden }: ITableColumns): MixpanelEvent => ({
-  eventName: "table_columns_viewed",
+  eventName: "app_table_columns_viewed",
   properties: {
     table,
     columns: visible,
@@ -75,7 +75,7 @@ const columnsViewedEvent = (table: string, { visible, hidden }: ITableColumns): 
  * cannot: it can't tell a default nobody minded from one somebody chose.
  */
 const columnToggledEvent = (table: string, column: string, visible: boolean): MixpanelEvent => ({
-  eventName: "table_column_toggled",
+  eventName: "app_table_column_toggled",
   properties: { table, column, visible },
 });
 

--- a/src/renderer/src/controls/table/columnAnalytics.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.ts
@@ -1,0 +1,119 @@
+import type { MixpanelEvent } from "../../extensions/analytics/mixpanel/MixpanelEvents";
+import type { IExtensionApi } from "../../types/IExtensionContext";
+import type { ITableAttribute } from "../../types/ITableAttribute";
+
+/** What a table's columns are doing at a moment in time, by attribute id. */
+export interface ITableColumns {
+  /** On show, in the order they appear left to right. */
+  visible: string[];
+  /** Offered by the table's own toggle menu, but switched off. */
+  hidden: string[];
+}
+
+/**
+ * Whether what happens to an attribute is counted as happening to a column. Only the
+ * ones that can appear as a column can: an attribute confined to the details pane, or
+ * rendered inline in another cell, is not what a decision to drop a column is about.
+ */
+export const isColumn = (attribute: ITableAttribute): boolean =>
+  ["table", "both"].includes(attribute.placement);
+
+/**
+ * Splits a table's attributes into the columns on show and the ones its toggle menu
+ * offers but the user has switched off, so that a column absent from both lists reads
+ * as "never offered here" — no extension to provide it, or its own `condition` said no
+ * — rather than as one somebody turned off.
+ *
+ * `visible` is the table's own list rather than one worked out again here, so what is
+ * reported can't come to disagree with what is drawn.
+ */
+export const columnsOf = ({
+  attributes,
+  visible,
+  blacklist = [],
+}: {
+  attributes: ITableAttribute[];
+  visible: ITableAttribute[];
+  blacklist?: string[];
+}): ITableColumns => {
+  const excluded = new Set(blacklist);
+  const shown = new Set(visible.map((attribute) => attribute.id));
+
+  return {
+    visible: visible.map((attribute) => attribute.id),
+    hidden: attributes
+      .filter(
+        (attribute) =>
+          isColumn(attribute) &&
+          attribute.isToggleable === true &&
+          !excluded.has(attribute.id) &&
+          (attribute.condition?.() ?? true) &&
+          !shown.has(attribute.id),
+      )
+      .map((attribute) => attribute.id),
+  };
+};
+
+/**
+ * Says which columns a table is showing, so that a decision to drop one rests on how
+ * many installs still have it rather than on guesswork. One event per table per session
+ * keeps the answer per-install: the page can be left and come back to any number of
+ * times without weighting one user's layout more than another's.
+ */
+const columnsViewedEvent = (table: string, { visible, hidden }: ITableColumns): MixpanelEvent => ({
+  eventName: "table_columns_viewed",
+  properties: {
+    table,
+    columns: visible,
+    hidden_columns: hidden,
+    column_count: visible.length,
+  },
+});
+
+/**
+ * Says that the user showed or hid a column themselves, which the snapshot alone
+ * cannot: it can't tell a default nobody minded from one somebody chose.
+ */
+const columnToggledEvent = (table: string, column: string, visible: boolean): MixpanelEvent => ({
+  eventName: "table_column_toggled",
+  properties: { table, column, visible },
+});
+
+/**
+ * Tables whose columns this session has already reported. Module scope, so it is the
+ * window's lifetime that bounds it: a reload is a new session and reports again, which
+ * is the same thing every other per-session count here means.
+ */
+const reported = new Set<string>();
+
+/** Forgets what this session reported. For tests; a session has no reason to. */
+export const resetReportedColumns = (): void => reported.clear();
+
+/**
+ * Reports `table`'s columns, once per session. Silent on a table showing nothing yet:
+ * attributes arrive from extensions and can be gated on state, so an empty list means
+ * the set hasn't settled rather than that the user hid everything — and the table
+ * refuses to hide its last column anyway.
+ */
+export const emitTableColumnsViewed = (
+  api: IExtensionApi,
+  table: string,
+  columns: ITableColumns,
+): void => {
+  if (columns.visible.length === 0 || reported.has(table)) {
+    return;
+  }
+
+  reported.add(table);
+  api.events.emit("analytics-track-mixpanel-event", columnsViewedEvent(table, columns));
+};
+
+/** Reports a column the user showed or hid, with `visible` the state moved *to*. */
+export const emitTableColumnToggled = (
+  api: IExtensionApi,
+  table: string,
+  column: string,
+  visible: boolean,
+): void => {
+  api.events.emit("analytics-track-mixpanel-event", columnToggledEvent(table, column, visible));
+};

--- a/src/renderer/src/controls/table/columnAnalytics.ts
+++ b/src/renderer/src/controls/table/columnAnalytics.ts
@@ -92,9 +92,26 @@ const reported = new Set<string>();
  * who switched game mid-session reported nothing the second time and their only snapshot
  * was stamped with whichever game they happened to open first.
  *
+ * The game is the numeric Nexus id, the same one the event is stamped with. Keying on the
+ * internal id instead let a report be gated as one game and labelled another, because the
+ * two resolve at different times. See {@link gameIdPending}.
+ *
  * Neither a game id nor a table id contains a colon, so the two can't run together.
  */
-const reportKey = (table: string, game: string | undefined): string => `${game ?? "none"}:${table}`;
+const reportKey = (table: string, game: number | null): string => `${game ?? "none"}:${table}`;
+
+/**
+ * Whether a game is active but the numeric id it reports under hasn't arrived yet.
+ *
+ * The internal id is in state from the first frame; the numeric one comes from the games
+ * list. Until this session looks it up, mixpanel's `game_id` super property still holds
+ * the last session's, so reporting in that window labels the snapshot with the wrong game
+ * and spends the slot on it. No active game at all is not that case: nothing is coming.
+ */
+export const gameIdPending = (
+  internalGameId: string | undefined,
+  numericGameId: number | null,
+): boolean => internalGameId !== undefined && numericGameId === null;
 
 /** Forgets what this session reported. For tests; a session has no reason to. */
 export const resetReportedColumns = (): void => reported.clear();
@@ -106,12 +123,13 @@ export const resetReportedColumns = (): void => reported.clear();
  * to hide its last column anyway.
  *
  * `game` bounds the gate only. What the event is stamped with is mixpanel's `game_id`
- * super property, which the analytics layer keeps in step with the active game.
+ * super property, so this is the numeric id and the caller is expected to have waited for
+ * one. See {@link gameIdPending}.
  */
 export const emitTableColumnsViewed = (
   api: IExtensionApi,
   table: string,
-  game: string | undefined,
+  game: number | null,
   columns: ITableColumns,
 ): void => {
   const key = reportKey(table, game);

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -13,9 +13,9 @@ app_ui_mode_changed { is_legacy_ui } // the mode switched to, from Settings > Th
 
 Toolbar
 
-toolbar_action_clicked { toolbar, action, extension, surface } // mods page only for now
-toolbar_pin_changed { toolbar, action, extension, pinned } // pinned = the state moved to
-toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no action
+app_toolbar_action_clicked { toolbar, action, extension, surface } // mods page only for now
+app_toolbar_pin_changed { toolbar, action, extension, pinned } // pinned = the state moved to
+app_toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no action
 // action = the same stable id pinning stores against, never the translated label
 // extension = absent for an action the page owns rather than one registered into it
 // surface = bar | overflow | menu (reached directly, via the kebab, or inside Open.../Import...)
@@ -25,8 +25,8 @@ toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no acti
 
 Table
 
-table_columns_viewed { table, columns, hidden_columns, column_count } // once per table per session
-table_column_toggled { table, column, visible } // visible = the state moved to
+app_table_columns_viewed { table, columns, hidden_columns, column_count } // once per table per session
+app_table_column_toggled { table, column, visible } // visible = the state moved to
 // table = the id the table stores its layout against: mods | downloads | extensions |
 // collection-mods | collection-add-mods
 // column ids are the attribute ids that layout is stored against, never the translated header

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -23,6 +23,19 @@ toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no acti
 // the menu" rather than "did not fit" — and a menu interaction reports twice, the Open...
 // parent on `bar` and then the row on `menu`
 
+Table
+
+table_columns_viewed { table, columns, hidden_columns, column_count } // once per table per session
+table_column_toggled { table, column, visible } // visible = the state moved to
+// table = the id the table stores its layout against: mods | downloads | extensions |
+// collection-mods | collection-add-mods
+// column ids are the attribute ids that layout is stored against, never the translated header
+// columns = on show, in the order drawn; hidden_columns = offered by the toggle menu but off
+// a column in neither list was never offered here: no extension provides it, or its own
+// condition said no. Attributes that can't be a column (details pane, inline) are left out
+// of both, and toggling one is not an event
+// once per session, so the answer stays per install however often the page is opened
+
 Mods
 
 mods_download_started

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -25,12 +25,15 @@ app_toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no 
 
 Table
 
-app_table_columns_viewed { table, columns, hidden_columns, column_count } // once per table per session
+app_table_columns_viewed { table, visible_columns, hidden_columns, visible_column_count } // once per table per session
 app_table_column_toggled { table, column, visible } // visible = the state moved to
-// table = the id the table stores its layout against: mods | downloads | extensions |
-// collection-mods | collection-add-mods
+// table = mods | downloads | extensions | collection-mods-edit | collection-mods-view |
+// collection-add-mods
+// usually the id the table stores its layout against, except where two tables share one:
+// authoring a collection and viewing one are both `collection-mods` for layout but are
+// different sets of columns, so they report under their own ids and neither is dropped
 // column ids are the attribute ids that layout is stored against, never the translated header
-// columns = on show, in the order drawn; hidden_columns = offered by the toggle menu but off
+// visible_columns = on show, in the order drawn; hidden_columns = offered by the toggle menu but off
 // a column in neither list was never offered here: no extension provides it, or its own
 // condition said no. Attributes that can't be a column (details pane, inline) are left out
 // of both, and toggling one is not an event

--- a/src/renderer/src/extensions/analytics/README.md
+++ b/src/renderer/src/extensions/analytics/README.md
@@ -25,7 +25,7 @@ app_toolbar_pins_reset { toolbar } // the whole toolbar back to defaults, so no 
 
 Table
 
-app_table_columns_viewed { table, visible_columns, hidden_columns, visible_column_count } // once per table per session
+app_table_columns_viewed { table, visible_columns, hidden_columns, visible_column_count } // once per table per game per session
 app_table_column_toggled { table, column, visible } // visible = the state moved to
 // table = mods | downloads | extensions | collection-mods-edit | collection-mods-view |
 // collection-add-mods
@@ -37,7 +37,12 @@ app_table_column_toggled { table, column, visible } // visible = the state moved
 // a column in neither list was never offered here: no extension provides it, or its own
 // condition said no. Attributes that can't be a column (details pane, inline) are left out
 // of both, and toggling one is not an event
-// once per session, so the answer stays per install however often the page is opened
+// once per game a session, so the answer stays per install however often the page is
+// opened — and a user who switches game reports again rather than leaving their only
+// snapshot stamped with whichever game they opened first. game_id comes from the super
+// property, so it isn't in the event's own fields
+// game extensions contribute columns, so the same table is a different set of columns
+// from one game to the next, which is what makes the per-game breakdown worth having
 
 Mods
 

--- a/src/renderer/src/extensions/collections/views/CollectionPageEdit/ModsEditPage.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageEdit/ModsEditPage.tsx
@@ -974,6 +974,7 @@ class ModsEditPage extends ComponentEx<IProps, IModsPageState> {
       <div className="collection-mods-container">
         <Table
           actions={this.mActions}
+          analyticsId="collection-mods-edit"
           data={entries}
           showDetails={false}
           staticElements={this.mColumns}

--- a/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
+++ b/src/renderer/src/extensions/collections/views/CollectionPageView/index.tsx
@@ -644,6 +644,7 @@ class CollectionPage extends ComponentEx<IProps, IComponentState> {
                 <Panel.Body>
                   <Table
                     actions={this.mModActions}
+                    analyticsId="collection-mods-view"
                     data={itemRows}
                     showDetails={false}
                     staticElements={this.mAttributes}

--- a/src/renderer/src/extensions/mod_management/components/ModsToolbar.test.tsx
+++ b/src/renderer/src/extensions/mod_management/components/ModsToolbar.test.tsx
@@ -3,7 +3,7 @@ import path from "path";
 
 /**
  * The mods toolbar is the one toolbar whose use is counted, so what is checked here is
- * the opt-in itself: that a click on it reaches Mixpanel as `toolbar_action_clicked`, and
+ * the opt-in itself: that a click on it reaches Mixpanel as `app_toolbar_action_clicked`, and
  * that the classic bar this page still renders alongside it stays unmeasured.
  */
 import { render, screen } from "@testing-library/react";
@@ -53,7 +53,7 @@ describe("ModsToolbar", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Deploy Mods" }));
 
-    expect(trackedEvent()?.eventName).toBe("toolbar_action_clicked");
+    expect(trackedEvent()?.eventName).toBe("app_toolbar_action_clicked");
     expect(trackedEvent()?.properties).toEqual({
       action: "deploy",
       surface: "bar",

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.test.ts
@@ -1,5 +1,5 @@
 /**
- * The shape of `toolbar_action_clicked` as it reaches the generic Mixpanel funnel. The event
+ * The shape of `app_toolbar_action_clicked` as it reaches the generic Mixpanel funnel. The event
  * carries no game, version or user scope of its own — those are super properties
  * registered elsewhere — so what is asserted here is the whole of what a toolbar
  * contributes.
@@ -49,7 +49,7 @@ describe("useToolbarAnalytics", () => {
   it("reports the action, its toolbar and where it was reached from", () => {
     const event = report({ id: "deploy-mods" }, "bar");
 
-    expect(event.eventName).toBe("toolbar_action_clicked");
+    expect(event.eventName).toBe("app_toolbar_action_clicked");
     expect(event.properties).toEqual({ action: "deploy-mods", surface: "bar", toolbar: "mods" });
   });
 
@@ -72,7 +72,7 @@ describe("useToolbarAnalytics pin tracking", () => {
   it.each([true, false])("reports the state a pin was moved to (pinned=%s)", (pinned) => {
     const event = reportPin({ id: "deploy" }, pinned);
 
-    expect(event.eventName).toBe("toolbar_pin_changed");
+    expect(event.eventName).toBe("app_toolbar_pin_changed");
     expect(event.properties).toEqual({ action: "deploy", pinned, toolbar: "mods" });
   });
 
@@ -89,7 +89,7 @@ describe("useToolbarAnalytics pin tracking", () => {
 
     const event = lastEvent();
 
-    expect(event.eventName).toBe("toolbar_pins_reset");
+    expect(event.eventName).toBe("app_toolbar_pins_reset");
     expect(event.properties).toEqual({ toolbar: "mods" });
   });
 });

--- a/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
+++ b/src/renderer/src/ui/components/toolbar/useToolbarAnalytics.hook.ts
@@ -28,7 +28,7 @@ const toolbarActionClickedEvent = ({
   surface,
   ...event
 }: IToolbarActionEvent & { surface: ToolbarSurface }): MixpanelEvent => ({
-  eventName: "toolbar_action_clicked",
+  eventName: "app_toolbar_action_clicked",
   properties: { ...actionProperties(event), surface },
 });
 
@@ -41,7 +41,7 @@ const toolbarPinChangedEvent = ({
   pinned,
   ...event
 }: IToolbarActionEvent & { pinned: boolean }): MixpanelEvent => ({
-  eventName: "toolbar_pin_changed",
+  eventName: "app_toolbar_pin_changed",
   properties: { ...actionProperties(event), pinned },
 });
 
@@ -51,7 +51,7 @@ const toolbarPinChangedEvent = ({
  * do not.
  */
 const toolbarPinsResetEvent = ({ toolbar }: { toolbar: string }): MixpanelEvent => ({
-  eventName: "toolbar_pins_reset",
+  eventName: "app_toolbar_pins_reset",
   properties: { toolbar },
 });
 


### PR DESCRIPTION
Closes [LAZ-894](https://linear.app/nexus-mods/issue/LAZ-894/add-tracking-for-table-column-usage), which unblocks [LAZ-1006](https://linear.app/nexus-mods/issue/LAZ-1006).

## What this adds

Two Mixpanel events, so a decision to drop a column from the table view can rest on how many installs still show it:

| event | properties |
|---|---|
| `table_columns_viewed` | `table`, `columns`, `hidden_columns`, `column_count` |
| `table_column_toggled` | `table`, `column`, `visible` |

The snapshot fires once per table per session; the toggle fires whenever the user shows or hides a column from the header's **Toggle Columns** menu. Both are documented in `src/renderer/src/extensions/analytics/README.md`.

Confirmed live in a dev build against a managed Stardew Valley install:

```json
{"eventName":"table_columns_viewed","game_id":1303,
 "properties":{"table":"mods",
   "columns":["enabled","name","version","category","endorsed","sdv-compatibility"],
   "hidden_columns":["author","archiveName","modSize","installTime","enabledTime",
                     "downloadTime","modType","modSource","tracked","collection",
                     "content","loadOrder","dependencies","modHighlight"],
   "column_count":6}}

{"eventName":"table_column_toggled","properties":{"table":"mods","column":"author","visible":true}}
{"eventName":"table_column_toggled","properties":{"table":"mods","column":"author","visible":false}}
```

Across that session — two toggles and a trip to Downloads and back — `table_columns_viewed` fired exactly once per table, and the downloads table reported its own columns (`filename`, `filetime`, `filesize`, `progress`, with `logicalname` and `game` hidden).

## Worth knowing when reading it

**`hidden_columns` is what makes the numbers usable.** Without it, a column missing from `columns` is ambiguous between "the user switched it off" and "no extension here offers it, or its own `condition` said no". A column in neither list was never offered, so the denominator isn't a guess.

**Once per table per session keeps the answer per install.** The page can be left and returned to any number of times without weighting one user's layout more than another's. The session is the window's lifetime, so a reload reports again — the same thing every other per-session count here means.

**The report waits for the columns to hold still**, and every change to the attributes pushes it out again. Attributes arrive from extensions and can be gated on state, so the first frame is not yet what the user is looking at: `sdv-compatibility` above comes from the Stardew Valley extension and joins the table a moment after the rest, and a snapshot on mount would have missed it.

**Every table reports, not just the mods one.** The counting lives in the shared table control, so `table` names which one and downloads, extensions and both collection tables come for free. The dashboard filters to `table = "mods"` for LAZ-894's own question.

**Ids are the attribute ids the column layout is already stored against**, never the translated header — the same contract the toolbar work settled on. A label is translated, so an id derived from one splits a column across as many ids as there are languages.

**Attributes that can never be a column are left out**, and toggling one is not an event. The same menu offers inline and detail-pane attributes; hiding one of those says nothing about the columns this is counting.

**`visible` in the snapshot is the table's own list**, not one worked out again beside it, so what is reported cannot come to disagree with what is drawn.

## Testing

`pnpm run verify` passes. 11 new unit tests in `columnAnalytics.test.ts` cover the visible/hidden/never-offered split, blacklisting, the once-per-session gate, per-table independence, the empty-table hold-off and toggle direction. E2E was not run.


---

## Since review

Four changes on top of the above. Where they contradict the event table, the JSON samples or the notes earlier in this description, **these are what's current** — the text above is left as it was written.

The events now read:

| event | properties |
|---|---|
| `app_table_columns_viewed` | `table`, `visible_columns`, `hidden_columns`, `visible_column_count` |
| `app_table_column_toggled` | `table`, `column`, `visible` |

**The five events are prefixed `app_`** (`e0e3bf20b`), covering the three toolbar events as well as these two. That matches `app_launched`, `app_ui_mode_changed` and `app_game_manage`, and leaves `mods_` and `collections_` as the only groups without it. A rename rather than an alias, so the old names stop arriving instead of co-existing — anything already pointed at `toolbar_` needs repointing.

**`collection-mods` was two different tables reporting as one** (`3e5773e6c`). Authoring a collection (`CollectionPageEdit/ModsEditPage`) and viewing one (`CollectionPageView`) share that `tableId` deliberately — it's the key their column layout is stored against — but the columns behind it barely overlap: edit offers `tags`, `category`, `source`, `version-match`, `install-type` and `phase`, view offers `collection_status`, `version`, `uploader` and `collection-resync`, and only `name`, `required` and `instructions` are common. Because the once-a-session gate keyed on that id, whichever page was opened first reported and the other never did, so which of the two column sets the numbers held came down to where the user went first.

Renaming a table to separate them would have discarded the column layouts users have saved against it, so the analytics identity splits from the persistence one: a new `analyticsId` prop defaults to `tableId` and is set only where an id is already taken. `onSetAttributeVisible` keeps `tableId`, so nothing about stored layouts moves. `table` is now `mods | downloads | extensions | collection-mods-edit | collection-mods-view | collection-add-mods` — plain `collection-mods` no longer appears at all.

The other duplicate id, `mods` in `ModList`, is the modern and classic branches of one table with one set of attributes, so it stays as it is.

**The snapshot's fields are named for what they hold** (`3e5773e6c`): `visible_columns` and `visible_column_count`, matching the `visible` / `hidden` the code's own `ITableColumns` uses, rather than `columns` / `hidden_columns` sitting next to each other.

**The session gate ignored game switches** (`807af1dc1`). Game extensions contribute columns — `sdv-compatibility` in the sample above is one — and those are exactly the columns that differ per game. Keyed on the table alone, switching game mid-session re-mounted the mods table and reported nothing, leaving the install's only snapshot stamped with whichever game was open first: right for anyone managing one game, quietly wrong for everyone else. The gate keys on the game as well now, so it's once per table **per game** per session. The report already re-fired on a switch, from the attributes changing, so the gate was the only thing suppressing it.

Nothing was added to the event for this: `game_id` is already a Mixpanel super property, so every event carries the active game. The game is read where the report is built rather than taken from props, so it's the one in effect when the debounce fires — the game the reported columns came from. `activeGameId` is declared to return a string but gives `undefined` with no active profile, so an absent game keys as its own thing; that leaves a game-agnostic table like `extensions` reporting once per game visited, which doesn't distort anything, since "how many installs show this column" is a count of distinct installs and repeat events from one install don't move it.

### Worth knowing about these

**`analyticsId` has no automated guard.** `controls/Table.tsx` has no test file, so nothing fails if a future colliding table forgets to set it — the rule is stated on the prop and enforced by review. The alternative I considered was keying the gate on the offered column set instead of an explicit id, which can't silently drop, but then both events still read `collection-mods` and can't be told apart, which is worse for analysis.

**One window remains open, in the analytics layer rather than here.** The `game_id` super property is the numeric Nexus id set by `setGameContext`, while the gate uses the internal game id, and when the numeric id is unresolved (games cache still loading) `MixpanelAnalytics` deliberately keeps the previously persisted value. So during a switch an event could in principle be stamped with the outgoing game. The 2s debounce makes it unlikely, but it's real and worth a separate look if the per-game breakdown matters a lot.

### Testing since review

15 unit tests in `columnAnalytics.test.ts` now (up from 11), the four new ones covering the two ids reporting separately, a table reporting again for an unseen game, still reporting once for a seen one, and no-active-game as its own key.

Full renderer suite passes — 213 files, 2310 tests, 9 skipped — with lint clean and no new typecheck errors. That's lint and tests rather than a full `pnpm run verify`; `build` wasn't re-run for these three commits, and E2E still wasn't run. The live dev-build capture in the sample above predates the renames, so the names in that JSON are the old ones.
