### PR TITLE
Add docs for game support, releasing and extensions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Project and coding documentation. To set up and build Vortex, start with
 
 ## Subsystems
 
+- [extensions.md](extensions.md) - What an extension is, how core, bundled and user extensions load, the lifecycle and the registration surface
+- [game-support.md](game-support.md) - How a game comes to be supported: bundled extensions, stubs, GDL, community extensions, and how they are published and picked up
 - [mod-management/collections.md](mod-management/collections.md) - Collections and phased installation; phase invariants
 - [mod-management/EXTERNAL-CHANGES.md](mod-management/EXTERNAL-CHANGES.md) - The External Changes dialog: change types, actions, auto-resolution
 - [updater.md](updater.md) - How updates are detected, downloaded and applied; install types, the state machine, channels and the analytics funnel
@@ -34,6 +36,7 @@ Project and coding documentation. To set up and build Vortex, start with
 
 ## Building and shipping
 
+- [releasing.md](releasing.md) - Start here: the whole path from merged PR to a user, which doc owns each stage, plus the post-release automation, signing operations and announcing
 - [packaging/windows.md](packaging/windows.md) - Local unsigned installers, the pipeline, signed CI builds
 - [packaging/flatpak.md](packaging/flatpak.md) - Building and installing the Flatpak
 - [flatpak/technical.md](flatpak/technical.md) - Flatpak manifest and runtime details

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,153 @@
+# Extensions
+
+What an extension is in Vortex, how the three kinds get loaded, and what the
+registration surface looks like. For someone who has read
+[repo-layout.md](repo-layout.md) and wants the model rather than the file list.
+For games specifically, and for how extensions are published and picked up, see
+[game-support.md](game-support.md).
+
+Almost all of Vortex is extensions. Mod management, collections, the FOMOD
+installers, download management and the Nexus integration are all extensions, so
+this is not a plugin system bolted onto an application. It is how the
+application is assembled.
+
+## An extension is a directory with two files
+
+The load contract is small: a directory containing an entry point named
+`index.cjs` or `index.js`, and an `info.json` beside it that parses.
+`src/renderer/src/ExtensionManager.ts` gives up on a directory that is missing
+either. No `main` field is honoured.
+
+The entry point's default export is an init function,
+`(context: IExtensionContext) => boolean`. A bare function export works too;
+`getExtensionInitFunc` handles the `__esModule` interop. `info.json` carries
+`name`, `version` and `author`, optionally `id` and `namespace`, and is parsed by
+`parseExtensionInfo` in
+`src/renderer/src/extensions/extension_manager/extensionInfo.ts`.
+
+Translation extensions are the exception: they have no entry point, so a
+directory with no `index.js` is logged at debug level and skipped rather than
+treated as broken.
+
+## Three kinds, three ways of loading
+
+`prepareExtensions()` in `ExtensionManager.ts` assembles all of them.
+
+**Static, or core.** An explicit hardcoded map from name to `require()` call,
+45 entries covering everything in `src/renderer/src/extensions/`. These
+are compiled into the renderer bundle and marked `dynamic: false`.
+`src/renderer/src/extensions/index.ts` is _not_ the registry; its `import {}`
+statements exist only so `tsc` recompiles on change and are removed at build
+time.
+
+**Order in that map matters.** It is the load order, and there is a real
+dependency encoded in it: `gameversion_management` is listed before
+`gamemode_management` so that `GameVersionManager` exists by the time
+`gamemode_management`'s `once` calls `setupGameMode`. If you add a core
+extension, think about where in the map it goes.
+
+**Bundled.** Rescanned from disk on every boot, from
+`getVortexPath("bundledPlugins")`, and never persisted. This is where
+`extensions/` and `extensions/games/` end up after packaging. Loaded with
+`bundled: true`.
+
+**User.** Extensions the user installed, loaded from persisted state and then
+reconciled against disk. This is the Extensions page's territory, and the path
+that game extensions, themes and translations arrive by. See
+[game-support.md](game-support.md) for publishing and pickup.
+
+Bundled and user extensions are both "dynamic": loaded with a real `require` at
+runtime rather than bundled into the renderer, which is why they need an app
+relaunch rather than a hot reload.
+
+## Lifecycle
+
+1. **`init(context)`** runs for every extension. This is registration time and
+   nothing else. Call the `register*` methods you need and return.
+2. **`once()`** callbacks run after the store is set up and every extension has
+   been initialised.
+
+The rule that catches people: **you cannot assume anything about the order
+extensions load in, or that they load synchronously.** If your extension needs
+another one to have finished initialising, check for that inside your `once`
+callback and react to a state change, rather than assuming it already happened.
+The one exception is the static map above, where order is fixed because it is
+written down.
+
+`requireVersion(range)` declares a Vortex version range, and
+`requireExtension(extId, version?, optional?)` declares a dependency on another
+extension.
+
+`onceMain()` runs on the Electron main process and is **deprecated**. It will be
+removed. If you need an unrestricted Node environment, use a separate Node
+process and talk to it over IPC, and tell the Vortex team what you are trying to
+do first.
+
+## What needs a relaunch
+
+[CONTRIBUTING.md](../CONTRIBUTING.md) covers this for day-to-day work. In short,
+edits that cannot be hot-applied include reducers, utils and an extension's
+`index.ts` init code, and the dynamic extensions in `extensions/` and
+`extensions/games/` need a full app relaunch rather than a `pnpm run dev`
+restart.
+
+## The registration surface
+
+`IExtensionContext` in `src/renderer/src/types/IExtensionContext.ts` declares 44
+`register*` methods. They are all documented inline; the point of this table is
+to tell you which corner to go and read.
+
+| Area                   | Methods                                                                                                                                                                                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Game support           | `registerGame`, `registerGameStub`, `registerGameStore`, `registerGameInfoProvider`, `registerGameVersionProvider`, `registerGameSpecificCollectionsData`, `registerToolVariables`                                                                                                         |
+| Mod install and deploy | `registerInstaller`, `registerModType`, `registerDeploymentMethod`, `registerMerge`, `registerArchiveType`, `registerModSource`, `registerRepositoryLookup`, `registerAttributeExtractor`                                                                                                  |
+| Load order             | `registerLoadOrder`, `registerLoadOrderPage`                                                                                                                                                                                                                                               |
+| UI surfaces            | `registerMainPage`, `registerDashlet`, `registerSettings`, `registerAction`, `registerActionCheck`, `registerBanner`, `registerFooter`, `registerOverlay`, `registerDialog`, `registerToDo`, `registerTableAttribute`, `registerControlWrapper`, `registerPreview`, `registerHistoryStack` |
+| State                  | `registerReducer`, `registerSettingsHive`, `registerPersistor`, `registerMigration`, `registerProfileFeature`, `registerProfileFile`                                                                                                                                                       |
+| Diagnostics            | `registerTest`, `registerHealthCheck`                                                                                                                                                                                                                                                      |
+| API and integration    | `registerAPI`, `registerProtocol`, `registerDownloadProtocol`, `registerInterpreter`, `registerStartHook`                                                                                                                                                                                  |
+
+For the published API surface an external author writes against, read
+`etc/vortex.api.md`. It is generated by `pnpm run api`, so no hand-written
+summary of it belongs in this doc. It is only as current as the last person to
+regenerate it, though, so if something in it looks wrong against the source,
+regenerate before believing it.
+
+## Extension types
+
+`ExtensionType` in `src/renderer/src/types/extensions.ts` is `game`,
+`translation` or `theme`. The same three appear in the
+`GET /v3/vortex/extensions` response that the Extensions page reads.
+
+Several fields on `ExtensionInfo` are marked deprecated and are no longer read
+from `info.json`, including `bundled`, `type`, `modId` and `fileId`. `bundled` in
+particular is computed at load time from which of the three paths above the
+extension came in by, so do not put it in an `info.json` and expect it to mean
+anything.
+
+## Worth reading as reference
+
+- `src/renderer/src/extensions/mod_management/` for a large core extension
+- `extensions/games/game-palworld/src/index.js` for the smallest useful one, a
+  game stub in twenty lines
+- `extensions/gamebryo-plugin-management/` for a substantial bundled extension
+
+## Key Files
+
+| Path                                             | Purpose                                                                                             |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `src/renderer/src/ExtensionManager.ts`           | Finds, loads and initialises everything. `prepareExtensions` is the entry point worth reading first |
+| `src/renderer/src/types/IExtensionContext.ts`    | `IExtensionContext`, the 44 `register*` methods, `once`, `requireExtension`                         |
+| `src/renderer/src/types/extensions.ts`           | `ExtensionInfo`, `ExtensionInit`, `ExtensionType`                                                   |
+| `src/renderer/src/extensions/extension_manager/` | The Extensions page: listing, install, state                                                        |
+| `etc/vortex.api.md`                              | Generated report of the published `vortex-api` surface                                              |
+| `packages/vortex-api/`                           | The extension-facing API package published to npm                                                   |
+
+## Related
+
+- [game-support.md](game-support.md) for games, and for publishing and pickup
+- [repo-layout.md](repo-layout.md) for where things live
+- [../RELEASES.md](../RELEASES.md) for `vortex-api` deprecation windows
+- [investigation/vscode.md](investigation/vscode.md) and
+  [investigation/obsidian.md](investigation/obsidian.md) for how other products
+  solve this, kept as prior art rather than as descriptions of Vortex

