### PR TITLE
feat(ui): announce a download in a flyout (LAZ-999)

### DIFF
--- a/src/renderer/src/ui/components/overlay_arrow/OverlayArrow.test.tsx
+++ b/src/renderer/src/ui/components/overlay_arrow/OverlayArrow.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
+
+import { OverlayArrow, type OverlayArrowSide } from "./OverlayArrow";
+
+// --- Helpers ---
+
+const renderArrow = (side: OverlayArrowSide = "right", tipFromEnd = 24) => {
+  const { container } = render(<OverlayArrow side={side} tipFromEnd={tipFromEnd} />);
+  const svg = container.querySelector("svg");
+
+  return { path: svg?.querySelector("path"), svg };
+};
+
+// --- Tests ---
+
+describe("OverlayArrow", () => {
+  it("draws the shape the tooltip's own arrow draws", () => {
+    // What notices if Floating UI ever changes its arrow geometry.
+    render(
+      <Tooltip content="Downloading Eastern Vagabond Armor" open placement="right">
+        <button type="button">Downloads</button>
+      </Tooltip>,
+    );
+    const fromTooltip = document
+      .querySelector("#overlays .nxm-overlay-arrow path")
+      ?.getAttribute("d");
+
+    const { path } = renderArrow();
+
+    expect(fromTooltip).toBeTruthy();
+    expect(path?.getAttribute("d")).toBe(fromTooltip);
+  });
+
+  it("carries the shared class, so both are painted by one rule", () => {
+    const { svg } = renderArrow();
+    expect(svg).toHaveClass("nxm-overlay-arrow");
+  });
+
+  it("centres its tip on the offset rather than hanging its corner there", () => {
+    // The box is 14 across once rotated, so its edge sits half of that back.
+    const { svg } = renderArrow("right", 24);
+    expect(svg).toHaveStyle({ bottom: "17px" });
+  });
+
+  it("sits just outside the panel edge, so the outline meets its border", () => {
+    const { svg } = renderArrow("right");
+    expect(svg).toHaveStyle({ right: "calc(100% - 1px)" });
+  });
+
+  it.each([
+    ["right", "rotate(90deg)"],
+    ["left", "rotate(-90deg)"],
+    ["bottom", "rotate(180deg)"],
+  ] as Array<[OverlayArrowSide, string]>)("turns to point back at a %s trigger", (side, turn) => {
+    const { svg } = renderArrow(side);
+    expect(svg).toHaveStyle({ transform: turn });
+  });
+
+  it("measures a top-side arrow across the other axis", () => {
+    const { svg } = renderArrow("top", 24);
+    expect(svg).toHaveStyle({ right: "17px", top: "100%" });
+  });
+
+  it("is hidden from assistive tech, being pure decoration", () => {
+    const { svg } = renderArrow();
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("outlines only its slanted edges, leaving the base against the panel", () => {
+    const { svg } = renderArrow();
+    const clipped = svg?.querySelector("path[clip-path]");
+
+    expect(clipped).toBeInTheDocument();
+    expect(svg?.querySelector("clipPath")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/ui/components/overlay_arrow/OverlayArrow.tsx
+++ b/src/renderer/src/ui/components/overlay_arrow/OverlayArrow.tsx
@@ -1,0 +1,66 @@
+import React, { useId } from "react";
+
+/** Shared with the tooltip's `FloatingArrow`, so the two shapes can't drift apart. */
+export const OVERLAY_ARROW_WIDTH = 12;
+export const OVERLAY_ARROW_HEIGHT = 8;
+/** Floating UI doubles this, so 1 renders as a 1px edge. */
+export const OVERLAY_ARROW_STROKE_WIDTH = 1;
+
+export type OverlayArrowSide = "bottom" | "left" | "right" | "top";
+
+const SIDES: Record<OverlayArrowSide, { rotation: string; inset: string }> = {
+  bottom: { rotation: "rotate(180deg)", inset: "100%" },
+  left: { rotation: "rotate(-90deg)", inset: `calc(100% - ${OVERLAY_ARROW_STROKE_WIDTH}px)` },
+  right: { rotation: "rotate(90deg)", inset: `calc(100% - ${OVERLAY_ARROW_STROKE_WIDTH}px)` },
+  top: { rotation: "", inset: "100%" },
+};
+
+const arrowPath = (width: number, height: number): string =>
+  `M0,0 H${width} L${width / 2},${height} Q${width / 2},${height} ${width / 2},${height} Z`;
+
+interface IOverlayArrowProps {
+  side: OverlayArrowSide;
+  tipFromEnd: number;
+}
+
+/**
+ * The tooltip's arrow, for a panel that isn't a tooltip. Headless UI positions its own
+ * panels, so `FloatingArrow` — which needs a floating context — can't draw their beak.
+ */
+export const OverlayArrow = ({ side, tipFromEnd }: IOverlayArrowProps) => {
+  const clipPathId = useId();
+  const { inset, rotation } = SIDES[side];
+  const strokeWidth = OVERLAY_ARROW_STROKE_WIDTH * 2;
+  const d = arrowPath(OVERLAY_ARROW_WIDTH, OVERLAY_ARROW_HEIGHT);
+  const box = OVERLAY_ARROW_WIDTH + strokeWidth;
+  const crossEdge = side === "left" || side === "right" ? "bottom" : "right";
+
+  return (
+    <svg
+      aria-hidden
+      className="nxm-overlay-arrow"
+      height={OVERLAY_ARROW_WIDTH}
+      style={{
+        [crossEdge]: tipFromEnd - box / 2,
+        [side]: inset,
+        position: "absolute",
+        transform: rotation,
+      }}
+      viewBox={`0 0 ${OVERLAY_ARROW_WIDTH} ${OVERLAY_ARROW_WIDTH}`}
+      width={box}
+    >
+      <path clipPath={`url(#${clipPathId})`} d={d} fill="none" strokeWidth={strokeWidth + 1} />
+
+      <path d={d} />
+
+      <clipPath id={clipPathId}>
+        <rect
+          height={OVERLAY_ARROW_WIDTH}
+          width={box}
+          x={-OVERLAY_ARROW_STROKE_WIDTH}
+          y={OVERLAY_ARROW_STROKE_WIDTH}
+        />
+      </clipPath>
+    </svg>
+  );
+};

--- a/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.demo.tsx
@@ -12,7 +12,7 @@ import {
   mdiRefresh,
   mdiTune,
 } from "@mdi/js";
-import React from "react";
+import React, { useState } from "react";
 
 import { Button } from "@/ui/components/button/Button";
 import { Icon } from "@/ui/components/icon/Icon";
@@ -56,6 +56,41 @@ const ModHealthContent = () => (
     </div>
   </div>
 );
+
+/** A tooltip the caller can show with nothing on the trigger, as the download flyout does. */
+const ControlledTooltip = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isPersistent, setIsPersistent] = useState(false);
+
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <Tooltip
+        content="Shown because the caller said so, not because you hovered."
+        open={isOpen}
+        persistent={isPersistent}
+        onOpenChange={(next) => {
+          setIsOpen(next);
+          // Handing over to the pointer.
+          setIsPersistent(false);
+        }}
+      >
+        <Button appearance="subdued" brand="neutral">
+          Controlled trigger
+        </Button>
+      </Tooltip>
+
+      <Button
+        brand="primary"
+        onClick={() => {
+          setIsPersistent(!isOpen);
+          setIsOpen(!isOpen);
+        }}
+      >
+        {isOpen ? "Hide it" : "Announce it"}
+      </Button>
+    </div>
+  );
+};
 
 export const TooltipDemo = () => (
   <div className="space-y-8">
@@ -323,6 +358,20 @@ export const TooltipDemo = () => (
           </Button>
         </Tooltip>
       </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
+        Controlled open state
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        Pass `open` and the caller owns whether the tooltip is showing; `onOpenChange` reports every
+        hover, focus and dismissal along with Floating UI's reason for it, so the caller can tell
+        those apart from an open it asked for itself. Omit both and hover owns it.
+      </Typography>
+
+      <ControlledTooltip />
     </div>
 
     <div className="space-y-4">

--- a/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.test.tsx
@@ -1,7 +1,8 @@
+import type { OpenChangeReason } from "@floating-ui/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 
 import { Tooltip, type ITooltipPlacement } from "./Tooltip";
 import { TooltipDelayGroup } from "./TooltipDelayGroup";
@@ -167,6 +168,28 @@ describe("Tooltip", () => {
     });
   });
 
+  // A disabled tooltip used to keep its hover, focus and delay-group machinery live. It
+  // rendered nothing, but it still claimed the delay group's currentId, and the group
+  // closes whichever member is not current — so the real tooltip on the same trigger (the
+  // spine's download button has both) was shut again the moment it opened, and you had to
+  // hover twice.
+  it("asks for nothing while disabled, so it cannot disturb another tooltip", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Tooltip disabled content="Downloads" delay={0} onOpenChange={onOpenChange}>
+        <button type="button">Downloads</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Downloads" });
+
+    await userEvent.hover(trigger);
+    trigger.focus();
+    await userEvent.click(document.body);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it("attaches nothing when the body resolves to nothing", async () => {
     // The XOr type normally prevents this; the runtime guard covers a caller
     // passing `content={someMaybeUndefinedValue}`.
@@ -187,6 +210,163 @@ describe("Tooltip", () => {
     await userEvent.hover(screen.getByRole("button", { name: "Clipped trigger" }));
     await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
     expect(screen.getByTestId("clipper")).not.toContainElement(screen.getByRole("tooltip"));
+  });
+});
+
+describe("Tooltip with a controlled open state", () => {
+  const renderControlled = (
+    open: boolean,
+    onOpenChange: (open: boolean, reason?: OpenChangeReason) => void = () => undefined,
+  ) => {
+    render(
+      <Tooltip
+        content="Deploys every enabled mod"
+        delay={0}
+        open={open}
+        onOpenChange={onOpenChange}
+      >
+        <button type="button">Deploy</button>
+      </Tooltip>,
+    );
+
+    return { trigger: screen.getByRole("button", { name: "Deploy" }) };
+  };
+
+  it("shows the content without anyone hovering", async () => {
+    renderControlled(true);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+  });
+
+  it("stays down on hover, because the caller owns the answer", async () => {
+    const { trigger } = renderControlled(false);
+    await userEvent.hover(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("reports a hover so the caller can tell it from an open it asked for", async () => {
+    const onOpenChange = vi.fn();
+    const { trigger } = renderControlled(false, onOpenChange);
+
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(true, "hover"));
+  });
+
+  it("reports a dismissal, so the caller can stop saying open", async () => {
+    const onOpenChange = vi.fn();
+    renderControlled(true, onOpenChange);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false, "escape-key"));
+  });
+});
+
+describe("Tooltip that persists", () => {
+  const renderPersistent = (
+    persistent: boolean,
+    onOpenChange: (open: boolean, reason?: OpenChangeReason) => void = () => undefined,
+  ) => {
+    render(
+      <>
+        <Tooltip
+          content="Downloading Eastern Vagabond Armor"
+          delay={0}
+          open
+          persistent={persistent}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Downloads</button>
+        </Tooltip>
+
+        <button type="button">Somewhere else</button>
+      </>,
+    );
+
+    return {
+      elsewhere: screen.getByRole("button", { name: "Somewhere else" }),
+      trigger: screen.getByRole("button", { name: "Downloads" }),
+    };
+  };
+
+  it("ignores a press elsewhere in the app", async () => {
+    const onOpenChange = vi.fn();
+    const { elsewhere } = renderPersistent(true, onOpenChange);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.click(elsewhere);
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false, "outside-press");
+  });
+
+  it("ignores a press on its own trigger", async () => {
+    const onOpenChange = vi.fn();
+    const { trigger } = renderPersistent(true, onOpenChange);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.click(trigger);
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false, "reference-press");
+  });
+
+  it("still closes on Escape, so it is never a trap", async () => {
+    const onOpenChange = vi.fn();
+    renderPersistent(true, onOpenChange);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false, "escape-key"));
+  });
+
+  it("yields to a press elsewhere once it stops persisting", async () => {
+    const onOpenChange = vi.fn();
+    const { elsewhere } = renderPersistent(false, onOpenChange);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+    await userEvent.click(elsewhere);
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false, "outside-press"));
+  });
+
+  // A delay group closes whichever member is not current, so only one shows at a time.
+  // That is the mechanism an announcement has to be exempt from.
+  const renderInGroup = (persistent: boolean, onOpenChange: Mock) => {
+    render(
+      <TooltipDelayGroup as="div" delay={0}>
+        <Tooltip
+          content="Downloading Eastern Vagabond Armor"
+          delay={0}
+          open
+          persistent={persistent}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Downloads</button>
+        </Tooltip>
+
+        <Tooltip content="Notifications" delay={0}>
+          <button type="button">Bell</button>
+        </Tooltip>
+      </TooltipDelayGroup>,
+    );
+  };
+
+  it("is not closed by a neighbour opening in the same delay group", async () => {
+    const onOpenChange = vi.fn();
+    renderInGroup(true, onOpenChange);
+    await waitFor(() => expect(screen.getAllByRole("tooltip")).toHaveLength(1));
+
+    await userEvent.hover(screen.getByRole("button", { name: "Bell" }));
+    await waitFor(() => expect(screen.getAllByRole("tooltip")).toHaveLength(2));
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false, undefined);
+  });
+
+  it("is asked to close by a neighbour when it is not persisting", async () => {
+    const onOpenChange = vi.fn();
+    renderInGroup(false, onOpenChange);
+    await waitFor(() => expect(screen.getAllByRole("tooltip")).toHaveLength(1));
+
+    await userEvent.hover(screen.getByRole("button", { name: "Bell" }));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false, undefined));
   });
 });
 

