### PR TITLE
Ship node-loot runtime pieces as core assets

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5157,6 +5157,10 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    optionalDependencies:
+      loot:
+        specifier: 'catalog:'
+        version: https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/cc1515667f494be188e3b1172a3bc8db3dc52eb5
 
   src/shared:
     dependencies:

--- a/src/main/copy-assets.mjs
+++ b/src/main/copy-assets.mjs
@@ -47,6 +47,27 @@ await copy(
   join(BUILD, "assets/css/bootstrap.scss"),
 );
 
+// node-loot runtime pieces, resolved from the renderer's deps: loot must stay out
+// of @vortex/main's tree, or electron-rebuild force-rebuilds it against electron
+// headers and the link fails where libloot is absent. The install-time node-gyp
+// build targets napi, so electron loads it without a rebuild. The package layout
+// is preserved so async.js's relative require of build/Release/node-loot resolves,
+// and libloot.dll is placed next to the binding because the Windows loader
+// searches the loaded module's directory.
+try {
+  const rendererRequire = createRequire(join(WORKSPACE, "src/renderer/package.json"));
+  const lootDir = dirname(rendererRequire.resolve("loot/package.json"));
+  await copy(join(lootDir, "index.js"), join(ASSETS, "loot/index.js"));
+  await copy(join(lootDir, "async.js"), join(ASSETS, "loot/async.js"));
+  await copy(
+    join(lootDir, "build/Release/node-loot.node"),
+    join(ASSETS, "loot/build/Release/node-loot.node"),
+  );
+  await copy(join(lootDir, "loot_api/libloot.dll"), join(ASSETS, "loot/build/Release/libloot.dll"));
+} catch {
+  console.log("skipped node-loot runtime pieces (loot is not installed on this platform)");
+}
+
 // Static files
 await copy(join(WORKSPACE, "LICENSE.md"), join(BUILD, "LICENSE.md"));
 await copy(join(WORKSPACE, "src/renderer/src/index.html"), join(BUILD, "index.html"));

--- a/src/main/electron-builder.config.json
+++ b/src/main/electron-builder.config.json
@@ -74,6 +74,7 @@
     "node_modules/react-select/scss",
     "node_modules/@nexusmods/fomod-installer-ipc/dist/*.exe",
     "assets/dotnetprobe*",
+    "assets/loot/**",
     "assets/*.exe",
     "assets/css/**",
     "**/*.node",

--- a/src/main/prepare-dist-package.mjs
+++ b/src/main/prepare-dist-package.mjs
@@ -1,5 +1,5 @@
 import { createWriteStream } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -35,6 +35,14 @@ async function downloadFile(url, dest) {
 }
 
 async function prepareWin() {
+  // assert that loot runtime assets exist; fail the build if they don't.
+  const lootRelease = resolve(DIST_DIR, "assets", "loot", "build", "Release");
+  for (const file of ["node-loot.node", "libloot.dll"]) {
+    await access(resolve(lootRelease, file)).catch(() => {
+      throw new Error(`missing loot runtime asset: ${resolve(lootRelease, file)}`);
+    });
+  }
+
   const tempDir = resolve(MAIN_DIR, "temp");
   await downloadFile(
     "https://aka.ms/vs/17/release/vc_redist.x64.exe",
@@ -57,6 +65,10 @@ async function main() {
   const nodeModulesDir = resolve(MAIN_DIR, "node_modules");
   mainPkg.dependencies = await resolveDepVersions(mainPkg.dependencies, nodeModulesDir);
   mainPkg.devDependencies = await resolveDepVersions(mainPkg.devDependencies, nodeModulesDir);
+  mainPkg.optionalDependencies = await resolveDepVersions(
+    mainPkg.optionalDependencies,
+    nodeModulesDir,
+  );
 
   await writeFile(DIST_PACKAGE_PATH, JSON.stringify(mainPkg, null, 2) + "\n", "utf8");
 

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -228,5 +228,8 @@
   },
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "catalog:"
+  },
+  "optionalDependencies": {
+    "loot": "catalog:"
   }
 }


### PR DESCRIPTION
build wiring for the gamebryo-plugin-management core move (LAZ-1026). Inert until the move lands.

- loot becomes an optionalDependency of @vortex/renderer and @vortex/main (optional is
  load-bearing for the Linux install).
- copy-assets lays out assets/loot: index.js, async.js, and the binding with libloot.dll
  co-located, package layout preserved so no require rewrites are needed.
- electron-builder unpacks assets/loot and excludes the redundant node_modules/loot payload;
  prepare-dist now resolves optionalDependencies catalog versions.

Stacked on #24104.

part of LAZ-1026