### PR TITLE
pin plugin persistor and load order reducer behaviour

### DIFF
--- a/extensions/gamebryo-plugin-management/src/reducers/loadOrder.test.ts
+++ b/extensions/gamebryo-plugin-management/src/reducers/loadOrder.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, test } from "vitest";
 
-import { setPluginEnabled, setPluginOrder } from "../actions/loadOrder";
+import { setPluginEnabled, setPluginOrder, updatePluginOrder } from "../actions/loadOrder";
 import { loadOrderReducer } from "./loadOrder";
 
-// the reducer keys entries by action; redux-act actions stringify to their type, so index with the
-// action itself. state is keyed by the plugin id (lowercased, ghost suffix stripped).
-const setEnabled = loadOrderReducer.reducers[setPluginEnabled as any];
-const setOrder = loadOrderReducer.reducers[setPluginOrder as any];
+// drive the reducer through the real action creators so the payload shapes under test
+// stay the ones production dispatches. state is keyed by the plugin id (lowercased,
+// ghost suffix stripped).
+function reduce(state: unknown, action: { type: string; payload: unknown }) {
+  return loadOrderReducer.reducers[action.type](state, action.payload);
+}
 
 describe("loadOrder setPluginEnabled", () => {
   test("toggles an existing entry by id regardless of the payload's case", () => {
     const state = { "skyui.esp": { name: "SkyUI.esp", enabled: false, loadOrder: 3 } };
 
-    const result = setEnabled(state, { pluginName: "SkyUI.esp", enabled: true });
+    const result = reduce(state, setPluginEnabled("SkyUI.esp", true));
 
     // existing entry is updated in place: enabled flips, load order is preserved.
     expect(result["skyui.esp"]).toEqual({ name: "SkyUI.esp", enabled: true, loadOrder: 3 });
@@ -27,7 +29,7 @@ describe("loadOrder setPluginEnabled", () => {
       },
     };
 
-    const result = setEnabled(state, { pluginName: "LegacyoftheDragonborn.esm", enabled: true });
+    const result = reduce(state, setPluginEnabled("LegacyoftheDragonborn.esm", true));
 
     expect(result["legacyofthedragonborn.esm"].loadOrder).toBe(12);
     expect(result["legacyofthedragonborn.esm"].enabled).toBe(true);
@@ -36,14 +38,14 @@ describe("loadOrder setPluginEnabled", () => {
   test("matches an existing entry when the payload carries a ghost suffix", () => {
     const state = { "skyui.esp": { name: "SkyUI.esp", enabled: false, loadOrder: 3 } };
 
-    const result = setEnabled(state, { pluginName: "SkyUI.esp.ghost", enabled: true });
+    const result = reduce(state, setPluginEnabled("SkyUI.esp.ghost", true));
 
     expect(Object.keys(result)).toEqual(["skyui.esp"]);
     expect(result["skyui.esp"].loadOrder).toBe(3);
   });
 
   test("inserts a brand-new plugin with loadOrder -1", () => {
-    const result = setEnabled({}, { pluginName: "New.esp", enabled: true });
+    const result = reduce({}, setPluginEnabled("New.esp", true));
 
     expect(result["new.esp"]).toEqual({ name: "New.esp", enabled: true, loadOrder: -1 });
   });
@@ -53,14 +55,64 @@ describe("loadOrder setPluginOrder", () => {
   test("preserves a mixed-case plugin's enabled state across a full reorder", () => {
     const state = { "skyui.esp": { name: "SkyUI.esp", enabled: true, loadOrder: 0 } };
 
-    const result = setOrder(state, { plugins: ["SkyUI.esp"], defaultEnable: false });
+    const result = reduce(state, setPluginOrder(["SkyUI.esp"], false));
 
     expect(result["skyui.esp"]).toEqual({ name: "SkyUI.esp", enabled: true, loadOrder: 0 });
   });
 
   test("falls back to defaultEnable for plugins not previously known", () => {
-    const result = setOrder({}, { plugins: ["Unseen.esp"], defaultEnable: true });
+    const result = reduce({}, setPluginOrder(["Unseen.esp"], true));
 
     expect(result["unseen.esp"]).toEqual({ name: "Unseen.esp", enabled: true, loadOrder: 0 });
+  });
+
+  test("an empty list clears every entry (the profile-switch clean slate)", () => {
+    const state = { "skyui.esp": { name: "SkyUI.esp", enabled: true, loadOrder: 0 } };
+
+    const result = reduce(state, setPluginOrder([], false));
+
+    expect(result).toEqual({});
+  });
+});
+
+describe("loadOrder updatePluginOrder", () => {
+  test("orders the listed plugins and appends unlisted entries after them", () => {
+    const state = {
+      "a.esp": { name: "A.esp", enabled: true, loadOrder: 5 },
+      "b.esp": { name: "B.esp", enabled: false, loadOrder: 0 },
+    };
+
+    const result = reduce(state, updatePluginOrder(["B.esp"], false, false));
+
+    expect(result["b.esp"].loadOrder).toBe(0);
+    expect(result["a.esp"].loadOrder).toBe(1);
+    expect(result["a.esp"].enabled).toBe(true);
+  });
+
+  test("setEnabled enables the listed plugins and disables the rest", () => {
+    const state = {
+      "a.esp": { name: "A.esp", enabled: true, loadOrder: 0 },
+      "b.esp": { name: "B.esp", enabled: false, loadOrder: 1 },
+    };
+
+    const result = reduce(state, updatePluginOrder(["B.esp"], true, false));
+
+    expect(result["b.esp"].enabled).toBe(true);
+    expect(result["a.esp"].enabled).toBe(false);
+  });
+
+  test("falls back to defaultEnable for plugins not previously known", () => {
+    const result = reduce({}, updatePluginOrder(["New.esp"], false, true));
+
+    expect(result["new.esp"]).toEqual({ name: "New.esp", enabled: true, loadOrder: 0 });
+  });
+
+  test("matches existing entries by id regardless of the list's case", () => {
+    const state = { "skyui.esp": { name: "skyui.esp", enabled: true, loadOrder: 4 } };
+
+    const result = reduce(state, updatePluginOrder(["SkyUI.esp"], false, false));
+
+    expect(Object.keys(result)).toEqual(["skyui.esp"]);
+    expect(result["skyui.esp"]).toEqual({ name: "SkyUI.esp", enabled: true, loadOrder: 0 });
   });
 });

--- a/extensions/gamebryo-plugin-management/src/util/PluginPersistor.test.ts
+++ b/extensions/gamebryo-plugin-management/src/util/PluginPersistor.test.ts
@@ -4,14 +4,19 @@ import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
-const paths = vi.hoisted(() => ({ pluginDir: "", dataDir: "", native: [] as string[] }));
+const paths = vi.hoisted(() => ({
+  pluginDir: "",
+  dataDir: "",
+  native: [] as string[],
+  format: "fallout4" as "fallout4" | "original",
+}));
 
 // resolve the persistor's game paths into per-test temp dirs
 vi.mock("./gameSupport", () => ({
   gameSupported: (gameId: string) => gameId === "skyrimse",
   gameDataPath: () => paths.dataDir,
   pluginPath: () => paths.pluginDir,
-  pluginFormat: () => "fallout4",
+  pluginFormat: () => paths.format,
   nativePlugins: () => paths.native,
 }));
 
@@ -43,10 +48,27 @@ describe("PluginPersistor", () => {
     hive = next;
   };
 
+  const tmpDirs: string[] = [];
+  const tmpDir = (prefix: string) => {
+    const dir = nodeFs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  };
+
+  const persistors: PluginPersistor[] = [];
+  const makePersistor = async (controlOrder: boolean = false) => {
+    const made = new PluginPersistor(vi.fn(), () => controlOrder);
+    made.setResetCallback(vi.fn(async () => undefined));
+    await made.loadFiles("skyrimse");
+    persistors.push(made);
+    return made;
+  };
+
   beforeEach(async () => {
-    paths.pluginDir = nodeFs.mkdtempSync(path.join(os.tmpdir(), "plugin-persistor-"));
-    paths.dataDir = nodeFs.mkdtempSync(path.join(os.tmpdir(), "plugin-data-"));
+    paths.pluginDir = tmpDir("plugin-persistor-");
+    paths.dataDir = tmpDir("plugin-data-");
     paths.native = [];
+    paths.format = "fallout4";
     // one plugin enabled and persisted (the install-time single-plugin case) plus one
     // known-but-disabled plugin whose position only the persistor remembers
     nodeFs.writeFileSync(
@@ -66,8 +88,12 @@ describe("PluginPersistor", () => {
 
   afterEach(async () => {
     await persistor.disable();
-    nodeFs.rmSync(paths.pluginDir, { recursive: true, force: true });
-    nodeFs.rmSync(paths.dataDir, { recursive: true, force: true });
+    for (const made of persistors.splice(0)) {
+      await made.disable();
+    }
+    for (const dir of tmpDirs.splice(0)) {
+      nodeFs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("does not rehydrate state from a known-plugins refresh", async () => {
@@ -328,6 +354,156 @@ describe("PluginPersistor", () => {
     await persistor.syncFromState("skyrimse", hive as Record<string, ILoadOrder>);
 
     expect(JSON.parse(await persistor.getItem(["multi.esp"])).enabled).toBe(true);
+  });
+
+  describe("missing plugins.txt", () => {
+    it("stays writable when no plugins.txt exists yet", async () => {
+      paths.pluginDir = tmpDir("plugin-missing-");
+      const fresh = await makePersistor();
+
+      fresh.setKnownPlugins({ "new.esp": "New.esp" });
+      await fresh.setItem(["new.esp"], JSON.stringify({ enabled: true, loadOrder: 0 }));
+
+      await vi.waitFor(() => {
+        const written = nodeFs.readFileSync(path.join(paths.pluginDir, "plugins.txt"), "latin1");
+        expect(written).toContain("*New.esp");
+      });
+    });
+
+    it("keeps its state and recreates the file when plugins.txt is deleted externally", async () => {
+      nodeFs.rmSync(path.join(paths.pluginDir, "plugins.txt"));
+
+      await persistor.loadFiles("skyrimse");
+
+      expect(JSON.parse(await persistor.getItem(["old.esp"])).enabled).toBe(true);
+      await vi.waitFor(() => {
+        const written = nodeFs.readFileSync(path.join(paths.pluginDir, "plugins.txt"), "latin1");
+        expect(written).toContain("*Old.esp");
+      });
+    });
+  });
+
+  it("keeps blueprint plugins out of both plugin files", async () => {
+    persistor.setKnownPlugins({ "old.esp": "Old.esp", "bp.esm": "BP.esm" }, new Set(["bp.esm"]));
+
+    await vi.waitFor(() => {
+      const pluginsTxt = nodeFs.readFileSync(path.join(paths.pluginDir, "plugins.txt"), "latin1");
+      const loadorderTxt = nodeFs.readFileSync(path.join(paths.pluginDir, "loadorder.txt"), "utf8");
+      expect(pluginsTxt).toContain("*Old.esp");
+      expect(pluginsTxt).not.toContain("BP.esm");
+      expect(loadorderTxt).toContain("Old.esp");
+      expect(loadorderTxt).not.toContain("BP.esm");
+    });
+  });
+
+  describe("native plugin load order", () => {
+    let native: PluginPersistor;
+
+    beforeEach(async () => {
+      paths.native = ["skyrim.esm"];
+      paths.pluginDir = tmpDir("plugin-native-lo-");
+      nodeFs.writeFileSync(
+        path.join(paths.pluginDir, "plugins.txt"),
+        `${VORTEX_HEADER}\r\n*Old.esp\r\n`,
+        { encoding: "latin1" },
+      );
+      native = await makePersistor();
+      native.setKnownPlugins({ "skyrim.esm": "Skyrim.esm", "old.esp": "Old.esp" });
+    });
+
+    it("reports an installed native plugin at its native index", async () => {
+      expect(JSON.parse(await native.getItem(["skyrim.esm"])).loadOrder).toBe(0);
+    });
+
+    it("round-trips a dynamic plugin's load order across the native offset", async () => {
+      await native.setItem(["old.esp"], JSON.stringify({ enabled: true, loadOrder: 3 }));
+
+      expect(JSON.parse(await native.getItem(["old.esp"])).loadOrder).toBe(3);
+    });
+  });
+
+  describe("original plugin format (Oblivion/Fallout 3 family)", () => {
+    // the mocked gameSupport pairs the original format with "skyrimse", a pairing
+    // production never produces; deserialize's skyrim exemption from file-time
+    // ordering is therefore deliberately not covered here
+    beforeEach(() => {
+      paths.format = "original";
+      paths.pluginDir = tmpDir("plugin-original-");
+      paths.dataDir = tmpDir("plugin-original-data-");
+      // both files must exist: the original format reads loadorder.txt as the order
+      // reference first and plugins.txt (enabled names only, no markers) second
+      nodeFs.writeFileSync(
+        path.join(paths.pluginDir, "loadorder.txt"),
+        `${VORTEX_HEADER}\r\nOld.esp\r\nParked.esp\r\n`,
+        { encoding: "utf8" },
+      );
+      nodeFs.writeFileSync(
+        path.join(paths.pluginDir, "plugins.txt"),
+        `${VORTEX_HEADER}\r\nOld.esp\r\n`,
+        { encoding: "latin1" },
+      );
+    });
+
+    it("reads the order from loadorder.txt and the enabled set from plugins.txt", async () => {
+      const p = await makePersistor(true);
+
+      expect(JSON.parse(await p.getItem(["old.esp"]))).toMatchObject({
+        enabled: true,
+        loadOrder: 0,
+      });
+      expect(JSON.parse(await p.getItem(["parked.esp"]))).toMatchObject({
+        enabled: false,
+        loadOrder: 1,
+      });
+    });
+
+    it("writes only enabled plugins to plugins.txt, without enable markers", async () => {
+      const p = await makePersistor(true);
+      p.setKnownPlugins({ "old.esp": "Old.esp", "parked.esp": "Parked.esp" });
+
+      await vi.waitFor(() => {
+        const pluginsTxt = nodeFs.readFileSync(path.join(paths.pluginDir, "plugins.txt"), "latin1");
+        const loadorderTxt = nodeFs.readFileSync(
+          path.join(paths.pluginDir, "loadorder.txt"),
+          "utf8",
+        );
+        expect(pluginsTxt).toContain("Old.esp");
+        expect(pluginsTxt).not.toContain("*Old.esp");
+        expect(pluginsTxt).not.toContain("Parked.esp");
+        expect(loadorderTxt).toContain("Parked.esp");
+      });
+    });
+
+    it("orders plugins by their file time when not controlling the load order", async () => {
+      // Parked.esp deliberately older than Old.esp: on-disk time, not loadorder.txt, wins
+      const early = new Date(Date.now() - 60_000);
+      const late = new Date();
+      nodeFs.writeFileSync(path.join(paths.dataDir, "Old.esp"), "");
+      nodeFs.writeFileSync(path.join(paths.dataDir, "Parked.esp"), "");
+      nodeFs.utimesSync(path.join(paths.dataDir, "Parked.esp"), early, early);
+      nodeFs.utimesSync(path.join(paths.dataDir, "Old.esp"), late, late);
+
+      const p = await makePersistor(false);
+
+      expect(JSON.parse(await p.getItem(["parked.esp"])).loadOrder).toBe(0);
+      expect(JSON.parse(await p.getItem(["old.esp"])).loadOrder).toBe(1);
+    });
+
+    it("stamps data file times to match the load order when controlling it", async () => {
+      const epoch = 946684800; // 2000-01-01
+      nodeFs.writeFileSync(path.join(paths.dataDir, "Old.esp"), "");
+      nodeFs.writeFileSync(path.join(paths.dataDir, "Parked.esp"), "");
+
+      const p = await makePersistor(true);
+      p.setKnownPlugins({ "old.esp": "Old.esp", "parked.esp": "Parked.esp" });
+
+      await vi.waitFor(() => {
+        expect(nodeFs.statSync(path.join(paths.dataDir, "Old.esp")).mtimeMs).toBe(epoch * 1000);
+        expect(nodeFs.statSync(path.join(paths.dataDir, "Parked.esp")).mtimeMs).toBe(
+          (epoch + 86400) * 1000,
+        );
+      });
+    });
   });
 
   it("rehydrates when the installed-native set changes, and only then", async () => {

--- a/extensions/gamebryo-plugin-management/test-utils/vortex-api.ts
+++ b/extensions/gamebryo-plugin-management/test-utils/vortex-api.ts
@@ -21,14 +21,19 @@ import { batchDispatch, makeOverlayableDictionary } from "../../../src/renderer/
  */
 
 // real node-fs behavior wrapped in Bluebird (production code relies on Bluebird's
-// predicate .catch), except readdirAsync which tests arrange per-case
+// predicate .catch and chains .filter on readdirAsync). readdirAsync is a vi.fn whose
+// default reads the real directory; suites arrange it per-case to override, and
+// mockReset restores this default. utimesAsync returns a native promise: its only
+// consumer uses a plain .catch.
 export const fs = {
-  readdirAsync: vi.fn(),
+  readdirAsync: vi.fn((dirPath: string) => PromiseBB.resolve(nodeFs.promises.readdir(dirPath))),
   ensureDirAsync: (dirPath: string) =>
     PromiseBB.resolve(nodeFs.promises.mkdir(dirPath, { recursive: true })).then(() => undefined),
   readFileAsync: (filePath: string, options?: { encoding?: BufferEncoding }) =>
     PromiseBB.resolve(nodeFs.promises.readFile(filePath, options)),
   statAsync: (filePath: string) => PromiseBB.resolve(nodeFs.promises.stat(filePath)),
+  utimesAsync: (filePath: string, atime: number, mtime: number) =>
+    nodeFs.promises.utimes(filePath, atime, mtime),
   // inert: a real OS watcher takes the worker process down on Windows CI, and nothing here
   // drives the persistor through fs events - the tests trigger its reads directly
   watch: () => ({ on: () => undefined, close: () => undefined }) as unknown as nodeFs.FSWatcher,

--- a/extensions/gamebryo-plugin-management/test-utils/vortex-api.ts
+++ b/extensions/gamebryo-plugin-management/test-utils/vortex-api.ts
@@ -20,24 +20,28 @@ import { batchDispatch, makeOverlayableDictionary } from "../../../src/renderer/
  * doubles that the `vortexApiTest` fixture owns and resets.
  */
 
+// the real fs module's declaration; typing the double against it makes signature
+// drift fail the typecheck
+type RealFs = typeof import("../../../src/renderer/src/util/fs");
+
 // real node-fs behavior wrapped in Bluebird (production code relies on Bluebird's
 // predicate .catch and chains .filter on readdirAsync). readdirAsync is a vi.fn whose
 // default reads the real directory; suites arrange it per-case to override, and
-// mockReset restores this default. utimesAsync returns a native promise: its only
-// consumer uses a plain .catch.
-export const fs = {
-  readdirAsync: vi.fn((dirPath: string) => PromiseBB.resolve(nodeFs.promises.readdir(dirPath))),
-  ensureDirAsync: (dirPath: string) =>
+// mockReset restores this default.
+export const fs: Partial<RealFs> = {
+  readdirAsync: vi.fn((dirPath) => PromiseBB.resolve(nodeFs.promises.readdir(dirPath))),
+  ensureDirAsync: (dirPath) =>
     PromiseBB.resolve(nodeFs.promises.mkdir(dirPath, { recursive: true })).then(() => undefined),
-  readFileAsync: (filePath: string, options?: { encoding?: BufferEncoding }) =>
-    PromiseBB.resolve(nodeFs.promises.readFile(filePath, options)),
-  statAsync: (filePath: string) => PromiseBB.resolve(nodeFs.promises.stat(filePath)),
-  utimesAsync: (filePath: string, atime: number, mtime: number) =>
-    nodeFs.promises.utimes(filePath, atime, mtime),
+  readFileAsync: (filePath, options) =>
+    PromiseBB.resolve(nodeFs.promises.readFile(filePath, options ?? null)),
+  statAsync: (filePath) => PromiseBB.resolve(nodeFs.promises.stat(filePath)),
+  utimesAsync: (filePath, atime, mtime) =>
+    PromiseBB.resolve(nodeFs.promises.utimes(filePath, atime, mtime)),
   // inert: a real OS watcher takes the worker process down on Windows CI, and nothing here
   // drives the persistor through fs events - the tests trigger its reads directly
-  watch: () => ({ on: () => undefined, close: () => undefined }) as unknown as nodeFs.FSWatcher,
-  writeFileAsync: (filePath: string, data: string | Buffer, options?: { encoding?: string }) =>
+  watch: () =>
+    ({ on: () => undefined, close: () => undefined }) as unknown as ReturnType<RealFs["watch"]>,
+  writeFileAsync: (filePath, data, options) =>
     PromiseBB.resolve(
       nodeFs.promises.writeFile(filePath, data, options as { encoding?: BufferEncoding }),
     ),


### PR DESCRIPTION
Pre-move tranche of LAZ-1025: characterization tests pinning current plugin management behaviour
ahead of the gamebryo-plugin-management core move (LAZ-1026).

- PluginPersistor: missing plugins.txt, the original plugin format, blueprint exclusion, native
  load order offsets.
- loadOrder reducer: setPluginOrder clean slate, updatePluginOrder semantics; tests drive the
  real action creators.

part of LAZ-1025