### PR TITLE
extend the api harness for the gamebryo test tranche

### DIFF
--- a/src/renderer/src/StyleManager.ts
+++ b/src/renderer/src/StyleManager.ts
@@ -24,9 +24,8 @@ export default class StyleManager {
       { type: "builtin", file: "thirdparty" },
       { type: "builtin", file: "desktop" },
       // collections and gamebryo plugin management are core (static) extensions; their
-      // stylesheets live in src/stylesheets and are compiled as built-in partials
-      // (inserted before "style", matching where the old setStylesheet calls placed
-      // the extendable partials).
+      // stylesheets live in src/stylesheets and are compiled as built-in partials,
+      // inserted before "style" like the extendable partials.
       { type: "builtin", file: "collections" },
       { type: "builtin", file: "gamebryo_plugin_management" },
       { type: "builtin", file: "style" },

--- a/src/renderer/src/extensions/gamebryo_plugin_management/archiveCheck.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/archiveCheck.ts
@@ -83,7 +83,8 @@ export async function testIncompatibleArchives(api: IExtensionApi): Promise<ITes
 
 async function checkForErrors(
   api: IExtensionApi,
-  pluginsObj: { [id: string]: IPluginCombined },
+  // keyed by plugin id
+  pluginsObj: Record<string, IPluginCombined>,
 ): Promise<ITestResult> {
   // Check this is a game we want to run this check on.
   const state = api.getState<IStateWithGamebryo>();

--- a/src/renderer/src/extensions/gamebryo_plugin_management/index.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/index.ts
@@ -58,12 +58,7 @@ import { testIncompatibleArchives } from "./archiveCheck";
 import LootInterface from "./autosort";
 import { ESPFile } from "./esp/ESPFile";
 import { genLockIndexAttribute, onceIndexLock } from "./indexlock";
-import { indexReducer } from "./reducers/indexlock";
-import { loadOrderReducer } from "./reducers/loadOrder";
-import { pluginsReducer } from "./reducers/plugins";
-import { settingsReducer } from "./reducers/settings";
-import userlistReducer from "./reducers/userlist";
-import userlistEditReducer from "./reducers/userlistEdit";
+import { REDUCER_BINDINGS } from "./reducers/bindings";
 import { GHOST_EXT } from "./statics";
 import { IESPFile } from "./types/IESPFile";
 import { ILOOTList, ILootReference, ILOOTSortApiCall } from "./types/ILOOTList";
@@ -395,16 +390,9 @@ function register(
   context: IExtensionContextExt,
   setPluginLight: (id: string, enable: boolean) => void,
 ) {
-  context.registerReducer(["session", "plugins"], pluginsReducer);
-  context.registerReducer(["loadOrder"], loadOrderReducer);
-  context.registerReducer(["userlist"], userlistReducer);
-  context.registerReducer(["masterlist"], {
-    defaults: { globals: [], plugins: [], groups: [] },
-    reducers: {},
-  });
-  context.registerReducer(["settings", "plugins"], settingsReducer);
-  context.registerReducer(["session", "pluginDependencies"], userlistEditReducer);
-  context.registerReducer(["persistent", "plugins", "lockedIndices"], indexReducer);
+  for (const { path: statePath, reducer } of REDUCER_BINDINGS) {
+    context.registerReducer(statePath, reducer);
+  }
 
   context.registerTableAttribute("gamebryo-plugins", genLockIndexAttribute(context.api));
 

--- a/src/renderer/src/extensions/gamebryo_plugin_management/reducers/bindings.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/reducers/bindings.ts
@@ -1,0 +1,24 @@
+import type { IExtensionReducer } from "../../../types/extensions";
+import { indexReducer } from "./indexlock";
+import { loadOrderReducer } from "./loadOrder";
+import { pluginsReducer } from "./plugins";
+import { settingsReducer } from "./settings";
+import userlistReducer from "./userlist";
+import userlistEditReducer from "./userlistEdit";
+
+/**
+ * The reducer specs this extension owns, at their state paths. register() registers each, and the
+ * gamebryo test harness binds the same list, so the two cannot drift.
+ */
+export const REDUCER_BINDINGS: IExtensionReducer[] = [
+  { path: ["session", "plugins"], reducer: pluginsReducer },
+  { path: ["loadOrder"], reducer: loadOrderReducer },
+  { path: ["userlist"], reducer: userlistReducer },
+  {
+    path: ["masterlist"],
+    reducer: { defaults: { globals: [], plugins: [], groups: [] }, reducers: {} },
+  },
+  { path: ["settings", "plugins"], reducer: settingsReducer },
+  { path: ["session", "pluginDependencies"], reducer: userlistEditReducer },
+  { path: ["persistent", "plugins", "lockedIndices"], reducer: indexReducer },
+];

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -19,6 +19,7 @@
  * Test-only: nothing in the production tree imports this module.
  */
 import { EventEmitter } from "events";
+import * as os from "os";
 import * as path from "path";
 
 import type { IFileInfo, IPreference, IUserInfo } from "@nexusmods/nexus-api";
@@ -44,6 +45,7 @@ import { downloadPathForGame } from "../extensions/download_management/selectors
 import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
 import type { ILoadOrderEntry } from "../extensions/file_based_loadorder/types/types";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
+import type { IPlugin } from "../extensions/gamebryo_plugin_management/types/IPlugins";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
 import type {
@@ -52,6 +54,7 @@ import type {
   IModRequirementExt,
 } from "../extensions/health_check/types";
 import { ModFileCategory } from "../extensions/health_check/types";
+import type { IHistoryEvent } from "../extensions/history_management/types";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import { modsReducer } from "../extensions/mod_management/reducers/mods";
@@ -73,6 +76,7 @@ import type { IProfile, IProfileMod } from "../extensions/profile_management/typ
 import type { IPCDownloadAdapter } from "../IPCDownloadAdapter";
 import trackingReducer from "../reducers/collectionInstallTracking";
 import { addToTree, Decision, deriveReducer } from "../reducers/index";
+import ReduxWatcher from "../store/ReduxWatcher";
 import type {
   CollectionModStatus,
   ICollectionInstallSession,
@@ -81,7 +85,7 @@ import type {
 } from "../types/collections/ICollectionInstallSession";
 import type { IAvailableExtension, IExtensionReducer } from "../types/extensions";
 import type { DialogActions, DialogType, IDialogContent, IDialogResult } from "../types/IDialog";
-import type { IExtensionApi } from "../types/IExtensionContext";
+import type { IExtensionApi, IRunOptions } from "../types/IExtensionContext";
 import type { IGame } from "../types/IGame";
 import type { IHealthCheckResult, IModCheckContext, IModHealthCheck } from "../types/IHealthCheck";
 import {
@@ -89,6 +93,7 @@ import {
   HealthCheckSeverity,
   HealthCheckTrigger,
 } from "../types/IHealthCheck";
+import type { INotification } from "../types/INotification";
 import type { IExtensionState, IState } from "../types/IState";
 import local from "../util/local";
 import type { IStarterInfo } from "../util/StarterInfo";
@@ -170,6 +175,15 @@ export function makeMod(overrides: Partial<IMod> = {}): IMod {
     type: "",
     installationPath: "mods/mod-1",
     attributes: {},
+    ...overrides,
+  };
+}
+
+export function makePlugin(overrides: Partial<IPlugin> = {}): IPlugin {
+  return {
+    filePath: path.join(os.tmpdir(), "vortex-test-plugins", "One.esp"),
+    isNative: false,
+    deployed: true,
     ...overrides,
   };
 }
@@ -732,6 +746,12 @@ export function makeApiHarness(
     makeDriverState(overrides),
     applyMiddleware(thunkMiddleware, recorder),
   );
+  // the production state-watching mechanism over the harness store, backing api.onStateChange.
+  // setState is a real dispatch, so watchers registered before a setState fire on it. Unlike
+  // production's stateChangeHandler wrapper, watcher errors fail loud instead of being logged.
+  const watcher = new ReduxWatcher<IState>(store, (err) => {
+    throw err;
+  });
   // seed every bound slice: its spec's defaults under whatever makeDriverState placed there
   // from the overrides. Slices with no seed get plain defaults from the store's INIT dispatch.
   store.dispatch({ type: HYDRATE_REPLACE_TYPE, payload: store.getState() });
@@ -745,6 +765,9 @@ export function makeApiHarness(
   const dialogCalls: Array<{ type: DialogType; title: string }> = [];
   const errorNotifications: IApiHarness["errorNotifications"] = [];
   const notifications: IApiHarness["notifications"] = [];
+  const historyEntries: IApiHarness["historyEntries"] = [];
+  const showHistoryCalls: IApiHarness["showHistoryCalls"] = [];
+  const runExecutableCalls: IApiHarness["runExecutableCalls"] = [];
 
   const api = {
     getState: () => store.getState(),
@@ -759,10 +782,18 @@ export function makeApiHarness(
     onAsync: (event: string, cb: (...args: unknown[]) => unknown) => {
       events.on(event, cb);
     },
-    onStateChange: () => undefined,
-    sendNotification: (notification: { type: string; message: string }) => {
-      notifications.push(notification);
+    onStateChange: (statePath: string[], cb: (previous: unknown, current: unknown) => void) => {
+      watcher.on(statePath, ({ prevValue, currentValue }) => cb(prevValue, currentValue));
     },
+    sendNotification: (notification: INotification) => {
+      notifications.push(notification);
+      return notification.id ?? "test-notification";
+    },
+    runExecutable: (executable: string, args: string[], options: IRunOptions) => {
+      runExecutableCalls.push({ executable, args, options });
+      return Promise.resolve();
+    },
+    genMd5Hash: () => Promise.resolve({ md5sum: "test-md5", numBytes: 0 }),
     dismissNotification: () => undefined,
     showErrorNotification: (
       title: string,
@@ -781,7 +812,15 @@ export function makeApiHarness(
       return Promise.resolve(nextDialog);
     },
     translate: (key: string) => key,
-    ext: { awaitProfileSwitch: () => Promise.resolve() },
+    ext: {
+      awaitProfileSwitch: () => Promise.resolve(),
+      addToHistory: (stack: string, entry: IHistoryEvent) => {
+        historyEntries.push({ stack, entry });
+      },
+      showHistory: (stackId: string) => {
+        showHistoryCalls.push(stackId);
+      },
+    },
     emitAndAwait: () => Promise.resolve([]),
   } as unknown as IExtensionApi;
 
@@ -804,6 +843,9 @@ export function makeApiHarness(
     dialogCalls,
     errorNotifications,
     notifications,
+    historyEntries,
+    showHistoryCalls,
+    runExecutableCalls,
   };
 }
 

--- a/src/renderer/src/test-utils/gamebryoTest.ts
+++ b/src/renderer/src/test-utils/gamebryoTest.ts
@@ -1,6 +1,7 @@
-import { loadOrderReducer } from "../extensions/gamebryo_plugin_management/reducers/loadOrder";
-import { pluginsReducer } from "../extensions/gamebryo_plugin_management/reducers/plugins";
+import { REDUCER_BINDINGS } from "../extensions/gamebryo_plugin_management/reducers/bindings";
 import type { IStateWithGamebryo } from "../extensions/gamebryo_plugin_management/types/IStateWithGamebryo";
+import { transactionsReducer } from "../extensions/mod_management/reducers/transactions";
+import { sessionReducer } from "../reducers/session";
 import type { IState } from "../types/IState";
 import { makeGameHarness, type IHarnessReducerBinding } from "./builders";
 import { test as harnessTest } from "./harnessTest";
@@ -8,12 +9,14 @@ import type { IGamebryoHarness, IGamebryoHarnessOpts } from "./harnessTypes";
 
 const asGamebryo = (state: IState): IStateWithGamebryo => state as IStateWithGamebryo;
 
-// the extension's reducer specs, bound to the slices they own (the root loadOrder hive and
-// session.plugins); the harness seeds each from its spec's defaults
-const GAMEBRYO_BINDINGS: IHarnessReducerBinding[] = [
-  { path: ["loadOrder"], reducer: loadOrderReducer },
-  { path: ["session", "plugins"], reducer: pluginsReducer },
+// core slices the extension's handlers read but does not own
+const CORE_BINDINGS: IHarnessReducerBinding[] = [
+  { path: ["persistent", "transactions"], reducer: transactionsReducer },
+  { path: ["session", "base"], reducer: sessionReducer },
 ];
+
+// the extension's own registrations plus the core slices above
+const GAMEBRYO_BINDINGS: IHarnessReducerBinding[] = [...REDUCER_BINDINGS, ...CORE_BINDINGS];
 
 /**
  * A gamebryo-flavoured api harness: an active profile on a gamebryo game with a staging folder

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -15,6 +15,7 @@ import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
 import type { IStateWithGamebryo } from "../extensions/gamebryo_plugin_management/types/IStateWithGamebryo";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
+import type { IHistoryEvent } from "../extensions/history_management/types";
 import type InstallContext from "../extensions/mod_management/InstallContext";
 import type InstallManager from "../extensions/mod_management/InstallManager";
 import type { IMod, IModRule } from "../extensions/mod_management/types/IMod";
@@ -27,8 +28,9 @@ import type {
   ICollectionInstallState,
 } from "../types/collections/ICollectionInstallSession";
 import type { DialogType, IDialogResult } from "../types/IDialog";
-import type { IExtensionApi } from "../types/IExtensionContext";
+import type { IExtensionApi, IRunOptions } from "../types/IExtensionContext";
 import type { IHealthCheckResult } from "../types/IHealthCheck";
+import type { INotification } from "../types/INotification";
 import type { IState } from "../types/IState";
 
 /** A dispatched redux-act action as the harness sees it. */
@@ -78,8 +80,14 @@ export interface IApiHarness {
   // showErrorNotification calls, recorded in order. allowReport matters: a false here is what
   // keeps the Report button off a failure the user caused or can act on themselves
   errorNotifications: Array<{ title: string; message: unknown; allowReport: boolean | undefined }>;
-  // sendNotification calls, recorded in order
-  notifications: Array<{ type: string; message: string }>;
+  // sendNotification calls, recorded in order (full notification, so ids/actions are assertable)
+  notifications: INotification[];
+  // ext.addToHistory calls, recorded in order
+  historyEntries: Array<{ stack: string; entry: IHistoryEvent }>;
+  // ext.showHistory calls, recorded in order
+  showHistoryCalls: string[];
+  // api.runExecutable calls, recorded in order (the call is captured, nothing is spawned)
+  runExecutableCalls: Array<{ executable: string; args: string[]; options: IRunOptions }>;
 }
 
 export interface IDriverHarness extends IApiHarness {


### PR DESCRIPTION
Groundwork for the post-move characterization suites: api.onStateChange is backed by the production ReduxWatcher over the harness store, the fake api gains capture surfaces (runExecutable, history, full notification payloads), and the extension's reducer registrations move to an exported REDUCER_BINDINGS list that register() loops and the gamebryo harness binds, so the two cannot drift. makePlugin builds pluginList entries.

Part of LAZ-1025