### PR TITLE
Say what the play button will launch (LAZ-976)

### DIFF
--- a/src/renderer/src/ui/components/button/Button.demo.tsx
+++ b/src/renderer/src/ui/components/button/Button.demo.tsx
@@ -73,8 +73,6 @@ export const ButtonDemo = () => {
         </Typography>
 
         <div className="flex flex-wrap items-center gap-4">
-          <Button size="lg">Large</Button>
-
           <Button>Medium (default)</Button>
 
           <Button size="sm">Small</Button>
@@ -154,8 +152,6 @@ export const ButtonDemo = () => {
         </div>
 
         <div className="flex flex-wrap items-center gap-4">
-          <Button aria-label="Settings (lg)" leftIconPath={mdiCog} size="lg" />
-
           <Button aria-label="Settings (md)" leftIconPath={mdiCog} />
 
           <Button aria-label="Settings (sm)" leftIconPath={mdiCog} size="sm" />

--- a/src/renderer/src/ui/components/button/Button.test.tsx
+++ b/src/renderer/src/ui/components/button/Button.test.tsx
@@ -98,15 +98,9 @@ describe("Button", () => {
       expect(getButton()).toHaveClass("nxm-button-sm");
     });
 
-    it('applies lg class for size="lg"', () => {
-      render(<Button size="lg">Click</Button>);
-      expect(getButton()).toHaveClass("nxm-button-lg");
-    });
-
     it('does not apply a size class for size="md" (default)', () => {
       render(<Button>Click</Button>);
       expect(getButton()).not.toHaveClass("nxm-button-sm");
-      expect(getButton()).not.toHaveClass("nxm-button-lg");
     });
   });
 

--- a/src/renderer/src/ui/components/button/Button.tsx
+++ b/src/renderer/src/ui/components/button/Button.tsx
@@ -19,7 +19,7 @@ export type IButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   brand?: IButtonBrand;
   appearance?: IButtonAppearance;
   isLoading?: boolean;
-  size?: "sm" | "md" | "lg";
+  size?: "sm" | "md";
   children?: string;
   customContent?: ReactNode;
   disabled?: boolean;
@@ -91,9 +91,8 @@ export const Button = forwardRef<HTMLButtonElement, IButtonProps>(
         {
           "nxm-button-disabled": !!disabled || !!ariaDisabled || isLoading,
           "nxm-button-icon-only": !customContent && !children,
-          // `md` is the base class, so only the sizes either side of it modify it.
+          // `md` is the base class, so only `sm` modifies it.
           "nxm-button-sm": size === "sm",
-          "nxm-button-lg": size === "lg",
         },
       )}
       disabled={disabled || isLoading}