--- a/src/renderer/src/ui/components/tooltip/Tooltip.tsx
+++ b/src/renderer/src/ui/components/tooltip/Tooltip.tsx
@@ -32,6 +32,11 @@ import React, {
   useState,
 } from "react";
 
+import {
+  OVERLAY_ARROW_HEIGHT,
+  OVERLAY_ARROW_STROKE_WIDTH,
+  OVERLAY_ARROW_WIDTH,
+} from "@/ui/components/overlay_arrow/OverlayArrow";
 import { joinClasses } from "@/ui/utils/joinClasses";
 import type { XOr } from "@/ui/utils/types";
 
@@ -43,12 +48,8 @@ const TRIGGER_GAP = 8;
 const COLLISION_PADDING = 8;
 /** Floor for the reported height, so a cramped corner scrolls rather than collapses. */
 const MIN_AVAILABLE_HEIGHT = 96;
-const ARROW_HEIGHT = 8;
-const ARROW_WIDTH = 12;
 /** Keeps the arrow off the tooltip's rounded corners. */
 const ARROW_PADDING = 8;
-/** FloatingArrow doubles and clips this, so 1 renders as a 1px edge. */
-const ARROW_STROKE_WIDTH = 1;
 const TRANSITION_MS = 30;
 
 export type ITooltipPlacement = Placement;
@@ -65,9 +66,18 @@ interface ITooltipBaseProps {
   disabled?: boolean;
   /** Lets the pointer travel into the tooltip and use its content. */
   interactive?: boolean;
+  /** Controlled open state. Omit to let hover and focus own it. */
+  open?: boolean;
+  /**
+   * For a tooltip that shows itself rather than answering a hover: a press anywhere, or a
+   * neighbour in the same delay group opening, leaves it up. Escape still closes it.
+   */
+  persistent?: boolean;
   /** Preferred side. Flips and slides automatically when it would overflow. */
   placement?: ITooltipPlacement;
   showArrow?: boolean;
+  /** Every open and close, with Floating UI's reason for it. */
+  onOpenChange?: (open: boolean, reason?: OpenChangeReason) => void;
 }
 
 export type ITooltipProps = ITooltipBaseProps &
