### PR TITLE
rebuild the api test harness on the production reducer composition

### DIFF
--- a/src/renderer/src/extensions/mod_management/util/VersionFilter.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/VersionFilter.test.ts
@@ -16,14 +16,11 @@ const OTHER_PROFILE_ID = "profile-fallout4";
  * what decides which mod list the counts come from.
  */
 function seed(mods: Record<string, Record<string, IMod>>): IApiHarness {
-  const harness = makeApiHarness({
+  return makeApiHarness({
     profiles: { [PROFILE_ID]: makeProfile({ id: PROFILE_ID, gameId: GAME_ID }) },
     mods,
+    activeProfileId: PROFILE_ID,
   });
-  harness.setState((draft) => {
-    draft.settings.profiles.activeProfileId = PROFILE_ID;
-  });
-  return harness;
 }
 
 /**
@@ -234,10 +231,16 @@ describe("VersionFilter", () => {
           return Reflect.ownKeys(target);
         },
       });
-      const { getState } = seed({ [GAME_ID]: counted });
+      // matches() takes the state as an argument; seeding the proxy through the harness store
+      // would deep-merge (and de-proxy) it
+      const base = seed({}).getState();
+      const state = {
+        ...base,
+        persistent: { ...base.persistent, mods: { [GAME_ID]: counted } },
+      };
 
       const matched = Object.values(mods).filter(
-        (mod) => filter.matches(["multi-version"], mod, getState()) === true,
+        (mod) => filter.matches(["multi-version"], mod, state) === true,
       );
 
       expect(scans).toBe(1);

--- a/src/renderer/src/reducers/index.ts
+++ b/src/renderer/src/reducers/index.ts
@@ -180,7 +180,7 @@ function hydrateRed(
   return rehydrate(state, payload, pathArray, replace, ele.defaults);
 }
 
-function deriveReducer(
+export function deriveReducer(
   statePath: string,
   ele: any,
   querySanitize: (errors: string[]) => Decision,
@@ -216,7 +216,7 @@ function deriveReducer(
   }
 }
 
-function addToTree(tree: any, statePath: string[], spec: IReducerSpec) {
+export function addToTree(tree: any, statePath: string[], spec: IReducerSpec) {
   if (statePath.length === 0) {
     if (tree.reducers === undefined) {
       tree.reducers = {};

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -25,7 +25,9 @@ import type { IFileInfo, IPreference, IUserInfo } from "@nexusmods/nexus-api";
 import type NexusT from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
 import type { Api, DownloaderApi } from "@vortex/shared/preload";
+import { applyMiddleware, createStore, type Middleware } from "redux";
 import { batch } from "redux-act";
+import thunkMiddleware from "redux-thunk";
 import { vi } from "vitest";
 
 import type { MixpanelEvent } from "../extensions/analytics/mixpanel/MixpanelEvents";
@@ -70,15 +72,16 @@ import { MEMBERSHIP_ROLE, transformUserInfoFromApi } from "../extensions/nexus_i
 import type { IProfile, IProfileMod } from "../extensions/profile_management/types/IProfile";
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
+import { addToTree, Decision, deriveReducer } from "../reducers/index";
 import type {
   CollectionModStatus,
   ICollectionInstallSession,
   ICollectionInstallState,
   ICollectionModInstallInfo,
 } from "../types/collections/ICollectionInstallSession";
-import type { IAvailableExtension } from "../types/extensions";
+import type { IAvailableExtension, IExtensionReducer } from "../types/extensions";
 import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../types/IDialog";
-import type { IExtensionApi, IReducerSpec } from "../types/IExtensionContext";
+import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IGame } from "../types/IGame";
 import type { IHealthCheckResult, IModCheckContext, IModHealthCheck } from "../types/IHealthCheck";
 import {
@@ -445,7 +448,7 @@ export function makeModHealthCheck(
     category: HealthCheckCategory.Mods,
     severity: HealthCheckSeverity.Warning,
     triggers: [HealthCheckTrigger.Manual],
-    checkMod: async () => makeHealthCheckResult(),
+    checkMod: () => Promise.resolve(makeHealthCheckResult()),
     ...overrides,
   };
 }
@@ -454,7 +457,7 @@ export function makeModCheckContext(overrides: Partial<IModCheckContext> = {}): 
   return {
     modId: "mod-1",
     files: [],
-    readFile: async () => Buffer.alloc(0),
+    readFile: () => Promise.resolve(Buffer.alloc(0)),
     attributes: {},
     ...overrides,
   };
@@ -543,24 +546,6 @@ export function makeRevision(
 export type { CollectionModStatus };
 
 const BATCH_TYPE: string = (batch as unknown as { getType: () => string }).getType();
-const sessionReducers = trackingReducer.reducers as Record<
-  string,
-  (state: ICollectionInstallState, payload: unknown) => ICollectionInstallState
->;
-// the real mods reducer, applied to state.persistent.mods so the durable writes the driver
-// makes alongside the session (addModRule with `ignored`, setModAttribute install-spec stamps)
-// are observable by read-back, not just recordable as dispatched actions. keyed by gameId.
-type ModsSlice = Record<string, Record<string, IMod>>;
-const modsReducers = modsReducer.reducers as Record<
-  string,
-  (state: ModsSlice, payload: unknown) => ModsSlice
->;
-// the real download reducer, applied to state.persistent.downloads, so writes onto a download's
-// modInfo (the collection-rule tags the install path records) are observable by read-back
-const downloadReducers = downloadStateReducer.reducers as Record<
-  string,
-  (state: IState["persistent"]["downloads"], payload: unknown) => IState["persistent"]["downloads"]
->;
 
 function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
   const slices: IDriverHarnessState = {
@@ -571,6 +556,9 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
     knownGames: [],
     availableExtensions: [],
     userInfo: undefined,
+    activeProfileId: undefined,
+    lastActiveProfile: {},
+    installPath: {},
     ...overrides,
   };
   // a structurally-partial IState holding only the slices the driver reads; the single cast
@@ -597,11 +585,12 @@ function makeDriverState(overrides: Partial<IDriverHarnessState> = {}): IState {
       downloads: { collectionsInstallWhileDownloading: false, path: "{USERDATA}\\downloads" },
       interface: { language: "en", foregroundDL: false },
       gameMode: { discovered: {} },
-      // empty skeletons so tests can assign settings.mods.installPath[gameId] /
-      // settings.profiles.activeProfileId through the typed draft without a cast (the single
-      // as-unknown-as-IState below covers the omitted fields)
-      mods: { installPath: {} },
-      profiles: { activeProfileId: undefined, nextProfileId: undefined, lastActiveProfile: {} },
+      mods: { installPath: slices.installPath },
+      profiles: {
+        activeProfileId: slices.activeProfileId,
+        nextProfileId: undefined,
+        lastActiveProfile: slices.lastActiveProfile,
+      },
     },
   } as unknown as IState;
 }
@@ -662,16 +651,25 @@ export function resetHarnessRegistries(): void {
 }
 
 /**
- * An extension reducer spec a domain harness hooks into the harness dispatch, alongside the
- * built-ins. `spec.reducers` is keyed by action type; `read`/`write` address the state slice
- * the spec owns (the harness state is plain mutable data).
+ * A reducer spec bound to the state path it owns: the production IExtensionReducer shape, so a
+ * domain harness binds its extension's reducers the way the extension registers them.
  */
-export interface IHarnessReducerBinding {
-  spec: IReducerSpec;
-  // the slice is opaque to the harness: whatever the spec's reducers produce, keyed as they key it
-  read: (state: IState) => Record<string, unknown>;
-  write: (state: IState, slice: Record<string, unknown>) => void;
-}
+export type IHarnessReducerBinding = IExtensionReducer;
+
+// the real reducers every harness applies, bound to the slices they own
+const DEFAULT_BINDINGS: IHarnessReducerBinding[] = [
+  { path: ["session", "collections"], reducer: trackingReducer },
+  { path: ["persistent", "mods"], reducer: modsReducer },
+  { path: ["session", "nexus"], reducer: nexusSessionReducer },
+  { path: ["persistent", "nexus"], reducer: nexusPersistentReducer },
+  { path: ["persistent", "downloads"], reducer: downloadStateReducer },
+];
+
+// carries the setState escape hatch through the store as a whole-state replacement dispatch
+const REPLACE_TYPE = "__harness_replace_state";
+// the production hydration action: each bound slice becomes the payload's value at its path,
+// merged over the spec's defaults
+const HYDRATE_REPLACE_TYPE = "__hydrate_replace";
 
 /**
  * A controllable fake IExtensionApi over a seeded, structurally-partial IState. This is the
@@ -679,12 +677,11 @@ export interface IHarnessReducerBinding {
  *
  * - `events` is a real EventEmitter, so `emit(...)` actually runs any `on`/`onAsync` listeners
  *   (a vi.fn() stub could not).
- * - `dispatch` applies the real install-tracking reducer to `state.session.collections` AND the
- *   real mods reducer to `state.persistent.mods` (so both the session and durable writes are
- *   observable by read-back), and records every action (so writes with no harness reducer are
- *   still assertable). Batched actions are unwrapped.
- * - the persistent / session slices are seeded from `overrides` (builder-style) and can be
- *   mutated mid-test via `setState`.
+ * - `dispatch` drives a real redux store whose reducer folds the specs bound in DEFAULT_BINDINGS
+ *   (install tracking, mods, downloads, nexus) over the slices they own, and records every
+ *   action (so writes with no harness reducer are still assertable). Batches are unwrapped.
+ * - the persistent / session slices are seeded from `overrides` (builder-style); `setState`
+ *   applies a draft mutation as a whole-state replacement dispatch.
  * - `extraReducers` lets a domain harness (e.g. gamebryo) bind its extension's reducer specs
  *   to the slices they own, so its writes are observable by read-back too.
  */
@@ -692,72 +689,54 @@ export function makeApiHarness(
   overrides: Partial<IDriverHarnessState> = {},
   extraReducers: IHarnessReducerBinding[] = [],
 ): IApiHarness {
-  const state = makeDriverState(overrides);
-  // each bound slice starts from its spec's defaults (copied, so harnesses never share one)
-  for (const binding of extraReducers) {
-    binding.write(state, { ...binding.spec.defaults });
+  const bindings = [...DEFAULT_BINDINGS, ...extraReducers];
+  // the production reducer composition: addToTree places each spec at its path, deriveReducer
+  // turns the tree into one reducer, and its safeCombineReducers layers preserve the reducerless
+  // seeded slices. Verifier findings are ignored - test seeds are deliberately partial.
+  const tree = {};
+  for (const binding of bindings) {
+    addToTree(tree, binding.path, binding.reducer);
   }
-  const dispatched: ITrackedAction[] = [];
+  const derived: (state: IState, action: ITrackedAction) => IState = deriveReducer(
+    "",
+    tree,
+    () => Decision.IGNORE,
+    (err: Error) => {
+      throw err;
+    },
+  );
+  const rootReducer = (state: IState, action: ITrackedAction): IState =>
+    action.type === REPLACE_TYPE ? (action.payload as IState) : derived(state, action);
 
-  const apply = (action: ITrackedAction | null | undefined): void => {
-    if (action == null) {
-      return;
-    }
-    // redux-act batches several actions into one; unwrap so each is applied + recorded
+  const dispatched: ITrackedAction[] = [];
+  // redux-act batches several actions into one; unwrap so each is recorded individually (the
+  // derived reducers unwrap batches themselves)
+  const record = (action: ITrackedAction): void => {
     if (action.type === BATCH_TYPE && Array.isArray(action.payload)) {
-      (action.payload as ITrackedAction[]).forEach(apply);
+      (action.payload as ITrackedAction[]).forEach(record);
       return;
     }
     dispatched.push(action);
-    const sessionReducer = sessionReducers[action.type];
-    if (sessionReducer !== undefined) {
-      state.session.collections = sessionReducer(state.session.collections, action.payload);
-    }
-    const modsReducerFn = modsReducers[action.type];
-    if (modsReducerFn !== undefined) {
-      state.persistent.mods = modsReducerFn(state.persistent.mods, action.payload);
-    }
-    const nexusSession = nexusSessionReducer.reducers[action.type];
-    if (nexusSession !== undefined) {
-      state.session["nexus"] = nexusSession(state.session["nexus"], action.payload);
-    }
-    const nexusPersistent = nexusPersistentReducer.reducers[action.type];
-    if (nexusPersistent !== undefined) {
-      state.persistent["nexus"] = nexusPersistent(state.persistent["nexus"], action.payload);
-    }
-    const downloadReducerFn = downloadReducers[action.type];
-    if (downloadReducerFn !== undefined) {
-      state.persistent.downloads = downloadReducerFn(state.persistent.downloads, action.payload);
-    }
-    for (const binding of extraReducers) {
-      const reduce = binding.spec.reducers[action.type];
-      if (reduce !== undefined) {
-        binding.write(state, reduce(binding.read(state), action.payload));
-      }
-    }
   };
+  // sits behind the same thunk middleware the production store applies, so only plain actions
+  // arrive here; the two harness bookkeeping actions stay out of the record
+  const recorder: Middleware = () => (next) => (action) => {
+    const tracked = action as ITrackedAction;
+    if (tracked.type !== REPLACE_TYPE && tracked.type !== HYDRATE_REPLACE_TYPE) {
+      record(tracked);
+    }
+    return next(tracked);
+  };
+  const store = createStore(
+    rootReducer,
+    makeDriverState(overrides),
+    applyMiddleware(thunkMiddleware, recorder),
+  );
+  // seed every bound slice: its spec's defaults under whatever makeDriverState placed there
+  // from the overrides. Slices with no seed get plain defaults from the store's INIT dispatch.
+  store.dispatch({ type: HYDRATE_REPLACE_TYPE, payload: store.getState() });
 
-  // store subscribers, for code that watches the store directly rather than via onStateChange
-  const subscribers: Array<() => void> = [];
-  const notifySubscribers = () => {
-    subscribers.slice().forEach((listener) => listener());
-  };
-
-  const subscribe = (listener: () => void) => {
-    subscribers.push(listener);
-    return () => {
-      const idx = subscribers.indexOf(listener);
-      if (idx !== -1) {
-        subscribers.splice(idx, 1);
-      }
-    };
-  };
-
-  const dispatch = (action: ITrackedAction) => {
-    apply(action);
-    notifySubscribers();
-    return action;
-  };
+  const dispatch = (action: ITrackedAction) => store.dispatch(action);
 
   const events = new EventEmitter();
   events.setMaxListeners(0);
@@ -768,8 +747,12 @@ export function makeApiHarness(
   const notifications: IApiHarness["notifications"] = [];
 
   const api = {
-    getState: () => state,
-    store: { getState: () => state, dispatch, subscribe },
+    getState: () => store.getState(),
+    store: {
+      getState: () => store.getState(),
+      dispatch,
+      subscribe: (listener: () => void) => store.subscribe(listener),
+    },
     events,
     // a driver registers will-install-mod via onAsync; route it onto the same bus so a
     // plain emit() runs it (the returned promise is ignored, which is fine for assertions)
@@ -808,10 +791,12 @@ export function makeApiHarness(
     emit: (event: string, ...args: unknown[]) => {
       events.emit(event, ...args);
     },
-    getState: () => state,
+    getState: () => store.getState(),
     setState: (mutate: (draft: IState) => void) => {
-      mutate(state);
-      notifySubscribers();
+      // copy-on-write
+      const draft = structuredClone(store.getState());
+      mutate(draft);
+      store.dispatch({ type: REPLACE_TYPE, payload: draft });
     },
     setNextDialog: (result: IDialogResult) => {
       nextDialog = result;
@@ -836,13 +821,12 @@ export function makeGameHarness(
     {
       profiles: { [profileId]: makeProfile({ id: profileId, gameId }) },
       mods: { [gameId]: opts.mods ?? {} },
+      activeProfileId: profileId,
+      lastActiveProfile: { [gameId]: profileId },
+      installPath: opts.installPath ?? {},
     },
     extraReducers,
   );
-  base.setState((draft) => {
-    draft.settings.profiles.activeProfileId = profileId;
-    draft.settings.profiles.lastActiveProfile = { [gameId]: profileId };
-  });
   return { ...base, gameId, profileId };
 }
 
@@ -912,10 +896,7 @@ export function makeInstallManagerHarness(
   gameId = "skyrimse",
 ): IInstallManagerHarness {
   registerHarnessGame(gameId);
-  const base = makeApiHarness(overrides);
-  base.setState((draft) => {
-    draft.settings.mods.installPath[gameId] = `C:/staging/${gameId}`;
-  });
+  const base = makeApiHarness({ installPath: { [gameId]: `C:/staging/${gameId}` }, ...overrides });
   const manager = new ManagerCtor(base.api, (gid: string) => `C:/staging/${gid}`);
   // single seam: reach the manager's private phase map once here so suites get a typed handle
   // instead of casting the manager per test
@@ -995,10 +976,8 @@ export function makeHealthCheckHarness(
   const profileId = opts.profileId ?? "profile-1";
   const base = makeApiHarness({
     profiles: { [profileId]: makeProfile({ id: profileId, gameId }) },
-  });
-  base.setState((draft) => {
-    draft.settings.profiles.activeProfileId = profileId;
-    draft.settings.profiles.lastActiveProfile = { [gameId]: profileId };
+    activeProfileId: profileId,
+    lastActiveProfile: { [gameId]: profileId },
   });
 
   const registry = new RegistryCtor(base.api);
@@ -1065,7 +1044,7 @@ export function makeHealthCheckHarness(
         gameId: checkGameId,
         name: id,
         triggers: [HealthCheckTrigger.ModsChanged, HealthCheckTrigger.Manual],
-        checkMod: async () => makeHealthCheckResult({ checkId: id }),
+        checkMod: () => Promise.resolve(makeHealthCheckResult({ checkId: id })),
       }),
     );
     return id;
@@ -1277,10 +1256,16 @@ export function makeNxmHarness(opts: Partial<IDriverHarnessState> = {}): INxmHar
   return {
     ...base,
     nexus,
-    freeUserQueue: () => base.getState().session["nexus"].freeUserDLQueue ?? [],
+    freeUserQueue: () => {
+      const nexusSession = base.getState().session["nexus"] as { freeUserDLQueue?: string[] };
+      return nexusSession.freeUserDLQueue ?? [];
+    },
     setUserInfo: (userInfo) => {
       base.setState((draft) => {
-        draft.persistent["nexus"].userInfo = userInfo;
+        const nexusPersistent = draft.persistent["nexus"] as {
+          userInfo?: Partial<IValidateKeyDataV2>;
+        };
+        nexusPersistent.userInfo = userInfo;
       });
     },
     getDownloadURLs,

--- a/src/renderer/src/test-utils/gamebryoTest.ts
+++ b/src/renderer/src/test-utils/gamebryoTest.ts
@@ -11,20 +11,8 @@ const asGamebryo = (state: IState): IStateWithGamebryo => state as IStateWithGam
 // the extension's reducer specs, bound to the slices they own (the root loadOrder hive and
 // session.plugins); the harness seeds each from its spec's defaults
 const GAMEBRYO_BINDINGS: IHarnessReducerBinding[] = [
-  {
-    spec: loadOrderReducer,
-    read: (state) => asGamebryo(state).loadOrder,
-    write: (state, slice) => {
-      asGamebryo(state).loadOrder = slice as IStateWithGamebryo["loadOrder"];
-    },
-  },
-  {
-    spec: pluginsReducer,
-    read: (state) => asGamebryo(state).session.plugins ?? {},
-    write: (state, slice) => {
-      asGamebryo(state).session.plugins = slice as IStateWithGamebryo["session"]["plugins"];
-    },
-  },
+  { path: ["loadOrder"], reducer: loadOrderReducer },
+  { path: ["session", "plugins"], reducer: pluginsReducer },
 ];
 
 /**
@@ -34,11 +22,12 @@ const GAMEBRYO_BINDINGS: IHarnessReducerBinding[] = [
  * reducers.
  */
 export function makeGamebryoHarness(opts: IGamebryoHarnessOpts = {}): IGamebryoHarness {
-  const base = makeGameHarness(opts, GAMEBRYO_BINDINGS);
-  base.setState((draft) => {
-    // so the real installPath selector resolves a concrete staging folder
-    draft.settings.mods.installPath[base.gameId] = `C:/staging/${base.gameId}`;
-  });
+  // seed a staging folder so the real installPath selector resolves a concrete path
+  const gameId = opts.gameId ?? "skyrimse";
+  const base = makeGameHarness(
+    { installPath: { [gameId]: `C:/staging/${gameId}` }, ...opts },
+    GAMEBRYO_BINDINGS,
+  );
   return { ...base, getGamebryoState: () => asGamebryo(base.getState()) };
 }
 

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -53,6 +53,12 @@ export interface IDriverHarnessState {
   availableExtensions: Array<{ modId: number }>;
   // the cached membership (state.persistent.nexus.userInfo); undefined models "not fetched yet"
   userInfo: Partial<IValidateKeyDataV2> | undefined;
+  // the active profile id (state.settings.profiles.activeProfileId)
+  activeProfileId: string | undefined;
+  // last active profile per game, keyed by gameId (state.settings.profiles.lastActiveProfile)
+  lastActiveProfile: Record<string, string>;
+  // staging folder per game, keyed by gameId (state.settings.mods.installPath)
+  installPath: Record<string, string>;
 }
 
 export interface IApiHarness {
@@ -89,6 +95,8 @@ export interface IGameHarnessOpts {
   profileId?: string;
   // the game's installed mods, keyed by modId (state.persistent.mods[gameId])
   mods?: Record<string, IMod>;
+  // staging folder per game, keyed by gameId (state.settings.mods.installPath)
+  installPath?: Record<string, string>;
 }
 
 export interface IGameHarness extends IApiHarness {


### PR DESCRIPTION
makeApiHarness now drives a real redux store built by the production composition: addToTree/deriveReducer (newly exported) place the bound reducer specs at their state paths, thunk middleware matches the production store, and slices seed through the production __hydrate_replace action (spec defaults under the override-seeded values). Bindings are plain IExtensionReducer entries, setState applies its draft mutation as a cloned whole-state replacement dispatch, and harness-internal seeding moved into preloaded overrides. Also clears the file's remaining lint warnings.

Part of LAZ-1025