--- a/docs/game-support.md
+++ b/docs/game-support.md
@@ -1,0 +1,225 @@
+# Game Support in Vortex
+
+How a game comes to be supported: the routes that produce a game extension, how
+those extensions reach a user's machine, and what marks one as official rather
+than community. For someone who knows the codebase but has not worked on game
+extensions before. For where game art comes from and which image wins on each
+surface, see [game-art-assets.md](game-art-assets.md).
+
+## Four routes, one load contract
+
+Four different things produce game support, and Vortex cannot tell them apart.
+Whatever the route, what it ends up loading is a directory containing:
+
+- `index.cjs` or `index.js`, the entry point, and
+- `info.json`, which must parse.
+
+That is the whole contract. `src/renderer/src/ExtensionManager.ts` looks for the
+first matching entry filename (`mExtensionFormats`), reads `info.json` beside it,
+and gives up on the directory if either is missing. No `main` field is honoured,
+so the entry point has to carry one of those two names.
+
+```
+  hand-written extension    --+
+  extensions/games/game-*/    |
+                              |
+  stub, then a download     --+
+  extensions/games/game-*/    |    a directory holding
+                              +--> index.js and info.json,
+  GDL-built game            --+    which Vortex loads
+  gdl-games repo              |
+                              |
+  community extension       --+
+  published to the site
+```
+
+The first two ship inside the installer. The last two arrive as a zip uploaded
+to a Nexus mod page and downloaded on demand, which is also how a stub gets
+filled in.
+
+There are 86 folders in `extensions/games/`. Nine of them are stubs; the rest are
+real extensions built from source in this repo.
+
+## Bundled extensions
+
+A bundled game extension is a workspace package under `extensions/games/game-*`.
+It builds its entry point and assets into `dist/`, and generates `dist/info.json`
+from its `package.json` via `pnpm extractInfo`, a bin provided by
+`packages/vortex-api` (`bin/extractInfo.mjs`). The build output ships inside the
+installer, so a change to one of these only reaches users in a Vortex release.
+
+**Prefer GDL for new games.** Hand-written bundled extensions are the historical
+default, not the current one. See the GDL section below.
+
+> In flight: GDL is also being adopted _in place_ in this repo, replacing a
+> game's `src/index.*` with a `game.yaml` in the same `extensions/games/game-*`
+> folder. That work is on `origin/halgari/pathfinder-to-gdl` and is not on
+> `master`: there is no `game.yaml` under `extensions/games/` here yet. Expect
+> this section to need revisiting when it lands.
+
+## Stubs
+
+A stub is a bundled extension that exists only to say "this game is supported,
+fetch the real thing when someone wants it". It is a real extension directory,
+not a metadata-only placeholder: it has a small entry point that calls
+`registerGameStub`. `extensions/games/game-palworld/src/index.js` is the whole of
+one:
+
+```js
+context.registerGameStub(
+    {
+        id: "palworld",
+        name: "Palworld",
+        executable: null,
+        mergeMods: false,
+        queryModPath: () => ".",
+        requiredFiles: [],
+    },
+    { name: "Game: Palworld", modId: 770 },
+);
+```
+
+The first argument is a minimal `IGame`, enough to render a row on the Games page.
+The second is an `IExtensionDownloadInfo` (`name`, `modId`, and optionally
+`fileId`), which is where Vortex fetches the real extension from. With no
+`fileId`, it takes the current file on that mod page.
+
+Why stubs exist: the real extension is distributed through the site and updated
+independently of Vortex releases. The nine stubs are the biggest and most
+actively maintained titles, several of which have their own repositories
+(`Nexus-Mods/game-cyberpunk2077`, `Nexus-Mods/game-starfield`). Shipping them as
+stubs means a fix for one of those games does not have to wait for a Vortex
+release.
+
+Handling lives in `src/renderer/src/extensions/gamemode_management/`:
+
+- `index.ts` registers the stub into `$.extensionStubs`. If a full extension has
+  already registered that game id, the stub is skipped, so the real extension
+  always wins over its own placeholder.
+- `util/getGame.ts` falls back to `$.extensionStubs` when a game id is not among
+  the loaded extensions, which is what lets a stubbed game resolve at all.
+- `removeDisappearedGames` is passed the stub map so a game whose extension has
+  gone missing can be offered for reinstall rather than silently vanishing.
+
+## GDL
+
+GDL (Game Description Language) is a build-time toolchain: a declarative
+`game.yaml`, a `gameart.webp`, and an optional `src/hooks.ts` for logic that YAML
+cannot express, compiled into an ordinary bundled Vortex extension. Nothing at
+runtime knows a game came from YAML.
+
+It lives in two repositories, both of which document themselves properly:
+
+- [`Nexus-Mods/game-description-language`](https://github.com/Nexus-Mods/game-description-language)
+  is the toolchain and the `game.yaml` reference: game registration, stores, mod
+  types, installer routing, discovery, lifecycle hooks, diagnostics and release
+  metadata. Read this for the YAML surface.
+- [`Nexus-Mods/gdl-games`](https://github.com/Nexus-Mods/gdl-games) is the
+  monorepo of games built from it, one `games/<id>/` folder each, sharing a single
+  copy of the toolchain as a submodule. Nx infers a project per `game.yaml`, so
+  there is no per-game config. Read this to add or maintain a game.
+
+Deliberately not duplicated here. Those READMEs are maintained and detailed, and
+a second copy of the YAML reference in this repo would be wrong within a release.
+
+## Art
+
+[game-art-assets.md](game-art-assets.md) is the reference for art: the five
+sources, which image wins on each surface, how the numeric Nexus id is resolved,
+and caching. Two things it is worth knowing alongside this doc.
+
+**The local logo filename is a convention, not a requirement.** `IGame.logo` is
+an extension-relative path, resolved as `path.join(game.extensionPath, game.logo)`
+in `GameRow.tsx` and `GameThumbnail.tsx`. Any filename works.
+`game-art-assets.md` describes it as `gameart.jpg` because that is what almost
+every bundled extension uses (165 of them), but `gameart.png` and `gameart.webp`
+both appear in `extensions/games/` too, and GDL games use `gameart.webp`.
+
+**The local logo is the floor, not the ceiling.** It ships inside the extension,
+so it works offline and covers games with no numeric Nexus id, which in practice
+means community games. The Nexus tile and thumbnail are preferred where they can
+be resolved.
+
+## Publishing and pickup
+
+This is the path for anything not shipped in the installer: GDL-built games,
+community extensions, and the real extensions behind the stubs. Themes and
+translations use the same path.
+
+1. **Publish.** Upload the packaged zip to a Nexus mod page. GDL's `gdl package`
+   produces `out/<id>-vortex-v<version>.zip` for this.
+2. **Listing.** Vortex fetches `GET /v3/vortex/extensions`.
+   `src/renderer/src/extensions/extension_manager/availableExtensions.ts` is the
+   only module that touches the wire types; everything downstream works with
+   `IAvailableExtension`. Each asset carries `mod_id`, `file_id`, `version`,
+   `author_name` and `uploaded_at`, grouped by type (`game`, `translation`,
+   `theme`).
+3. **Install.** `installExtension.ts` unpacks it, `reducers.ts` holds the state,
+   and `BrowseExtensions.tsx` is the Extensions page UI.
+
+Publishing is not fully automatic on the site side. An uploaded file can sit
+blocked pending content preview and need releasing by hand before the download
+works. The same trap applies to Vortex's own installer; see the announcing
+section of [releasing.md](releasing.md).
+
+## Official versus community
+
+An extension is classified from the `author` field of its `info.json`, parsed by
+`parseExtensionInfo` in
+`src/renderer/src/extensions/extension_manager/extensionInfo.ts` and judged by
+`isContributed` in `src/renderer/src/util/isContributed.ts`:
+
+```ts
+const OFFICIAL_AUTHORS = [COMPANY_ID, NEXUSMODS_EXT_ID];
+export function isContributed(author: string | undefined): boolean {
+    return !!author && !OFFICIAL_AUTHORS.includes(author);
+}
+```
+
+`COMPANY_ID` is `"Black Tree Gaming Ltd."` and `NEXUSMODS_EXT_ID` is
+`"Nexus Mods"` (`src/renderer/src/util/constants.ts`). An exact match on either,
+or an empty author, counts as official. Anything else is community. The result
+becomes `IGame.contributed`, set in
+`src/renderer/src/extensions/gamemode_management/index.ts`, which holds the
+contributor's name for a community game and is undefined for an official one.
+
+**This is not just a badge.** The classification decides whether a crash is
+reportable to us:
+
+- `resolveAllowReport` in `src/renderer/src/util/errorHandling.ts` returns
+  `!isContributed(error.extension)`, so a crash attributed to a community
+  extension is not offered for reporting.
+- `errorHandler` in `src/renderer/src/extensions/file_based_loadorder/util.ts`
+  gates its error notifications the same way.
+- `src/renderer/src/extensions/mod_management/eventHandlers.ts` sets the
+  `extension_type` error context to `community` or `official`.
+
+So a wrong `author` silently changes error-reporting behaviour, which is why it
+is worth getting right rather than treating as cosmetic. It has been wrong in
+production before: commit `8a3160027` fixed the Cyberpunk 2077 community
+extension showing as official. Because the comparison is an exact string match,
+a near miss (a trailing full stop, "Nexus Mods Ltd", a personal account name on a
+first-party extension) misclassifies silently. GDL emits this field from
+`game.author`.
+
+## Key Files
+
+| Path                                                                   | Purpose                                                                                            |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `src/renderer/src/ExtensionManager.ts`                                 | Finds, loads and initialises extensions; owns the `index.cjs`/`index.js` plus `info.json` contract |
+| `src/renderer/src/extensions/gamemode_management/index.ts`             | `registerGame`, `registerGameStub`, sets `IGame.contributed`                                       |
+| `src/renderer/src/extensions/gamemode_management/util/getGame.ts`      | Resolves a game id, falling back to registered stubs                                               |
+| `src/renderer/src/extensions/extension_manager/availableExtensions.ts` | Boundary to `GET /v3/vortex/extensions`; wire types stop here                                      |
+| `src/renderer/src/extensions/extension_manager/installExtension.ts`    | Installs a downloaded extension                                                                    |
+| `src/renderer/src/extensions/extension_manager/extensionInfo.ts`       | Parses `info.json`                                                                                 |
+| `src/renderer/src/util/isContributed.ts`                               | Official versus community, from the author string                                                  |
+| `src/renderer/src/types/IGame.ts`                                      | The `IGame` interface a game extension registers                                                   |
+| `extensions/games/game-palworld/src/index.js`                          | A stub, in full                                                                                    |
+| `packages/vortex-api/bin/extractInfo.mjs`                              | Generates `info.json` from `package.json` at build time                                            |
+
+## Related
+
+- [game-art-assets.md](game-art-assets.md) for art sources and precedence
+- [releasing.md](releasing.md) for how Vortex itself is built, signed and shipped
+- [../RELEASES.md](../RELEASES.md) for `vortex-api` deprecation windows and how
+  extension authors are notified of breaking changes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,203 @@
+# Releasing Vortex
+
+The path a merged PR takes to reach a user, and which doc owns each stage. Start
+here if you know how to get code onto a release branch but not what happens
+after that. Every stage that has its own doc gets a link rather than a summary,
+so this page stays a map.
+
+The three things documented nowhere else are at the bottom: the automation that
+fires off a release, signing as an operation rather than a boundary, and
+announcing.
+
+## The path, end to end
+
+```
+  master
+    |
+    +--> release branch (v2.7)            branching-and-release-strategy.md
+    |          |    ^
+    |          +----+  cherry-picks both ways while active
+    |                                     cherry-pick-workflow.md
+    v
+  Package workflow, dispatched by hand    packaging/windows.md
+    |
+    |  builds and signs, then in parallel:
+    |    * draft release on Vortex and on Vortex-Staging
+    |    * installer uploaded to R2 (staged, not yet the live download)
+    |
+    |  the release is a draft, so the v* tag does not exist yet
+    v
+  Undraft the release on GitHub           publishing-releases.md
+    |
+    |  this is the go-live action, and there is no second step
+    |
+    +--> `released` fires, which uploads the installer to Nexus Mods
+    |    (stable only; a pre-release fires `prereleased` instead)
+    +--> the release becomes visible to the updater channel   updater.md
+    +--> `prereleased` or `released` also syncs Linear and annotates Mixpanel
+    +--> the v* tag is created, which marks error fingerprints released
+    v
+  Website download tag is pointed at the new version
+    |    independent of the Nexus upload; neither waits for the other
+    v
+  Announce
+```
+
+[publishing-releases.md](publishing-releases.md) is the doc to have open while
+doing this. It has
+the dispatch inputs, the guardrails, and the troubleshooting list, including the
+publish-order trap on multi-release days.
+
+## Which doc for which stage
+
+| Stage                                            | Doc                                                                                            |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Where a fix lands, and when to stop backporting  | [branching-and-release-strategy.md](branching-and-release-strategy.md)                         |
+| Moving a fix between master and a release branch | [cherry-pick-workflow.md](cherry-pick-workflow.md)                                             |
+| Building an installer, locally or in CI          | [packaging/windows.md](packaging/windows.md)                                                   |
+| Drafting, undrafting, R2, the Nexus upload       | [publishing-releases.md](publishing-releases.md)                                               |
+| How users are offered the update                 | [updater.md](updater.md)                                                                       |
+| Exercising the update cycle before shipping      | [updater-testing.md](updater-testing.md), [updater-rehearsal.md](updater-rehearsal.md)         |
+| Linux packaging                                  | [packaging/flatpak.md](packaging/flatpak.md), [flatpak/maintenance.md](flatpak/maintenance.md) |
+| Which versions are still supported               | [../RELEASES.md](../RELEASES.md)                                                               |
+| Drafting the changelog entry                     | `.claude/skills/changelog/skill.md`                                                            |
+
+## Post-release automation
+
+Five workflows run around a release without anyone asking them to. None of them
+is covered by another doc.
+
+**`linear-release.yml`** fires on `prereleased` and `released`. It works out the
+commit range since the previous tag using `.github/actions/linear-release` in
+`prepare` mode, syncs every issue in that range onto a Linear release named after
+the tag, then marks that release complete. Dispatchable with an explicit tag;
+the dispatch path defaults to `dry-run: true`, and on dispatch the channel is
+inferred from the tag (a `-` means pre-release).
+
+**`annotate-mixpanel-release.yml`** fires on `prereleased` and `released`. It
+posts a "Vortex `<version>` Released" annotation to the EU Mixpanel project at
+the release's publish time, converted into the project timezone. Stable and beta
+use different Mixpanel tag ids so dashboards can toggle them separately. It
+checks that day's existing annotations first, so a re-run does not double up.
+Dispatch defaults to a dry run that prints the payload.
+
+**`fingerprint-released.yml`** fires on a `v*` **tag push**, not on a release
+event. `package.yml` creates the release as a draft, and GitHub does not create
+the tag for a draft, so in the normal flow this lands at undraft time along with
+the other two. The distinction matters when something is not the normal flow: a
+tag pushed by hand, moved, or recreated triggers this and nothing else. It runs
+`.github/actions/fingerprints` in `release` mode against ClickHouse to mark
+error fingerprints as released. See
+[error-reporting/](error-reporting/README.md) for what fingerprints are and how
+they are resolved.
+
+**`nightly.yml`** packages Vortex every day at 19:00 UTC on a Windows runner with
+`use-codesigning: "false"`, and uploads the unpacked build, the installer and
+`latest.yml` as artifacts with two-day retention. Nothing is published or
+distributed. It is a build canary: if packaging has broken, this tells you
+before a release does.
+
+**`signing-test.yml`** is covered in the next section.
+
+Both `linear-release.yml` and `annotate-mixpanel-release.yml` treat betas as
+releases. This is worth remembering, because the Nexus upload does not: a beta
+updates Linear and Mixpanel while never reaching the site.
+
+## Signing as an operation
+
+[packaging/windows.md](packaging/windows.md) draws the boundary correctly:
+signing happens in CI, the secrets are not available locally, and you should not
+run `pnpm package` on your machine. What follows is the operational side.
+
+Signing uses SSL.com's eSigner via their CodeSignTool, driven by four secrets:
+`ES_USERNAME`, `ES_PASSWORD`, `ES_CREDENTIAL_ID` and `ES_TOTP_SECRET`. The
+Package workflow takes them as environment variables, and
+`.github/actions/package` falls back to an unsigned build when they are absent.
+
+Two scripts at the repo root exist for this and nothing else:
+
+- `download-codesigntool.ps1` fetches the current CodeSignTool release from
+  `SSLcom/CodeSignTool` on GitHub, resolving the version dynamically rather than
+  pinning it, and extracts it to `./CodeSignTool`.
+- `test-codesigntool.ps1` checks the extracted tool is there, then runs
+  `CodeSignTool.bat credential_info` with those credentials. It does not sign
+  anything. It confirms the credentials and the certificate are usable.
+
+**`signing-test.yml` runs that pair every Wednesday at 14:05 UTC**, plus on
+dispatch. It is the cert-and-credential canary, and it uses the same four
+secrets the Package workflow does, so a green run is real evidence that the next
+release will be able to sign.
+
+The consequence worth internalising: because CodeSignTool is fetched fresh rather
+than pinned, and because the credentials sit behind a certificate that expires,
+signing can break without anything in this repo changing. A red Signing Test on a
+Wednesday is the warning. If it is ignored, the next release either produces an
+unsigned installer or fails outright, and unsigned builds also change updater
+behaviour (see the `publisherName` caveat in
+[updater-testing.md](updater-testing.md)).
+
+## Announcing
+
+Nothing in this repository or in CI does any of this. It is a manual process
+owned partly by engineering and partly by content and community.
+
+> Reconstructed from Slack rather than from anything in the repo. Treat the
+> shape as right and the specifics as needing confirmation from the release
+> manager and the comms side before you rely on them.
+
+**The handoff.** The release manager posts "Vortex vX.Y is now live!" in
+`#team-lazer-sharks` and tags the comms subteam. That tag is the handoff, and
+forgetting it stalls everything downstream, because nobody outside the channel
+knows there is anything to do.
+
+**The changelog is not the release notes.** These are two different documents for
+two different audiences, and conflating them has caused repeated problems.
+
+- `CHANGELOG.md` is engineering-facing. It records what merged, with PR links.
+  The repo is public, so it can and does reference things users cannot yet see.
+- Release notes are user-facing, written by content, and must exclude anything a
+  user cannot reach. A feature that is merged but suppressed behind a feature
+  flag does not belong in them.
+
+Both failure modes have happened: release notes describing a health-check feature
+that was merged but hidden in the UI, and a "full changelog" link pointing at the
+previous release's branch. If you are the engineer being asked what to highlight,
+give content the specific user-visible features rather than pointing them at the
+changelog and hoping.
+
+**Feature flags are part of releasing.** Unleash constraints are set per version
+by hand, by someone outside the release workflow, in the form "this version and
+newer". Unleash has no greater-than-or-equal operator, so a naive greater-than
+constraint excludes the very release you are shipping. If a release depends on a
+flag being on, confirm the constraint includes the boundary version and that
+someone has actually set it.
+
+**The site can hold the file back.** An uploaded `.exe` can sit blocked pending
+content preview generation and needs releasing by hand before the download works.
+The release is not usable at that point even though every workflow went green.
+The same trap applies to game and community extensions; see
+[game-support.md](game-support.md).
+
+**Betas never reach the Nexus site.** They go out through GitHub Releases and the
+updater beta channel only. `publishing-releases.md` covers the mechanism (the
+`released` event does not fire for a pre-release); it matters here because it is
+what people get wrong when announcing.
+
+**Wider distribution** goes out through Discord and named community curators,
+plus a news post on the site for a major release. That is content and community
+territory, not engineering's.
+
+## Key Files
+
+| Path                                                 | Purpose                                                                                                   |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/package.yml`                      | The release build. Dispatch only. Inputs for artifacts, signing, the two draft releases and the R2 upload |
+| `.github/actions/package/action.yml`                 | What the build actually does, including the signing fallback                                              |
+| `.github/workflows/upload-release-to-r2.yml`         | Manual R2 upload, the fallback when the packaged one did not land                                         |
+| `.github/workflows/linear-release.yml`               | Syncs issues onto a Linear release                                                                        |
+| `.github/workflows/annotate-mixpanel-release.yml`    | Mixpanel annotation per release                                                                           |
+| `.github/workflows/fingerprint-released.yml`         | Marks error fingerprints released, on `v*` tag push                                                       |
+| `.github/workflows/nightly.yml`                      | Unsigned nightly package as a build canary                                                                |
+| `.github/workflows/signing-test.yml`                 | Weekly signing credential canary                                                                          |
+| `download-codesigntool.ps1`, `test-codesigntool.ps1` | Fetch and validate SSL.com CodeSignTool                                                                   |
+| `scripts/verify-packaged-asar.mjs`                   | Guards against electron-builder shipping wrong nested dependency versions                                 |


### PR DESCRIPTION
Three docs for onboarding: how a game comes to be supported, what happens to a release after it is packaged, and what an extension is. Game support and extensions had nothing at all. Releasing had six accurate docs and no map, so that one is mostly links plus the post-release automation, signing operations and announcing.

The announcing section is reconstructed from Slack rather than from the repo, so it needs a check from Vitalii and comms before anyone relies on it.