### PR TITLE
feat(ui): let users turn motion down (LAZ-1066)

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -82,6 +82,42 @@ build/test/format loop.
 - Shared components also expose semantic `nxm-`-prefixed classes
   (`nxm-tab-button`). Keep that pattern for reusable primitives.
 
+## Motion
+
+Users can turn non-essential animation down: **Settings → Interface → Reduce motion**,
+which follows the OS `prefers-reduced-motion` preference until they set it themselves.
+The answer is published as `data-reduce-motion="true"` on `<html>`
+(`util/reduceMotion.ts`); the rules keyed off it live in
+`src/stylesheets/ui/theme/motion.css`.
+
+- **Reduced means instant, not gentler.** Don't swap movement for a fade - a state change
+  lands immediately. Neutralise a transition by starting it from its final state rather
+  than by zeroing the duration:
+  `enterFrom="translate-y-6 opacity-0 reduce-motion:translate-y-0 reduce-motion:opacity-100"`.
+  That leaves nothing to animate while keeping the duration a `Transition` reads to time
+  itself. Drop delays too (`reduce-motion:delay-0`) - there is nothing left to wait for.
+- Prefer `transition-*` **without** an explicit `duration-*`. Those resolve their
+  duration through `--default-transition-duration`, which the attribute overrides, so
+  they flatten for free. A `duration-*` utility sets the duration directly and survives
+  on purpose - a component that names its own duration often depends on it - so opt
+  decorative ones out with the `reduce-motion:` variant:
+  `transition-[width] duration-300 reduce-motion:duration-0`.
+- **Don't use Tailwind's `motion-reduce:` / `motion-safe:` variants.** They compile to
+  `prefers-reduced-motion` media queries, so they follow the OS and can't see the app's
+  own setting. `reduce-motion:` is the app-aware equivalent.
+- In JavaScript, use `useReduceMotion()` in components and `isReduceMotionActive()`
+  elsewhere - for movement computed in JS rather than declared in CSS: a scroll tween, an
+  autoplay interval, a staged sequence. Clear any "is animating" flag when the preference
+  is on rather than leaving it set; an animation that never runs never fires
+  `animationend`.
+- **Keep essential motion.** Spinners (`animate-spin`), and anything whose movement _is_
+  the information (a countdown ring, a progress bar's width), have to keep working - a
+  static spinner says nothing. Skeleton shimmer (`animate-pulse`) is not essential and is
+  switched off centrally.
+- Only the Tailwind/`nxm-` surface responds so far. The legacy SCSS
+  (`src/stylesheets/vortex/**`, bundled Bootstrap) compiles its durations in and is not
+  covered yet, so the classic toolbar's flashing buttons still flash.
+
 ## State (Redux)
 
 - `useSelector` with a **stable selector reference**: a module-level function,

--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -12,16 +12,25 @@ import { EndorsedStatus } from '@nexusmods/nexus-api';
 import { FC } from 'react';
 import { i18n } from 'i18next';
 import I18next from 'i18next';
+import { ICategoryDictionary } from '@/extensions/category_management/types/ICategoryDictionary';
 import { ICollection } from '@nexusmods/nexus-api';
 import { ICollectionManifest } from '@nexusmods/nexus-api';
 import { ICollectionSearchOptions } from '@nexusmods/nexus-api';
 import { ICollectionSearchResult } from '@nexusmods/nexus-api';
+import { IDiscoveryResult } from '@/extensions/gamemode_management/types/IDiscoveryResult';
+import { IDownload } from '@/extensions/download_management/types/IDownload';
 import { IDownloadURL } from '@nexusmods/nexus-api';
 import { IFeedbackResponse } from '@nexusmods/nexus-api';
 import { IFileInfo } from '@nexusmods/nexus-api';
+import { IGameStored } from '@/extensions/gamemode_management/types/IGameStored';
 import { IHashResult } from 'modmeta-db';
+import { IHealthCheckPersistentState } from '@/extensions/health_check/reducers/persistent';
+import { IHealthCheckSessionState } from '@/extensions/health_check/reducers/session';
+import { IHistoryPersistent } from '@/extensions/history_management/reducers';
+import { IHistoryState } from '@/extensions/history_management/reducers';
 import { IIssue } from '@nexusmods/nexus-api';
 import { ILookupResult } from 'modmeta-db';
+import { IMod } from '@/extensions/mod_management/types/IMod';
 import { IModFileContentPage } from '@nexusmods/nexus-api';
 import { IModFileContentPageQuery } from '@nexusmods/nexus-api';
 import { IModFileContentSearchFilter } from '@nexusmods/nexus-api';
@@ -30,10 +39,12 @@ import { IModInfo as IModInfo_2 } from '@nexusmods/nexus-api';
 import { IModRequirements } from '@nexusmods/nexus-api';
 import { IPreference } from '@nexusmods/nexus-api';
 import { IPreferenceQuery } from '@nexusmods/nexus-api';
+import { IProfile } from '@/extensions/profile_management/types/IProfile';
 import { IReference } from 'modmeta-db';
 import { IRevision } from '@nexusmods/nexus-api';
 import { IRule } from 'modmeta-db';
 import { IServer } from 'modmeta-db';
+import { IUpdaterSessionState } from '@/extensions/updater/reducers';
 import { Modal as Modal_2 } from 'react-bootstrap';
 import { ModalBody } from 'react-bootstrap';
 import { ModalFooter } from 'react-bootstrap';
@@ -77,7 +88,7 @@ type ActionFunc = (instanceId: string | string[]) => IActionDefinition[];
 
 // @public (undocumented)
 export namespace actions {
-    export { Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, ICheckbox, IConditionResult, IControlBase, IDialog, IDialogAction, IDialogContent, IDialogResult, IDictionary, IEnableOptions, IInput, ILink, addDialog, addDiscoveredGame, addDiscoveredTool, addExtension, addLocalDownload, addMod, addModRule, addMods, addNotification, cacheModReference, clearDialog, clearDiscoveredGame, clearModRules, clearOAuthCredentials, clearPendingPluginSort, clearUIBlocker, closeBrowser, closeDialog, closeDialogs, collapseGroup, completeMigration, dismissAllNotifications, dismissDialog, dismissNotification, displayGroup, downloadProgress, endDialog, finalizingDownload, finalizingProgress, finishDownload, fireNotificationAction, forgetExtension, forgetMod, initDownload, loadCategories, mergeDownloadModInfo, pauseDownload, removeCategory, removeDownload, removeDownloadSilent, removeExtension, removeMod, removeModRule, removeProfile, renameCategory, resetSuppression, setActivator, setAdvancedMode, setAlwaysCompactHeaders, setApplicationVersion, setAssociatedWithNXMURLs, setAttributeFilter, setAttributeSort, setAttributeVisible, setAutoDeployment, setAutoEnable, setAutoInstall, setAutoStart, setCategory, setCategoryOrder, setCleanupOnDeploy, setCollapsedGroups, setCollectionConcurrency, setCommandLine, setCompatibleGames, setConfirmPurge, setCopyOnIFF, setCustomTitlebar, setDeploymentNecessary, setDesktopNotifications, setDialogState, setDialogVisible, setDownloadFilePath, setDownloadGameFilter, setDownloadHash, setDownloadHashByFile, setDownloadInstalled, setDownloadInterrupted, setDownloadModInfo, setDownloadPath, setDownloadPausable, setDownloadSpeed, setDownloadSpeeds, setDownloadTime, setExtensionEnabled, setExtensionEndorsed, setExtensionLoadFailures, setExtensionVersion, setFBLoadOrder, setFBLoadOrderEntry, setFeature, setFileOverride, setForcedLogout, setForegroundDL, setGameHidden, setGameParameters, setGamePath, setGameSearchPaths, setGroupingAttribute, setHideTopLevelCategory, setINITweakEnabled, setInstallPath, setInstallPathMode, setInstallType, setInstanceId, setLanguage, setLoadOrder, setLoadOrderEntry, setMaxBandwidth, setMaxDownloads, setMaximized, setModArchiveId, setModAttribute, setModAttributes, setModEnabled, setModInstallationPath, setModState, setModType, setModsEnabled, setNetworkConnected, setNewestVersion, setNextProfile, setOAuthCredentials, setOpenMainPage, setPendingPluginSort, setPickerLayout, setPrimaryTool, setProfile, setProfileActivated, setProfilesVisible, setProgress, setRelativeTimes, setSettingsPage, setShowDLDropzone, setShowDLGraph, setShowModDropzone, setSortManaged, setSortUnmanaged, setStartMinimized, setStateVersion, setSuggestInstallPathDirectory, setTabsMinimized, setToolOrder, setToolPid, setToolPinned, setToolRunning, setToolStopped, setToolValid, setToolVisible, setUIBlocker, setUpdateChannel, setUpdaterActive, setUpdaterSnapshot, setUseModernLayout, setUserAPIKey, setUserInfo, setWarnedAdmin, setWindowPosition, setWindowSize, setZoomFactor, setupNotificationSuppression, showDialog, showURL, showUsageInstruction, startActivity, startDialog, startDownload, startNotification, stopActivity, stopAllNotifications, stopNotification, suppressNotification, triggerDialogLink, updateCategories, updateNotification, willRemoveProfile };
+    export { Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, ICheckbox, IConditionResult, IControlBase, IDialog, IDialogAction, IDialogContent, IDialogResult, IDictionary, IEnableOptions, IInput, ILink, addDialog, addDiscoveredGame, addDiscoveredTool, addExtension, addLocalDownload, addMod, addModRule, addMods, addNotification, cacheModReference, clearDialog, clearDiscoveredGame, clearModRules, clearOAuthCredentials, clearPendingPluginSort, clearUIBlocker, closeBrowser, closeDialog, closeDialogs, collapseGroup, completeMigration, dismissAllNotifications, dismissDialog, dismissNotification, displayGroup, downloadProgress, endDialog, finalizingDownload, finalizingProgress, finishDownload, fireNotificationAction, forgetExtension, forgetMod, initDownload, loadCategories, mergeDownloadModInfo, pauseDownload, removeCategory, removeDownload, removeDownloadSilent, removeExtension, removeMod, removeModRule, removeProfile, renameCategory, resetSuppression, setActivator, setAdvancedMode, setAlwaysCompactHeaders, setApplicationVersion, setAssociatedWithNXMURLs, setAttributeFilter, setAttributeSort, setAttributeVisible, setAutoDeployment, setAutoEnable, setAutoInstall, setAutoStart, setCategory, setCategoryOrder, setCleanupOnDeploy, setCollapsedGroups, setCollectionConcurrency, setCommandLine, setCompatibleGames, setConfirmPurge, setCopyOnIFF, setCustomTitlebar, setDeploymentNecessary, setDesktopNotifications, setDialogState, setDialogVisible, setDownloadFilePath, setDownloadGameFilter, setDownloadHash, setDownloadHashByFile, setDownloadInstalled, setDownloadInterrupted, setDownloadModInfo, setDownloadPath, setDownloadPausable, setDownloadSpeed, setDownloadSpeeds, setDownloadTime, setExtensionEnabled, setExtensionEndorsed, setExtensionLoadFailures, setExtensionVersion, setFBLoadOrder, setFBLoadOrderEntry, setFeature, setFileOverride, setForcedLogout, setForegroundDL, setGameHidden, setGameParameters, setGamePath, setGameSearchPaths, setGroupingAttribute, setHideTopLevelCategory, setINITweakEnabled, setInstallPath, setInstallPathMode, setInstallType, setInstanceId, setLanguage, setLoadOrder, setLoadOrderEntry, setMaxBandwidth, setMaxDownloads, setMaximized, setModArchiveId, setModAttribute, setModAttributes, setModEnabled, setModInstallationPath, setModState, setModType, setModsEnabled, setNetworkConnected, setNewestVersion, setNextProfile, setOAuthCredentials, setOpenMainPage, setPendingPluginSort, setPickerLayout, setPrimaryTool, setProfile, setProfileActivated, setProfilesVisible, setProgress, setReduceMotion, setRelativeTimes, setSettingsPage, setShowDLDropzone, setShowDLGraph, setShowModDropzone, setSortManaged, setSortUnmanaged, setStartMinimized, setStateVersion, setSuggestInstallPathDirectory, setTabsMinimized, setToolOrder, setToolPid, setToolPinned, setToolRunning, setToolStopped, setToolValid, setToolVisible, setUIBlocker, setUpdateChannel, setUpdaterActive, setUpdaterSnapshot, setUseModernLayout, setUserAPIKey, setUserInfo, setWarnedAdmin, setWindowPosition, setWindowSize, setZoomFactor, setupNotificationSuppression, showDialog, showURL, showUsageInstruction, startActivity, startDialog, startDownload, startNotification, stopActivity, stopAllNotifications, stopNotification, suppressNotification, triggerDialogLink, updateCategories, updateNotification, willRemoveProfile };
 }
 
 // @public (undocumented)
@@ -245,9 +256,6 @@ type DownloadCheckpoint<T = unknown> = {
     completedRanges: ByteRange[];
     etag: string | undefined;
 };
-
-// @public (undocumented)
-type DownloadState = "init" | "started" | "paused" | "finalizing" | "finished" | "failed" | "redirect";
 
 // Warning: (ae-forgotten-export) The symbol "IDraggableListProps" needs to be exported by the entry point api.d.ts
 //
@@ -442,13 +450,13 @@ type GameInfoQuery = (game: any) => PromiseLike<{
 }>;
 
 // Warning: (ae-forgotten-export) The symbol "IGame" needs to be exported by the entry point api.d.ts
-// Warning: (ae-forgotten-export) The symbol "IDiscoveryResult" needs to be exported by the entry point api.d.ts
+// Warning: (ae-forgotten-export) The symbol "IDiscoveryResult$1" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
-type GameVersionProviderFunc = (game: IGame, discovery: IDiscoveryResult) => PromiseLike<string>;
+type GameVersionProviderFunc = (game: IGame, discovery: IDiscoveryResult$1) => PromiseLike<string>;
 
 // @public (undocumented)
-type GameVersionProviderTest = (game: IGame, discovery: IDiscoveryResult) => PromiseLike<boolean>;
+type GameVersionProviderTest = (game: IGame, discovery: IDiscoveryResult$1) => PromiseLike<boolean>;
 
 // Warning: (ae-forgotten-export) The symbol "ITableState" needs to be exported by the entry point api.d.ts
 //
@@ -963,24 +971,6 @@ interface IBrowserState {
 // @public (undocumented)
 type IButtonBrand = "primary" | "info" | "neutral" | "success" | "danger" | "premium";
 
-// @public (undocumented)
-interface ICategory {
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    order: number;
-    // (undocumented)
-    parentCategory: string;
-}
-
-// @public (undocumented)
-interface ICategoryDictionary {
-    // Warning: (ae-forgotten-export) The symbol "ICategory" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    [id: string]: ICategory;
-}
-
 // Warning: (ae-forgotten-export) The symbol "IControlBase" needs to be exported by the entry point api.d.ts
 //
 // @public (undocumented)
@@ -1117,7 +1107,7 @@ interface ICollectionsGameSupportEntry {
     //
     // (undocumented)
     generator: (state: IState, gameId: string, stagingPath: string, modIds: string[], mods: {
-        [modId: string]: IMod;
+        [modId: string]: IMod$1;
     }) => Promise<any>;
     // Warning: (ae-forgotten-export) The symbol "IGameSpecificInterfaceProps" needs to be exported by the entry point api.d.ts
     //
@@ -1513,7 +1503,7 @@ interface IDiscoveryPhase {
 }
 
 // @public
-interface IDiscoveryResult {
+interface IDiscoveryResult$1 {
     // (undocumented)
     environment?: {
         [key: string]: string;
@@ -1574,41 +1564,6 @@ interface IDNDContainerProps {
     children?: React$1.ReactNode;
     // (undocumented)
     style?: React$1.CSSProperties;
-}
-
-// @public
-interface IDownload {
-    // Warning: (ae-forgotten-export) The symbol "IDownloadFailCause" needs to be exported by the entry point api.d.ts
-    failCause?: IDownloadFailCause;
-    fileMD5?: string;
-    fileTime: number;
-    game: string[];
-    // (undocumented)
-    id: string;
-    installed?: {
-        gameId: string;
-        modId: string;
-    };
-    localPath?: string;
-    // Warning: (ae-forgotten-export) The symbol "IModInfo$2" needs to be exported by the entry point api.d.ts
-    modInfo: IModInfo$2;
-    pausable?: boolean;
-    pauseCount?: number;
-    received: number;
-    size: number;
-    startTime: number;
-    // Warning: (ae-forgotten-export) The symbol "DownloadState" needs to be exported by the entry point api.d.ts
-    state: DownloadState;
-    urls: string[];
-    verified: number;
-}
-
-// @public (undocumented)
-interface IDownloadFailCause {
-    // (undocumented)
-    htmlFile?: string;
-    // (undocumented)
-    message?: string;
 }
 
 // @public (undocumented)
@@ -2218,7 +2173,7 @@ interface IGameLoadOrderEntry {
 // @public (undocumented)
 interface IGameSpecificInterfaceProps {
     // (undocumented)
-    collection: IMod;
+    collection: IMod$1;
     // (undocumented)
     revisionInfo: IRevision;
     // (undocumented)
@@ -2244,46 +2199,6 @@ interface IGameStore {
     name?: string;
     priority?: number;
     reloadGames?: () => default_2<void>;
-}
-
-// @public
-interface IGameStored {
-    // (undocumented)
-    contributed?: string;
-    // (undocumented)
-    details?: {
-        [key: string]: any;
-    };
-    // (undocumented)
-    environment?: {
-        [key: string]: string;
-    };
-    // (undocumented)
-    executable: string;
-    // (undocumented)
-    extensionPath?: string;
-    // (undocumented)
-    final?: boolean;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    imageURL?: string;
-    // (undocumented)
-    logo?: string;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    parameters?: string[];
-    // (undocumented)
-    requiredFiles: string[];
-    // (undocumented)
-    shell?: boolean;
-    // (undocumented)
-    shortName?: string;
-    // Warning: (ae-forgotten-export) The symbol "IToolStored" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    supportedTools?: IToolStored[];
 }
 
 // @public (undocumented)
@@ -2347,21 +2262,6 @@ interface IHealthCheck {
 }
 
 // @public (undocumented)
-interface IHealthCheckPersistentState {
-    feedbackGiven: {
-        [modId: number]: string[];
-    };
-    fileRequirementsEnabled: boolean;
-    hiddenFileRequirements: {
-        [sourceFileUID: string]: string[];
-    };
-    hiddenRequirements: {
-        [modId: number]: string[];
-    };
-    modRequirementsEnabled: boolean;
-}
-
-// @public (undocumented)
 interface IHealthCheckResult<TMetadata = unknown> {
     // (undocumented)
     checkId: string;
@@ -2386,15 +2286,6 @@ interface IHealthCheckResult<TMetadata = unknown> {
 }
 
 // @public (undocumented)
-interface IHealthCheckSessionState {
-    lastFullRun?: number;
-    results: {
-        [checkId: string]: IHealthCheckResult;
-    };
-    runningChecks: string[];
-}
-
-// @public (undocumented)
 interface IHistoryEvent {
     // (undocumented)
     data: any;
@@ -2411,14 +2302,6 @@ interface IHistoryEvent {
 }
 
 // @public (undocumented)
-interface IHistoryPersistent {
-    // (undocumented)
-    historyStacks: {
-        [key: string]: IHistoryEvent[];
-    };
-}
-
-// @public (undocumented)
 interface IHistoryStack {
     // Warning: (ae-forgotten-export) The symbol "Revertability" needs to be exported by the entry point api.d.ts
     canRevert: (event: IHistoryEvent) => Revertability;
@@ -2426,12 +2309,6 @@ interface IHistoryStack {
     describeRevert: (event: IHistoryEvent) => string;
     revert: (event: IHistoryEvent) => Promise<void>;
     size: number;
-}
-
-// @public (undocumented)
-interface IHistoryState {
-    // (undocumented)
-    stackToShow: string;
 }
 
 // @public (undocumented)
@@ -2752,7 +2629,7 @@ interface IMergeFilter {
 }
 
 // @public
-interface IMod {
+interface IMod$1 {
     // (undocumented)
     archiveId?: string;
     // Warning: (ae-forgotten-export) The symbol "IModAttributes" needs to be exported by the entry point api.d.ts
@@ -2808,46 +2685,6 @@ interface IModifiers {
     ctrl: boolean;
     // (undocumented)
     shift: boolean;
-}
-
-// @public
-interface IModInfo$2 {
-    // (undocumented)
-    [key: string]: any;
-    // (undocumented)
-    collectionSlug?: string;
-    // (undocumented)
-    game?: string;
-    // Warning: (ae-forgotten-export) The symbol "INexusModMeta" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    meta?: INexusModMeta;
-    // (undocumented)
-    name?: string;
-    // (undocumented)
-    nexus?: {
-        ids?: {
-            collectionSlug?: string;
-            collectionId?: number;
-            fileId?: number;
-            gameId?: string;
-            modId?: number;
-            revisionId?: number;
-            revisionNumber?: number;
-        };
-        parentCollectionId?: string;
-        parentRevisionId?: string;
-        fileInfo?: IFileInfo;
-        [key: string]: any;
-    };
-    // (undocumented)
-    referenceTag?: string;
-    // (undocumented)
-    referenceTags?: string[];
-    // (undocumented)
-    revisionNumber?: number;
-    // (undocumented)
-    source?: string;
 }
 
 // @public
@@ -3067,7 +2904,7 @@ interface IMoreProps {
 interface INexusAPIExtension {
     // (undocumented)
     nexusCheckModsVersion?: (gameId: string, mods: {
-        [modId: string]: IMod;
+        [modId: string]: IMod$1;
     }, forceFull: boolean | "silent") => void;
     // (undocumented)
     nexusDownload?: (gameId: string, modId: number, fileId: number, fileName?: string, allowInstall?: boolean) => PromiseLike<string>;
@@ -3131,43 +2968,6 @@ interface INexusAPIExtension {
     nexusSubmitCollection?: (collectionInfo: ICollectionManifest, assetFilePath: string, collectionId: number, callback: (err: Error, response?: any) => void) => void;
     // (undocumented)
     nexusSubmitFeedback?: (title: string, message: string, hash: string, feedbackFiles: string[], anonymous: boolean, callback: (err: Error, response?: IFeedbackResponse) => void) => void;
-}
-
-// @public
-interface INexusModMeta {
-    // (undocumented)
-    archived?: boolean;
-    // (undocumented)
-    details?: {
-        author?: string;
-        category?: string;
-        description?: string;
-        fileId?: string;
-        homepage?: string;
-        modId?: string;
-    };
-    // (undocumented)
-    domainName?: string;
-    // (undocumented)
-    expires?: number;
-    // (undocumented)
-    fileMD5?: string;
-    // (undocumented)
-    fileName?: string;
-    // (undocumented)
-    fileSizeBytes?: number;
-    // (undocumented)
-    fileVersion?: string;
-    // (undocumented)
-    gameId?: string;
-    // (undocumented)
-    logicalFileName?: string;
-    // (undocumented)
-    source?: string;
-    // (undocumented)
-    sourceURI?: string;
-    // (undocumented)
-    status?: string;
 }
 
 // @public
@@ -3396,38 +3196,6 @@ interface IPosition {
 interface IPreviewFile {
     filePath: string;
     label: string;
-}
-
-// @public (undocumented)
-interface IProfile {
-    // (undocumented)
-    features?: {
-        [featureId: string]: any;
-    };
-    // (undocumented)
-    gameId: string;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    lastActivated: number;
-    // (undocumented)
-    modState: {
-        [id: string]: IProfileMod;
-    };
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    pendingRemove?: boolean;
-}
-
-// @public (undocumented)
-interface IProfileMod {
-    // (undocumented)
-    disabledTime?: number;
-    // (undocumented)
-    enabled: boolean;
-    // (undocumented)
-    enabledTime: number;
 }
 
 // @public (undocumented)
@@ -3773,8 +3541,6 @@ interface ISessionGameMode {
     disabled: {
         [gameId: string]: string;
     };
-    // Warning: (ae-forgotten-export) The symbol "IGameStored" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     known: IGameStored[];
     // (undocumented)
@@ -3803,12 +3569,8 @@ interface ISessionState {
     //
     // (undocumented)
     gameMode: ISessionGameMode;
-    // Warning: (ae-forgotten-export) The symbol "IHealthCheckSessionState" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     healthCheck: IHealthCheckSessionState;
-    // Warning: (ae-forgotten-export) The symbol "IHistoryState" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     history: IHistoryState;
     // Warning: (ae-forgotten-export) The symbol "INotificationState" needs to be exported by the entry point api.d.ts
@@ -3819,8 +3581,6 @@ interface ISessionState {
     //
     // (undocumented)
     overlays: IOverlaysState;
-    // Warning: (ae-forgotten-export) The symbol "IUpdaterSessionState" needs to be exported by the entry point api.d.ts
-    //
     // (undocumented)
     updater: IUpdaterSessionState;
 }
@@ -3963,6 +3723,8 @@ interface ISettingsInterface {
     };
     // (undocumented)
     profilesVisible: boolean;
+    // (undocumented)
+    reduceMotion?: boolean;
     // (undocumented)
     relativeTimes: boolean;
     // (undocumented)
@@ -4467,36 +4229,6 @@ interface IToolIconProps {
 }
 
 // @public (undocumented)
-interface IToolStored {
-    // (undocumented)
-    defaultPrimary?: boolean;
-    // (undocumented)
-    detach?: boolean;
-    // (undocumented)
-    environment: {
-        [key: string]: string;
-    };
-    // (undocumented)
-    exclusive?: boolean;
-    // (undocumented)
-    executable: string;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    logo: string;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    onStart?: "hide" | "hide_recover" | "close";
-    // (undocumented)
-    parameters: string[];
-    // (undocumented)
-    shell?: boolean;
-    // (undocumented)
-    shortName?: string;
-}
-
-// @public (undocumented)
 interface ITString {
     // (undocumented)
     key: string;
@@ -4528,14 +4260,6 @@ interface IUnavailableReason {
 interface IUpdateable {
     // (undocumented)
     forceUpdate: () => void;
-}
-
-// @public
-interface IUpdaterSessionState {
-    // Warning: (ae-forgotten-export) The symbol "UpdaterSnapshot" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    snapshot?: UpdaterSnapshot;
 }
 
 // @public (undocumented)
@@ -5112,7 +4836,7 @@ export const TriStateCheckbox: any;
 
 // @public (undocumented)
 export namespace types {
-    export { ActionFunc, ApiEventArgs, ApiEventMap, ApiEventName, ApiEventResult, ApiEvents, ArchiveHandlerCreator, AttributeExtractor, AttributeRenderer, CheckFunction, CollectionModStatus, Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, DirectoryCleaningMode, ExtensionInfo, ExtensionLoadFailureDependency, ExtensionLoadFailureException, LoadOrder as FBLOLoadOrder, LockedState as FBLOLockState, GameEntryNotFound, GameInfoQuery, GameLaunchType, GameStoreNotFound, HealthCheckCategory, HealthCheckFixFunction, HealthCheckFunction, HealthCheckSeverity, HealthCheckTrigger, IActionDefinition, IActionOptions, IApiFuncOptions, IApp, IArchiveHandler, IArchiveOptions, IAttachment, IAttributeState, IAvailableExtension, IBrowserState, ICheckbox, IChoiceType, ICollectionInstallSession, ICollectionInstallState, ICollectionModInstallInfo, ICollectionsPersistentState, IComponentContext, IConditionResult, IControlBase, ICustomExecutionInfo, ICustomProps, IDashletOptions, IDashletSettings, IDeployOptions, IDeployedFile, IDeploymentManifest, IDeploymentMethod, IDialog, IDialogAction, IDialogContent, IDialogResult, IDimensions, IDiscoveredTool, IDiscoveryPhase, IDiscoveryResult, IDiscoveryState, IDownload, IEditChoice, IEnableOptions, IErrorOptions, IExecInfo, IExtension, IExtensionApi, IExtensionApiExtension, IExtensionContext, IExtensionLoadFailure, IExtensionOptional, IExtensionState$1 as IExtensionState, ILoadOrderGameInfo as IFBLOGameInfo, IInvalidResult as IFBLOInvalidResult, IItemRendererProps as IFBLOItemRendererProps, ILoadOrderEntry$1 as IFBLOLoadOrderEntry, IValidationResult as IFBLOValidationResult, IFileChange, IFileFilter, IFileListItem, IFilterProps, IGame, IGameDetail, IGameInfoEntry, IGameModeSettings, IGameStore, IGameStoreEntry, IGameStored, IHealthCheck, IHealthCheckEntry, IHealthCheckResult, IHistoryEvent, IHistoryStack, IInput, IInstallResult, IInstallationDetails, IInstallerInstall, IInstallerMatch, IInstallerSpec, IInstruction, ILegacyTestAdapter, ILink, ILoadOrderDisplayItem, ILoadOrderEntry$1 as ILoadOrderEntry, ILoadOrderGameInfo, ILookupDetails, ILookupResult, IMainPageOptions, IMembership, IMergeFilter, IMod, IModCheckContext, IModHealthCheck, IModInfo$1 as IModInfo, IModInstallSpec, IModLookupInfo, IModPatches, IModReference, IModRepoId, IModRule, IModRuleExtra, IModSourceOptions, IModTable, IModType, IModTypeOptions, IModifiers, INotification, INotificationAction, INotificationState, IOpenOptions, IOverlay, IOverlayOptions, IOverlaysState, IPersistor, IPosition, IPreviewFile, IProfile, IProfileMod, IProgress, IProgressProfile, IProgressProfileDeploying, IProgressWithProfile, IQuery, IQueryArgEntry, IReducerSpec, IReference$1 as IReference, IReferenceIdentifiers, IRegisterProtocol, IRegisterRepositoryLookup, IRegisteredExtension, IRemoveModOptions, IRowState, IRunOptions, IRunParameters, IRunningTool, ISaveOptions, ISession, ISessionGameMode, ISessionState, ISettings, ISettingsAutomation, ISettingsDownloads, ISettingsGameMode, ISettingsInterface, ISettingsMods, ISettingsNotification, ISettingsProfiles, ISettingsUpdate, ISettingsWorkarounds, IStarterInfo, IState, IStateDownloads, IStateGameMode, IStatePaths, IStateTransactions, IStateVerifier, IStoreQuery, ISupportedResult, ITableAttribute, ITableFilter, ITableState, ITableStates, ITestResult, ITestSupportedDetails, IToDoButton, ITool, IToolStored, IToolbarState, IToolbarStates, IUIBlocker, IUnavailableReason, IUser, IValidateKeyData, IValidationResult, IVerifierRepairContext, IWindow, InstallFunc, InstallPathMode, InstallerMatchMode, InstallerSpecInstallFunc, InstructionType, LoadOrder, MergeFunc, MergeTest, NotificationDismiss, NotificationType, PayloadT, PerModCheckFunction, PersistingType, PersistorKey, Placement, ProblemSeverity, ProgressDelegate, PropsCallback, PropsCallbackTyped, RegisterAction, RegisterBanner, RegisterControlWrapper, RegisterDashlet, RegisterDialog, RegisterFooter, RegisterMainPage, RegisterOverlay, RegisterSettings, RegisterToDo, Revertability, SortDirection, SortType, StateChangeCallback, TFunction$1 as TFunction, TestSupported, ThunkStore, ToDoType, ToolParameterCB, UPDATE_CHANNELS, UpdateChannel, UpdateType, ValidationState, VerifierDrop, VerifierDropParent, addReducer, isModHealthCheck, toUpdateChannel };
+    export { ActionFunc, ApiEventArgs, ApiEventMap, ApiEventName, ApiEventResult, ApiEvents, ArchiveHandlerCreator, AttributeExtractor, AttributeRenderer, CheckFunction, CollectionModStatus, Condition, ConditionResults, DialogActions, DialogContentItem, DialogType, DirectoryCleaningMode, ExtensionInfo, ExtensionLoadFailureDependency, ExtensionLoadFailureException, LoadOrder as FBLOLoadOrder, LockedState as FBLOLockState, GameEntryNotFound, GameInfoQuery, GameLaunchType, GameStoreNotFound, HealthCheckCategory, HealthCheckFixFunction, HealthCheckFunction, HealthCheckSeverity, HealthCheckTrigger, IActionDefinition, IActionOptions, IApiFuncOptions, IApp, IArchiveHandler, IArchiveOptions, IAttachment, IAttributeState, IAvailableExtension, IBrowserState, ICheckbox, IChoiceType, ICollectionInstallSession, ICollectionInstallState, ICollectionModInstallInfo, ICollectionsPersistentState, IComponentContext, IConditionResult, IControlBase, ICustomExecutionInfo, ICustomProps, IDashletOptions, IDashletSettings, IDeployOptions, IDeployedFile, IDeploymentManifest, IDeploymentMethod, IDialog, IDialogAction, IDialogContent, IDialogResult, IDimensions, IDiscoveredTool, IDiscoveryPhase, IDiscoveryResult$1 as IDiscoveryResult, IDiscoveryState, IDownload, IEditChoice, IEnableOptions, IErrorOptions, IExecInfo, IExtension, IExtensionApi, IExtensionApiExtension, IExtensionContext, IExtensionLoadFailure, IExtensionOptional, IExtensionState$1 as IExtensionState, ILoadOrderGameInfo as IFBLOGameInfo, IInvalidResult as IFBLOInvalidResult, IItemRendererProps as IFBLOItemRendererProps, ILoadOrderEntry$1 as IFBLOLoadOrderEntry, IValidationResult as IFBLOValidationResult, IFileChange, IFileFilter, IFileListItem, IFilterProps, IGame, IGameDetail, IGameInfoEntry, IGameModeSettings, IGameStore, IGameStoreEntry, IGameStored$1 as IGameStored, IHealthCheck, IHealthCheckEntry, IHealthCheckResult, IHistoryEvent, IHistoryStack, IInput, IInstallResult, IInstallationDetails, IInstallerInstall, IInstallerMatch, IInstallerSpec, IInstruction, ILegacyTestAdapter, ILink, ILoadOrderDisplayItem, ILoadOrderEntry$1 as ILoadOrderEntry, ILoadOrderGameInfo, ILookupDetails, ILookupResult, IMainPageOptions, IMembership, IMergeFilter, IMod$1 as IMod, IModCheckContext, IModHealthCheck, IModInfo$1 as IModInfo, IModInstallSpec, IModLookupInfo, IModPatches, IModReference, IModRepoId, IModRule, IModRuleExtra, IModSourceOptions, IModTable, IModType, IModTypeOptions, IModifiers, INotification, INotificationAction, INotificationState, IOpenOptions, IOverlay, IOverlayOptions, IOverlaysState, IPersistor, IPosition, IPreviewFile, IProfile$1 as IProfile, IProfileMod, IProgress, IProgressProfile, IProgressProfileDeploying, IProgressWithProfile, IQuery, IQueryArgEntry, IReducerSpec, IReference$1 as IReference, IReferenceIdentifiers, IRegisterProtocol, IRegisterRepositoryLookup, IRegisteredExtension, IRemoveModOptions, IRowState, IRunOptions, IRunParameters, IRunningTool, ISaveOptions, ISession, ISessionGameMode, ISessionState, ISettings, ISettingsAutomation, ISettingsDownloads, ISettingsGameMode, ISettingsInterface, ISettingsMods, ISettingsNotification, ISettingsProfiles, ISettingsUpdate, ISettingsWorkarounds, IStarterInfo, IState, IStateDownloads, IStateGameMode, IStatePaths, IStateTransactions, IStateVerifier, IStoreQuery, ISupportedResult, ITableAttribute, ITableFilter, ITableState, ITableStates, ITestResult, ITestSupportedDetails, IToDoButton, ITool, IToolStored, IToolbarState, IToolbarStates, IUIBlocker, IUnavailableReason, IUser, IValidateKeyData, IValidationResult, IVerifierRepairContext, IWindow, InstallFunc, InstallPathMode, InstallerMatchMode, InstallerSpecInstallFunc, InstructionType, LoadOrder, MergeFunc, MergeTest, NotificationDismiss, NotificationType, PayloadT, PerModCheckFunction, PersistingType, PersistorKey, Placement, ProblemSeverity, ProgressDelegate, PropsCallback, PropsCallbackTyped, RegisterAction, RegisterBanner, RegisterControlWrapper, RegisterDashlet, RegisterDialog, RegisterFooter, RegisterMainPage, RegisterOverlay, RegisterSettings, RegisterToDo, Revertability, SortDirection, SortType, StateChangeCallback, TFunction$1 as TFunction, TestSupported, ThunkStore, ToDoType, ToolParameterCB, UPDATE_CHANNELS, UpdateChannel, UpdateType, ValidationState, VerifierDrop, VerifierDropParent, addReducer, isModHealthCheck, toUpdateChannel };
 }
 
 // @public (undocumented)
@@ -5123,54 +4847,6 @@ const UPDATE_CHANNELS: readonly ["stable", "beta", "none"];
 //
 // @public (undocumented)
 type UpdateChannel = ValuesOf<typeof UPDATE_CHANNELS>;
-
-// @public
-type UpdateKind = "patch" | "update" | "downgrade";
-
-// @public
-interface UpdaterSnapshot {
-    justUpdatedFrom?: string;
-    // Warning: (ae-forgotten-export) The symbol "UpdaterState" needs to be exported by the entry point api.d.ts
-    //
-    // (undocumented)
-    state: UpdaterState;
-}
-
-// @public
-type UpdaterState = {
-    type: "disabled";
-} | {
-    type: "idle";
-} | {
-    type: "checking";
-    manual: boolean;
-} | {
-    type: "available";
-    version: string;
-    releaseNotes?: string;
-} | {
-    type: "downgrade-offered";
-    version: string;
-} | {
-    type: "downloading";
-    version: string;
-    kind: UpdateKind;
-    manual: boolean;
-    percent?: number;
-} | {
-    type: "staged";
-    version: string;
-    kind: UpdateKind;
-    releaseNotes?: string;
-} | {
-    type: "error";
-    message: string;
-    manual: boolean;
-    retry?: {
-        version: string;
-        releaseNotes?: string;
-    };
-};
 
 // @public (undocumented)
 type UpdateType = "drag-n-drop" | "props-update" | "refresh";
@@ -5333,44 +5009,37 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 
 // Warnings were encountered during analysis:
 //
-// lib/api.d.ts:165:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:167:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:634:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1010:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1165:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1508:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2301:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3205:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3332:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3630:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3687:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3806:3 - (ae-forgotten-export) The symbol "UpdateKind" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4084:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4509:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5191:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5196:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5199:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5202:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5217:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5260:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5294:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5297:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5316:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5381:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5450:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5482:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5529:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5531:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5532:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5533:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5535:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5537:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5546:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5547:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5548:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5564:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8929:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8930:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:175:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:177:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:644:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:704:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:953:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1080:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1580:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1798:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2977:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3434:5 - (ae-forgotten-export) The symbol "IMod$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3831:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4256:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4961:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4966:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4969:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4972:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4987:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5030:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5067:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5087:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5152:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5221:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5253:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5302:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5303:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5304:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5308:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5317:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5335:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8715:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8716:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
+++ b/src/renderer/src/extensions/settings_interface/SettingsInterface.tsx
@@ -10,23 +10,25 @@ import { useSelector } from "react-redux";
 import type * as Redux from "redux";
 import type { ThunkDispatch } from "redux-thunk";
 
-import { showDialog } from "../../actions/notifications";
-import { resetSuppression } from "../../actions/notificationSettings";
-import { setCustomTitlebar } from "../../actions/window";
+import { showDialog } from "@/actions";
+import { resetSuppression } from "@/actions";
+import { setCustomTitlebar } from "@/actions";
+import type { IAvailableExtension } from "@/types/extensions";
+import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "@/types/IDialog";
+import type { IState } from "@/types/IState";
+import { Button } from "@/ui/components/button/Button";
+import { Picker } from "@/ui/components/picker/Picker";
+import { Typography } from "@/ui/components/typography/Typography";
+import { relaunch } from "@/util/commandLine";
+import { log } from "@/util/log";
+import { getPreloadApi } from "@/util/preloadAccess";
+import { useReduceMotion } from "@/util/reduceMotion";
+import { truthy } from "@/util/util";
+
 import { ComponentEx, connect, translate } from "../../controls/ComponentEx";
 import More from "../../controls/More";
 import Toggle from "../../controls/Toggle";
-import type { IAvailableExtension } from "../../types/extensions";
-import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../../types/IDialog";
-import type { IState } from "../../types/IState";
-import { Button } from "../../ui/components/button/Button";
-import { Picker } from "../../ui/components/picker/Picker";
-import { Typography } from "../../ui/components/typography/Typography";
-import { relaunch } from "../../util/commandLine";
 import getVortexPath from "../../util/getVortexPath";
-import { log } from "../../util/log";
-import { getPreloadApi } from "../../util/preloadAccess";
-import { truthy } from "../../util/util";
 import getTextModManagement from "../mod_management/texts";
 import getTextProfiles from "../profile_management/texts";
 import {
@@ -44,6 +46,7 @@ import {
   setHideTopLevelCategory,
   setLanguage,
   setProfilesVisible,
+  setReduceMotion,
   setRelativeTimes,
 } from "./actions/interface";
 import { nativeCountryName, nativeLanguageName } from "./languagemap";
@@ -76,6 +79,7 @@ interface IConnectedProps {
 interface IActionProps {
   onSetLanguage: (language: string) => void;
   onSetAlwaysCompactHeaders: (enabled: boolean) => void;
+  onSetReduceMotion: (enabled: boolean) => void;
   onSetAutoDeployment: (enabled: boolean) => void;
   onSetAutoInstall: (enabled: boolean) => void;
   onSetAutoEnable: (enabled: boolean) => void;
@@ -101,6 +105,7 @@ type IProps = IBaseProps &
   IActionProps &
   IConnectedProps & {
     currentLanguage: string;
+    reduceMotion: boolean;
     extensions: IAvailableExtension[];
     languages: ILanguage[];
     onReloadLanguages: () => void;
@@ -142,6 +147,8 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
       profilesVisible,
       hideTopLevelCategory,
       onSetForegroundDL,
+      onSetReduceMotion,
+      reduceMotion,
       relativeTimes,
       startup,
       startMinimized,
@@ -241,6 +248,16 @@ class SettingsInterfaceImpl extends ComponentEx<IProps, {}> {
 
                 <Typography appearance="subdued" typographyType="body-sm">
                   {t("Keep page headers compact for less motion and more vertical space.")}
+                </Typography>
+              </Toggle>
+            </div>
+
+            <div>
+              <Toggle checked={reduceMotion} onToggle={onSetReduceMotion}>
+                {t("Reduce motion")}
+
+                <Typography appearance="subdued" typographyType="body-sm">
+                  {t("Minimise non-essential animations and visual effects.")}
                 </Typography>
               </Toggle>
             </div>
@@ -552,6 +569,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<any, null, Redux.Action>): I
     onSetAlwaysCompactHeaders: (enabled: boolean) => {
       dispatch(setAlwaysCompactHeaders(enabled));
     },
+    onSetReduceMotion: (enabled: boolean) => {
+      dispatch(setReduceMotion(enabled));
+    },
     onResetNotificationSuppression: () => {
       dispatch(resetSuppression(null));
     },
@@ -644,6 +664,10 @@ function SettingsInterface(props: IBaseProps) {
 
   const forceReload = React.useCallback(() => setIteration((i) => i + 1), []);
 
+  // Effective rather than stored, so the toggle shows what the OS asked for until the
+  // user makes a choice of their own.
+  const reduceMotion = useReduceMotion();
+
   React.useEffect(() => {
     (async () => {
       const langs = await readLocales(exts);
@@ -665,6 +689,7 @@ function SettingsInterface(props: IBaseProps) {
       currentLanguage={lang}
       extensions={exts}
       languages={languages}
+      reduceMotion={reduceMotion}
       onReloadLanguages={forceReload}
     />
   );

--- a/src/renderer/src/extensions/settings_interface/actions/interface.test.ts
+++ b/src/renderer/src/extensions/settings_interface/actions/interface.test.ts
@@ -41,3 +41,13 @@ describe("setAlwaysCompactHeaders", () => {
     });
   });
 });
+
+describe("setReduceMotion", () => {
+  it("creates the correct action", () => {
+    expect(interfaceActions.setReduceMotion(true)).toEqual({
+      error: false,
+      type: "SET_REDUCE_MOTION",
+      payload: true,
+    });
+  });
+});

--- a/src/renderer/src/extensions/settings_interface/actions/interface.ts
+++ b/src/renderer/src/extensions/settings_interface/actions/interface.ts
@@ -47,3 +47,9 @@ export const setAlwaysCompactHeaders = safeCreateAction(
   "SET_ALWAYS_COMPACT_HEADERS",
   (enabled: boolean) => enabled,
 );
+
+/**
+ * turn non-essential animation down. Dispatching this records an explicit choice; until
+ * then the setting is absent and the operating system's preference is followed.
+ */
+export const setReduceMotion = safeCreateAction("SET_REDUCE_MOTION", (enabled: boolean) => enabled);

--- a/src/renderer/src/extensions/settings_interface/reducers/interface.test.ts
+++ b/src/renderer/src/extensions/settings_interface/reducers/interface.test.ts
@@ -37,3 +37,21 @@ describe("setAlwaysCompactHeaders", () => {
     expect(result).toEqual({ alwaysCompactHeaders: true });
   });
 });
+
+describe("setReduceMotion", () => {
+  it("records the choice", () => {
+    const result = settingsReducer.reducers.SET_REDUCE_MOTION({}, true);
+    expect(result).toEqual({ reduceMotion: true });
+  });
+
+  // Unset means "follow the OS", so an explicit false has to be stored as false rather
+  // than left absent.
+  it("records turning it back off", () => {
+    const result = settingsReducer.reducers.SET_REDUCE_MOTION({ reduceMotion: true }, false);
+    expect(result).toEqual({ reduceMotion: false });
+  });
+
+  it("has no default, so an untouched setting follows the OS", () => {
+    expect(settingsReducer.defaults).not.toHaveProperty("reduceMotion");
+  });
+});

--- a/src/renderer/src/extensions/settings_interface/reducers/interface.ts
+++ b/src/renderer/src/extensions/settings_interface/reducers/interface.ts
@@ -27,6 +27,9 @@ const settingsReducer: IReducerSpec = {
       update(state, { foregroundDL: { $set: payload } }),
     [actions.setAlwaysCompactHeaders as any]: (state, payload) =>
       update(state, { alwaysCompactHeaders: { $set: payload } }),
+    // Deliberately absent from the defaults below: unset means "follow the OS".
+    [actions.setReduceMotion as any]: (state, payload) =>
+      update(state, { reduceMotion: { $set: payload } }),
   },
   defaults: {
     language: "en",

--- a/src/renderer/src/renderer.tsx
+++ b/src/renderer/src/renderer.tsx
@@ -168,6 +168,7 @@ import GlobalNotifications from "./util/GlobalNotifications";
 import { init as getI18n, changeLanguage, fallbackTFunc, type TFunction } from "./util/i18n";
 import { showError } from "./util/message";
 import migrate from "./util/migrate";
+import { applyReduceMotion, reduceMotionFromState } from "./util/reduceMotion";
 import { readStartupSettings } from "./util/startupSettings";
 import { getSafe } from "./util/storeHelper";
 import { bytesToString, getAllPropertyNames } from "./util/util";
@@ -920,6 +921,7 @@ function renderer(extensions: ExtensionManager | null) {
   }
 
   webFrame.setZoomFactor(getSafe(store.getState(), ["settings", "window", "zoomFactor"], 1));
+  applyReduceMotion(reduceMotionFromState(store.getState()));
 
   ReactDOM.render(<LoadingScreen extensions={extensions} />, document.getElementById("content"));
   ipcRenderer.send("show-window");

--- a/src/renderer/src/types/IState.ts
+++ b/src/renderer/src/types/IState.ts
@@ -2,16 +2,17 @@ import type { EndorsedStatus, ICollection, IRevision } from "@nexusmods/nexus-ap
 import type { IParameters } from "@vortex/shared/cli";
 import type { DownloadCheckpoint } from "@vortex/shared/download";
 
-import type { ICategoryDictionary } from "../extensions/category_management/types/ICategoryDictionary";
-import type { IDownload } from "../extensions/download_management/types/IDownload";
-import type { IDiscoveryResult } from "../extensions/gamemode_management/types/IDiscoveryResult";
-import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
-import type { IHealthCheckPersistentState } from "../extensions/health_check/reducers/persistent";
-import type { IHealthCheckSessionState } from "../extensions/health_check/reducers/session";
-import type { IHistoryPersistent, IHistoryState } from "../extensions/history_management/reducers";
-import type { IMod } from "../extensions/mod_management/types/IMod";
-import type { IProfile } from "../extensions/profile_management/types/IProfile";
-import type { IUpdaterSessionState } from "../extensions/updater/reducers";
+import type { ICategoryDictionary } from "@/extensions/category_management/types/ICategoryDictionary";
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
+import type { IDiscoveryResult } from "@/extensions/gamemode_management/types/IDiscoveryResult";
+import type { IGameStored } from "@/extensions/gamemode_management/types/IGameStored";
+import type { IHealthCheckPersistentState } from "@/extensions/health_check/reducers/persistent";
+import type { IHealthCheckSessionState } from "@/extensions/health_check/reducers/session";
+import type { IHistoryPersistent, IHistoryState } from "@/extensions/history_management/reducers";
+import type { IMod } from "@/extensions/mod_management/types/IMod";
+import type { IProfile } from "@/extensions/profile_management/types/IProfile";
+import type { IUpdaterSessionState } from "@/extensions/updater/reducers";
+
 import type { ICollectionInstallState } from "./collections/ICollectionInstallSession";
 import type { ExtensionType, IAvailableExtension, IExtension } from "./extensions";
 import type { IAttributeState } from "./IAttributeState";
@@ -226,6 +227,7 @@ export interface ISettingsInterface {
   hideTopLevelCategory: boolean;
   relativeTimes: boolean;
   alwaysCompactHeaders: boolean;
+  reduceMotion?: boolean;
   dashboardLayout: string[];
   foregroundDL: boolean;
   dashletSettings: { [dashletId: string]: IDashletSettings };

--- a/src/renderer/src/util/reduceMotion.test.ts
+++ b/src/renderer/src/util/reduceMotion.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from "@testing-library/react";
+import type * as ReactReduxTypes from "react-redux";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** The stored override, flipped per test and read through the mocked hook. */
+const settings = vi.hoisted(() => ({
+  interface: {} as { reduceMotion?: boolean },
+}));
+
+vi.mock("react-redux", async () => {
+  const actual = await vi.importActual<typeof ReactReduxTypes>("react-redux");
+
+  return {
+    ...actual,
+    useSelector: (selector: (state: unknown) => unknown) => selector({ settings }),
+  };
+});
+
+import { applyReduceMotion, isReduceMotionActive, useReduceMotion } from "./reduceMotion";
+
+/**
+ * A MediaQueryList the test drives. `set` flips the answer and notifies listeners the way
+ * the OS does when its accessibility setting changes.
+ */
+const osPreference = () => {
+  const listeners = new Set<() => void>();
+  let matches = false;
+
+  window.matchMedia = ((media: string) => ({
+    get matches() {
+      return matches;
+    },
+    media,
+    addEventListener: (_event: string, listener: () => void) => listeners.add(listener),
+    removeEventListener: (_event: string, listener: () => void) => listeners.delete(listener),
+  })) as unknown as typeof window.matchMedia;
+
+  return {
+    set: (value: boolean) => {
+      matches = value;
+      listeners.forEach((listener) => listener());
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+const originalMatchMedia = window.matchMedia;
+
+describe("useReduceMotion", () => {
+  let os: ReturnType<typeof osPreference>;
+
+  beforeEach(() => {
+    settings.interface = {};
+    os = osPreference();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("follows the OS while the user has made no choice", () => {
+    const { result } = renderHook(() => useReduceMotion());
+
+    expect(result.current).toBe(false);
+
+    act(() => os.set(true));
+
+    expect(result.current).toBe(true);
+  });
+
+  // The whole point of the setting: someone whose OS says nothing, or says the opposite
+  // of what they want in Vortex, gets to decide.
+  it("lets the user's choice win over the OS, in both directions", () => {
+    settings.interface.reduceMotion = true;
+    const { result: on } = renderHook(() => useReduceMotion());
+
+    expect(on.current).toBe(true);
+
+    settings.interface.reduceMotion = false;
+    act(() => os.set(true));
+    const { result: off } = renderHook(() => useReduceMotion());
+
+    expect(off.current).toBe(false);
+  });
+
+  it("stops listening to the OS once unmounted", () => {
+    const { unmount } = renderHook(() => useReduceMotion());
+
+    expect(os.listenerCount()).toBe(1);
+
+    unmount();
+
+    expect(os.listenerCount()).toBe(0);
+  });
+});
+
+describe("applyReduceMotion", () => {
+  afterEach(() => applyReduceMotion(false));
+
+  // The attribute is what the stylesheets key off, and what isReduceMotionActive reads,
+  // so the two never disagree.
+  it("publishes the preference on the root element", () => {
+    applyReduceMotion(true);
+
+    expect(document.documentElement.dataset.reduceMotion).toBe("true");
+    expect(isReduceMotionActive()).toBe(true);
+  });
+
+  it("removes the attribute rather than setting it false", () => {
+    applyReduceMotion(true);
+    applyReduceMotion(false);
+
+    expect(document.documentElement.hasAttribute("data-reduce-motion")).toBe(false);
+    expect(isReduceMotionActive()).toBe(false);
+  });
+});

--- a/src/renderer/src/util/reduceMotion.ts
+++ b/src/renderer/src/util/reduceMotion.ts
@@ -1,0 +1,84 @@
+import { useSyncExternalStore } from "react";
+import { useSelector } from "react-redux";
+
+import type { IState } from "../types/IState";
+
+const REDUCE_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/** The attribute `<html>` carries while motion is turned down. */
+export const REDUCE_MOTION_ATTRIBUTE = "reduceMotion";
+
+const query = (): MediaQueryList | undefined =>
+  typeof window === "undefined" || typeof window.matchMedia !== "function"
+    ? undefined
+    : window.matchMedia(REDUCE_MOTION_QUERY);
+
+const subscribeToOs = (onChange: () => void): (() => void) => {
+  const list = query();
+  if (list === undefined) {
+    return () => undefined;
+  }
+
+  list.addEventListener("change", onChange);
+  return () => list.removeEventListener("change", onChange);
+};
+
+const osPrefersReduce = (): boolean => query()?.matches ?? false;
+
+/** The user's explicit choice, or undefined while they haven't made one. */
+const selectOverride = (state: IState): boolean | undefined =>
+  state.settings.interface.reduceMotion;
+
+/**
+ * Whether the operating system asks for reduced motion. Follows the preference live,
+ * without a restart; false where the platform doesn't report one.
+ */
+export const useOsReduceMotion = (): boolean =>
+  useSyncExternalStore(subscribeToOs, osPrefersReduce);
+
+/**
+ * Whether non-essential animation should be turned down: the user's own choice, or the
+ * operating system's preference until they make one.
+ *
+ * Drives the `data-reduce-motion` attribute on `<html>`, which is what the stylesheets
+ * key off; read this in components that decide about motion in JavaScript, and
+ * {@link isReduceMotionActive} outside of React.
+ */
+export const useReduceMotion = (): boolean => {
+  const override = useSelector(selectOverride);
+  const os = useOsReduceMotion();
+
+  return override ?? os;
+};
+
+/**
+ * {@link useReduceMotion} for code that can't hold a hook. Reads the attribute the app
+ * stamps on `<html>` rather than the store, so both answers come from one place.
+ */
+export const isReduceMotionActive = (): boolean =>
+  typeof document !== "undefined" &&
+  document.documentElement.dataset[REDUCE_MOTION_ATTRIBUTE] === "true";
+
+/**
+ * Publish the current answer to the stylesheets. Called at startup and whenever the
+ * preference changes; the attribute is removed rather than set to "false" so the CSS only
+ * needs the one selector.
+ */
+export const applyReduceMotion = (reduce: boolean): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  if (reduce) {
+    document.documentElement.dataset[REDUCE_MOTION_ATTRIBUTE] = "true";
+  } else {
+    delete document.documentElement.dataset[REDUCE_MOTION_ATTRIBUTE];
+  }
+};
+
+/**
+ * The effective preference from a state snapshot, for the startup path that runs before
+ * React mounts.
+ */
+export const reduceMotionFromState = (state: IState): boolean =>
+  selectOverride(state) ?? osPrefersReduce();

--- a/src/renderer/src/views/components/Menu/Menu.tsx
+++ b/src/renderer/src/views/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type FC, useLayoutEffect, useRef, useEffect } from "react";
+import React, { useState, type FC, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 
@@ -33,7 +33,6 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
   const { visibleTools } = useToolsContext();
   const toolCount = visibleTools.length;
   const [canScrollUp, setCanScrollUp] = useState(false);
-  const [isAnimating, setIsAnimating] = useState(false);
 
   const onScroll = (event: Event) => setCanScrollUp((event.target as HTMLDivElement).scrollTop > 0);
 
@@ -46,13 +45,6 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
     element.addEventListener("scroll", onScroll);
     return () => element.removeEventListener("scroll", onScroll);
   }, [scrollRef]);
-
-  useLayoutEffect(() => {
-    setIsAnimating(true);
-    const timer = setTimeout(() => setIsAnimating(false), 150);
-
-    return () => clearTimeout(timer);
-  }, [menuIsCollapsed]);
 
   return (
     <TooltipDelayGroup
@@ -100,7 +92,7 @@ const MenuContent: FC<React.PropsWithChildren<unknown>> = () => {
         <div className="pointer-events-none absolute right-0 bottom-0 size-3 bg-surface-base" />
       </div>
 
-      <ToolsSection isAnimating={isAnimating} />
+      <ToolsSection />
 
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-1 h-6 bg-linear-to-t from-surface-base to-transparent" />
     </TooltipDelayGroup>

--- a/src/renderer/src/views/components/Menu/ToolsSection.test.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** The context values under test, set per case. */
+const context = vi.hoisted(() => ({
+  menuIsCollapsed: false,
+  visibleTools: [{ id: "tool-1", exePath: "a.exe" }] as unknown[],
+}));
+
+vi.mock("@/contexts", () => ({
+  useWindowContext: () => ({ menuIsCollapsed: context.menuIsCollapsed }),
+}));
+
+vi.mock("../Spine/SpineContext", () => ({
+  useSpineContext: () => ({ selection: { type: "game", gameId: "stardewvalley" } }),
+}));
+
+vi.mock("./ToolsContext", () => ({
+  useToolsContext: () => ({
+    gameId: "stardewvalley",
+    gameName: "Stardew Valley",
+    visibleTools: context.visibleTools,
+    primaryStarter: undefined,
+    primaryToolId: undefined,
+    isPrimaryRunning: false,
+    exclusiveRunning: false,
+    isToolRunning: () => false,
+    startTool: vi.fn(),
+    handlePlay: vi.fn(),
+  }),
+}));
+
+vi.mock("./ToolButton", () => ({
+  ToolButton: () => <button data-testid="tool" type="button" />,
+}));
+
+import { ToolsSection } from "./ToolsSection";
+
+describe("ToolsSection", () => {
+  beforeEach(() => {
+    context.menuIsCollapsed = false;
+    context.visibleTools = [{ id: "tool-1", exePath: "a.exe" }];
+  });
+
+  it("lays the row out for the width the menu is at", () => {
+    const { rerender } = render(<ToolsSection />);
+
+    expect(screen.getByTestId("menu-tools")).toHaveClass("w-full");
+
+    context.menuIsCollapsed = true;
+    rerender(<ToolsSection />);
+
+    expect(screen.getByTestId("menu-tools")).toHaveClass("w-10");
+  });
+
+  // The choreography, not just the fact of an animation: the row waits out the menu's
+  // resize offset and invisible, then travels. Losing the delay is a silent regression —
+  // the row still animates, it just stops waiting — so it is asserted rather than left
+  // to the eye.
+  it("holds the row back before it slides up", () => {
+    render(<ToolsSection />);
+
+    const row = screen.getByTestId("menu-tools");
+
+    expect(row).toHaveClass("delay-150", "duration-200");
+    expect(row).toHaveClass("translate-y-6", "opacity-0");
+  });
+
+  // Reduced motion means instant, not a gentler animation: the row starts where it ends,
+  // so there is no travel to make and no fade in its place.
+  it("gives the row nothing to animate when motion is turned down", () => {
+    render(<ToolsSection />);
+
+    expect(screen.getByTestId("menu-tools")).toHaveClass(
+      "reduce-motion:translate-y-0",
+      "reduce-motion:opacity-100",
+      "reduce-motion:delay-0",
+    );
+  });
+
+  // The entry animation is replayed by remounting on the width change, which is what
+  // lets Transition own the sequencing instead of a flag cleared by a timer. If the key
+  // stopped changing the row would sit still, so this pins the mechanism rather than the
+  // animation.
+  it("remounts the row when the menu changes width", () => {
+    const { rerender } = render(<ToolsSection />);
+    const before = screen.getByTestId("menu-tools");
+
+    context.menuIsCollapsed = true;
+    rerender(<ToolsSection />);
+
+    expect(screen.getByTestId("menu-tools")).not.toBe(before);
+  });
+
+  it("keeps the same row when nothing about the width changed", () => {
+    const { rerender } = render(<ToolsSection />);
+    const before = screen.getByTestId("menu-tools");
+
+    rerender(<ToolsSection />);
+
+    expect(screen.getByTestId("menu-tools")).toBe(before);
+  });
+
+  it("leaves the row out when the game has no tools", () => {
+    context.visibleTools = [];
+
+    render(<ToolsSection />);
+
+    expect(screen.queryByTestId("menu-tools")).toBeNull();
+  });
+});

--- a/src/renderer/src/views/components/Menu/ToolsSection.tsx
+++ b/src/renderer/src/views/components/Menu/ToolsSection.tsx
@@ -1,5 +1,6 @@
 import { pathToFileURL } from "url";
 
+import { Transition } from "@headlessui/react";
 import { mdiPlay } from "@mdi/js";
 import React, { type FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -128,11 +129,7 @@ const PlayButton: FC<React.PropsWithChildren<PlayButtonProps>> = ({
   );
 };
 
-interface ToolsSectionProps {
-  isAnimating: boolean;
-}
-
-export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ isAnimating }) => {
+export const ToolsSection = () => {
   const { menuIsCollapsed } = useWindowContext();
   const { selection } = useSpineContext();
   const {
@@ -160,12 +157,19 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
       ])}
     >
       {!!visibleTools.length && (
-        <div
+        <Transition
+          appear
+          show
+          as="div"
           className={joinClasses([
-            "flex items-center gap-1 border-b border-stroke-weak pb-3 transition-[translate,opacity]",
+            "flex items-center gap-1 border-b border-stroke-weak pb-3",
             menuIsCollapsed ? "w-10 flex-wrap justify-center" : "w-full flex-wrap-reverse",
-            isAnimating ? "translate-y-6 opacity-0 duration-0" : "duration-200",
           ])}
+          data-testid="menu-tools"
+          enter="transition-[translate,opacity] delay-150 duration-200 reduce-motion:delay-0"
+          enterFrom="translate-y-6 opacity-0 reduce-motion:translate-y-0 reduce-motion:opacity-100"
+          enterTo="translate-y-0 opacity-100"
+          key={menuIsCollapsed ? "collapsed" : "expanded"}
         >
           {visibleTools.map((starter) => (
             <ToolButton
@@ -175,7 +179,7 @@ export const ToolsSection: FC<React.PropsWithChildren<ToolsSectionProps>> = ({ i
               onClick={() => startTool(starter)}
             />
           ))}
-        </div>
+        </Transition>
       )}
 
       <PlayButton

--- a/src/renderer/src/views/components/Spine/notifications/components/NotificationItem.tsx
+++ b/src/renderer/src/views/components/Spine/notifications/components/NotificationItem.tsx
@@ -94,7 +94,7 @@ export const NotificationItem = ({
         {type === "activity" && notification.progress !== undefined && (
           <div className="h-1 w-full overflow-hidden rounded-full bg-surface-high">
             <div
-              className="h-full rounded-full bg-info-strong transition-[width] duration-300"
+              className="h-full rounded-full bg-info-strong transition-[width] duration-300 reduce-motion:duration-0"
               style={{ width: `${notification.progress}%` }}
             />
           </div>

--- a/src/renderer/src/views/layout/LayoutContainer.tsx
+++ b/src/renderer/src/views/layout/LayoutContainer.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import { useMenuLayerContext, useWindowContext } from "../../contexts";
 import type { IState } from "../../types/IState";
 import { joinClasses } from "../../ui/utils/joinClasses";
+import { applyReduceMotion, useReduceMotion } from "../../util/reduceMotion";
 import startupSettings from "../../util/startupSettings";
 
 export interface ILayoutContainerProps {
@@ -23,6 +24,14 @@ export const LayoutContainer: FC<React.PropsWithChildren<ILayoutContainerProps>>
   const { menuLayerOpen, setMenuLayerRef } = useMenuLayerContext();
 
   const { customTitlebar, useModernLayout } = useSelector((state: IState) => state.settings.window);
+
+  const reduceMotion = useReduceMotion();
+
+  // Publishes the preference to the stylesheets. Startup applies it once before React
+  // mounts; this keeps it in step afterwards, whether the user or the OS changed it.
+  useEffect(() => {
+    applyReduceMotion(reduceMotion);
+  }, [reduceMotion]);
 
   // Add custom titlebar class on mount
   const initializedRef = useRef(false);

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -48,6 +48,23 @@ if (typeof window !== "undefined" && !(window as any).api) {
   };
 }
 
+// happy-dom has no matchMedia, and anything reading a media preference (reduced motion)
+// calls it during render. Reports "no preference" and accepts listeners without firing
+// them; a test that cares drives it by replacing window.matchMedia itself.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  (window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    // Deprecated half of the MediaQueryList API, still what some libraries reach for.
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
+}
+
 // Initialize once per (isolated) test file so getVortexPath returns the stub paths above.
 // The instance getter throws until initialized; use that to init exactly once.
 beforeAll(async () => {

--- a/src/stylesheets/ui/theme/index.css
+++ b/src/stylesheets/ui/theme/index.css
@@ -1,4 +1,5 @@
 @import "./generic.css";
 @import "./colours.css";
 @import "./overrides.css";
+@import "./motion.css";
 @import "./typography.css";

--- a/src/stylesheets/ui/theme/motion.css
+++ b/src/stylesheets/ui/theme/motion.css
@@ -1,0 +1,19 @@
+/* Reduced motion. The app stamps `data-reduce-motion` on <html> - see util/reduceMotion.ts. */
+
+/* The app-aware counterpart to Tailwind's `motion-reduce:`, which only ever sees the OS. */
+@custom-variant reduce-motion ([data-reduce-motion="true"] &);
+
+@layer theme {
+    [data-reduce-motion="true"] {
+        /* Flattens every `transition-*`; an explicit `duration-*` survives it on purpose. */
+        --default-transition-duration: 0.01ms; /* not 0s: that fires no transitionend */
+    }
+}
+
+@layer utilities {
+    [data-reduce-motion="true"] {
+        .animate-pulse {
+            animation: none;
+        }
+    }
+}


### PR DESCRIPTION
Adds the **Reduce motion** setting from [LAZ-1066](https://linear.app/nexus-mods/issue/LAZ-1066/add-a-reduce-motion-setting-to-vortex): Settings → Interface → Customisation, helper text *"Minimise non-essential animations and visual effects."*

> **Stacked on #24108** (LAZ-948). Base is `laz-948`, so this diff is just the reduce-motion commit — GitHub will retarget to `master` once 948 merges. Review that one first.

## Why

Motion causes discomfort, dizziness or migraines for people with vestibular sensitivities, and Vortex had no lever at all: an audit of the tree found **zero** `prefers-reduced-motion` handling in our own source. The only thing honouring it was `react-hot-toast`, from inside `node_modules`. LAZ-948 exists partly for the same reason — its description cites the header's collapse animation — but one setting per animation doesn't scale.

## How it works

`settings.interface.reduceMotion` is `boolean | undefined`, and is **deliberately absent from the reducer defaults**: unset means "ask the OS", so the toggle follows `prefers-reduced-motion` until the user decides, then their choice wins. The effective answer is published as `data-reduce-motion` on `<html>` — once at startup (beside the existing `zoomFactor` restore) and then whenever the setting or the OS changes. That single attribute is what both the stylesheets and `isReduceMotionActive()` read, so there's one source of truth rather than two.

Turned down, transitions flatten through `--default-transition-duration`, which every Tailwind `transition-*` utility and all of `ui/**` resolve through — one rule, no `!important`, no specificity fight.

**An explicit `duration-*` survives on purpose.** It sets `transition-duration` directly, and a component that names its own duration usually depends on it: Headless UI reads durations to sequence a `Transition`, so a blanket `transition-duration: 0` wouldn't flatten the download button's arrow/progress handover — it would break it, firing `afterLeave` immediately. Decorative cases opt out with a new `reduce-motion:` variant.

**Use `reduce-motion:`, not Tailwind's `motion-reduce:`** — the built-in variants compile to media queries, so they only ever see the OS and can't respond to the app's setting.

**Reduced means instant, not gentler.** An opt-out starts a transition at its final state rather than zeroing its duration, and drops any delay with it. Documented in `docs/frontend.md` so it stays consistent as more of the app is converted.

## What changes visibly

Spinners keep spinning, skeleton shimmer stops, hover fades and the page-header shrink become instant. The tools row swaps its flag-and-timer entry (`isAnimating` + `setTimeout(150)`) for a `Transition` keyed on the menu width — which removes a timer to keep in step and makes the reduced case declarative.

## Testing

`pnpm run verify` passes; eslint and `tsc --noEmit` clean on the touched paths. New unit tests cover the action, the reducer (including that it has no default), the hook's OS/override precedence and listener teardown, and the tools row's choreography.

Verified against a **real GNOME 46 Wayland session**, not just emulated media: the OS setting reaches the media query, the attribute lands at boot with no override stored, an explicit toggle overrides it, and the choice survives a restart. Windows and macOS still want a second pair of hands.

## Deliberately out of scope

- **Only the Tailwind/`nxm-` surface responds.** The legacy SCSS compiles its durations in, so the classic toolbar's flashing buttons (`toolbar-flash-button`, `pulseColor 6s infinite`) still flash, as do the tutorial spotlight, sortable-tree arrows and Bootstrap's modal slide. Worth its own ticket for the legacy sweep.
- **Toasts** follow the OS but not the app setting: `react-hot-toast` reads and caches the media query at module scope, so reaching it needs a CSS override we chose not to add here.
- **The keyboard/AT criterion is not met.** `controls/Toggle.tsx` is a click-handled `<div>` — not focusable, not announced — and it's excluded by decision since it's being replaced. This AC rides on that work.
- `etc/vortex.api.md` is regenerated and carries pre-existing drift: `pnpm run api` restores an nx-cached report keyed on a gitignored input, so the committed copy hadn't been regenerated since the updater work landed. Only `reduceMotion` is new here.
