### PR TITLE
Fix dot path game installation having spurious conflicts

### DIFF
--- a/extensions/mod-dependency-manager/src/util/blacklist.ts
+++ b/extensions/mod-dependency-manager/src/util/blacklist.ts
@@ -37,7 +37,7 @@ function isBlacklisted(filePath: string, game: types.IGame): boolean {
   // TODO: this could become reaaaaly slow as the blacklist gets larger...
   return getBlacklist(game).some((pattern) => {
     try {
-      return minimatch(filePath, pattern, { nocase: true });
+      return minimatch(filePath, pattern, { nocase: true, nodot: true });
     } catch (err) {
       return false;
     }


### PR DESCRIPTION
If the Skyrim Special Edition is installed in a path containing `.`, like `Z:\.local\share\Steam\...` Vortex was reporting spurious conflicts, because `isBlacklisted` wasn't functioning correctly with paths containing a dot.

This fix is relevant to Wine/Proton usecase and to the Windows users, who may install the game to path having `.` in it.