@@ -85,10 +95,19 @@ export const Tooltip = ({
   delay = { close: 50, open: 250 },
   disabled = false,
   interactive = false,
+  open: controlledOpen,
+  persistent = false,
   placement = "top",
   showArrow = true,
+  onOpenChange,
 }: ITooltipProps) => {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const setOpen = (next: boolean, reason?: OpenChangeReason) => {
+    setUncontrolledOpen(next);
+    onOpenChange?.(next, reason);
+  };
 
   // Disabling unregisters the trigger as Floating UI's reference, so a tooltip left open
   // across it would come back unplaced — in the window's corner — once re-enabled.
@@ -98,7 +117,7 @@ export const Tooltip = ({
     setWasDisabled(disabled);
 
     if (disabled) {
-      setOpen(false);
+      setUncontrolledOpen(false);
     }
   }
 
@@ -119,12 +138,12 @@ export const Tooltip = ({
       return;
     }
 
-    setOpen(next);
+    setOpen(next, reason);
   };
 
   const { context, floatingStyles, refs } = useFloating({
     middleware: [
-      offset(showArrow ? TRIGGER_GAP + ARROW_HEIGHT : TRIGGER_GAP),
+      offset(showArrow ? TRIGGER_GAP + OVERLAY_ARROW_HEIGHT : TRIGGER_GAP),
       // Swap sides rather than overflow. crossAxis off so shift handles the other axis,
       // or a trigger near an edge flips to an unasked-for side when a nudge would do.
       flip({ crossAxis: false, fallbackAxisSideDirection: "start", padding: COLLISION_PADDING }),
@@ -161,7 +180,8 @@ export const Tooltip = ({
 
   // Inside a TooltipDelayGroup the group owns the timing once something is open,
   // so moving along a row swaps instantly. Standalone, currentId stays null.
-  const groupContext = useDelayGroup(context);
+  // A persistent tooltip leaves the group, which closes whichever member is not current.
+  const groupContext = useDelayGroup(context, { enabled: !disabled && !persistent });
   const hoverDelay = groupContext.currentId === null ? delay : groupContext.delay;
 
   const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
@@ -171,15 +191,18 @@ export const Tooltip = ({
     initial: { opacity: 0, transform: "scale(0.90)" },
   });
 
+  // A disabled tooltip that still listened would claim the delay group and close the real one.
   const interactions = useInteractions([
     useHover(context, {
       delay: hoverDelay,
+      enabled: !disabled,
       handleClose: interactive ? safePolygon({ blockPointerEvents: false }) : null,
       // Enter only, or nudging the pointer reopens what Escape just dismissed.
       move: false,
     }),
-    useFocus(context),
-    useDismiss(context),
+    useFocus(context, { enabled: !disabled }),
+    // Escape stays either way: a tooltip with no way to dismiss it is a trap.
+    useDismiss(context, { enabled: !disabled, outsidePress: !persistent }),
     useRole(context, { role: "tooltip" }),
   ]);
 
@@ -206,7 +229,12 @@ export const Tooltip = ({
     (
       referenceProps.onPointerDown as ((event: ReactPointerEvent<HTMLElement>) => void) | undefined
     )?.(event);
-    setOpen(false);
+
+    if (persistent) {
+      return;
+    }
+
+    setOpen(false, "reference-press");
   };
 
   return (
@@ -230,7 +258,7 @@ export const Tooltip = ({
                   can't sit on .nxm-tooltip without clipping the arrow. */}
               <div
                 className={joinClasses("nxm-tooltip-body", {
-                  "nxm-tooltip-content": customContent === undefined,
+                  "nxm-tooltip-content": !customContent,
                 })}
               >
                 {body}
@@ -238,12 +266,12 @@ export const Tooltip = ({
 
               {showArrow && (
                 <FloatingArrow
-                  className="nxm-tooltip-arrow"
+                  className="nxm-overlay-arrow"
                   context={context}
-                  height={ARROW_HEIGHT}
+                  height={OVERLAY_ARROW_HEIGHT}
                   ref={arrowRef}
-                  strokeWidth={ARROW_STROKE_WIDTH}
-                  width={ARROW_WIDTH}
+                  strokeWidth={OVERLAY_ARROW_STROKE_WIDTH}
+                  width={OVERLAY_ARROW_WIDTH}
                 />
               )}
             </div>

--- a/src/renderer/src/util/util.test.ts
+++ b/src/renderer/src/util/util.test.ts
@@ -333,6 +333,26 @@ describeOnWindows("sanitizeFilename", () => {
   });
 });
 
+describe("timeToString", () => {
+  // Zero-padded: the download flyout and the downloads page both read off this, so a
+  // download has to show the same "01:23" in either place.
+  it("pads minutes and seconds to two digits", () => {
+    expect(util.timeToString(486)).toBe("08:06");
+  });
+
+  it("leaves two-digit minutes alone", () => {
+    expect(util.timeToString(754)).toBe("12:34");
+  });
+
+  it("adds the hour once there is one", () => {
+    expect(util.timeToString(3723)).toBe("01:02:03");
+  });
+
+  it("floors part-seconds", () => {
+    expect(util.timeToString(1.9)).toBe("00:01");
+  });
+});
+
 describe("nexusModsURL", () => {
   it("creates basic urls", () => {
     expect(util.nexusModsURL(["foo", "bar"])).toBe("https://www.nexusmods.com/foo/bar");

--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.test.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import type * as ReactRedux from "react-redux";
@@ -137,9 +137,6 @@ describe("DownloadButton", () => {
     });
   });
 
-  // LAZ-984: the ring is the button's only active affordance while a download is
-  // running — there's no border in that branch — so both of its strokes have to
-  // respond to selection.
   describe("ring colours", () => {
     it("keeps the track subdued while another page is open", () => {
       setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
@@ -211,6 +208,82 @@ describe("DownloadButton", () => {
       await userEvent.click(button);
 
       expect(mocks.selectDownloads).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("flyout", () => {
+    it("keeps to the plain label while nothing is downloading", async () => {
+      const { button } = renderComponent();
+
+      await userEvent.hover(button);
+      await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+      expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("download-flyout-name")).not.toBeInTheDocument();
+    });
+
+    it("shows itself when a download arrives, with nobody hovering", async () => {
+      const { rerender } = render(<DownloadButton />);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+      setStore([{ state: "started", size: 1000, received: 0 }], 1);
+      rerender(<DownloadButton />);
+
+      await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+      expect(screen.getByTestId("download-flyout-estimating")).toBeInTheDocument();
+    });
+
+    it("counts the rest of the queue behind the download it names", async () => {
+      const { rerender } = render(<DownloadButton />);
+
+      setStore(
+        [
+          { state: "started", size: 1000, received: 0 },
+          { state: "started", size: 1000, received: 0 },
+        ],
+        1,
+      );
+      rerender(<DownloadButton />);
+
+      await waitFor(() => expect(screen.getByTestId("download-flyout-more")).toBeInTheDocument());
+    });
+
+    // The estimate is sampled by the button, not the panel, because the panel unmounts
+    // when it closes — sampling in there started from nothing on every reopen.
+    it("keeps its estimate when the flyout is closed and brought back", async () => {
+      // Arriving after mount, since a download already running when it mounts is
+      // deliberately not announced.
+      const { rerender } = render(<DownloadButton />);
+      const button = screen.getByRole("button", { name: "Downloads" });
+      setStore([{ state: "started", size: 1000, received: 0 }], 1);
+      rerender(<DownloadButton />);
+      await waitFor(() =>
+        expect(screen.getByTestId("download-flyout-estimating")).toBeInTheDocument(),
+      );
+
+      // Two readings far enough apart to measure a rate.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      setStore([{ state: "started", size: 1000, received: 100 }], 1);
+      rerender(<DownloadButton />);
+      await waitFor(() =>
+        expect(screen.getByTestId("download-flyout-remaining")).toBeInTheDocument(),
+      );
+
+      await userEvent.keyboard("{Escape}");
+      await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
+      await userEvent.hover(button);
+      await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
+      expect(screen.getByTestId("download-flyout-remaining")).toBeInTheDocument();
+      expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+    });
+
+    it("stays down for downloads already running when it mounted", () => {
+      setStore([{ state: "started", size: 1000, received: 250 }], 8.6);
+      renderComponent();
+
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
@@ -1,75 +1,28 @@
 import { mdiDownload, mdiDownloadOutline } from "@mdi/js";
-import React from "react";
+import React, { type ReactNode, useMemo } from "react";
 import { useSelector } from "react-redux";
 
-import type { DownloadState } from "@/extensions/download_management/types/IDownload";
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
 import type { IState } from "@/types/IState";
+import { Tooltip } from "@/ui/components/tooltip/Tooltip";
 import { Typography } from "@/ui/components/typography/Typography";
 import { joinClasses } from "@/ui/utils/joinClasses";
+import type { XOr } from "@/ui/utils/types";
 
 import { SpineButton } from "../SpineButton";
 import { useSpineContext } from "../SpineContext";
+import { DownloadFlyout } from "./DownloadFlyout";
+import { useDownloadEta } from "./useDownloadEta.hook";
+import { useDownloadFlyout } from "./useDownloadFlyout.hook";
+import { useDownloadProgress } from "./useDownloadProgress.hook";
 
-const ACTIVE_DOWNLOAD_STATES: DownloadState[] = ["init", "started", "finalizing"];
+/** Serves as both the button's accessible name and its resting tooltip. */
+const LABEL = "Downloads";
 
-interface DownloadProgress {
-  isDownloading: boolean;
-  isPaused: boolean;
-  progress: number; // 0-100
-  speedMBps: number; // Speed in MB/s
-  estimatedMins: number; // Estimated time remaining in minutes
-}
-
-const useDownloadProgress = (): DownloadProgress => {
-  return useSelector((state: IState) => {
-    const files = state.persistent.downloads?.files ?? {};
-    const speed = state.persistent.downloads?.speed ?? 0;
-    const allDownloads = Object.values(files);
-
-    const activeDownloads = allDownloads.filter((dl) => ACTIVE_DOWNLOAD_STATES.includes(dl.state));
-    const pausedDownloads = allDownloads.filter((dl) => dl.state === "paused");
-
-    // If there are no active or paused downloads, nothing is happening
-    if (activeDownloads.length === 0 && pausedDownloads.length === 0) {
-      return {
-        isDownloading: false,
-        isPaused: false,
-        progress: 0,
-        speedMBps: 0,
-        estimatedMins: 0,
-      };
-    }
-
-    // Combine active and paused downloads for progress calculation
-    const relevantDownloads = [...activeDownloads, ...pausedDownloads];
-
-    const totalSize = relevantDownloads.reduce(
-      (sum, dl) => sum + Math.max(1, dl.size ?? 0, dl.received),
-      0,
-    );
-    const totalReceived = relevantDownloads.reduce((sum, dl) => sum + dl.received, 0);
-
-    const progress = totalSize > 0 ? (totalReceived * 100) / totalSize : 0;
-
-    // isPaused: true only if ALL downloads are paused (none actively downloading)
-    const isPaused = activeDownloads.length === 0 && pausedDownloads.length > 0;
-
-    // Speed in MB/s (speed from state is in bytes/s)
-    const speedMBps = speed / (1024 * 1024);
-
-    // Estimated time remaining in minutes
-    const remainingBytes = totalSize - totalReceived;
-    const estimatedMins = speed > 0 ? remainingBytes / speed / 60 : 0;
-
-    return {
-      isDownloading: true,
-      isPaused,
-      progress,
-      speedMBps,
-      estimatedMins,
-    };
-  });
-};
+const selectDownload =
+  (id: string | undefined) =>
+  (state: IState): IDownload | undefined =>
+    id === undefined ? undefined : state.persistent.downloads?.files?.[id];
 
 const ProgressRing = ({
   isActive,
@@ -132,44 +85,76 @@ export const DownloadButton = () => {
 
   const isActive = selection.type === "downloads";
 
-  const { isDownloading, isPaused, progress, speedMBps, estimatedMins } = useDownloadProgress();
+  const { activeIds, estimatedMins, isDownloading, isPaused, progress, speedMBps } =
+    useDownloadProgress();
+
+  const { downloadId, isAnnouncing, isOpen, onOpenChange } = useDownloadFlyout(activeIds);
+
+  const selectNamed = useMemo(() => selectDownload(downloadId), [downloadId]);
+  const download = useSelector(selectNamed);
+
+  // Sampled out here rather than in the flyout: the panel unmounts when it closes, so the
+  // rate would start from nothing every time the user brought it back.
+  const eta = useDownloadEta(download);
 
   // TODO: Add mechanism to toggle between speed and time display
   const isTime = false;
 
   const showProgress = isPaused || isDownloading;
 
+  const body: XOr<{ content: string }, { customContent: ReactNode }> =
+    downloadId === undefined
+      ? { content: LABEL }
+      : {
+          customContent: (
+            <DownloadFlyout
+              download={download}
+              eta={eta}
+              otherCount={Math.max(0, activeIds.length - 1)}
+            />
+          ),
+        };
+
   return (
-    <SpineButton
-      isCircular
-      // The ring is the outline while a download runs, so the border steps aside for it.
-      border={showProgress ? "none" : "visible"}
-      className="group/download flex-col gap-y-0.5"
-      iconPath={!showProgress && (isActive ? mdiDownload : mdiDownloadOutline)}
-      isActive={isActive}
-      title="Downloads"
-      onClick={() => selectDownloads()}
+    <Tooltip
+      {...body}
+      className={!!downloadId && "w-80"}
+      open={isOpen}
+      persistent={isAnnouncing}
+      placement="right"
+      onOpenChange={onOpenChange}
     >
-      {showProgress && (
-        <>
-          {!isPaused && (
-            <Typography
-              as="span"
-              brand="none"
-              className="leading-none font-semibold"
-              type="body-sm"
-            >
-              {isTime ? Math.ceil(estimatedMins) : speedMBps.toFixed(1)}
-            </Typography>
-          )}
+      <SpineButton
+        isCircular
+        tooltipDisabled
+        border={showProgress ? "none" : "visible"}
+        className="group/download flex-col gap-y-0.5"
+        iconPath={!showProgress && (isActive ? mdiDownload : mdiDownloadOutline)}
+        isActive={isActive}
+        title={LABEL}
+        onClick={() => selectDownloads()}
+      >
+        {showProgress && (
+          <>
+            {!isPaused && (
+              <Typography
+                as="span"
+                brand="none"
+                className="leading-none font-semibold"
+                type="body-sm"
+              >
+                {isTime ? Math.ceil(estimatedMins) : speedMBps.toFixed(1)}
+              </Typography>
+            )}
 
-          <span className="text-[0.375rem] leading-none tracking-[1px] uppercase">
-            {isPaused ? "paused" : isTime ? "mins" : "mb/s"}
-          </span>
+            <span className="text-[0.375rem] leading-none tracking-[1px] uppercase">
+              {isPaused ? "paused" : isTime ? "mins" : "mb/s"}
+            </span>
 
-          <ProgressRing isActive={isActive} isPaused={isPaused} progress={progress} />
-        </>
-      )}
-    </SpineButton>
+            <ProgressRing isActive={isActive} isPaused={isPaused} progress={progress} />
+          </>
+        )}
+      </SpineButton>
+    </Tooltip>
   );
 };

--- a/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadButton.tsx
@@ -88,7 +88,8 @@ export const DownloadButton = () => {
   const { activeIds, estimatedMins, isDownloading, isPaused, progress, speedMBps } =
     useDownloadProgress();
 
-  const { downloadId, isAnnouncing, isOpen, onOpenChange } = useDownloadFlyout(activeIds);
+  const { downloadId, isAnnouncing, isOpen, onOpenChange, onTriggerEnter, onTriggerLeave } =
+    useDownloadFlyout(activeIds);
 
   const selectNamed = useMemo(() => selectDownload(downloadId), [downloadId]);
   const download = useSelector(selectNamed);
@@ -133,6 +134,8 @@ export const DownloadButton = () => {
         isActive={isActive}
         title={LABEL}
         onClick={() => selectDownloads()}
+        onMouseEnter={onTriggerEnter}
+        onMouseLeave={onTriggerLeave}
       >
         {showProgress && (
           <>
@@ -140,14 +143,14 @@ export const DownloadButton = () => {
               <Typography
                 as="span"
                 brand="none"
-                className="leading-none font-semibold"
+                className="relative z-1 leading-none font-semibold text-shadow-halo text-shadow-translucent-dark-100"
                 type="body-sm"
               >
                 {isTime ? Math.ceil(estimatedMins) : speedMBps.toFixed(1)}
               </Typography>
             )}
 
-            <span className="text-[0.375rem] leading-none tracking-[1px] uppercase">
+            <span className="relative z-1 text-[0.375rem] leading-none tracking-[1px] uppercase">
               {isPaused ? "paused" : isTime ? "mins" : "mb/s"}
             </span>
 

--- a/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.test.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type * as ReactRedux from "react-redux";
+import { describe, expect, it, vi } from "vitest";
+
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
+import type { IState } from "@/types/IState";
+
+// Only AdultAwareImage reaches the store now, for the blur preference.
+vi.mock("react-redux", async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactRedux>()),
+  useSelector: (selector: (state: IState) => unknown) =>
+    selector({ persistent: {} } as unknown as IState),
+}));
+
+import { DownloadFlyout, formatRemaining } from "./DownloadFlyout";
+import type { DownloadEta } from "./useDownloadEta.hook";
+
+// --- Helpers ---
+
+const download = (overrides: Partial<IDownload> = {}): IDownload =>
+  ({
+    id: "dl1",
+    modInfo: {},
+    received: 0,
+    size: 1000,
+    state: "started",
+    urls: [],
+    ...overrides,
+  }) as unknown as IDownload;
+
+const renderComponent = ({
+  dl = download(),
+  eta = { status: "estimating" } as DownloadEta,
+  otherCount = 0,
+}: { dl?: IDownload | undefined; eta?: DownloadEta; otherCount?: number } = {}) =>
+  render(<DownloadFlyout download={dl} eta={eta} otherCount={otherCount} />);
+
+// --- Tests ---
+
+describe("DownloadFlyout", () => {
+  it("names nothing until the name lands", () => {
+    // The on-disk name is a placeholder until the download completes.
+    renderComponent({ dl: download({ localPath: "__vortex_tmp_9f2c" }) });
+
+    expect(screen.queryByTestId("download-flyout-name")).not.toBeInTheDocument();
+    // The status line still says something, so the row isn't blank.
+    expect(screen.getByTestId("download-flyout-estimating")).toBeInTheDocument();
+  });
+
+  it("names the file once there is a name to give", () => {
+    renderComponent({ dl: download({ localPath: "EasternVagabondArmor-1.2.zip" }) });
+
+    expect(screen.getByTestId("download-flyout-name")).toBeInTheDocument();
+  });
+
+  it("waits for the thumbnail while the mod metadata is still coming", () => {
+    renderComponent({ dl: download({ modInfo: { nexus: { ids: { modId: 123 } } } }) });
+
+    expect(document.querySelector(".nxm-image-spinner")).toBeInTheDocument();
+  });
+
+  it("leaves the frame empty for a download that will never have one", () => {
+    // No nexus ids means no metadata fetch, so no image is on its way.
+    renderComponent({ dl: download() });
+
+    expect(document.querySelector(".nxm-image-spinner")).not.toBeInTheDocument();
+  });
+
+  it("counts the downloads queued behind the one it names", () => {
+    renderComponent({ otherCount: 10 });
+    expect(screen.getByTestId("download-flyout-more")).toBeInTheDocument();
+  });
+
+  it("says nothing about others when there are none", () => {
+    renderComponent();
+    expect(screen.queryByTestId("download-flyout-more")).not.toBeInTheDocument();
+  });
+
+  it("says it is calculating while the estimate is still pending", () => {
+    renderComponent({ eta: { status: "estimating" } });
+
+    expect(screen.getByTestId("download-flyout-estimating")).toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-remaining")).not.toBeInTheDocument();
+  });
+
+  it("shows the time left once there is an estimate", () => {
+    renderComponent({ eta: { seconds: 486, status: "ready" } });
+
+    expect(screen.getByTestId("download-flyout-remaining")).toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+  });
+
+  // The panel is still on screen for its exit transition when a download finishes, so a
+  // status line that reappeared here would flash on the way out.
+  it("says nothing on the status line when there is no estimate to make", () => {
+    renderComponent({ eta: { status: "unavailable" } });
+
+    expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-remaining")).not.toBeInTheDocument();
+  });
+
+  it("has nothing to show for a download that is no longer there", () => {
+    renderComponent({ dl: undefined, eta: { status: "unavailable" } });
+
+    expect(screen.queryByTestId("download-flyout-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-remaining")).not.toBeInTheDocument();
+  });
+});
+
+describe("formatRemaining", () => {
+  it("drops the leading zero, so minutes read as the design has them", () => {
+    expect(formatRemaining(486)).toBe("8:06");
+  });
+
+  it("keeps two-digit minutes intact", () => {
+    expect(formatRemaining(754)).toBe("12:34");
+  });
+
+  it("keeps the hour when there is one", () => {
+    expect(formatRemaining(3723)).toBe("1:02:03");
+  });
+
+  it("rounds part-seconds up rather than down to zero", () => {
+    expect(formatRemaining(0.4)).toBe("0:01");
+  });
+});

--- a/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.test.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.test.tsx
@@ -13,7 +13,7 @@ vi.mock("react-redux", async (importOriginal) => ({
     selector({ persistent: {} } as unknown as IState),
 }));
 
-import { DownloadFlyout, formatRemaining } from "./DownloadFlyout";
+import { DownloadFlyout } from "./DownloadFlyout";
 import type { DownloadEta } from "./useDownloadEta.hook";
 
 // --- Helpers ---
@@ -91,6 +91,26 @@ describe("DownloadFlyout", () => {
     expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
   });
 
+  // i18next isn't initialised here, so `t` hands back the key: the assertions read the
+  // string that was chosen, which is the whole difference between these two cases.
+  it("says how much is left when the download is paused", () => {
+    renderComponent({ eta: { percentRemaining: 45, status: "paused" } });
+
+    expect(screen.getByTestId("download-flyout-paused")).toHaveTextContent(
+      "Paused {{percent}}% remaining",
+    );
+    expect(screen.queryByTestId("download-flyout-remaining")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
+  });
+
+  // Without a size there is no percentage to give, but the pause itself still matters.
+  it("still says it is paused with no percentage to report", () => {
+    renderComponent({ eta: { percentRemaining: undefined, status: "paused" } });
+
+    expect(screen.getByTestId("download-flyout-paused")).toHaveTextContent("Paused");
+    expect(screen.getByTestId("download-flyout-paused")).not.toHaveTextContent("%");
+  });
+
   // The panel is still on screen for its exit transition when a download finishes, so a
   // status line that reappeared here would flash on the way out.
   it("says nothing on the status line when there is no estimate to make", () => {
@@ -106,23 +126,5 @@ describe("DownloadFlyout", () => {
     expect(screen.queryByTestId("download-flyout-name")).not.toBeInTheDocument();
     expect(screen.queryByTestId("download-flyout-estimating")).not.toBeInTheDocument();
     expect(screen.queryByTestId("download-flyout-remaining")).not.toBeInTheDocument();
-  });
-});
-
-describe("formatRemaining", () => {
-  it("drops the leading zero, so minutes read as the design has them", () => {
-    expect(formatRemaining(486)).toBe("8:06");
-  });
-
-  it("keeps two-digit minutes intact", () => {
-    expect(formatRemaining(754)).toBe("12:34");
-  });
-
-  it("keeps the hour when there is one", () => {
-    expect(formatRemaining(3723)).toBe("1:02:03");
-  });
-
-  it("rounds part-seconds up rather than down to zero", () => {
-    expect(formatRemaining(0.4)).toBe("0:01");
   });
 });

--- a/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
+import {
+  friendlyDownloadName,
+  isTempDownloadName,
+} from "@/extensions/download_management/util/downloadNames";
+import { AdultAwareImage } from "@/ui/components/image/AdultAwareImage";
+import { Typography } from "@/ui/components/typography/Typography";
+import { timeToString } from "@/util/util";
+
+import type { DownloadEta } from "./useDownloadEta.hook";
+
+/** `modInfo.nexus` is untyped, and both fields land after the download itself. */
+interface INexusModImagery {
+  contains_adult_content?: boolean;
+  picture_url?: string;
+}
+
+/**
+ * Whether a thumbnail is on its way. `nexus.ids.modId` is what makes the metadata fetch
+ * run at all, so without it no image is ever coming and the frame should stay empty
+ * rather than sit there spinning — a manual download has no picture to wait for.
+ */
+const expectsImage = (download: IDownload | undefined): boolean =>
+  download?.modInfo?.nexus?.ids?.modId !== undefined;
+
+/** "08:06" reads like a stopwatch; the design asks for "8:06". */
+export const formatRemaining = (seconds: number): string =>
+  timeToString(Math.ceil(seconds)).replace(/^0(?=\d)/, "");
+
+interface IDownloadFlyoutProps {
+  download: IDownload | undefined;
+  eta: DownloadEta;
+  otherCount: number;
+}
+
+/**
+ * What the spine's download button says when it announces a download: the file, how many
+ * others are queued behind it, and how long it has left.
+ *
+ * Presentational: the download and its estimate are read by the button, which outlives
+ * this panel.
+ */
+export const DownloadFlyout = ({ download, eta, otherCount }: IDownloadFlyoutProps) => {
+  const { t } = useTranslation(["common"]);
+  const name = download === undefined ? undefined : friendlyDownloadName(download);
+
+  // The on-disk name is a __vortex_tmp_* placeholder until the download completes, so a
+  // temp name means the metadata hasn't landed.
+  const hasName = !!name && !isTempDownloadName(name);
+  const nexusMod = download?.modInfo?.nexus?.modInfo as INexusModImagery | undefined;
+
+  return (
+    <div className="flex h-12.5 w-full items-start gap-x-2.5 p-2">
+      <AdultAwareImage
+        alt=""
+        className="w-7.5 rounded-xs"
+        imageType="mod"
+        isAdult={nexusMod?.contains_adult_content ?? false}
+        isLoading={expectsImage(download) && nexusMod?.picture_url === undefined}
+        src={nexusMod?.picture_url}
+      />
+
+      <div className="flex min-w-0 grow flex-col gap-0.5">
+        <Typography
+          appearance="moderate"
+          as="div"
+          className="flex gap-x-2.5 font-semibold"
+          typographyType="body-sm"
+        >
+          {hasName && (
+            <div className="grow truncate" data-testid="download-flyout-name">
+              {t("Downloading {{name}}", { replace: { name } })}
+            </div>
+          )}
+
+          {!!otherCount && (
+            <div className="shrink-0" data-testid="download-flyout-more">
+              {t("+{{ count }} more", { count: otherCount })}
+            </div>
+          )}
+        </Typography>
+
+        {eta.status !== "unavailable" && (
+          <Typography
+            appearance="subdued"
+            as="span"
+            data-testid={
+              eta.status === "ready" ? "download-flyout-remaining" : "download-flyout-estimating"
+            }
+            typographyType="body-sm"
+          >
+            {eta.status === "ready"
+              ? t("{{time}} remaining", { replace: { time: formatRemaining(eta.seconds) } })
+              : t("Calculating time remaining...")}
+          </Typography>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.tsx
+++ b/src/renderer/src/views/components/Spine/download_button/DownloadFlyout.tsx
@@ -18,18 +18,6 @@ interface INexusModImagery {
   picture_url?: string;
 }
 
-/**
- * Whether a thumbnail is on its way. `nexus.ids.modId` is what makes the metadata fetch
- * run at all, so without it no image is ever coming and the frame should stay empty
- * rather than sit there spinning — a manual download has no picture to wait for.
- */
-const expectsImage = (download: IDownload | undefined): boolean =>
-  download?.modInfo?.nexus?.ids?.modId !== undefined;
-
-/** "08:06" reads like a stopwatch; the design asks for "8:06". */
-export const formatRemaining = (seconds: number): string =>
-  timeToString(Math.ceil(seconds)).replace(/^0(?=\d)/, "");
-
 interface IDownloadFlyoutProps {
   download: IDownload | undefined;
   eta: DownloadEta;
@@ -52,6 +40,37 @@ export const DownloadFlyout = ({ download, eta, otherCount }: IDownloadFlyoutPro
   const hasName = !!name && !isTempDownloadName(name);
   const nexusMod = download?.modInfo?.nexus?.modInfo as INexusModImagery | undefined;
 
+  const getStatus = (): { testId: string; text: string } | undefined => {
+    switch (eta.status) {
+      case "ready":
+        return {
+          testId: "download-flyout-remaining",
+          text: t("{{time}} remaining", {
+            replace: { time: timeToString(Math.ceil(eta.seconds)) },
+          }),
+        };
+      case "paused":
+        return {
+          testId: "download-flyout-paused",
+          text:
+            eta.percentRemaining === undefined
+              ? t("Paused")
+              : t("Paused {{percent}}% remaining", {
+                  replace: { percent: eta.percentRemaining },
+                }),
+        };
+      case "estimating":
+        return {
+          testId: "download-flyout-estimating",
+          text: t("Calculating time remaining..."),
+        };
+      default:
+        return undefined;
+    }
+  };
+
+  const status = getStatus();
+
   return (
     <div className="flex h-12.5 w-full items-start gap-x-2.5 p-2">
       <AdultAwareImage
@@ -59,7 +78,7 @@ export const DownloadFlyout = ({ download, eta, otherCount }: IDownloadFlyoutPro
         className="w-7.5 rounded-xs"
         imageType="mod"
         isAdult={nexusMod?.contains_adult_content ?? false}
-        isLoading={expectsImage(download) && nexusMod?.picture_url === undefined}
+        isLoading={!!download?.modInfo?.nexus?.ids?.modId && !nexusMod?.picture_url}
         src={nexusMod?.picture_url}
       />
 
@@ -83,18 +102,14 @@ export const DownloadFlyout = ({ download, eta, otherCount }: IDownloadFlyoutPro
           )}
         </Typography>
 
-        {eta.status !== "unavailable" && (
+        {!!status && (
           <Typography
             appearance="subdued"
             as="span"
-            data-testid={
-              eta.status === "ready" ? "download-flyout-remaining" : "download-flyout-estimating"
-            }
+            data-testid={status.testId}
             typographyType="body-sm"
           >
-            {eta.status === "ready"
-              ? t("{{time}} remaining", { replace: { time: formatRemaining(eta.seconds) } })
-              : t("Calculating time remaining...")}
+            {status.text}
           </Typography>
         )}
       </div>

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadEta.hook.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadEta.hook.ts
@@ -15,7 +15,21 @@ const MIN_SAMPLE_MS = 250;
 export type DownloadEta =
   | { status: "estimating" }
   | { status: "ready"; seconds: number }
+  | { status: "paused"; percentRemaining: number | undefined }
   | { status: "unavailable" };
+
+/**
+ * How much is left to fetch, as a whole percent, or undefined when the server never sent a
+ * size to measure against. Rounded up for the same reason the clock is: while bytes are
+ * still outstanding it shouldn't read as nothing left.
+ */
+const percentRemaining = ({ received, size }: IDownload): number | undefined => {
+  if (!size || received === undefined) {
+    return undefined;
+  }
+
+  return Math.min(100, Math.max(0, Math.ceil(((size - received) / size) * 100)));
+};
 
 /**
  * Time remaining for one download.
@@ -75,7 +89,13 @@ export const useDownloadEta = (download: IDownload | undefined): DownloadEta => 
     );
   }, [isRunning, received]);
 
-  // Paused, finishing or gone: there is no estimate to make, rather than one pending.
+  // A pause is worth announcing, and how much is left to fetch survives it — what's gone is
+  // the rate that would turn it into a time.
+  if (download?.state === "paused") {
+    return { status: "paused", percentRemaining: percentRemaining(download) };
+  }
+
+  // Finishing or gone: there is no estimate to make, rather than one pending.
   if (!isStarting) {
     return { status: "unavailable" };
   }

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadEta.hook.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadEta.hook.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { IDownload } from "@/extensions/download_management/types/IDownload";
+
+/** Weight given to the newest sample, low enough that a stalled second doesn't spike it. */
+const SMOOTHING = 0.3;
+/** Below this, a gap says more about dispatch timing than about bandwidth. */
+const MIN_SAMPLE_MS = 250;
+
+/**
+ * How long a download has left, and when there's no answer, why not — "still working it
+ * out" has to be distinguishable from "never going to know", or a paused download reads
+ * as one that is starting.
+ */
+export type DownloadEta =
+  | { status: "estimating" }
+  | { status: "ready"; seconds: number }
+  | { status: "unavailable" };
+
+/**
+ * Time remaining for one download.
+ *
+ * Sampled rather than read off the store: `downloads.speed` is the aggregate across every
+ * download, and `startTime` is dead — nothing has written it since the `init` ->
+ * `started` flip moved into the progress reducer.
+ */
+export const useDownloadEta = (download: IDownload | undefined): DownloadEta => {
+  const received = download?.received;
+  const size = download?.size;
+  const isRunning = download?.state === "started";
+  // `init` has nothing to measure yet but is still on its way, unlike paused or finishing.
+  const isStarting = download?.state === "init" || isRunning;
+
+  const [rate, setRate] = useState<number | undefined>(undefined);
+  const sampleRef = useRef<{ at: number; received: number } | undefined>(undefined);
+
+  useEffect(() => {
+    sampleRef.current = undefined;
+    setRate(undefined);
+  }, [download?.id]);
+
+  useEffect(() => {
+    if (received === undefined || !isRunning) {
+      return;
+    }
+
+    const now = Date.now();
+    const previous = sampleRef.current;
+
+    if (previous === undefined) {
+      sampleRef.current = { at: now, received };
+      return;
+    }
+
+    const elapsed = now - previous.at;
+
+    // Keep the older reading rather than replacing it, so updates that are each too close
+    // together still add up to one gap wide enough to measure. Replacing it every time
+    // means a fast, regular cadence never measures anything.
+    if (elapsed < MIN_SAMPLE_MS) {
+      return;
+    }
+
+    sampleRef.current = { at: now, received };
+
+    const delta = received - previous.received;
+
+    if (delta <= 0) {
+      return;
+    }
+
+    const sampled = (delta * 1000) / elapsed;
+    setRate((current) =>
+      current === undefined ? sampled : current + SMOOTHING * (sampled - current),
+    );
+  }, [isRunning, received]);
+
+  // Paused, finishing or gone: there is no estimate to make, rather than one pending.
+  if (!isStarting) {
+    return { status: "unavailable" };
+  }
+
+  // Running with no size means the server never sent one, so an estimate never arrives.
+  // While still `init` a missing size is just one the first progress hasn't reported yet.
+  if (isRunning && (size === undefined || size <= 0)) {
+    return { status: "unavailable" };
+  }
+
+  if (!isRunning || received === undefined || size === undefined || !rate || rate <= 0) {
+    return { status: "estimating" };
+  }
+
+  return { status: "ready", seconds: Math.max(0, (size - received) / rate) };
+};

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadEta.test.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadEta.test.ts
@@ -102,9 +102,10 @@ describe("useDownloadEta", () => {
     expect(seconds(result.current)).toBeCloseTo(9, 3);
 
     // Not "estimating": a paused download is not on its way, and the flyout would
-    // otherwise sit on "Download starting..." for as long as it stayed paused.
+    // otherwise sit on "Download starting..." for as long as it stayed paused. The pause
+    // replaces the estimate rather than leaving the last one standing.
     act(() => rerender({ dl: download(100, { state: "paused" }) }));
-    expect(result.current.status).toBe("unavailable");
+    expect(result.current).toEqual({ status: "paused", percentRemaining: 90 });
   });
 
   it("says nothing when the server never sent a size", () => {
@@ -155,4 +156,26 @@ describe("useDownloadEta", () => {
       expect(result.current.status).toBe("unavailable");
     },
   );
+
+  // A paused download keeps its place in the flyout: the bytes still say how much is left,
+  // even though the rate that would turn that into a time is gone.
+  describe("paused", () => {
+    it("reports the percent still to fetch", () => {
+      const { result } = renderEta(download(750, { state: "paused" }));
+
+      expect(result.current).toEqual({ status: "paused", percentRemaining: 25 });
+    });
+
+    it("rounds up, so outstanding bytes never read as none left", () => {
+      const { result } = renderEta(download(999, { state: "paused" }));
+
+      expect(result.current).toEqual({ status: "paused", percentRemaining: 1 });
+    });
+
+    it("has no percent to give when the server sent no size", () => {
+      const { result } = renderEta(download(750, { size: 0, state: "paused" }));
+
+      expect(result.current).toEqual({ status: "paused", percentRemaining: undefined });
+    });
+  });
 });

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadEta.test.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadEta.test.ts
@@ -1,0 +1,158 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DownloadState, IDownload } from "@/extensions/download_management/types/IDownload";
+
+import { type DownloadEta, useDownloadEta } from "./useDownloadEta.hook";
+
+const download = (
+  received: number,
+  { size = 1000, state = "started" }: { size?: number; state?: DownloadState } = {},
+): IDownload => ({ id: "dl1", received, size, state }) as unknown as IDownload;
+
+const renderEta = (initial: IDownload | undefined) =>
+  renderHook(({ dl }) => useDownloadEta(dl), { initialProps: { dl: initial } });
+
+/** The seconds on a ready estimate, or the status when there isn't one to read. */
+const seconds = (eta: DownloadEta): number | string =>
+  eta.status === "ready" ? eta.seconds : eta.status;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDownloadEta", () => {
+  it("has nothing to say without a download", () => {
+    const { result } = renderEta(undefined);
+    expect(result.current.status).toBe("unavailable");
+  });
+
+  it("reports that it is still working an estimate out", () => {
+    const { result } = renderEta(download(0));
+    expect(result.current.status).toBe("estimating");
+  });
+
+  it("estimates from the bytes that arrived between two readings", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(100) });
+    });
+
+    // 100 bytes in a second, 900 to go.
+    expect(seconds(result.current)).toBeCloseTo(9, 3);
+  });
+
+  it("smooths the rate rather than tracking every reading", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(100) });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(300) });
+    });
+
+    // The rate doubled, but only 30% of that lands: 100 + 0.3 * (200 - 100) = 130 B/s.
+    expect(seconds(result.current)).toBeCloseTo(700 / 130, 3);
+  });
+
+  it("ignores readings too close together to mean anything", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender({ dl: download(100) });
+    });
+
+    expect(result.current.status).toBe("estimating");
+  });
+
+  it("adds up readings that are each too close, rather than dropping them all", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    // Two 200ms ticks: neither clears the threshold alone, together they do.
+    act(() => {
+      vi.advanceTimersByTime(200);
+      rerender({ dl: download(50) });
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+      rerender({ dl: download(100) });
+    });
+
+    // 100 bytes over 400ms is 250 B/s, so 900 bytes take 3.6s.
+    expect(seconds(result.current)).toBeCloseTo(3.6, 3);
+  });
+
+  it("stops estimating while a download is paused", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(100) });
+    });
+    expect(seconds(result.current)).toBeCloseTo(9, 3);
+
+    // Not "estimating": a paused download is not on its way, and the flyout would
+    // otherwise sit on "Download starting..." for as long as it stayed paused.
+    act(() => rerender({ dl: download(100, { state: "paused" }) }));
+    expect(result.current.status).toBe("unavailable");
+  });
+
+  it("says nothing when the server never sent a size", () => {
+    const { rerender, result } = renderEta(download(0, { size: 0 }));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(100, { size: 0 }) });
+    });
+
+    // Running with no size means one is never coming, so this is not pending.
+    expect(result.current.status).toBe("unavailable");
+  });
+
+  it("starts over when it is pointed at a different download", () => {
+    const { rerender, result } = renderEta(download(0));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      rerender({ dl: download(100) });
+    });
+    expect(seconds(result.current)).toBeCloseTo(9, 3);
+
+    act(() => rerender({ dl: { ...download(500), id: "dl2" } }));
+    expect(result.current.status).toBe("estimating");
+  });
+
+  it("counts a download that has not moved yet as still starting", () => {
+    const { result } = renderEta(download(0, { size: 0, state: "init" }));
+
+    // A missing size during `init` is one the first progress hasn't reported yet, unlike
+    // a running download whose server never sends one.
+    expect(result.current.status).toBe("estimating");
+  });
+
+  it.each(["finalizing", "finished", "failed"] as DownloadState[])(
+    "has no estimate to make once a download is %s",
+    (state) => {
+      const { rerender, result } = renderEta(download(0));
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+        rerender({ dl: download(100) });
+      });
+      expect(seconds(result.current)).toBeCloseTo(9, 3);
+
+      act(() => rerender({ dl: download(1000, { state }) }));
+      expect(result.current.status).toBe("unavailable");
+    },
+  );
+});

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.hook.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.hook.ts
@@ -11,6 +11,9 @@ export interface IDownloadFlyout {
   isAnnouncing: boolean;
   isOpen: boolean;
   onOpenChange: (open: boolean, reason?: OpenChangeReason) => void;
+  /** For the trigger's own hover handlers — see `onTriggerEnter`. */
+  onTriggerEnter: () => void;
+  onTriggerLeave: () => void;
 }
 
 /**
@@ -104,5 +107,14 @@ export const useDownloadFlyout = (activeIds: string[]): IDownloadFlyout => {
     [cancelAutoDismiss],
   );
 
-  return { downloadId, isAnnouncing, isOpen, onOpenChange };
+  const onTriggerEnter = useCallback(() => {
+    isPointerOnRef.current = true;
+    cancelAutoDismiss();
+  }, [cancelAutoDismiss]);
+
+  const onTriggerLeave = useCallback(() => {
+    isPointerOnRef.current = false;
+  }, []);
+
+  return { downloadId, isAnnouncing, isOpen, onOpenChange, onTriggerEnter, onTriggerLeave };
 };

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.hook.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.hook.ts
@@ -1,0 +1,108 @@
+import type { OpenChangeReason } from "@floating-ui/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const AUTO_DISMISS_MS = 5000;
+
+/** Reasons that mean the pointer is on the button, so the flyout is its own again. */
+const POINTER_REASONS: OpenChangeReason[] = ["focus", "hover", "safe-polygon"];
+
+export interface IDownloadFlyout {
+  downloadId: string | undefined;
+  isAnnouncing: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean, reason?: OpenChangeReason) => void;
+}
+
+/**
+ * When the download flyout shows itself and which download it names. It opens on its own
+ * when a download appears and then dismisses itself; hovering the button is what brings
+ * it back, which the `Tooltip` it drives handles by itself.
+ */
+export const useDownloadFlyout = (activeIds: string[]): IDownloadFlyout => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isAnnouncing, setIsAnnouncing] = useState(false);
+  const [downloadId, setDownloadId] = useState<string | undefined>(undefined);
+
+  // Undefined until the first run, which seeds it: a session resuming with downloads
+  // already in flight has no news to announce.
+  const knownIdsRef = useRef<Set<string> | undefined>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const isPointerOnRef = useRef(false);
+  const hasActiveRef = useRef(false);
+
+  const cancelAutoDismiss = useCallback(() => {
+    if (timerRef.current !== undefined) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => cancelAutoDismiss, [cancelAutoDismiss]);
+
+  useEffect(() => {
+    const known = knownIdsRef.current;
+    knownIdsRef.current = new Set(activeIds);
+    hasActiveRef.current = activeIds.length > 0;
+
+    // The named download is deliberately kept: the panel is still on screen for its exit
+    // transition, and dropping it now flicks the content back to the plain label first.
+    if (activeIds.length === 0) {
+      cancelAutoDismiss();
+      setIsAnnouncing(false);
+      setIsOpen(false);
+      return;
+    }
+
+    setDownloadId((current) =>
+      current !== undefined && activeIds.includes(current) ? current : activeIds[0],
+    );
+
+    if (known === undefined) {
+      return;
+    }
+
+    const arrived = activeIds.find((id) => !known.has(id));
+
+    if (arrived === undefined) {
+      return;
+    }
+
+    setDownloadId(arrived);
+    setIsAnnouncing(true);
+    setIsOpen(true);
+
+    cancelAutoDismiss();
+
+    // Dismissing under the pointer would snatch the panel away mid-read, and `Tooltip`
+    // won't reopen it until the pointer leaves and comes back.
+    if (!isPointerOnRef.current) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = undefined;
+        setIsAnnouncing(false);
+        setIsOpen(false);
+      }, AUTO_DISMISS_MS);
+    }
+  }, [activeIds, cancelAutoDismiss]);
+
+  const onOpenChange = useCallback(
+    (next: boolean, reason?: OpenChangeReason) => {
+      isPointerOnRef.current = next && reason !== undefined && POINTER_REASONS.includes(reason);
+
+      cancelAutoDismiss();
+      // Once the pointer is driving it's an ordinary tooltip again, free to yield to a
+      // press elsewhere and to its neighbours.
+      setIsAnnouncing(false);
+
+      // Opening with nothing in flight is the moment it is safe to forget the download
+      // that was kept above: the panel is about to show the plain label instead.
+      if (next && !hasActiveRef.current) {
+        setDownloadId(undefined);
+      }
+
+      setIsOpen(next);
+    },
+    [cancelAutoDismiss],
+  );
+
+  return { downloadId, isAnnouncing, isOpen, onOpenChange };
+};

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.test.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.test.ts
@@ -84,6 +84,54 @@ describe("useDownloadFlyout", () => {
     expect(result.current.isOpen).toBe(true);
   });
 