--- a/src/renderer/src/views/components/Menu/Menu.tsx
+++ b/src/renderer/src/views/components/Menu/Menu.tsx
@@ -59,7 +59,7 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
       as="div"
       className={joinClasses([
         "relative -mt-1 flex shrink-0 flex-col pr-0.5 transition-[width]",
-        menuIsCollapsed ? "w-16" : "w-56",
+        menuIsCollapsed ? "w-16" : "w-55.5",
       ])}
     >
       {canScrollUp && (
@@ -70,7 +70,7 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
         <div
           className={joinClasses([
             "flex flex-col gap-y-0.5 pt-1 transition-[width]",
-            menuIsCollapsed ? `w-10 ${toolPadding[toolCount]}` : "w-50 pb-34",
+            menuIsCollapsed ? `w-10 ${toolPadding[toolCount]}` : "w-49 pb-34",
           ])}
         >
           {selection.type === "downloads" ? (

--- a/src/renderer/src/views/components/Menu/Menu.tsx
+++ b/src/renderer/src/views/components/Menu/Menu.tsx
@@ -2,10 +2,11 @@ import React, { useState, type FC, useLayoutEffect, useRef, useEffect } from "re
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 
-import { setOpenMainPage } from "../../../actions";
-import { usePagesContext, useWindowContext } from "../../../contexts";
-import { TooltipDelayGroup } from "../../../ui/components/tooltip/TooltipDelayGroup";
-import { joinClasses } from "../../../ui/utils/joinClasses";
+import { setOpenMainPage } from "@/actions";
+import { usePagesContext, useWindowContext } from "@/contexts";
+import { TooltipDelayGroup } from "@/ui/components/tooltip/TooltipDelayGroup";
+import { joinClasses } from "@/ui/utils/joinClasses";
+
 import { getIconPath } from "../iconMap";
 import { useSpineContext } from "../Spine/SpineContext";
 import { DownloadsMenuContent } from "./DownloadsMenuContent";
@@ -14,11 +15,11 @@ import { ToolsProvider, useToolsContext } from "./ToolsContext";
 import { ToolsSection } from "./ToolsSection";
 
 const toolPadding = {
-  1: "pb-28",
-  2: "pb-37.5",
-  3: "pb-47",
-  4: "pb-56.5",
-  5: "pb-66",
+  1: "pb-32",
+  2: "pb-42",
+  3: "pb-52",
+  4: "pb-62",
+  5: "pb-72",
 };
 
 const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
@@ -69,7 +70,7 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
         <div
           className={joinClasses([
             "flex flex-col gap-y-0.5 pt-1 transition-[width]",
-            menuIsCollapsed ? `w-10 ${toolPadding[toolCount]}` : "w-50 pb-28",
+            menuIsCollapsed ? `w-10 ${toolPadding[toolCount]}` : "w-50 pb-34",
           ])}
         >
           {selection.type === "downloads" ? (

--- a/src/renderer/src/views/components/Menu/ToolButton.tsx
+++ b/src/renderer/src/views/components/Menu/ToolButton.tsx
@@ -3,24 +3,24 @@ import { pathToFileURL } from "url";
 import { mdiCircleOutline, mdiLoading, mdiPlay } from "@mdi/js";
 import React, { type ButtonHTMLAttributes, type FC, useMemo } from "react";
 
-import { useWindowContext } from "../../../contexts";
-import { Icon } from "../../../ui/components/icon/Icon";
-import { Tooltip } from "../../../ui/components/tooltip/Tooltip";
-import { Typography } from "../../../ui/components/typography/Typography";
-import { joinClasses } from "../../../ui/utils/joinClasses";
-import type { IStarterInfo } from "../../../util/StarterInfo";
+import { useWindowContext } from "@/contexts";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Image } from "@/ui/components/image/Image";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { Typography } from "@/ui/components/typography/Typography";
+import { joinClasses } from "@/ui/utils/joinClasses";
+import type { IStarterInfo } from "@/util/StarterInfo";
+
 import StarterInfo from "../../../util/StarterInfo";
 
 interface ToolButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   starter: IStarterInfo;
-  isPrimary?: boolean;
   isValid?: boolean;
   isRunning?: boolean;
 }
 
 export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
   starter,
-  isPrimary = false,
   isValid = true,
   isRunning = false,
   ...props
@@ -46,17 +46,18 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
     >
       <button
         aria-label={starter.name}
-        className={joinClasses("group/tool-button relative size-8 shrink-0 rounded-sm", {
+        className={joinClasses("group/tool-button relative size-9 shrink-0 rounded-sm", {
           "pointer-events-none cursor-not-allowed": isRunning,
         })}
         {...props}
       >
         {imageSrc ? (
-          <img
+          <Image
             alt={starter.name}
-            className={joinClasses("absolute inset-0 size-full rounded-sm object-cover", {
+            className={joinClasses("absolute inset-0 size-full rounded-sm", {
               "opacity-40 grayscale": !isValid,
             })}
+            imageType="other"
             src={imageSrc}
           />
         ) : (

--- a/src/renderer/src/views/components/Menu/ToolButton.tsx
+++ b/src/renderer/src/views/components/Menu/ToolButton.tsx
@@ -5,7 +5,6 @@ import React, { type ButtonHTMLAttributes, type FC, useMemo } from "react";
 
 import { useWindowContext } from "@/contexts";
 import { Icon } from "@/ui/components/icon/Icon";
-import { Image } from "@/ui/components/image/Image";
 import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
@@ -52,12 +51,11 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
         {...props}
       >
         {imageSrc ? (
-          <Image
+          <img
             alt={starter.name}
-            className={joinClasses("absolute inset-0 size-full rounded-sm", {
+            className={joinClasses("absolute inset-0 size-full rounded-sm object-cover", {
               "opacity-40 grayscale": !isValid,
             })}
-            imageType="other"
             src={imageSrc}
           />
         ) : (
@@ -65,7 +63,7 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
             appearance="moderate"
             as="span"
             className={joinClasses(
-              "absolute inset-0 flex items-center justify-center bg-surface-high leading-none",
+              "absolute inset-0 flex items-center justify-center rounded-sm bg-surface-high leading-none",
               { "opacity-40": !isValid },
             )}
             typographyType="body-lg"
@@ -77,7 +75,7 @@ export const ToolButton: FC<React.PropsWithChildren<ToolButtonProps>> = ({
         <span
           className={joinClasses(
             [
-              "absolute inset-0 z-1 flex items-center justify-center rounded-sm border border-stroke-moderate transition-colors",
+              "absolute inset-0 z-1 flex items-center justify-center rounded-sm border border-surface-low transition-colors",
               "group-hover/tool-button:border-stroke-strong group-hover/tool-button:bg-translucent-600",
               "group-focus-visible/tool-button:border-stroke-strong group-focus-visible/tool-button:bg-translucent-600",
             ],

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -155,15 +155,15 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
   return (
     <div
       className={joinClasses([
-        "absolute bottom-3 left-3 z-2 flex flex-col items-center gap-y-3 shadow-lg transition-[left,width]",
-        menuIsCollapsed ? "w-10" : "w-50",
+        "absolute bottom-3 left-3 z-2 flex flex-col items-center gap-y-3 transition-[left,width]",
+        menuIsCollapsed ? "w-10" : "w-49",
       ])}
     >
       {!!visibleTools.length && (
         <div
           className={joinClasses([
-            "flex flex-wrap items-center gap-1 border-b border-stroke-weak pb-3 transition-[translate,opacity]",
-            menuIsCollapsed ? "w-10 justify-center" : "w-full",
+            "flex items-center gap-1 border-b border-stroke-weak pb-3 transition-[translate,opacity]",
+            menuIsCollapsed ? "w-10 flex-wrap justify-center" : "w-full flex-wrap-reverse",
             isAnimating ? "translate-y-6 opacity-0 duration-0" : "duration-200",
           ])}
         >

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -6,17 +6,22 @@ import { useTranslation } from "react-i18next";
 
 import { useWindowContext } from "@/contexts";
 import { Button } from "@/ui/components/button/Button";
+import { Icon } from "@/ui/components/icon/Icon";
+import { Image } from "@/ui/components/image/Image";
 import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import type { IStarterInfo } from "@/util/StarterInfo";
 import StarterInfo from "@/util/StarterInfo";
 
 import { useSpineContext } from "../Spine/SpineContext";
+import { formatGameDisplayName } from "../Spine/utils";
 import { ToolButton } from "./ToolButton";
 import { useToolsContext } from "./ToolsContext";
 
 interface PlayButtonProps {
   primaryStarter: IStarterInfo | undefined;
+  gameName: string | undefined;
   isPrimaryRunning: boolean;
   isCollapsed: boolean;
   disabled: boolean;
@@ -25,6 +30,7 @@ interface PlayButtonProps {
 
 const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
   primaryStarter,
+  gameName,
   isPrimaryRunning,
   isCollapsed,
   disabled,
@@ -33,7 +39,7 @@ const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
   const { t } = useTranslation();
 
   const launcherIconSrc = useMemo(() => {
-    if (!primaryStarter || isCollapsed) return undefined;
+    if (!primaryStarter) return undefined;
     try {
       const iconPath = StarterInfo.getIconPath(primaryStarter);
       if (iconPath) {
@@ -43,31 +49,81 @@ const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
       // ignore
     }
     return undefined;
-  }, [primaryStarter, isCollapsed]);
+  }, [primaryStarter]);
 
   const label = isPrimaryRunning ? t("Running...") : t("Play");
 
+  /** What the button says it will do, for the tooltip's first line and the aria-label. */
+  const playLabel = isPrimaryRunning
+    ? t("Running...")
+    : gameName
+      ? t("Play {{game}}", { replace: { game: formatGameDisplayName(gameName) } })
+      : t("Play");
+
   return (
     <div className="relative w-full">
-      <Tooltip content={label} disabled={!isCollapsed} placement="right">
-        <Button
-          aria-label={isCollapsed ? label : undefined}
-          brand="neutral"
-          className="w-full transition-all"
-          disabled={disabled}
-          leftIconPath={mdiPlay}
-          size="lg"
-          onClick={onClick}
-        >
-          {!isCollapsed && label}
-        </Button>
-      </Tooltip>
+      <Tooltip
+        customContent={
+          <div className="space-y-1 px-4 py-3">
+            <Typography
+              appearance="moderate"
+              as="p"
+              className="font-semibold"
+              typographyType="body-sm"
+            >
+              {playLabel}
+            </Typography>
 
-      {!!launcherIconSrc && (
-        <div className="pointer-events-none absolute inset-0 z-2 flex items-center p-1">
-          <img alt="" className="size-7 rounded-xs object-cover" src={launcherIconSrc} />
-        </div>
-      )}
+            {!!primaryStarter && (
+              <>
+                <Typography appearance="subdued" as="p" typographyType="body-sm">
+                  {t("Launch with")}
+                </Typography>
+
+                <div className="flex items-center gap-x-1.5">
+                  {!!launcherIconSrc && (
+                    <Image
+                      alt=""
+                      className="size-5 shrink-0 rounded-xs"
+                      imageType="other"
+                      src={launcherIconSrc}
+                    />
+                  )}
+
+                  <Typography appearance="moderate" as="span" typographyType="body-sm">
+                    {primaryStarter.name}
+                  </Typography>
+                </div>
+              </>
+            )}
+          </div>
+        }
+        placement="right"
+      >
+        <Button
+          aria-label={isCollapsed ? playLabel : undefined}
+          brand="neutral"
+          className={joinClasses(["w-full transition-all", isCollapsed ? "h-10" : "h-12"])}
+          customContent={
+            <>
+              <Icon className="nxm-button-icon" path={mdiPlay} size="lg" />
+
+              {!isCollapsed && (
+                <Typography
+                  appearance="inverted"
+                  as="span"
+                  className="font-semibold"
+                  typographyType="body-lg"
+                >
+                  {label}
+                </Typography>
+              )}
+            </>
+          }
+          disabled={disabled}
+          onClick={onClick}
+        />
+      </Tooltip>
     </div>
   );
 };
@@ -81,6 +137,7 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
   const { selection } = useSpineContext();
   const {
     gameId,
+    gameName,
     visibleTools,
     primaryStarter,
     primaryToolId,
@@ -98,15 +155,15 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
   return (
     <div
       className={joinClasses([
-        "absolute bottom-3 left-3 z-2 flex flex-col items-center gap-y-1.5 rounded-md border-t border-surface-mid bg-surface-low py-1.5 shadow-lg transition-[width,padding]",
-        menuIsCollapsed ? "w-10 px-0.5" : "w-50 px-1.5",
+        "absolute bottom-3 left-3 z-2 flex flex-col items-center gap-y-3 shadow-lg transition-[left,width]",
+        menuIsCollapsed ? "w-10" : "w-50",
       ])}
     >
-      {visibleTools.length > 0 && (
+      {!!visibleTools.length && (
         <div
           className={joinClasses([
-            "flex flex-wrap items-center gap-1.5 transition-[translate,opacity]",
-            menuIsCollapsed ? "w-8" : "w-46",
+            "flex flex-wrap items-center gap-1 border-b border-stroke-weak pb-3 transition-[translate,opacity]",
+            menuIsCollapsed ? "w-10 justify-center" : "w-full",
             isAnimating ? "translate-y-6 opacity-0 duration-0" : "duration-200",
           ])}
         >
@@ -123,6 +180,7 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
 
       <PlayButton
         disabled={exclusiveRunning || isPrimaryRunning || !primaryStarter}
+        gameName={gameName}
         isCollapsed={menuIsCollapsed}
         isPrimaryRunning={isPrimaryRunning}
         primaryStarter={primaryToolId ? primaryStarter : undefined}

--- a/src/renderer/src/views/components/Menu/useTools.ts
+++ b/src/renderer/src/views/components/Menu/useTools.ts
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from "react";
 
+import { log } from "@/util/log";
+import type { IStarterInfo } from "@/util/StarterInfo";
+
 import type { IExtensionApi } from "../../../types/api";
-import { log } from "../../../util/log";
 import { activeProfile } from "../../../util/selectors";
-import type { IStarterInfo } from "../../../util/StarterInfo";
 import StarterInfo from "../../../util/StarterInfo";
 import { useToolsData } from "./useToolsData";
 import { useToolsRunning } from "./useToolsRunning";
@@ -19,6 +20,7 @@ export type ShowErrorCallback = (
 
 export interface UseToolsResult {
   gameId: string | undefined;
+  gameName: string | undefined;
   visibleTools: IStarterInfo[];
   primaryStarter: IStarterInfo | undefined;
   primaryToolId: string | undefined;
@@ -127,11 +129,12 @@ export const useTools = (onShowError: ShowErrorCallback, api: IExtensionApi): Us
 
     log("info", `Enabled mods at game launch: ${enabledMods.length}`);
 
-    StarterInfo.run(primaryStarter as StarterInfo, api, onShowError);
+    StarterInfo.run(primaryStarter, api, onShowError);
   }, [primaryStarter, api, onShowError]);
 
   return {
     gameId,
+    gameName: gameStarter?.name,
     visibleTools,
     primaryStarter,
     primaryToolId,

--- a/src/renderer/src/views/components/Menu/useTools.ts
+++ b/src/renderer/src/views/components/Menu/useTools.ts
@@ -10,7 +10,7 @@ import { useToolsData } from "./useToolsData";
 import { useToolsRunning } from "./useToolsRunning";
 import { useToolsValidation } from "./useToolsValidation";
 
-const MAX_VISIBLE_TOOLS = 5;
+const MAX_VISIBLE_TOOLS = 10;
 
 export type ShowErrorCallback = (
   message: string,

--- a/src/renderer/src/views/components/Spine/Spine.tsx
+++ b/src/renderer/src/views/components/Spine/Spine.tsx
@@ -1,4 +1,4 @@
-import { mdiHome, mdiPlus } from "@mdi/js";
+import { mdiHome, mdiHomeOutline, mdiPlus } from "@mdi/js";
 import React, { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 
@@ -69,7 +69,7 @@ export const Spine: FC<React.PropsWithChildren<unknown>> = () => {
       className="box-content flex w-18 shrink-0 flex-col items-center justify-between border-r border-stroke-weak py-3"
     >
       <SpineButton
-        iconPath={mdiHome}
+        iconPath={selection.type === "home" ? mdiHome : mdiHomeOutline}
         isActive={selection.type === "home"}
         title="Home"
         onClick={selectHome}

--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
@@ -1,4 +1,4 @@
-import { mdiDownload } from "@mdi/js";
+import { mdiDownload, mdiDownloadOutline } from "@mdi/js";
 import React from "react";
 import { useSelector } from "react-redux";
 
@@ -145,7 +145,7 @@ export const DownloadButton = () => {
       // The ring is the outline while a download runs, so the border steps aside for it.
       border={showProgress ? "none" : "visible"}
       className="group/download flex-col gap-y-0.5"
-      iconPath={!showProgress && mdiDownload}
+      iconPath={!showProgress && (isActive ? mdiDownload : mdiDownloadOutline)}
       isActive={isActive}
       title="Downloads"
       onClick={() => selectDownloads()}

--- a/src/renderer/src/views/components/Spine/notifications/components/NotificationControls.tsx
+++ b/src/renderer/src/views/components/Spine/notifications/components/NotificationControls.tsx
@@ -1,4 +1,4 @@
-import { mdiEyeOff, mdiClose } from "@mdi/js";
+import { mdiEyeOffOutline, mdiClose } from "@mdi/js";
 import React, { type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -31,7 +31,7 @@ export const NotificationControls = ({
         <Button
           appearance="weak"
           brand="neutral"
-          leftIconPath={mdiEyeOff}
+          leftIconPath={mdiEyeOffOutline}
           size="sm"
           title={t("Never show again")}
           onClick={onSuppress}

--- a/src/renderer/src/views/layout/ModernLayout.tsx
+++ b/src/renderer/src/views/layout/ModernLayout.tsx
@@ -3,7 +3,7 @@ import React, { type FC } from "react";
 import { useSwitchingProfile } from "../../hooks";
 import { ModernContentPane } from "../components/ContentPane";
 import { Header } from "../components/Header/Header";
-import { Menu } from "../components/Menu";
+import { Menu } from "../components/Menu/Menu";
 import { Spine } from "../components/Spine/Spine";
 import { SpineProvider } from "../components/Spine/SpineContext";
 import { DialogLayer } from "./DialogLayer";

--- a/src/renderer/src/views/pages/Tools/useToolsData.ts
+++ b/src/renderer/src/views/pages/Tools/useToolsData.ts
@@ -12,7 +12,7 @@ import type StarterInfo from "../../../util/StarterInfo";
 import { truthy } from "../../../util/util";
 import { generateGameStarter, generateToolStarters } from "./toolStarters";
 
-const MAX_PINNED_TOOLS = 5;
+const MAX_PINNED_TOOLS = 10;
 
 async function validateTools(starters: IStarterInfo[], discoveryPath: string): Promise<string[]> {
   const validIds: string[] = [];

--- a/src/stylesheets/ui/elements/button.css
+++ b/src/stylesheets/ui/elements/button.css
@@ -320,24 +320,4 @@
             width: calc(var(--spacing) * 6);
         }
     }
-
-    .nxm-button-lg {
-        min-width: calc(var(--spacing) * 24);
-        min-height: calc(var(--spacing) * 9);
-        padding-inline: calc(var(--spacing) * 3);
-
-        font-size: var(--text-body-lg);
-        line-height: var(--text-body-lg--line-height);
-        letter-spacing: var(--text-body-lg--letter-spacing);
-
-        & .nxm-button-icon {
-            width: calc(var(--spacing) * 5);
-            height: calc(var(--spacing) * 5);
-        }
-
-        &.nxm-button-icon-only {
-            min-width: 0;
-            width: calc(var(--spacing) * 9);
-        }
-    }
 }

--- a/src/stylesheets/vortex/supertable.scss
+++ b/src/stylesheets/vortex/supertable.scss
@@ -205,10 +205,10 @@
             left: 0;
             right: 0;
             content: "";
-            height: 10px;
+            height: 6px;
             position: absolute;
             pointer-events: none;
-            background: linear-gradient(to bottom, rgb(0 0 0 / 50%), transparent);
+            background: linear-gradient(to bottom, rgb(0 0 0 / 30%), transparent);
         }
     }
 }


### PR DESCRIPTION
Closes [LAZ-976](https://linear.app/nexus-mods/issue/LAZ-976/tool-shortcut-improvements).

## What this adds

The launcher icon comes off the play button and the information moves into a rich tooltip on it, per the Figma on the issue:

<img width="466" height="358" alt="image" src="https://github.com/user-attachments/assets/1cb6964e-0adc-4b27-aece-6c7e7f4f684b" />


Pinned tool tooltip
<img width="479" height="423" alt="image" src="https://github.com/user-attachments/assets/cea58a3e-bd84-4a3b-92ad-86334f903482" />



No pinned tool tooltip
<img width="479" height="423" alt="image (2)" src="https://github.com/user-attachments/assets/9322ad44-f83c-44e4-a670-c1f9b2261777" />


The "Launch with" half only appears when a primary tool is set, so a game launched directly says one thing rather than naming itself twice, and `Running...` still takes the first line while the game is running.

Along with it, the tools panel loses its rounded surface and its shadow for a plain divider above the play button, and the tiles go 32px → 36px.

## Also on this branch

**Ten pinned tools instead of five.** Both caps had to move together: `MAX_PINNED_TOOLS` on the Tools page gates the pin action and feeds the `{count}/{max}` heading, while `MAX_VISIBLE_TOOLS` slices what the sidebar draws. Raising only one would let ten be pinned but still show five.

**A new row lands above the existing ones, not below.** The expanded panel fits five tiles per row, and with `flex-wrap-reverse` the sixth opens a row *above* rather than below, so the tools already sitting next to Play keep their place instead of shuffling along. Rows top-to-bottom at nine tools are `6,7,8,9` then `1,2,3,4,5`; at ten it's `6,7,8,9,10` then `1,2,3,4,5`, so the cap is two rows. Collapsed is one tile per row, where reversing would just invert the column to 9→1, so it keeps the normal wrap.

**Outline icons unless active.** Home and Downloads take `mdiHomeOutline` / `mdiDownloadOutline` when their page isn't selected, and a notification's "Never show again" button takes `mdiEyeOffOutline`. This follows `health_check` and `iconMap.ts`, which already use the outline variants.

**A tool's icon is drawn directly rather than through `Image`.** `Image` wraps the img in a div that paints its own `border-stroke-weak`, which doubled with the border `ToolButton` already draws over its face; the tile also recolours that border to `border-surface-low`. The swap does lose `Image`'s `onError` fallback — `ToolButton`'s first-letter fallback only covers a missing icon path, not one that exists and fails to load.

**Menu trimmed 2px**, `w-56` → `w-55.5` and `w-50` → `w-49`. Worth knowing that `w-49` is 196px, and five 36px tiles with four 4px gaps come to exactly 196px, so the row is a zero-slack fit. It holds at 1x, 1.25x, 1.5x and 2x device pixel ratios, but any horizontal padding added to that container later drops it to four per row and makes six tools three rows.

## Worth knowing when reading it

**The icon was already being computed and thrown away.** `launcherIconSrc` returned early when the menu was collapsed, which was the only state the old tooltip appeared in, so the overlay it fed never actually drew. The overlay is gone in favour of the tooltip line, and that guard with it.

**`useTools` returns `gameName` now.** It builds `gameStarter` from the discovered game either way, so the name was already in hand; the alternative was a selector in the component for something the hook knew. The component runs it through `formatGameDisplayName`, the same helper the Spine and the downloads menu use, so the game is named consistently across the menu.

**`toolPadding` in Menu.tsx is re-derived, and it fixes a live overlap.** The tools panel is absolutely positioned over the page buttons, so that map is how much room they leave it. 36px tiles make each row of the collapsed rail cost 10 units instead of 9.5. More to the point, the expanded menu had the same sum hardcoded at `pb-28` and was already ~9px short of the panel it has to clear, so the tools were overlapping the last page button before this branch; `pb-34` clears it.

**…but that map does not yet cover the new cap, and it needs a follow-up.** `toolPadding` is keyed 1–5 only, so from six tools up `toolPadding[toolCount]` is `undefined` and the collapsed class string becomes `w-10 undefined` — no reservation at all. At nine tools the panel needs 433px and gets 0, which leaves five page buttons underneath it with no scroll room to reach them (the scroller isn't overflowing, so they can't be scrolled clear). Extending the map keeps its existing 15px slack: `9: "pb-112"`, `10: "pb-122"`. Expanded is milder but also short — `pb-34` reserves 136px against the 161px two rows need, so `pb-44`. Deliberately not done here; the collapsed rail is 409px of tiles at ten tools and probably wants a rethink rather than five more table rows.

**`Menu/index.tsx` → `Menu/Menu.tsx`**, matching `Header/Header.tsx`, `Page/Page.tsx` and `Spine/Spine.tsx`. Recorded as a rename, and `ModernLayout` is the only importer.

## The issue's first item

LAZ-976 also asks that no tools be pinned by default on any game. As far as the code goes that already holds and this branch changes nothing about it: the only thing that ever writes a pin is the Tools page toggle (`useToolsPage.ts:121`), and `visibleTools` requires `pinnedToolsMap[id] === true` explicitly rather than defaulting to shown. Worth confirming against a fresh profile before the issue is closed on that point.

## Testing

`pnpm run verify` passed as of the first commit (build, lint, typecheck, 2296 renderer tests; E2E not run).

For the changes since, I ran lint, oxfmt and the full renderer suite — 212 files, 2295 passed, 9 skipped — but not `build`, so that's lint + tests rather than a full verify. E2E not run. Renderer `tsc` reports two errors in `IPCDownloadAdapter.ts` about `@vortex/shared/errors`; those are a stale local build of `@vortex/shared` after the VortexError IPC migration, not this branch — the symbols are exported from `src/shared/src/api/errors.ts` and reproduce with these changes stashed.

There are still no tests over this menu — `ToolsSection` and `Menu` have none, and I didn't add any. The row-order and fit numbers above were measured by rendering the components' real class strings against the project's compiled Tailwind in Chrome, not in the running app.

Not verified in a running app. Worth a look before merging: the tooltip states (a game with a primary tool set and one without), and the panel at one, five, six and ten tools, collapsed and expanded — six is where the collapsed reservation drops to zero.
