### PR TITLE
feat(ui): colour the Manage Rules button while conflicts wait

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -573,6 +573,8 @@ interface IActionDefinitionEx extends IActionDefinition {
 
 // @public (undocumented)
 interface IActionOptions {
+    // Warning: (ae-forgotten-export) The symbol "IButtonBrand" needs to be exported by the entry point api.d.ts
+    brand?: () => IButtonBrand | undefined;
     // (undocumented)
     hollowIcon?: boolean;
     // (undocumented)
@@ -715,6 +717,7 @@ interface IBar {
 interface IBaseProps$1 {
     // (undocumented)
     actions: ITableRowAction[];
+    analyticsId?: string;
     // (undocumented)
     children?: React$2.ReactNode;
     // (undocumented)
@@ -956,6 +959,9 @@ interface IBrowserState {
     // (undocumented)
     url: string;
 }
+
+// @public (undocumented)
+type IButtonBrand = "primary" | "info" | "neutral" | "success" | "danger" | "premium";
 
 // @public (undocumented)
 interface ICategory {
@@ -5193,7 +5199,7 @@ export class VisibilityProxy extends React$2.PureComponent<any, {}> {
     render(): JSX.Element;
 }
 
-// @public
+// @public (undocumented)
 export class VortexError extends Error {
     constructor(message: string, data: VortexErrorData, meta?: {
         isTransient?: boolean;
@@ -5240,6 +5246,8 @@ export interface VortexErrorKindMap {
     "fs:not-a-file": FileSystemErrorData;
     // (undocumented)
     "fs:not-found": FileSystemErrorData;
+    // (undocumented)
+    "fs:read-only": FileSystemErrorData;
     "game-not-found": {
         gameId: string;
     };
@@ -5325,42 +5333,42 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 //
 // lib/api.d.ts:165:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:167:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:643:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1019:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1174:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1517:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2305:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3209:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3336:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3634:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3691:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3810:3 - (ae-forgotten-export) The symbol "UpdateKind" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4088:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4513:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5195:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5200:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5203:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5206:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5221:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5264:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5298:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5301:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5319:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5384:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5453:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5485:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5532:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5534:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5535:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5536:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5538:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5540:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5549:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5550:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5551:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5567:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8926:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8927:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:634:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1010:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1165:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1508:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2301:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3205:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3332:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3630:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3687:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3806:3 - (ae-forgotten-export) The symbol "UpdateKind" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4084:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4509:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5191:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5196:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5199:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5202:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5217:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5260:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5294:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5297:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5315:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5380:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5449:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5481:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5528:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5530:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5531:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5532:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5534:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5536:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5545:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5546:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5547:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5563:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8924:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8925:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/extensions/mod-dependency-manager/src/index.tsx
+++ b/extensions/mod-dependency-manager/src/index.tsx
@@ -1625,6 +1625,7 @@ function main(context: types.IExtensionContext) {
     {
       isModernOnly: true,
       notice: () => unresolvedConflictsNotice(context.api),
+      brand: () => (unresolvedConflictsNotice(context.api) ? "info" : undefined),
       pinned: true,
     },
     "Manage Rules",

--- a/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.test.tsx
+++ b/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import type * as ReactReduxTypes from "react-redux";
 import { describe, expect, it, vi } from "vitest";
 
-import type { IActionDefinition } from "@/types/IActionDefinition";
+import type { IActionDefinition, IActionOptions } from "@/types/IActionDefinition";
 
 const { getState, objects } = vi.hoisted(() => ({
   getState: vi.fn(() => ({})),
@@ -196,5 +196,43 @@ describe("useModToolbarActions tracking identity", () => {
     expect(onActionClick).not.toHaveBeenCalled();
     expect(only?.id).toBe("Open Mod Folder");
     expect(only?.extension).toBe("open-directory");
+  });
+});
+describe("useModToolbarActions brands", () => {
+  // Unresolved mod conflicts reach the bar as a brand on Manage Rules, so colour says
+  // there is something waiting without the user hovering for the tooltip.
+  it("takes the brand an action asks for", () => {
+    const branded = plain("Manage Rules", { brand: () => "info" });
+
+    expect(byLabel([branded], "Manage Rules")?.brand).toBe("info");
+  });
+
+  it("leaves an action that asks for nothing the default brand", () => {
+    expect(byLabel([plain("Manage Rules")], "Manage Rules")?.brand).toBeUndefined();
+  });
+
+  // The two are separate props: something to say is not a reason to change colour, and
+  // an action can do either on its own.
+  it("keeps a notice from branding the action", () => {
+    const withNotice = plain("Manage Rules", { notice: () => "2 unresolved conflicts" });
+    const action = byLabel([withNotice], "Manage Rules (2 unresolved conflicts)");
+
+    expect(action?.brand).toBeUndefined();
+  });
+
+  it("keeps a brand from adding to the label", () => {
+    expect(labels([plain("Manage Rules", { brand: () => "info" })])).toContain("Manage Rules");
+  });
+
+  // Read on render, so a resolved conflict has to take the colour with it.
+  it("drops the brand once the action stops asking for it", () => {
+    const brand = vi.fn(() => "info" as ReturnType<NonNullable<IActionOptions["brand"]>>);
+    const branded = plain("Manage Rules", { brand });
+
+    expect(byLabel([branded], "Manage Rules")?.brand).toBe("info");
+
+    brand.mockReturnValue(undefined);
+
+    expect(byLabel([branded], "Manage Rules")?.brand).toBeUndefined();
   });
 });

--- a/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
+++ b/src/renderer/src/extensions/mod_management/hooks/useModToolbarActions.hook.tsx
@@ -555,9 +555,14 @@ const useCheckVersionsAction = (t: TFunction): IPositionedAction => {
 const useRegisteredActions = (group: string): IPositionedAction[] => {
   const objects = useExtensionObjects<IActionDefinition>(registerAction, undefined, group, true);
 
-  // Read through the store, so a notice can follow state rather than be fixed at registration.
+  // Read through the store, so a notice and a brand can follow state rather than be
+  // fixed at registration.
   const notices = useSelector(
     () => objects.map((definition) => definition.options?.notice?.()),
+    shallowEqual,
+  );
+  const brands = useSelector(
+    () => objects.map((definition) => definition.options?.brand?.()),
     shallowEqual,
   );
 
@@ -603,6 +608,7 @@ const useRegisteredActions = (group: string): IPositionedAction[] => {
         // what IconBar built its DOM ids from.
         id: definition.title,
         label: !notice ? definition.title : `${definition.title} (${notice})`,
+        brand: brands[index],
         iconPath: getIconPath(definition.icon, mdiPuzzleOutline),
         pinned: definition.options?.pinned ?? false,
         disabled: typeof condition === "string",

--- a/src/renderer/src/types/IActionDefinition.ts
+++ b/src/renderer/src/types/IActionDefinition.ts
@@ -1,5 +1,7 @@
 import type * as React from "react";
 
+import type { IButtonBrand } from "../ui/components/button/Button";
+
 export interface IActionOptions {
   noCollapse?: boolean;
   namespace?: string;
@@ -8,6 +10,8 @@ export interface IActionOptions {
   isModernOnly?: boolean;
   /** What the action has to say beyond its title, read on render and bracketed after it. */
   notice?: () => string | undefined;
+  /** The colour the action asks for, read on render so it can follow state. */
+  brand?: () => IButtonBrand | undefined;
   /**
    * Whether the action sits on the toolbar until the user says otherwise, where that
    * toolbar lets them choose. Ignored by one that doesn't.


### PR DESCRIPTION
The mods toolbar already reports unresolved file conflicts on **Manage Rules**, but only in the tooltip — `Manage Rules (2 unresolved conflicts)` — so nothing shows until you hover. It now takes the **info** brand while any are waiting: the icon goes info-coloured on the bar, and its row's leading icon does the same when the action collapses into the overflow menu.

https://claude.ai/code/artifact/1172705a-f4c1-433c-a639-7cb919797501?via=auto_preview

## How

A registered action asks for a colour through a `brand` option of its own:

```ts
/** The colour the action asks for, read on render so it can follow state. */
brand?: () => IButtonBrand | undefined;
```

Read on render through the store, the same way `notice` is, so it can follow state rather than be fixed at registration. `notice` and `brand` are independent — having something to say is not itself a reason to change colour — and Manage Rules keys its brand off its own notice, which is the one place that decision belongs:

```ts
notice: () => unresolvedConflictsNotice(context.api),
brand: () => (unresolvedConflictsNotice(context.api) ? "info" : undefined),
```

No toolbar plumbing was needed: `IToolbarAction` already carries `brand` and `controlProps` already passes it through, which is also why the colour survives the collapse into the overflow menu.

Untouched: the classic toolbar's `ManageRuleButton`, which flashes for conflicts instead.