### PR TITLE
Fixed Error Classification

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -715,6 +715,7 @@ interface IBar {
 interface IBaseProps$1 {
     // (undocumented)
     actions: ITableRowAction[];
+    analyticsId?: string;
     // (undocumented)
     children?: React$2.ReactNode;
     // (undocumented)
@@ -5193,7 +5194,7 @@ export class VisibilityProxy extends React$2.PureComponent<any, {}> {
     render(): JSX.Element;
 }
 
-// @public
+// @public (undocumented)
 export class VortexError extends Error {
     constructor(message: string, data: VortexErrorData, meta?: {
         isTransient?: boolean;
@@ -5240,6 +5241,8 @@ export interface VortexErrorKindMap {
     "fs:not-a-file": FileSystemErrorData;
     // (undocumented)
     "fs:not-found": FileSystemErrorData;
+    // (undocumented)
+    "fs:read-only": FileSystemErrorData;
     "game-not-found": {
         gameId: string;
     };
@@ -5272,7 +5275,7 @@ export interface VortexErrorKindMap {
     "not-supported": {
         feature?: string;
     };
-    "os:generic": OsErrorData;
+    "os:generic": Pick<OsErrorData, "originalCode"> & Partial<OsErrorData>;
     "os:unsupported": {};
     "process-canceled": {
         extraInfo?: unknown;
@@ -5325,42 +5328,42 @@ export class ZoomableImage extends React$2.Component<IZoomableImageProps, {
 //
 // lib/api.d.ts:165:5 - (ae-forgotten-export) The symbol "IBBCodeContext" needs to be exported by the entry point api.d.ts
 // lib/api.d.ts:167:5 - (ae-forgotten-export) The symbol "DialogContentItem" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:643:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1019:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1174:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:1517:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:2305:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3209:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3336:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3634:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3691:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:3810:3 - (ae-forgotten-export) The symbol "UpdateKind" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4088:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:4513:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5195:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5200:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5203:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5206:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5221:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5264:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5298:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5301:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5319:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5384:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5453:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5485:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5532:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5534:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5535:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5536:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5538:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5540:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5549:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5550:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5551:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:5567:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8926:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
-// lib/api.d.ts:8927:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:634:3 - (ae-forgotten-export) The symbol "ByteRange" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1010:5 - (ae-forgotten-export) The symbol "IDiscoveredTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1165:5 - (ae-forgotten-export) The symbol "IItemRendererProps" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:1508:5 - (ae-forgotten-export) The symbol "IQueryArgEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:2296:3 - (ae-forgotten-export) The symbol "IChoices" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3200:5 - (ae-forgotten-export) The symbol "IEditChoice" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3327:5 - (ae-forgotten-export) The symbol "ICollectionModInstallInfo" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3625:5 - (ae-forgotten-export) The symbol "IProfileMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3682:5 - (ae-forgotten-export) The symbol "IMod" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:3801:3 - (ae-forgotten-export) The symbol "UpdateKind" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4079:3 - (ae-forgotten-export) The symbol "IGameDetail" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:4504:5 - (ae-forgotten-export) The symbol "IStateVerifier" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5186:7 - (ae-forgotten-export) The symbol "IProgress" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5191:5 - (ae-forgotten-export) The symbol "IExtensionLoadFailure" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5194:5 - (ae-forgotten-export) The symbol "IRunningTool" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5197:5 - (ae-forgotten-export) The symbol "IUIBlocker" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5212:5 - (ae-forgotten-export) The symbol "IRowState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5255:5 - (ae-forgotten-export) The symbol "IExtensionState$1" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5289:5 - (ae-forgotten-export) The symbol "IDownload" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5292:5 - (ae-forgotten-export) The symbol "DownloadCheckpoint" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5310:5 - (ae-forgotten-export) The symbol "IDashletSettings" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5375:5 - (ae-forgotten-export) The symbol "IAttributeState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5444:7 - (ae-forgotten-export) The symbol "IGameInfoEntry" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5476:5 - (ae-forgotten-export) The symbol "IOverlay" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5523:7 - (ae-forgotten-export) The symbol "IProfile" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5525:5 - (ae-forgotten-export) The symbol "IModTable" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5526:5 - (ae-forgotten-export) The symbol "IStateDownloads" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5527:5 - (ae-forgotten-export) The symbol "ICollectionsPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5529:7 - (ae-forgotten-export) The symbol "ICategoryDictionary" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5531:5 - (ae-forgotten-export) The symbol "IStateGameMode" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5540:5 - (ae-forgotten-export) The symbol "IStateTransactions" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5541:5 - (ae-forgotten-export) The symbol "IHistoryPersistent" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5542:5 - (ae-forgotten-export) The symbol "IHealthCheckPersistentState" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:5558:5 - (ae-forgotten-export) The symbol "IDiscoveryPhase" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8919:3 - (ae-forgotten-export) The symbol "MainPageBody" needs to be exported by the entry point api.d.ts
+// lib/api.d.ts:8920:3 - (ae-forgotten-export) The symbol "MainPageHeader" needs to be exported by the entry point api.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/main/src/downloading/errors.test.ts
+++ b/src/main/src/downloading/errors.test.ts
@@ -1,0 +1,33 @@
+import { ReadError, RequestError } from "got";
+import { assert, describe, expect, it } from "vitest";
+
+import { toNetworkError } from "./errors";
+
+const url = new URL("https://cdn.nexusmods.com/files/mod.7z");
+
+/** got attaches the request lazily; the classifier only reads the error itself. */
+const noRequest = {} as never;
+
+describe("toNetworkError", () => {
+  it("keeps the POSIX classification of a reset connection", () => {
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    const result = toNetworkError(url, new RequestError(cause.message, cause, noRequest));
+
+    assert(result.data.kind === "http:generic");
+    expect(result.data.originalCode).toBe("ECONNRESET");
+    expect(result.message).toBe("Network request failed");
+  });
+
+  it("treats a response stream that ended early as a transient network failure", () => {
+    const cause = Object.assign(new Error("Content-Length mismatch: expected 10, received 5"), {
+      code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    });
+    const result = toNetworkError(url, new ReadError(cause, noRequest));
+
+    assert(result.data.kind === "http:generic");
+    expect(result.data.url).toBe(url.toString());
+    expect(result.data.originalCode).toBe("ERR_HTTP_CONTENT_LENGTH_MISMATCH");
+    expect(result.isTransient).toBe(true);
+    expect(result.cause).toBeInstanceOf(ReadError);
+  });
+});

--- a/src/main/src/downloading/errors.test.ts
+++ b/src/main/src/downloading/errors.test.ts
@@ -18,7 +18,7 @@ describe("toNetworkError", () => {
     expect(result.message).toBe("Network request failed");
   });
 
-  it("treats a response stream that ended early as a transient network failure", () => {
+  it("classifies a response stream that ended early as a network failure", () => {
     const cause = Object.assign(new Error("Content-Length mismatch: expected 10, received 5"), {
       code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
     });
@@ -27,7 +27,7 @@ describe("toNetworkError", () => {
     assert(result.data.kind === "http:generic");
     expect(result.data.url).toBe(url.toString());
     expect(result.data.originalCode).toBe("ERR_HTTP_CONTENT_LENGTH_MISMATCH");
-    expect(result.isTransient).toBe(true);
+    expect(result.isTransient).toBe(false);
     expect(result.cause).toBeInstanceOf(ReadError);
   });
 });

--- a/src/main/src/downloading/errors.ts
+++ b/src/main/src/downloading/errors.ts
@@ -46,12 +46,12 @@ export function toNetworkError(endpoint: URL | ResolvedEndpoint, err: unknown): 
     );
     if (parsed.data.kind !== "unknown") return parsed;
 
-    // got's own codes (ERR_READING_RESPONSE_STREAM, ...) have no POSIX mapping: the connection
-    // dropped mid-request, which is worth retrying
+    // got's own codes (ERR_READING_RESPONSE_STREAM, ...) have no POSIX mapping; the retry
+    // strategy decides by `originalCode`
     return new VortexError(
-      "Network request failed (transient)",
+      "Network request failed",
       { kind: "http:generic", url: urlString, originalCode: err.code },
-      { cause: err, isTransient: true },
+      { cause: err },
     );
   }
 

--- a/src/main/src/downloading/errors.ts
+++ b/src/main/src/downloading/errors.ts
@@ -39,10 +39,19 @@ export function toNetworkError(endpoint: URL | ResolvedEndpoint, err: unknown): 
   }
 
   if (err instanceof RequestError) {
-    return parseError(err, { url: urlString }, ({ data, isTransient }) =>
+    const parsed = parseError(err, { url: urlString }, ({ data, isTransient }) =>
       data.kind === "http:generic" || data.kind === "os:generic"
         ? `Network request failed${isTransient ? " (transient)" : ""}`
         : undefined,
+    );
+    if (parsed.data.kind !== "unknown") return parsed;
+
+    // got's own codes (ERR_READING_RESPONSE_STREAM, ...) have no POSIX mapping: the connection
+    // dropped mid-request, which is worth retrying
+    return new VortexError(
+      "Network request failed (transient)",
+      { kind: "http:generic", url: urlString, originalCode: err.code },
+      { cause: err, isTransient: true },
     );
   }
 

--- a/src/renderer/src/extensions/mod_management/InstallManager.ts
+++ b/src/renderer/src/extensions/mod_management/InstallManager.ts
@@ -6281,15 +6281,18 @@ class InstallManager {
               queuedDownloads.splice(idx, 1);
 
               const errMsg = unknownToError(err).message;
-              const errCode = getErrorCode(err);
+              const parsedErr = parseError(err);
 
-              // Check if this is a network error that might have caused the download to be paused
+              // a failure of the connection itself (which may have paused the download), as
+              // opposed to a refusal by the server
               const isNetworkError =
-                errMsg?.includes("socket hang up") ||
-                errMsg?.includes("ECONNRESET") ||
-                errMsg?.includes("ETIMEDOUT") ||
-                errCode === "ECONNRESET" ||
-                errCode === "ETIMEDOUT";
+                parsedErr.data.kind === "http:generic" ||
+                parsedErr.data.kind === "http:timeout" ||
+                (parsedErr.data.kind === "http:bad-status" && parsedErr.data.statusCode >= 500) ||
+                (parsedErr.data.kind === "os:generic" &&
+                  ["ECONNRESET", "ECONNABORTED", "ETIMEDOUT"].includes(
+                    parsedErr.data.originalCode,
+                  ));
 
               // Check if this is a "File already downloaded" error (for cases where we get a generic error message)
               const isAlreadyDownloaded =

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
@@ -1,5 +1,4 @@
 import { HTTPError as NexusHTTPError, NexusError, RateLimitError } from "@nexusmods/nexus-api";
-import { VortexError } from "@vortex/shared";
 import PromiseBB from "bluebird";
 import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 
@@ -240,24 +239,6 @@ describe("nxm protocol resolver", () => {
       expect((err as HTTPError).statusCode).toBe(520);
       expect((err as HTTPError).message).toBe("HTTP (520) - Request Failed");
       expect((err as HTTPError).data).toMatchObject({ kind: "http:bad-status", statusCode: 520 });
-    });
-
-    test("classifies a dropped connection instead of passing the raw socket error on", async ({
-      makeNxm,
-    }) => {
-      const { harness, resolve } = makeNxm();
-      harness.getDownloadURLs.mockRejectedValue(
-        Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
-      );
-
-      const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
-
-      expect(err).toBeInstanceOf(VortexError);
-      expect((err as VortexError).data).toMatchObject({
-        kind: "os:generic",
-        originalCode: "ECONNRESET",
-      });
-      expect((err as VortexError).message).toBe("Network request failed");
     });
 
     test("reports a 401 as a log-in problem rather than a raw http error", async ({ makeNxm }) => {

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.test.ts
@@ -1,4 +1,5 @@
-import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import { HTTPError as NexusHTTPError, NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import { VortexError } from "@vortex/shared";
 import PromiseBB from "bluebird";
 import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 
@@ -223,6 +224,40 @@ describe("nxm protocol resolver", () => {
 
       expect(err).toBeInstanceOf(HTTPError);
       expect((err as HTTPError).statusCode).toBe(500);
+    });
+
+    test("turns the api client's own HTTPError into one the downloader can classify", async ({
+      makeNxm,
+    }) => {
+      const { harness, resolve } = makeNxm();
+      harness.getDownloadURLs.mockRejectedValue(
+        new NexusHTTPError(520, "Request Failed", "", "https://api/download_link"),
+      );
+
+      const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
+
+      expect(err).toBeInstanceOf(HTTPError);
+      expect((err as HTTPError).statusCode).toBe(520);
+      expect((err as HTTPError).message).toBe("HTTP (520) - Request Failed");
+      expect((err as HTTPError).data).toMatchObject({ kind: "http:bad-status", statusCode: 520 });
+    });
+
+    test("classifies a dropped connection instead of passing the raw socket error on", async ({
+      makeNxm,
+    }) => {
+      const { harness, resolve } = makeNxm();
+      harness.getDownloadURLs.mockRejectedValue(
+        Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+      );
+
+      const err = await resolve(MOD_URL).catch((caught: unknown) => caught);
+
+      expect(err).toBeInstanceOf(VortexError);
+      expect((err as VortexError).data).toMatchObject({
+        kind: "os:generic",
+        originalCode: "ECONNRESET",
+      });
+      expect((err as VortexError).message).toBe("Network request failed");
     });
 
     test("reports a 401 as a log-in problem rather than a raw http error", async ({ makeNxm }) => {

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -538,8 +538,9 @@ export class NxmProtocol {
       error = http;
     } else if (error instanceof NexusHTTPError) {
       const http = new HTTPError(error.statusCode, error.message, error.url);
-      // the api client already formats "HTTP (code) - message"
-      Object.assign(http, { message: error.message, stack: error.stack });
+      // the api client's message is already "HTTP (code) - message"
+      http.message = error.message;
+      http.stack = error.stack;
       error = http;
     }
 
@@ -552,12 +553,7 @@ export class NxmProtocol {
     if (error instanceof HTTPError && error.statusCode === 401) {
       throw new ProcessCanceled("You are not logged in to Nexus Mods!");
     }
-    // The error crosses IPC to the downloader, which only understands VortexError kinds; a raw
-    // socket failure from the api client would otherwise arrive as "Unknown error thrown".
-    const parsed = parseError(error, undefined, ({ data }) =>
-      data.kind === "os:generic" ? "Network request failed" : undefined,
-    );
-    throw parsed.data.kind === "unknown" ? error : parsed;
+    throw error;
   }
 
   /** Hand an incoming link to the queued download that sent the user to fetch it. */

--- a/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
+++ b/src/renderer/src/extensions/nexus_integration/nxmProtocol.ts
@@ -1,6 +1,6 @@
 import type { IDownloadURL, IFileUpdate, IRevision, IRevisionQuery } from "@nexusmods/nexus-api";
 import type NexusT from "@nexusmods/nexus-api";
-import { NexusError, RateLimitError } from "@nexusmods/nexus-api";
+import { HTTPError as NexusHTTPError, NexusError, RateLimitError } from "@nexusmods/nexus-api";
 import { getErrorMessageOrDefault } from "@vortex/shared";
 import { parseError } from "@vortex/shared";
 import type { Action } from "redux";
@@ -536,6 +536,11 @@ export class NxmProtocol {
       const http = new HTTPError(error.statusCode, error.message, error.request);
       http.stack = error.stack;
       error = http;
+    } else if (error instanceof NexusHTTPError) {
+      const http = new HTTPError(error.statusCode, error.message, error.url);
+      // the api client already formats "HTTP (code) - message"
+      Object.assign(http, { message: error.message, stack: error.stack });
+      error = http;
     }
 
     // A 401 means the Nexus client could not authenticate the request and could not (or did not)
@@ -547,7 +552,12 @@ export class NxmProtocol {
     if (error instanceof HTTPError && error.statusCode === 401) {
       throw new ProcessCanceled("You are not logged in to Nexus Mods!");
     }
-    throw error;
+    // The error crosses IPC to the downloader, which only understands VortexError kinds; a raw
+    // socket failure from the api client would otherwise arrive as "Unknown error thrown".
+    const parsed = parseError(error, undefined, ({ data }) =>
+      data.kind === "os:generic" ? "Network request failed" : undefined,
+    );
+    throw parsed.data.kind === "unknown" ? error : parsed;
   }
 
   /** Hand an incoming link to the queued download that sent the user to fetch it. */

--- a/src/shared/src/errors/base.ts
+++ b/src/shared/src/errors/base.ts
@@ -93,7 +93,7 @@ export interface VortexErrorKindMap {
    * request context). `originalCode` carries the raw code for logging and
    * message lookup; it is not meant to be branched on.
    */
-  "os:generic": OsErrorData;
+  "os:generic": Pick<OsErrorData, "originalCode"> & Partial<OsErrorData>;
 
   /**
    * Nothing above matched. The parser/classifier that produced this

--- a/src/shared/src/errors/parser.test.ts
+++ b/src/shared/src/errors/parser.test.ts
@@ -177,7 +177,7 @@ describe("parseError", () => {
       });
     });
 
-    describe("code without errno/syscall (socket hang up, TLS disconnect)", () => {
+    describe("ECONNRESET without errno/syscall (socket hang up, TLS disconnect)", () => {
       it("with URL -> http:generic", () => {
         const result = parseError(socketHangUp(), { url });
         assert(result.data.kind === "http:generic");
@@ -192,10 +192,13 @@ describe("parseError", () => {
         expect(result.message).toBe("socket hang up");
       });
 
-      it("a non-network code is still unknown", () => {
-        const result = parseError(Object.assign(new Error("boom"), { code: "ERR_SOMETHING" }));
-        assert(result.data.kind === "unknown");
-      });
+      test.for([{ code: "ERR_SOMETHING" }, { code: "ETIMEDOUT" }])(
+        "any other code without errno/syscall ($code) is still unknown",
+        ({ code }) => {
+          const result = parseError(Object.assign(new Error("boom"), { code }));
+          assert(result.data.kind === "unknown");
+        },
+      );
     });
   });
 });

--- a/src/shared/src/errors/parser.test.ts
+++ b/src/shared/src/errors/parser.test.ts
@@ -16,6 +16,11 @@ function makeSystemError(
   });
 }
 
+/** How Node reports a dropped socket: a POSIX code, but no errno or syscall. */
+function socketHangUp(): Error {
+  return Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+}
+
 describe("parseError", () => {
   it("passes a VortexError through unchanged, with data typed as the full union", () => {
     const original = new VortexError("already typed", { kind: "user-canceled", skipped: false });
@@ -173,8 +178,6 @@ describe("parseError", () => {
     });
 
     describe("code without errno/syscall (socket hang up, TLS disconnect)", () => {
-      const socketHangUp = () => Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
-
       it("with URL -> http:generic", () => {
         const result = parseError(socketHangUp(), { url });
         assert(result.data.kind === "http:generic");

--- a/src/shared/src/errors/parser.test.ts
+++ b/src/shared/src/errors/parser.test.ts
@@ -171,6 +171,29 @@ describe("parseError", () => {
         expect(result.isTransient).toBe(isTransient);
       });
     });
+
+    describe("code without errno/syscall (socket hang up, TLS disconnect)", () => {
+      const socketHangUp = () => Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+
+      it("with URL -> http:generic", () => {
+        const result = parseError(socketHangUp(), { url });
+        assert(result.data.kind === "http:generic");
+        expect(result.data.url).toBe(url);
+        expect(result.data.originalCode).toBe("ECONNRESET");
+      });
+
+      it("without URL -> os:generic, keeping the message", () => {
+        const result = parseError(socketHangUp());
+        assert(result.data.kind === "os:generic");
+        expect(result.data.originalCode).toBe("ECONNRESET");
+        expect(result.message).toBe("socket hang up");
+      });
+
+      it("a non-network code is still unknown", () => {
+        const result = parseError(Object.assign(new Error("boom"), { code: "ERR_SOMETHING" }));
+        assert(result.data.kind === "unknown");
+      });
+    });
   });
 });
 

--- a/src/shared/src/errors/parser.ts
+++ b/src/shared/src/errors/parser.ts
@@ -57,7 +57,7 @@ function parseNodeSystemError(
   const data = parseNodeSystemErrorData(cause);
   if (!data) {
     // "socket hang up" and TLS disconnects carry a POSIX code but no errno/syscall
-    const code = (cause as { code?: unknown }).code;
+    const code = "code" in cause ? cause.code : undefined;
     return typeof code === "string" && NETWORK_POSIX_CODES.has(code)
       ? networkError(code, { originalCode: code }, cause.message, context)
       : undefined;

--- a/src/shared/src/errors/parser.ts
+++ b/src/shared/src/errors/parser.ts
@@ -1,5 +1,5 @@
 import { z } from "../zodJitless";
-import { type OsErrorData, VortexError } from "./base";
+import { VortexError, type VortexErrorKindMap } from "./base";
 
 /**
  * Tries to parse the input as an error.
@@ -56,10 +56,13 @@ function parseNodeSystemError(
 ): { message: string; data: VortexError["data"]; isTransient?: boolean } | undefined {
   const data = parseNodeSystemErrorData(cause);
   if (!data) {
-    // "socket hang up" and TLS disconnects carry a POSIX code but no errno/syscall
+    // Node reports a peer closing the socket with a plain Error carrying only `code: "ECONNRESET"`,
+    // no errno or syscall: "socket hang up" from the http client and the TLS wrap's onerror.
+    // https://github.com/nodejs/node/blob/51c992f99bc0ec6dc1cafdc9f00defa28eead3ea/lib/internal/errors.js#L847-L856
+    // https://github.com/nodejs/node/blob/51c992f99bc0ec6dc1cafdc9f00defa28eead3ea/lib/internal/tls/wrap.js#L1361-L1366
     const code = "code" in cause ? cause.code : undefined;
-    return typeof code === "string" && NETWORK_POSIX_CODES.has(code)
-      ? networkError(code, { originalCode: code }, cause.message, context)
+    return code === "ECONNRESET"
+      ? networkError({ originalCode: code }, cause.message, context)
       : undefined;
   }
 
@@ -137,29 +140,28 @@ function parseNodeSystemError(
       isTransient: true,
     };
   } else if (NETWORK_POSIX_CODES.has(originalCode)) {
-    return networkError(originalCode, osData, message, context);
+    return networkError(osData, message, context);
   }
 
   return { message, data: { kind: "os:generic", ...osData } };
 }
 
 function networkError(
-  originalCode: string,
-  osData: Partial<OsErrorData>,
+  osData: VortexErrorKindMap["os:generic"],
   message: string,
   context?: { path?: string; url?: string },
 ): { message: string; data: VortexError["data"]; isTransient: boolean } {
-  const isTransient = originalCode === "ETIMEDOUT";
+  const isTransient = osData.originalCode === "ETIMEDOUT";
 
   if (context?.url !== undefined) {
     return {
-      message: `Network error (${originalCode}) for '${context.url}': ${message}`,
+      message: `Network error (${osData.originalCode}) for '${context.url}': ${message}`,
       data: { kind: "http:generic", url: context.url, ...osData },
       isTransient,
     };
   }
 
-  return { message, data: { kind: "os:generic", ...osData, originalCode }, isTransient };
+  return { message, data: { kind: "os:generic", ...osData }, isTransient };
 }
 
 export function parseNodeSystemErrorData(input: unknown): NodeSystemErrorData | undefined {

--- a/src/shared/src/errors/parser.ts
+++ b/src/shared/src/errors/parser.ts
@@ -1,5 +1,5 @@
 import { z } from "../zodJitless";
-import { VortexError } from "./base";
+import { type OsErrorData, VortexError } from "./base";
 
 /**
  * Tries to parse the input as an error.
@@ -56,7 +56,11 @@ function parseNodeSystemError(
 ): { message: string; data: VortexError["data"]; isTransient?: boolean } | undefined {
   const data = parseNodeSystemErrorData(cause);
   if (!data) {
-    return undefined;
+    // "socket hang up" and TLS disconnects carry a POSIX code but no errno/syscall
+    const code = (cause as { code?: unknown }).code;
+    return typeof code === "string" && NETWORK_POSIX_CODES.has(code)
+      ? networkError(code, { originalCode: code }, cause.message, context)
+      : undefined;
   }
 
   const { code: originalCode, errno, syscall } = data;
@@ -133,20 +137,29 @@ function parseNodeSystemError(
       isTransient: true,
     };
   } else if (NETWORK_POSIX_CODES.has(originalCode)) {
-    const isTransient = originalCode === "ETIMEDOUT";
-
-    if (context?.url !== undefined) {
-      return {
-        message: `Network error (${originalCode}) for '${context.url}': ${message}`,
-        data: { kind: "http:generic", url: context.url, ...osData },
-        isTransient,
-      };
-    }
-
-    return { message, data: { kind: "os:generic", ...osData }, isTransient };
+    return networkError(originalCode, osData, message, context);
   }
 
   return { message, data: { kind: "os:generic", ...osData } };
+}
+
+function networkError(
+  originalCode: string,
+  osData: Partial<OsErrorData>,
+  message: string,
+  context?: { path?: string; url?: string },
+): { message: string; data: VortexError["data"]; isTransient: boolean } {
+  const isTransient = originalCode === "ETIMEDOUT";
+
+  if (context?.url !== undefined) {
+    return {
+      message: `Network error (${originalCode}) for '${context.url}': ${message}`,
+      data: { kind: "http:generic", url: context.url, ...osData },
+      isTransient,
+    };
+  }
+
+  return { message, data: { kind: "os:generic", ...osData, originalCode }, isTransient };
 }
 
 export function parseNodeSystemErrorData(input: unknown): NodeSystemErrorData | undefined {

--- a/src/shared/src/errors/serialization.test.ts
+++ b/src/shared/src/errors/serialization.test.ts
@@ -1,6 +1,13 @@
 import { assert, describe, expect, it } from "vitest";
 
-import { CycleError, NotFound, ProcessCanceled, SetupError, UserCanceled } from "../types/errors";
+import {
+  CycleError,
+  HTTPError,
+  NotFound,
+  ProcessCanceled,
+  SetupError,
+  UserCanceled,
+} from "../types/errors";
 import { VortexError } from "./base";
 import {
   ORIGIN_REF_KEY,
@@ -281,6 +288,15 @@ describe("class reconstruction", () => {
     );
     expect(roundTrip(new UserCanceled(true))).toHaveProperty("skipped", true);
     expect(roundTrip(new CycleError([["a", "b"]]))).toHaveProperty("cycles", [["a", "b"]]);
+  });
+
+  it("revives an HTTPError with its status code and url", () => {
+    const wire = roundTrip(new HTTPError(520, "Request Failed", "https://api/download_link"));
+
+    expect(wire).toBeInstanceOf(HTTPError);
+    expect(wire).toHaveProperty("statusCode", 520);
+    expect(wire).toHaveProperty("url", "https://api/download_link");
+    expect(wire.data).toMatchObject({ kind: "http:bad-status", statusCode: 520 });
   });
 
   it("keeps the wire's message rather than the one the constructor synthesizes", () => {

--- a/src/shared/src/errors/serialization.test.ts
+++ b/src/shared/src/errors/serialization.test.ts
@@ -169,6 +169,12 @@ describe("toWireError (boundary entry point)", () => {
     expect(wire.data[ORIGIN_REF_KEY]).toBeUndefined();
   });
 
+  it("classifies a raw socket hang up rather than sending it as unknown", () => {
+    const wire = toWireError(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+    expect(wire.data).toMatchObject({ kind: "os:generic", originalCode: "ECONNRESET" });
+    expect(wire.message).toBe("socket hang up");
+  });
+
   it("does not tag a ref token when no tracker is passed", () => {
     const wire = toWireError(new VortexError("hi", { kind: "test:tag", name: "x" }));
     expect(wire.data[ORIGIN_REF_KEY]).toBeUndefined();

--- a/src/shared/src/errors/serialization.ts
+++ b/src/shared/src/errors/serialization.ts
@@ -3,6 +3,7 @@ import {
   CycleError,
   DataInvalid,
   GameNotFound,
+  HTTPError,
   MissingInterpreter,
   NotFound,
   NotSupportedError,
@@ -153,6 +154,8 @@ function reviveClass(message: string, data: VortexErrorData): VortexError | unde
       return new DataInvalid(message);
     case "game-not-found":
       return new GameNotFound(data.gameId);
+    case "http:bad-status":
+      return new HTTPError(data.statusCode, message, data.url);
     case "missing-interpreter":
       return new MissingInterpreter(message, data.url);
     case "not-found":

--- a/src/shared/src/types/errors.ts
+++ b/src/shared/src/types/errors.ts
@@ -155,28 +155,32 @@ export class TemporaryError extends Error {
   }
 }
 
-export class HTTPError extends Error {
-  private mCode: number;
-  private mMessage: string;
-  private mURL: string;
+/**
+ * @public
+ * @deprecated Use `VortexError` directly
+ */
+export class HTTPError extends VortexError {
+  #statusCode: number;
+  #statusMessage: string;
+  #url: string;
+
   constructor(statusCode: number, message: string, url: string) {
-    super(`HTTP (${statusCode}) - ${message}`);
-    this.name = this.constructor.name;
-    this.mCode = statusCode;
-    this.mMessage = message;
-    this.mURL = url;
+    super(`HTTP (${statusCode}) - ${message}`, { kind: "http:bad-status", url, statusCode });
+    this.#statusCode = statusCode;
+    this.#statusMessage = message;
+    this.#url = url;
   }
 
   public get statusCode(): number {
-    return this.mCode;
+    return this.#statusCode;
   }
 
   public get statusMessage(): string {
-    return this.mMessage;
+    return this.#statusMessage;
   }
 
   public get url(): string {
-    return this.mURL;
+    return this.#url;
   }
 }
 


### PR DESCRIPTION
HTTPError now survives IPC transition
Fixed instanceof HTTPError check
Nexus-API HTTPError is now mapped into our HTTPError RequestError is now http:generic

Closes fingerprints 158ae649, 4b4edc1d, f13a338b, 3fbb1069, d9b612cc, 4bf4c70a
Closes LAZ-1083