### PR TITLE
feat(ui): show a spinner while an Image loads, then fade it in

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -102,6 +102,11 @@ The answer is published as `data-reduce-motion="true"` on `<html>`
   on purpose - a component that names its own duration often depends on it - so opt
   decorative ones out with the `reduce-motion:` variant:
   `transition-[width] duration-300 reduce-motion:duration-0`.
+- Custom keyframes live in `src/stylesheets/ui/theme/animations.css`, registered as
+  `--animate-*` theme entries. Take the duration from `--default-transition-duration` for
+  the same reason as above, so the animation flattens without needing its own rule in
+  `motion.css`. A _delay_ is timing rather than motion, so keep it - a loader held back so
+  it never flashes on a short wait should still be held back.
 - **Don't use Tailwind's `motion-reduce:` / `motion-safe:` variants.** They compile to
   `prefers-reduced-motion` media queries, so they follow the OS and can't see the app's
   own setting. `reduce-motion:` is the app-aware equivalent.

--- a/src/renderer/src/ui/components/image/AdultAwareImage.test.tsx
+++ b/src/renderer/src/ui/components/image/AdultAwareImage.test.tsx
@@ -32,24 +32,24 @@ describe("AdultAwareImage", () => {
   it("blurs adult content when the user opts into blurring", () => {
     mockUserInfo({ adultBlurImages: true });
     renderComponent();
-    expect(getImg()).toHaveClass("blur-xl");
+    expect(getImg()).toHaveClass("nxm-image-media-blurred");
   });
 
   it("does not blur adult content when the user opts out", () => {
     mockUserInfo({ adultBlurImages: false });
     renderComponent();
-    expect(getImg()).not.toHaveClass("blur-xl");
+    expect(getImg()).not.toHaveClass("nxm-image-media-blurred");
   });
 
   it("never blurs non-adult content", () => {
     mockUserInfo({ adultBlurImages: true });
     renderComponent({ isAdult: false });
-    expect(getImg()).not.toHaveClass("blur-xl");
+    expect(getImg()).not.toHaveClass("nxm-image-media-blurred");
   });
 
   it("blurs adult content by default when no user is logged in", () => {
     mockUserInfo(undefined);
     renderComponent();
-    expect(getImg()).toHaveClass("blur-xl");
+    expect(getImg()).toHaveClass("nxm-image-media-blurred");
   });
 });

