### PR TITLE
Fixed game stubs failing to install the replacement

### DIFF
--- a/src/renderer/src/extensions/extension_manager/util.test.ts
+++ b/src/renderer/src/extensions/extension_manager/util.test.ts
@@ -63,4 +63,49 @@ describe("downloadAndInstallExtension", () => {
       expect.objectContaining({ catalogEntry: undefined }),
     );
   });
+
+  it("resolves the file id from the catalog when the download info only carries a mod id", async () => {
+    vi.mocked(fetchExtensionList).mockResolvedValueOnce([
+      makeAvailableExtension({ name: "Game: Cyberpunk 2077", modId: 196, fileId: 9 }),
+    ]);
+
+    const harness = makeApiHarness({
+      downloads: { "dl-1": makeDownload({ id: "dl-1", localPath: "cyberpunk.7z" }) },
+    });
+    const emitAndAwait = vi.fn(async () => ["dl-1"]);
+    harness.api.emitAndAwait = emitAndAwait as unknown as IExtensionApi["emitAndAwait"];
+
+    const result = await downloadAndInstallExtension(harness.api, {
+      name: "Game: Cyberpunk 2077",
+      modId: 196,
+    });
+
+    expect(result).toBe(true);
+    expect(emitAndAwait).toHaveBeenCalledWith(
+      "nexus-download",
+      "site",
+      196,
+      9,
+      expect.any(String),
+      false,
+    );
+  });
+
+  it("does not start a download when neither the info nor the catalog has a file id", async () => {
+    const harness = makeApiHarness();
+    const emitAndAwait = vi.fn(async () => ["dl-1"]);
+    harness.api.emitAndAwait = emitAndAwait as unknown as IExtensionApi["emitAndAwait"];
+    harness.api.showDialog = vi.fn(async () => ({
+      action: "Close",
+      input: {},
+    })) as unknown as IExtensionApi["showDialog"];
+
+    const result = await downloadAndInstallExtension(harness.api, {
+      name: "Game: Not Listed",
+      modId: 197,
+    });
+
+    expect(result).toBe(false);
+    expect(emitAndAwait).not.toHaveBeenCalled();
+  });
 });

--- a/src/renderer/src/extensions/extension_manager/util.ts
+++ b/src/renderer/src/extensions/extension_manager/util.ts
@@ -83,16 +83,6 @@ export async function downloadAndInstallExtension(
       return false;
     }
 
-    const downloadIds = await downloadFromNexus(api, ext);
-    if (downloadIds.length === 0) {
-      throw new ProcessCanceled("No download found");
-    }
-
-    const downloadId = downloadIds[0];
-    const download = api.getState().persistent.downloads.files[downloadId];
-
-    api.store.dispatch(setDownloadModInfo(downloadId, "internal", true));
-
     // the catalog only provides metadata here; install the download without it
     let availableExtensions: IAvailableExtension[] = [];
     try {
@@ -102,6 +92,21 @@ export async function downloadAndInstallExtension(
     }
 
     const catalogEntry = findInCatalog(availableExtensions, { modId: ext.modId });
+
+    const fileId = ext.fileId ?? catalogEntry?.fileId;
+    if (fileId === undefined) {
+      throw new ProcessCanceled(`Extension with mod id ${ext.modId} is not in the catalog`);
+    }
+
+    const downloadIds = await downloadFromNexus(api, ext, fileId);
+    if (downloadIds.length === 0) {
+      throw new ProcessCanceled("No download found");
+    }
+
+    const downloadId = downloadIds[0];
+    const download = api.getState().persistent.downloads.files[downloadId];
+
+    api.store.dispatch(setDownloadModInfo(downloadId, "internal", true));
 
     const state = api.getState();
     const downloadPath = downloadPathForGame(state, SITE_ID);
@@ -154,13 +159,14 @@ function archiveFileName(ext: IExtensionDownloadInfo): string {
 async function downloadFromNexus(
   api: IExtensionApi,
   ext: IExtensionDownloadInfo,
+  fileId: number,
 ): Promise<string[]> {
   log("debug", "download from nexus", archiveFileName(ext));
   return await api.emitAndAwait<"nexus-download">(
     "nexus-download",
     SITE_ID,
     ext.modId,
-    ext.fileId,
+    fileId,
     archiveFileName(ext),
     false,
   );

--- a/src/renderer/src/extensions/profile_management/index.ts
+++ b/src/renderer/src/extensions/profile_management/index.ts
@@ -538,14 +538,6 @@ function manageGameUndiscovered(api: IExtensionApi, gameId: string): PromiseBB<v
     const stubDownloadInfo = getGameStubDownloadInfo(gameId);
     let extension: IExtensionDownloadInfo;
     if (stubDownloadInfo !== undefined) {
-      if (stubDownloadInfo.modId !== undefined && stubDownloadInfo.fileId === undefined) {
-        const manifestEntry = state.session.extensions.available.find(
-          (ext) => ext.modId === stubDownloadInfo.modId,
-        );
-        if (manifestEntry !== undefined) {
-          stubDownloadInfo.fileId = manifestEntry.fileId;
-        }
-      }
       extension = stubDownloadInfo;
     } else {
       extension = state.session.extensions.available.find(

--- a/src/renderer/src/types/extensions.ts
+++ b/src/renderer/src/types/extensions.ts
@@ -65,7 +65,8 @@ export type IExtensionWithState = IExtensionState & {
 export interface IExtensionDownloadInfo {
   name: string;
   modId: number;
-  fileId: number;
+  // game stubs and bare nxm://site/mods/<id> links only know the mod; resolved from the catalog
+  fileId?: number;
 }
 
 /**


### PR DESCRIPTION
A stub extension now fails to install a replacement due to the fact that fileId is mandatory and is missing from the stub

Fixes fingerprint 97a6cf07
Closes LAZ-1082