### PR TITLE
Upgrade Electron to 44.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,17 +6,22 @@
   "type": "commonjs",
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "engines": {
-    "node": "24.17.0"
+    "node": "24.20.0",
+    "runtime": {
+      "name": "node",
+      "version": "24.20.0",
+      "onFail": "download"
+    }
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "24.17.0",
+      "version": "24.20.0",
       "onFail": "download"
     }
   },
   "volta": {
-    "node": "24.17.0",
+    "node": "24.20.0",
     "yarn": "1.22.19"
   },
   "scripts": {
@@ -46,9 +51,7 @@
   "lint-staged": {
     "*": "pnpm exec oxfmt --no-error-on-unmatched-pattern"
   },
-  "dependencies": {
-    "node": "catalog:"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@eslint-react/eslint-plugin": "catalog:",
     "@eslint/js": "catalog:",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "husky": "catalog:",
     "lint-staged": "catalog:",
     "minimist": "catalog:",
+    "node-abi": "catalog:",
     "nx": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ catalogs:
       specifier: 1.5.1-r.1
       version: 1.5.1-r.1
     '@electron/rebuild':
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 4.2.0
+      version: 4.2.0
     '@electron/remote':
       specifier: 2.1.3
       version: 2.1.3
@@ -588,8 +588,8 @@ catalogs:
       specifier: github:TanninOne/drivelist#720d1890db11482ec05fc0f6aa176cfa6e6844dd
       version: 10.0.2
     electron:
-      specifier: 43.0.0
-      version: 43.0.0
+      specifier: 44.2.0
+      version: 44.2.0
     electron-builder:
       specifier: 24.13.3
       version: 24.13.3
@@ -986,6 +986,7 @@ overrides:
   '@types/react-dom': '18'
   node-addon-api: 8.5.0
   node-gyp: 12.3.0
+  node-abi: 4.35.0
   '@types/node': 24.12.2
   react-dnd: 14.0.5
 
@@ -1072,6 +1073,9 @@ importers:
       minimist:
         specifier: 'catalog:'
         version: 1.2.8
+      node-abi:
+        specifier: 4.35.0
+        version: 4.35.0
       nx:
         specifier: 'catalog:'
         version: 23.0.1
@@ -1748,7 +1752,7 @@ importers:
         version: 2.30.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       exe-version:
         specifier: workspace:*
         version: link:../../packages/exe-version
@@ -2475,7 +2479,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       modmeta-db:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336(commander@14.0.3)(encoding-down@6.3.0)(express@4.22.1)(leveldown@5.6.0)(levelup@4.4.0)
@@ -3178,7 +3182,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       turbowalk:
         specifier: 'catalog:'
         version: https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f
@@ -3682,7 +3686,7 @@ importers:
         version: 2.4.1
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       exe-version:
         specifier: workspace:*
         version: link:../../packages/exe-version
@@ -3934,7 +3938,7 @@ importers:
         version: 24.12.2
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       enquirer:
         specifier: 'catalog:'
         version: 2.4.1
@@ -4098,7 +4102,7 @@ importers:
         version: 2.30.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       i18next:
         specifier: 'catalog:'
         version: 21.10.0
@@ -4131,7 +4135,7 @@ importers:
         version: 1.5.1-r.1
       '@electron/remote':
         specifier: 'catalog:'
-        version: 2.1.3(electron@43.0.0)
+        version: 2.1.3(electron@44.2.0)
       '@floating-ui/react':
         specifier: 'catalog:'
         version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
@@ -4501,7 +4505,7 @@ importers:
     devDependencies:
       '@electron/rebuild':
         specifier: 'catalog:'
-        version: 4.1.0(supports-color@10.2.2)
+        version: 4.2.0(supports-color@10.2.2)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 'catalog:'
         version: 0.6.2(react-refresh@0.18.0)(type-fest@5.6.0)(webpack@5.108.4)
@@ -4606,13 +4610,13 @@ importers:
         version: 10.1.0
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       electron-builder:
         specifier: 'catalog:'
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
       electron-extension-installer:
         specifier: 'catalog:'
-        version: 2.0.1(electron@43.0.0)
+        version: 2.0.1(electron@44.2.0)
       openapi-typescript:
         specifier: 'catalog:'
         version: 7.13.0(typescript@6.0.3)
@@ -4633,7 +4637,7 @@ importers:
         version: link:../shared
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
 
   src/renderer:
     dependencies:
@@ -4661,7 +4665,7 @@ importers:
         version: 7.16.8(@babel/core@7.29.7)
       '@electron/remote':
         specifier: 'catalog:'
-        version: 2.1.3(electron@43.0.0)
+        version: 2.1.3(electron@44.2.0)
       '@floating-ui/react':
         specifier: 'catalog:'
         version: 0.27.20(react-dom@18.3.1)(react@18.3.1)
@@ -4916,7 +4920,7 @@ importers:
         version: https://codeload.github.com/TanninOne/drivelist/tar.gz/720d1890db11482ec05fc0f6aa176cfa6e6844dd
       electron:
         specifier: 'catalog:'
-        version: 43.0.0(supports-color@10.2.2)
+        version: 44.2.0(supports-color@10.2.2)
       electron-context-menu:
         specifier: 'catalog:'
         version: 3.6.1
@@ -5908,8 +5912,8 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  '@electron/rebuild@4.1.0':
-    resolution: {integrity: sha512-GFky+1JeO8fpSqtZCh+2wFRN/MVbAhm7tXI2M7BA1Os79OR8LEoxRtAbRPyxvmKWhEMF/p10rNJkkgP1klI13g==}
+  '@electron/rebuild@4.2.0':
+    resolution: {integrity: sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -9317,8 +9321,8 @@ packages:
   electron-updater@6.8.9:
     resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
-  electron@43.0.0:
-    resolution: {integrity: sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==}
+  electron@44.2.0:
+    resolution: {integrity: sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -10927,12 +10931,8 @@ packages:
     resolution: {gitHosted: true, integrity: sha512-hFgO6i7T1ZGj3QwgI4OhpbevPJRQI6DBJq1h2VFxPnyO6Nx9NLTu76EmokUDqUMo0ei7IqMOwwD1soEC3IqWUQ==, tarball: https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479}
     version: 0.8.1
 
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
-
-  node-abi@4.31.0:
-    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
+  node-abi@4.35.0:
+    resolution: {integrity: sha512-ymk4aIzxdPopw2giv8Fs1Ec6vybGkjmyxUwVqhkI4MCy2tVfXdkOGGWieWVjL0THgH+7a8lRdevyupoYj3Js/Q==}
     engines: {node: '>=22.12.0'}
 
   node-abort-controller@3.1.1:
@@ -14024,20 +14024,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@4.1.0(supports-color@10.2.2)':
+  '@electron/rebuild@4.2.0(supports-color@10.2.2)':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
-      node-abi: 4.31.0
+      node-abi: 4.35.0
       node-api-version: 0.2.1
       node-gyp: 12.3.0
       read-binary-file-arch: 1.0.6(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/remote@2.1.3(electron@43.0.0)':
+  '@electron/remote@2.1.3(electron@44.2.0)':
     dependencies:
-      electron: 43.0.0(supports-color@10.2.2)
+      electron: 44.2.0(supports-color@10.2.2)
 
   '@electron/universal@1.5.1':
     dependencies:
@@ -17361,9 +17361,9 @@ snapshots:
       pupa: 2.1.1
       unused-filename: 2.1.0
 
-  electron-extension-installer@2.0.1(electron@43.0.0):
+  electron-extension-installer@2.0.1(electron@44.2.0):
     dependencies:
-      electron: 43.0.0(supports-color@10.2.2)
+      electron: 44.2.0(supports-color@10.2.2)
       jszip: 3.10.1
 
   electron-is-dev@2.0.0: {}
@@ -17403,7 +17403,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.0.0(supports-color@10.2.2):
+  electron@44.2.0(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0(supports-color@10.2.2)
@@ -19034,11 +19034,7 @@ snapshots:
       7z-bin: https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/025786f01319526b56400b0410af6268adc1125c
       bluebird: 3.7.2
 
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.8.5
-
-  node-abi@4.31.0:
+  node-abi@4.35.0:
     dependencies:
       semver: 7.8.5
 
@@ -19544,7 +19540,7 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
-      node-abi: 3.89.0
+      node-abi: 4.35.0
       npmlog: 4.1.2
       pump: 3.0.4
       rc: 1.2.8
@@ -19560,7 +19556,7 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.89.0
+      node-abi: 4.35.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,9 +731,6 @@ catalogs:
     nexus-api:
       specifier: github:Nexus-Mods/node-nexus-api#eeb7b953aab85bf2a336fd4999b38393a67c482a
       version: 1.7.3
-    node:
-      specifier: runtime:24.17.0
-      version: 24.17.0
     node-7z:
       specifier: github:Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
       version: 0.8.1
@@ -997,8 +994,8 @@ importers:
   .:
     dependencies:
       node:
-        specifier: 'catalog:'
-        version: runtime:24.17.0
+        specifier: runtime:24.20.0
+        version: runtime:24.20.0
     devDependencies:
       '@eslint-react/eslint-plugin':
         specifier: 'catalog:'
@@ -10973,7 +10970,7 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
-  node@runtime:24.17.0:
+  node@runtime:24.20.0:
     resolution:
       type: variations
       variants:
@@ -10981,9 +10978,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-Men8JJx0o6bf7KR1ginwA2IEWbQsN0n3xCPymZ0Jpyc=
+            integrity: sha256-FLW9etQKtfRxX7Ti+WSFjYINlCX+KR09ZfmJJua4nB4=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -10991,9 +10988,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-T8MmajcC7rw5zDdmHPTuzureMH4kKrZOTXznlJGX4R8=
+            integrity: sha256-QOVgfl7LPbkZJyN3baLXXZZiYPx0p6nnMcG9Z92pa8g=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -11001,9 +10998,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-gNpVL+A3KQyxMOnepZD17ut6pFBjbwyJq0FBVRHB7Cc=
+            integrity: sha256-nlsmRM8Qe++2rvymdrltMpa8EBOAlvAi7TeNYjPtgfQ=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -11011,9 +11008,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-+qDVm6f+cEXJUO0JsZBXj7ju5z5DWGhtOPzJnKWMFIA=
+            integrity: sha256-NRVgPiSHh5o5vHVxbxoq/9AnUAxkulDoRc9yyzMhkBM=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -11021,9 +11018,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-gE7UoaDvKNWSQIuErCqF6FirkSTa2TPhK0MjYJQRuAk=
+            integrity: sha256-pzSzbI0dFs5FXA65wymwfdEhwshVQ1UGSphhvJbDrcw=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -11031,9 +11028,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-plnpwm/NZI8zWdv9KS8HhDQWgEDy+xrPPJwbzT/Deys=
+            integrity: sha256-2MIktG7wHweKUj2bfbeSgjBvrigemGoVotv/6UfFMB4=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -11041,9 +11038,20 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-4EckJ6p5GtgL3EJv98xzzdKO0PYW0f+WiaI6f0fxJl8=
+            integrity: sha256-1ubRu7mtSssW1YC4m+ipyafkkJJuk708MKINRuFSv4o=
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-hV1YH4pOsagRfjQm3iX+AncFkv68+zE2mu4f+/7p6Ow=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -11051,10 +11059,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-SVdxL2f85Vd5zHlNm0354OgCoYyEGtWk5C8XvkkOY00=
-            prefix: node-v24.17.0-win-arm64
+            integrity: sha256-McZ5l0TeilRgFkMJgEDGjDaX5WyU5AfWHQ5fpfNBkdc=
+            prefix: node-v24.20.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -11062,10 +11070,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-8qozs1t1rKXz97hWdab2QjIBBT6TgZEeZJYfO9olKKs=
-            prefix: node-v24.17.0-win-x64
+            integrity: sha256-bKyf+8qPakcJHktcdy4GBgScOHHLZ9kAwM7d5jDlRbo=
+            prefix: node-v24.20.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v24.17.0/node-v24.17.0-win-x64.zip
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
@@ -11073,9 +11081,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-zFT3OhpBCNnjJesgHZCyXuq2DtySsqEyQLKHenTFlto=
+            integrity: sha256-LIxQfMsPIIEtlSa6jKRUsWUqre9o/IutBvB/sRIt0e8=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-arm64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64-musl.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -11084,14 +11092,14 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-+ITJWMBlL3zQ6kP9w53d0amEVuqbGt7KhZZIR+Ljn7A=
+            integrity: sha256-muE5n+9L2JkOFXc84TJ7M2oguel9jHVJ9PQspzxD9WI=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 24.17.0
+    version: 24.20.0
     hasBin: true
 
   noms@0.0.0:
@@ -19065,7 +19073,7 @@ snapshots:
 
   node-releases@2.0.36: {}
 
-  node@runtime:24.17.0: {}
+  node@runtime:24.20.0: {}
 
   noms@0.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ catalog:
   "@clickhouse/client": 1.18.3
   "@cyclonedx/cyclonedx-library": 10.0.0
   "@duckdb/node-api": 1.5.1-r.1
-  "@electron/rebuild": 4.1.0
+  "@electron/rebuild": 4.2.0
   "@electron/remote": 2.1.3
   "@eslint-react/eslint-plugin": 3.0.0
   "@eslint/js": 10.0.1
@@ -144,7 +144,7 @@ catalog:
   dnd-core: 9.5.1
   draggabilly: 2.4.1
   drivelist: github:TanninOne/drivelist#720d1890db11482ec05fc0f6aa176cfa6e6844dd
-  electron: 43.0.0
+  electron: 44.2.0
   electron-builder: 24.13.3
   electron-context-menu: 3.6.1
   electron-extension-installer: 2.0.1
@@ -193,6 +193,7 @@ catalog:
   modmeta-db: github:Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
   nexus-api: github:Nexus-Mods/node-nexus-api#eeb7b953aab85bf2a336fd4999b38393a67c482a
   node-7z: github:Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
+  node-abi: 4.35.0
   normalize-url: 6.1.0
   numeral: 2.0.6
   nx: 23.0.1
@@ -311,6 +312,7 @@ overrides:
   "@types/react-dom": "18"
   node-addon-api: 8.5.0
   node-gyp: 12.3.0
+  node-abi: 4.35.0
   # @types/node is a peer of react-dnd; differing versions across the tree fork
   # react-dnd into separate instances with distinct React contexts, breaking
   # react-sortable-tree's drag-and-drop context. Pin one version so a single

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -192,7 +192,6 @@ catalog:
   mixpanel-browser: 2.79.0
   modmeta-db: github:Nexus-Mods/modmeta-db#daa8935b6e38e255ec192c908adfce35d47c0336
   nexus-api: github:Nexus-Mods/node-nexus-api#eeb7b953aab85bf2a336fd4999b38393a67c482a
-  node: runtime:24.17.0
   node-7z: github:Nexus-Mods/node-7z#b75def8d0d7d81a03f4526c52b8ada9a34a06479
   normalize-url: 6.1.0
   numeral: 2.0.6

--- a/src/main/src/ipcHandlers.ts
+++ b/src/main/src/ipcHandlers.ts
@@ -573,8 +573,8 @@ export function init() {
   // Clipboard operations
   // ============================================================================
 
-  betterIpcMain.handle("clipboard:writeText", (_event: IpcMainInvokeEvent, text: string) => {
-    clipboard.writeText(text);
+  betterIpcMain.handle("clipboard:writeText", async (_event: IpcMainInvokeEvent, text: string) => {
+    await clipboard.writeText(text);
   });
 
   betterIpcMain.handle("clipboard:readText", () => {

--- a/src/renderer/src/controls/PlaceholderTextArea.tsx
+++ b/src/renderer/src/controls/PlaceholderTextArea.tsx
@@ -26,7 +26,10 @@ function PlaceholderTextArea(props: IPlaceholderTextAreaProps) {
   const [value, setValue] = React.useState("");
 
   const handlePaste = () => {
-    setValue(clipboard.readText());
+    clipboard
+      .readText()
+      .then((x) => setValue(x))
+      .catch(() => {});
   };
 
   const onShowContext = (event: React.MouseEvent<any>) => {

--- a/src/renderer/src/extensions/nexus_integration/views/LoginDialog.tsx
+++ b/src/renderer/src/extensions/nexus_integration/views/LoginDialog.tsx
@@ -330,11 +330,6 @@ class LoginDialog extends ComponentEx<IProps, ILoginDialogState> {
     this.nextState.apiKeyInput = key.replace(/\s/g, "");
   }
 
-  private handlePaste = () => {
-    this.storeKey(clipboard.readText());
-    this.nextState.context = undefined;
-  };
-
   private renderConfirmDialog() {
     return this.context.api.showDialog(
       "question",

--- a/src/shared/src/types/electron.ts
+++ b/src/shared/src/types/electron.ts
@@ -297,11 +297,8 @@ export interface LaunchItems {
 
 export interface LoginItemSettings {
   openAtLogin: boolean;
-  openAsHidden: boolean;
   wasOpenedAtLogin: boolean;
-  wasOpenedAsHidden: boolean;
-  restoreState: boolean;
-  status: string;
+  status: "not-registered" | "enabled" | "requires-approval" | "not-found";
   executableWillLaunchAtLogin: boolean;
   launchItems: LaunchItems[];
 }


### PR DESCRIPTION
Closes LAZ-729.

As far as breaking changes go, the previously deprecated `clipboard` API was now changed to align with the W3C API.

Otherwise should be a simple drop-in.