### PR TITLE
fix(ui): centre the download ring on its button (LAZ-1018)

### DIFF
--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
@@ -87,7 +87,11 @@ const ProgressRing = ({
   const offset = circumference - (progress / 100) * circumference;
 
   return (
-    <svg className="pointer-events-none absolute inset-0 -rotate-90" height={size} width={size}>
+    <svg
+      className="pointer-events-none absolute top-1/2 left-1/2 -translate-1/2 -rotate-90"
+      height={size}
+      width={size}
+    >
       {/* Background circle */}
       <circle
         className={joinClasses([


### PR DESCRIPTION
Closes [LAZ-1018](https://linear.app/nexus-mods/issue/LAZ-1018/investigate-misaligned-download-ring).

The Spine download button's progress ring was drawn 2px down and right of the button it outlines. `absolute inset-0` resolves against the button's padding box, which its 2px border insets to 44x44 at offset (2,2), while the svg's `width`/`height` attributes keep the box 48px square.

<img width="116" height="151" alt="image" src="https://github.com/user-attachments/assets/7807ff28-7156-4ab5-8114-24120fc68e2a" />


<img width="116" height="151" alt="image" src="https://github.com/user-attachments/assets/cd60069f-eeb9-48eb-9d86-c19956986378" />