--- a/src/renderer/src/ui/components/image/Image.demo.tsx
+++ b/src/renderer/src/ui/components/image/Image.demo.tsx
@@ -211,6 +211,46 @@ export const ImageDemo = () => (
 
     <div className="space-y-4">
       <Typography as="h3" typographyType="heading-xs">
+        Loading
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        A spinner stands in until the image has loaded, and the image fades in once it has. The
+        spinner is held back a moment, so anything that resolves in a frame or two — a local file,
+        or one already cached — never flashes one. This source never answers, so it keeps spinning.
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        With no `src` there is nothing to wait on, so an empty frame stays empty — most absent
+        sources never resolve. Pass `isLoading` where one is genuinely on its way, as the download
+        flyout does while a mod's metadata is still being fetched.
+      </Typography>
+
+      <Typography appearance="subdued" typographyType="body-sm">
+        The spinner is capped at three quarters of the frame's height, so it shrinks into a small
+        one rather than overflowing it. Both of these are waiting on the same source: the 30px
+        thumbnail on the right is the size the download flyout uses.
+      </Typography>
+
+      <div className="flex items-start gap-x-4">
+        <Image
+          alt="Loading example"
+          className="w-48"
+          imageType="collection"
+          src="https://10.255.255.1/never-answers.png"
+        />
+
+        <Image
+          alt="Small loading example"
+          className="w-7.5"
+          imageType="mod"
+          src="https://10.255.255.1/never-answers.png"
+        />
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <Typography as="h3" typographyType="heading-xs">
         Error Fallback
       </Typography>
 

--- a/src/renderer/src/ui/components/image/Image.test.tsx
+++ b/src/renderer/src/ui/components/image/Image.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { Image } from "./Image";
 
@@ -9,13 +9,18 @@ import { Image } from "./Image";
 const renderComponent = (props: Partial<React.ComponentProps<typeof Image>> = {}) => {
   const onError = vi.fn();
 
-  render(<Image alt="A mod" src="mod.png" onError={onError} {...props} />);
+  const { rerender } = render(<Image alt="A mod" src="mod.png" onError={onError} {...props} />);
 
-  return { onError };
+  return { onError, rerender };
 };
 
 const getImg = () => document.querySelector("img");
 const getContainer = () => getImg()?.parentElement ?? null;
+const getSpinner = () => document.querySelector(".nxm-image-spinner");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // --- Tests ---
 
@@ -29,6 +34,93 @@ describe("Image", () => {
     it("renders children inside the container", () => {
       renderComponent({ children: <span data-testid="badge" /> });
       expect(screen.getByTestId("badge")).toBeInTheDocument();
+    });
+  });
+
+  describe("loading", () => {
+    it("shows a spinner while the image is still coming", () => {
+      renderComponent();
+      expect(getSpinner()).toBeInTheDocument();
+    });
+
+    it("holds the image back until it has loaded", () => {
+      renderComponent();
+      expect(getImg()).toHaveClass("nxm-image-media-pending");
+    });
+
+    it("fades the image in and drops the spinner once it loads", () => {
+      renderComponent();
+      fireEvent.load(getImg() as Element);
+
+      expect(getImg()).not.toHaveClass("nxm-image-media-pending");
+      expect(getSpinner()).not.toBeInTheDocument();
+    });
+
+    it("passes a caller's onLoad through", () => {
+      const onLoad = vi.fn();
+      renderComponent({ onLoad });
+
+      fireEvent.load(getImg() as Element);
+
+      expect(onLoad).toHaveBeenCalledOnce();
+    });
+
+    it("waits for nothing when there is no src", () => {
+      renderComponent({ src: undefined });
+      expect(getSpinner()).not.toBeInTheDocument();
+    });
+
+    it("drops the spinner when the image fails instead of spinning forever", () => {
+      renderComponent({ src: "bad.png" });
+      fireEvent.error(getImg() as Element);
+
+      expect(getSpinner()).not.toBeInTheDocument();
+    });
+
+    it("waits again when pointed at a different image", () => {
+      const { rerender } = renderComponent();
+      fireEvent.load(getImg() as Element);
+      expect(getImg()).not.toHaveClass("nxm-image-media-pending");
+
+      rerender(<Image alt="A mod" src="other.png" />);
+
+      expect(getImg()).toHaveClass("nxm-image-media-pending");
+      expect(getSpinner()).toBeInTheDocument();
+    });
+
+    it("waits when the caller says a source is on its way", () => {
+      // With no src there is nothing here to wait on, so only the caller knows.
+      renderComponent({ isLoading: true, src: undefined });
+      expect(getSpinner()).toBeInTheDocument();
+    });
+
+    it("stops waiting once a caller-declared source has loaded", () => {
+      const { rerender } = renderComponent({ isLoading: true, src: undefined });
+      expect(getSpinner()).toBeInTheDocument();
+
+      rerender(<Image alt="A mod" src="mod.png" />);
+      fireEvent.load(getImg() as Element);
+
+      expect(getSpinner()).not.toBeInTheDocument();
+    });
+
+    it("gives up rather than spinning on when a declared source fails", () => {
+      renderComponent({ isLoading: true, src: "bad.png" });
+      fireEvent.error(getImg() as Element);
+
+      expect(getSpinner()).not.toBeInTheDocument();
+    });
+
+    // A cached image can be `complete` before React attaches onLoad, and that load event
+    // is then never seen — without this the image would stay faded out for good.
+    it("settles an image that was already complete when it mounted", () => {
+      vi.spyOn(window.HTMLImageElement.prototype, "complete", "get").mockReturnValue(true);
+      vi.spyOn(window.HTMLImageElement.prototype, "naturalWidth", "get").mockReturnValue(64);
+
+      renderComponent();
+
+      expect(getImg()).not.toHaveClass("nxm-image-media-pending");
+      expect(getSpinner()).not.toBeInTheDocument();
     });
   });
 
@@ -51,22 +143,22 @@ describe("Image", () => {
   describe("styling", () => {
     it("applies the blur class when isBlurred", () => {
       renderComponent({ isBlurred: true });
-      expect(getImg()).toHaveClass("blur-xl");
+      expect(getImg()).toHaveClass("nxm-image-media-blurred");
     });
 
-    it('uses object-cover for fit="cover"', () => {
+    it('fills the frame for fit="cover"', () => {
       renderComponent({ fit: "cover" });
-      expect(getImg()).toHaveClass("object-cover");
+      expect(getImg()).toHaveClass("nxm-image-media-cover");
     });
 
     it('applies the aspect class for imageType="collection"', () => {
       renderComponent({ imageType: "collection" });
-      expect(getContainer()).toHaveClass("aspect-collection");
+      expect(getContainer()).toHaveClass("nxm-image-collection");
     });
 
     it('applies the aspect class for imageType="game"', () => {
       renderComponent({ imageType: "game" });
-      expect(getContainer()).toHaveClass("aspect-game");
+      expect(getContainer()).toHaveClass("nxm-image-game");
     });
 
     it("merges className on the container and imageClassName on the img", () => {

--- a/src/renderer/src/ui/components/image/Image.tsx
+++ b/src/renderer/src/ui/components/image/Image.tsx
@@ -1,5 +1,5 @@
-import { mdiImageBroken } from "@mdi/js";
-import React, { useState, type ImgHTMLAttributes } from "react";
+import { mdiCircleOutline, mdiImageBroken, mdiLoading } from "@mdi/js";
+import React, { useCallback, useState, type ImgHTMLAttributes } from "react";
 
 import { Icon } from "@/ui/components/icon/Icon";
 import { joinClasses } from "@/ui/utils/joinClasses";
@@ -14,12 +14,13 @@ export interface IImageProps extends Omit<
   imageClassName?: string;
   imageType?: "collection" | "game" | "mod" | "other";
   isBlurred?: boolean;
+  isLoading?: boolean;
 }
 
 const imageTypeMap: Record<NonNullable<IImageProps["imageType"]>, string> = {
-  collection: "aspect-collection",
-  game: "aspect-game",
-  mod: "aspect-mod",
+  collection: "nxm-image-collection",
+  game: "nxm-image-game",
+  mod: "nxm-image-mod",
   other: "",
 };
 
@@ -31,53 +32,75 @@ export const Image = ({
   imageClassName,
   imageType = "other",
   isBlurred,
+  isLoading,
   onError,
+  onLoad,
   src,
   ...rest
 }: IImageProps) => {
   const [lastSrc, setLastSrc] = useState(src);
   const [errored, setErrored] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   if (src !== lastSrc) {
     setLastSrc(src);
     setErrored(false);
+    setLoaded(false);
   }
 
+  // A cached image can finish before onLoad attaches, and `complete` is true with no src.
+  const settleIfComplete = useCallback((image: HTMLImageElement | null) => {
+    if (image !== null && image.complete && !!image.naturalWidth) {
+      setLoaded(true);
+    }
+  }, []);
+
+  // Only the caller knows a source is coming when there is no src; a failed one is settled.
+  const showSpinner = !errored && (isLoading === true || (!!src && !loaded));
+
   return (
-    <div
-      className={joinClasses([
-        "group/image relative z-0 flex shrink-0 items-center justify-center overflow-hidden bg-surface-translucent-low",
-        imageTypeMap[imageType],
-        className,
-      ])}
-    >
+    <div className={joinClasses(["nxm-image", imageTypeMap[imageType], className])}>
       {!errored ? (
         <img
           {...rest}
           alt={alt}
           className={joinClasses(
             [
-              "absolute z-1 rounded-[inherit]",
-              isBlurred || fit === "cover" ? "size-full object-cover" : "max-h-full",
+              "nxm-image-media",
+              isBlurred || fit === "cover" ? "nxm-image-media-cover" : "nxm-image-media-contain",
               imageClassName,
             ],
             {
-              "blur-xl": isBlurred,
+              "nxm-image-media-blurred": isBlurred,
+              "nxm-image-media-pending": !loaded,
             },
           )}
+          ref={settleIfComplete}
           src={src}
           onError={(event) => {
             setErrored(true);
             onError?.(event);
           }}
+          onLoad={(event) => {
+            setLoaded(true);
+            onLoad?.(event);
+          }}
         />
       ) : (
-        <Icon className="text-neutral-subdued" path={mdiImageBroken} title={alt} />
+        <Icon className="nxm-image-fallback" path={mdiImageBroken} size="none" title={alt} />
+      )}
+
+      {showSpinner && (
+        <span className="nxm-image-spinner">
+          <Icon className="opacity-40" path={mdiCircleOutline} size="none" />
+
+          <Icon className="absolute inset-0" path={mdiLoading} size="none" />
+        </span>
       )}
 
       {children}
 
-      <div className="pointer-events-none absolute inset-0 z-5 rounded-[inherit] border border-stroke-weak" />
+      <div className="nxm-image-frame" />
     </div>
   );
 };

--- a/src/stylesheets/ui/elements/image.css
+++ b/src/stylesheets/ui/elements/image.css
@@ -1,0 +1,80 @@
+@layer components {
+    .nxm-image {
+        z-index: 0;
+        display: flex;
+        flex-shrink: 0;
+        position: relative;
+        overflow: hidden;
+        align-items: center;
+        justify-content: center;
+        background-color: var(--color-surface-translucent-low);
+
+        &.nxm-image-collection {
+            aspect-ratio: var(--aspect-collection);
+        }
+
+        &.nxm-image-game {
+            aspect-ratio: var(--aspect-game);
+        }
+
+        &.nxm-image-mod {
+            aspect-ratio: var(--aspect-mod);
+        }
+
+        & .nxm-image-media {
+            z-index: 1;
+            position: absolute;
+            border-radius: inherit;
+
+            transition-property: opacity;
+            transition-timing-function: var(--default-transition-timing-function);
+            transition-duration: var(--default-transition-duration);
+
+            &.nxm-image-media-pending {
+                opacity: 0;
+            }
+
+            &.nxm-image-media-cover {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+            }
+
+            &.nxm-image-media-contain {
+                max-height: 100%;
+            }
+
+            &.nxm-image-media-blurred {
+                filter: blur(var(--blur-xl));
+            }
+        }
+
+        & .nxm-image-fallback {
+            width: auto;
+            aspect-ratio: 1;
+            max-height: 75%;
+            color: var(--color-neutral-subdued);
+            height: calc(var(--spacing) * 5);
+        }
+
+        & .nxm-image-spinner {
+            width: auto;
+            flex-shrink: 0;
+            aspect-ratio: 1;
+            max-height: 75%;
+            position: relative;
+            color: var(--color-neutral-subdued);
+            height: calc(var(--spacing) * 5);
+            animation: var(--animate-deferred-fade-in), var(--animate-spin);
+        }
+
+        & .nxm-image-frame {
+            inset: 0;
+            z-index: 5;
+            position: absolute;
+            pointer-events: none;
+            border-radius: inherit;
+            border: 1px solid var(--color-stroke-weak);
+        }
+    }
+}

--- a/src/stylesheets/ui/elements/index.css
+++ b/src/stylesheets/ui/elements/index.css
@@ -4,6 +4,7 @@
 @import "./dropdown.css";
 @import "./grid.css";
 @import "./hover-overlay.css";
+@import "./image.css";
 @import "./link.css";
 @import "./modal.css";
 @import "./pagination.css";

--- a/src/stylesheets/ui/theme/animations.css
+++ b/src/stylesheets/ui/theme/animations.css
@@ -1,0 +1,14 @@
+@theme {
+    --animate-deferred-fade-in: deferred-fade-in var(--default-transition-duration) linear 250ms
+        both;
+
+    @keyframes deferred-fade-in {
+        from {
+            opacity: 0;
+        }
+
+        to {
+            opacity: 1;
+        }
+    }
+}

--- a/src/stylesheets/ui/theme/index.css
+++ b/src/stylesheets/ui/theme/index.css
@@ -1,3 +1,4 @@
+@import "./animations.css";
 @import "./generic.css";
 @import "./colours.css";
 @import "./overrides.css";


### PR DESCRIPTION
`Image` had no loading state: an image popped in the moment it arrived, and until then its frame sat empty. It now waits with a spinner and fades in on load, so every caller of the modern `Image` gets it — `GameRow`, `GameThumbnail`, `CollectionTile`, `ProfileSection`, `ToolsSection`, health check's `FileRequirement` and the download flyout.

<img width="396" height="360" alt="image" src="https://github.com/user-attachments/assets/6582ed27-cf58-4b8a-9d4c-6db352d3aaf2" />


## How it works

- **Fade in.** `.nxm-image-media-pending` holds the image at `opacity: 0` until `onLoad`, then a transition takes it to 1.
- **Spinner.** The same faint-track + `mdiLoading` spinner `Button` uses for its loading state, so the two match.
- **Held back 250ms.** Roughly half the callers show local files — game art, tool icons — that resolve in a frame or two. A spinner there would be a regression, not an improvement, so it only appears if a wait turns out to be a long one. CSS-only, no timer.
- **Sized from its height**, capped at 75% of the frame, so it shrinks into a small one rather than overflowing. The download flyout's thumbnail is 17px tall, where `Icon`'s default 20px spinner didn't fit.
- **`isLoading`.** With no `src` there is nothing to wait on, and most absent sources never resolve, so an empty frame stays empty unless the caller says one is coming. The download flyout passes it while a mod's metadata is still being fetched.

Two subtleties worth flagging for review:

- **A cached image can be `complete` before React attaches `onLoad`**, and that load event is then never seen — which would leave the image faded out permanently. A ref callback settles one that is already done. It checks `complete && naturalWidth`, not `complete` alone, because `complete` is also true for an absent or failed src.
- **A failed source settles rather than spinning on**, hence `!errored` in the guard.

## Reduce motion

The fade's duration comes from `--default-transition-duration`, which `motion.css` overrides to `0.01ms`, so it goes instant with the preference on and needs no rule of its own. The 250ms **delay is kept either way** — holding a loader back is a timing decision, not motion, and there is still a wait to sit out. `animate-spin` keeps spinning, as essential motion should.

`docs/frontend.md` gains a bullet for this, since custom keyframes weren't covered by the Motion section.

## Styling

All of `Image`'s styling moved out of the markup into `nxm-`-prefixed classes in a new `src/stylesheets/ui/elements/image.css`, following `tab.css`'s nesting. The one new keyframe lives in a new `src/stylesheets/ui/theme/animations.css` as an `--animate-*` theme entry, alongside the other `@theme` files.

Nesting doesn't cost callers their override hooks: `@layer components` precedes `@layer utilities`, so a caller's `className` / `imageClassName` utility still wins.