+  // Hovering a panel it opened itself is invisible to `onOpenChange` - the tooltip is
+  // already open, so floating-ui has no change to report - and the countdown used to run on
+  // and close the flyout under the pointer.
+  it("holds off its countdown while the pointer is on the button", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => result.current.onTriggerEnter());
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS * 2));
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  // Leaving doesn't close it here: the tooltip's own hover-close reports that through
+  // `onOpenChange`, which is what actually takes the panel down.
+  it("does not restart the countdown when the pointer leaves", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => result.current.onTriggerEnter());
+    act(() => result.current.onTriggerLeave());
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.onOpenChange(false, "hover"));
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  // The pointer already resting on the button when the download lands: the arrival path
+  // reads the same flag, so it never arms a countdown it would have to cancel.
+  it("never starts a countdown for a download that arrives under the pointer", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => result.current.onTriggerEnter());
+    act(() => rerender({ ids: ["dl1"] }));
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+    expect(result.current.isOpen).toBe(true);
+  });
+
   it("closes when the user dismisses it", () => {
     const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
       initialProps: { ids: [] as string[] },

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.test.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadFlyout.test.ts
@@ -1,0 +1,183 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AUTO_DISMISS_MS, useDownloadFlyout } from "./useDownloadFlyout.hook";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDownloadFlyout", () => {
+  it("says nothing while there is nothing downloading", () => {
+    const { result } = renderHook(() => useDownloadFlyout([]));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.downloadId).toBeUndefined();
+  });
+
+  it("stays shut for downloads already in flight when it mounts", () => {
+    // A session resuming mid-download has no news to announce.
+    const { result } = renderHook(() => useDownloadFlyout(["dl1"]));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.downloadId).toBe("dl1");
+  });
+
+  it("announces a download that arrives after it mounted", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.downloadId).toBe("dl1");
+  });
+
+  it("names the download that just arrived, not the one already running", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: ["dl1"] },
+    });
+
+    act(() => rerender({ ids: ["dl1", "dl2"] }));
+
+    expect(result.current.downloadId).toBe("dl2");
+  });
+
+  it("gets out of the way on its own", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("does not snatch itself away from a pointer that opened it", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => result.current.onOpenChange(true, "hover"));
+    act(() => rerender({ ids: ["dl1"] }));
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("drops its countdown once the user takes it over", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => result.current.onOpenChange(true, "hover"));
+
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("closes when the user dismisses it", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => result.current.onOpenChange(false, "escape-key"));
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("marks itself as announcing, so nothing the user does elsewhere takes it down", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+    expect(result.current.isAnnouncing).toBe(false);
+
+    act(() => rerender({ ids: ["dl1"] }));
+
+    expect(result.current.isAnnouncing).toBe(true);
+  });
+
+  it("stops announcing once it has had its say", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => vi.advanceTimersByTime(AUTO_DISMISS_MS));
+
+    expect(result.current.isAnnouncing).toBe(false);
+  });
+
+  it("hands over to the pointer, so it behaves like any other tooltip from then on", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    expect(result.current.isAnnouncing).toBe(true);
+
+    act(() => result.current.onOpenChange(true, "hover"));
+
+    expect(result.current.isAnnouncing).toBe(false);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("keeps naming something real when the download it named finishes", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1", "dl2"] }));
+    expect(result.current.downloadId).toBe("dl1");
+
+    act(() => rerender({ ids: ["dl2"] }));
+    expect(result.current.downloadId).toBe("dl2");
+  });
+
+  // The panel is still on screen for its exit transition when the queue empties, so
+  // dropping the name here made the content flick back to the plain label before closing.
+  it("keeps naming the download it announced while the panel closes", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => rerender({ ids: [] }));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.downloadId).toBe("dl1");
+  });
+
+  it("forgets it once opened again with nothing downloading", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => rerender({ ids: [] }));
+    act(() => result.current.onOpenChange(true, "hover"));
+
+    expect(result.current.downloadId).toBeUndefined();
+  });
+
+  it("falls silent once the last download is done", () => {
+    const { rerender, result } = renderHook(({ ids }) => useDownloadFlyout(ids), {
+      initialProps: { ids: [] as string[] },
+    });
+
+    act(() => rerender({ ids: ["dl1"] }));
+    act(() => rerender({ ids: [] }));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.isAnnouncing).toBe(false);
+  });
+});

--- a/src/renderer/src/views/components/Spine/download_button/useDownloadProgress.hook.ts
+++ b/src/renderer/src/views/components/Spine/download_button/useDownloadProgress.hook.ts
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+
+import type { DownloadState, IDownload } from "@/extensions/download_management/types/IDownload";
+import type { IState } from "@/types/IState";
+
+const ACTIVE_DOWNLOAD_STATES: DownloadState[] = ["init", "started", "finalizing"];
+
+/** Stable, so a store without downloads doesn't churn the memo. */
+const NO_FILES: Record<string, IDownload> = {};
+
+export interface IDownloadProgress {
+  /** The active downloads, then the paused: everything the figures below cover. */
+  activeIds: string[];
+  estimatedMins: number;
+  isDownloading: boolean;
+  isPaused: boolean;
+  progress: number;
+  speedMBps: number;
+}
+
+const selectDownloadFiles = (state: IState) => state.persistent.downloads?.files;
+const selectDownloadSpeed = (state: IState) => state.persistent.downloads?.speed ?? 0;
+
+/**
+ * Aggregate progress over everything currently downloading, for the spine's download
+ * button and its flyout.
+ *
+ * The slices are subscribed separately and combined here because a selector returning a
+ * fresh object re-renders on every dispatch, and the download adapter dispatches batched
+ * progress about once a second per download.
+ */
+export const useDownloadProgress = (): IDownloadProgress => {
+  const files = useSelector(selectDownloadFiles) ?? NO_FILES;
+  const speed = useSelector(selectDownloadSpeed);
+
+  return useMemo(() => {
+    const allDownloads = Object.entries(files);
+
+    const active = allDownloads.filter(([, dl]) => ACTIVE_DOWNLOAD_STATES.includes(dl.state));
+    const paused = allDownloads.filter(([, dl]) => dl.state === "paused");
+
+    if (active.length === 0 && paused.length === 0) {
+      return {
+        activeIds: [],
+        estimatedMins: 0,
+        isDownloading: false,
+        isPaused: false,
+        progress: 0,
+        speedMBps: 0,
+      };
+    }
+
+    // Paused downloads still have received bytes to report.
+    const relevant = [...active, ...paused];
+
+    const totalSize = relevant.reduce(
+      (sum, [, dl]) => sum + Math.max(1, dl.size ?? 0, dl.received),
+      0,
+    );
+    const totalReceived = relevant.reduce((sum, [, dl]) => sum + dl.received, 0);
+    const remainingBytes = totalSize - totalReceived;
+
+    return {
+      activeIds: relevant.map(([id]) => id),
+      estimatedMins: speed > 0 ? remainingBytes / speed / 60 : 0,
+      isDownloading: true,
+      isPaused: active.length === 0,
+      progress: totalSize > 0 ? (totalReceived * 100) / totalSize : 0,
+      speedMBps: speed / (1024 * 1024),
+    };
+  }, [files, speed]);
+};

--- a/src/renderer/src/views/components/Spine/notifications/Notifications.test.tsx
+++ b/src/renderer/src/views/components/Spine/notifications/Notifications.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { INotification, NotificationType } from "@/types/INotification";
 
 const mocks = vi.hoisted(() => ({
+  items: [] as INotification[],
   notifications: [] as INotification[],
 }));
 
@@ -21,8 +22,11 @@ vi.mock("@/ExtensionProvider", () => ({
 // redux store; the trigger is what moved, so the panel hooks are stubbed to empty.
 vi.mock("./hooks/useNotificationFiltering.hook", () => ({ useNotificationFiltering: () => [] }));
 vi.mock("./hooks/useNotificationItems.hook", () => ({
-  useNotificationItems: () => ({ items: [], collapsed: {} }),
+  useNotificationItems: () => ({ items: mocks.items, collapsed: {} }),
 }));
+
+// The panel's rows are someone else's tests; the beak is what this file cares about.
+vi.mock("./components/NotificationItem", () => ({ NotificationItem: () => null }));
 vi.mock("./hooks/useNotificationActions.hook", () => ({
   useNotificationActions: () => ({
     dismissAll: vi.fn(),
@@ -55,6 +59,7 @@ const renderComponent = (types: NotificationType[]) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.items = [];
   mocks.notifications = [];
 });
 
@@ -170,5 +175,30 @@ describe("Notifications trigger", () => {
     renderComponent([]);
     // The resting border is transparent — it only paints on hover or while open.
     expect(screen.getByRole("button", { name: "Notifications" })).toHaveClass("border-transparent");
+  });
+});
+
+// LAZ-999: the tray sits directly above the download flyout in the spine, so the two
+// have to read as the same kind of panel — same beak, same distance from their button.
+describe("Notifications beak", () => {
+  it("points back at the bell with the same arrow the download flyout uses", async () => {
+    mocks.items = [notification("info")];
+    renderComponent(["info"]);
+
+    await waitFor(() => {
+      expect(document.querySelector(".nxm-overlay-arrow")).toBeInTheDocument();
+    });
+  });
+
+  it("draws no hand-rolled beak of its own any more", async () => {
+    mocks.items = [notification("info")];
+    const { container } = renderComponent(["info"]);
+
+    await waitFor(() => {
+      expect(document.querySelector(".nxm-overlay-arrow")).toBeInTheDocument();
+    });
+
+    // The old beak was a rotated square, which could never match the tooltip's 12x8.
+    expect(container.querySelector("span.rotate-45")).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/src/views/components/Spine/notifications/Notifications.tsx
+++ b/src/renderer/src/views/components/Spine/notifications/Notifications.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 
 import { useExtensionContext } from "@/ExtensionProvider";
 import type { INotification, NotificationType } from "@/types/INotification";
+import { OVERLAY_ARROW_HEIGHT, OverlayArrow } from "@/ui/components/overlay_arrow/OverlayArrow";
 import { PopoverPanel } from "@/ui/components/popover/PopoverPanel";
 import { joinClasses } from "@/ui/utils/joinClasses";
 
@@ -156,8 +157,11 @@ const NotificationsContent = ({ close, popoverOpen }: INotificationsContentProps
       </PopoverButton>
 
       {popoverOpen && !!items.length && (
-        <PopoverPanel anchor={{ gap: 8, to: "right end" }} className="w-xs overflow-visible!">
-          <span className="pointer-events-none absolute bottom-6 left-0 size-2 -translate-x-1/2 translate-y-1/2 rotate-45 border-b border-l border-stroke-weak bg-surface-mid" />
+        <PopoverPanel
+          anchor={{ gap: 8 + OVERLAY_ARROW_HEIGHT, to: "right end" }}
+          className="w-xs overflow-visible!"
+        >
+          <OverlayArrow side="right" tipFromEnd={24} />
 
           <div className="max-h-[50vh] space-y-0.5 overflow-y-auto">
             {items.map((notification) => (

--- a/src/renderer/src/views/components/Spine/notifications/components/NotificationItem.tsx
+++ b/src/renderer/src/views/components/Spine/notifications/components/NotificationItem.tsx
@@ -1,5 +1,5 @@
 import {
-  mdiAlertOctagon,
+  mdiAlertOctagonOutline,
   mdiAlertOutline,
   mdiCheckCircleOutline,
   mdiInformationOutline,
@@ -18,7 +18,7 @@ import { NotificationContent } from "./NotificationContent";
 import { NotificationControls } from "./NotificationControls";
 
 const STATUS_MAP = {
-  error: { className: "text-danger-strong", icon: mdiAlertOctagon },
+  error: { className: "text-danger-strong", icon: mdiAlertOctagonOutline },
   warning: { className: "text-warning-strong", icon: mdiAlertOutline },
   success: { className: "text-success-strong", icon: mdiCheckCircleOutline },
   info: { className: "text-info-strong", icon: mdiInformationOutline },

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -7,6 +7,7 @@
 @import "./image.css";
 @import "./link.css";
 @import "./modal.css";
+@import "./overlay-arrow.css";
 @import "./pagination.css";
 @import "./pill.css";
 @import "./popover.css";

--- a/src/stylesheets/ui/elements/overlay-arrow.css
+++ b/src/stylesheets/ui/elements/overlay-arrow.css
@@ -1,0 +1,15 @@
+@layer components {
+    /* Shared by the tooltip's Floating UI arrow and the hand-placed OverlayArrow. */
+    .nxm-overlay-arrow {
+        pointer-events: none;
+        fill: var(--color-surface-mid);
+
+        path[clip-path] {
+            stroke: var(--color-surface-high);
+        }
+
+        path:not([clip-path]) {
+            stroke: var(--color-surface-mid);
+        }
+    }
+}

--- a/src/stylesheets/ui/elements/tooltip.css
+++ b/src/stylesheets/ui/elements/tooltip.css
@@ -32,16 +32,4 @@
         line-height: var(--text-body-sm--line-height);
         letter-spacing: var(--text-body-sm--letter-spacing);
     }
-
-    .nxm-tooltip-arrow {
-        fill: var(--color-surface-mid);
-
-        path[clip-path] {
-            stroke: var(--color-surface-high);
-        }
-
-        path:not([clip-path]) {
-            stroke: var(--color-surface-mid);
-        }
-    }
 }

--- a/src/stylesheets/ui/theme/generic.css
+++ b/src/stylesheets/ui/theme/generic.css
@@ -2,7 +2,6 @@
     --text-2xs: 0.625rem;
     --text-2xs--line-height: calc(1 / 0.625);
 
-    /* Tailwind's container scale stops at 7xl (80rem); this keeps its 8rem step. */
     --container-8xl: 88rem;
 
     --z-index-dropdown: 1020;
@@ -14,6 +13,11 @@
     --aspect-collection: 4 / 5;
     --aspect-game: 2 / 3;
     --aspect-mod: 16 / 9;
+
+    --text-shadow-halo:
+        2px 0 0 var(--color-black), -2px 0 0 var(--color-black), 0 2px 0 var(--color-black),
+        0 -2px 0 var(--color-black), 2px 2px 0 var(--color-black), 2px -2px 0 var(--color-black),
+        -2px 2px 0 var(--color-black), -2px -2px 0 var(--color-black);
 
     --shadow-sm:
         0px 2px 4px rgb(0 0 0 / 14%), 0px 3px 4px rgb(0 0 0 / 12%), 0px 1px 5px rgb(0 0 0 / 20%);


### PR DESCRIPTION
Adds the download flyout from [LAZ-999](https://linear.app/nexus-mods/issue/LAZ-999/mod-download-progress-flyout): a panel that pops out beside the spine's download button when a download starts, and comes back on hover.

<img width="536" height="478" alt="image" src="https://github.com/user-attachments/assets/9272ffe7-7981-4b06-b131-aeb1ba560c6b" />


## Why

Nothing in the UI confirmed that a download had actually started. The issue asks the flyout to do three things: confirm the download began, teach people where progress lives, and let them check it without losing their place.

## How it works

The download button's click has to keep navigating to the Downloads page, so it can't become a Headless UI `PopoverButton` the way the notification bell is. Instead the flyout is a rich `Tooltip`, which gains two optional additions:

- **`open` / `onOpenChange(open, reason)`** — a controlled open state, so the flyout can show itself with nothing on the trigger. Omit both and hover owns it exactly as before.
- **`persistent`** — for a tooltip that shows itself rather than answering a hover: a press anywhere, or a neighbour in the same delay group opening, leaves it up. Escape still closes it. It's dropped the moment the pointer takes over, so from then on it behaves like any other tooltip.

Three hooks sit behind it in `Spine/download_button/`:

- `useDownloadProgress` — lifted out of `DownloadButton` so the button and the flyout share one aggregate. Rebuilt as two narrow subscriptions plus a `useMemo`: it previously returned a fresh object from inside `useSelector`, re-rendering on every dispatch while the download adapter pushes batched progress about once a second per download.
- `useDownloadEta` — samples one download's own `received`. Neither store field can give a per-file rate: `downloads.speed` is the aggregate across every download, and `startTime` is dead — nothing has written it since the `init → started` flip moved into the progress reducer, which is why `SpeedOMeter` already sorts on `NaN` there.
- `useDownloadFlyout` — announces, dismisses itself after 5s, hands over to the pointer. Seeded at mount, so a session resuming with downloads already in flight doesn't announce them as news.

The arrow moved into a shared `OverlayArrow` + `.nxm-overlay-arrow` rule, and the notification tray now uses it. The tray's beak was a rotated square — a 90° tip, so necessarily 2:1, which could never match the tooltip's 12×8 SVG. The tray's anchor gap also went 8 → 16 (`8 + arrow height`, matching the tooltip's own offset), and that is what actually made the two panels' edges line up.

## Two bugs found on the way

- **A disabled `Tooltip` wasn't inert.** `disabled` only short-circuited the render; `useHover`, `useFocus`, `useDismiss` and `useDelayGroup` all still ran. The invisible tooltip claimed the delay group's `currentId`, the group closes whichever member isn't current, and that close cleared the real tooltip's pending open timeout — so the download button needed **two hovers** to show anything, its plain label included. `disabled` now reaches the interactions. `ToolbarPanelButton` uses the same `tooltipDisabled` trick, so this was latent there too.
- **`useDownloadEta` couldn't measure a fast cadence.** It replaced its stored sample on every update before checking the interval, so a run of updates closer together than the threshold never added up to a measurable gap. It only worked at all because the real adapter throttles to ~1/s.

## What changes visibly

- A 320px flyout beside the download button: mod thumbnail, the file being downloaded, `+N more` for the rest of the queue, and time remaining. It shows a single "Download starting…" line until a name and a rate exist.
- The notification tray sits 8px further from the bell and wears the tooltip's beak instead of its own.
