### PR TITLE
Fixed a signed-in session with no account and no login button

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -1955,6 +1955,52 @@ function onJWTTokenRefresh(api: IExtensionApi, credentials: IOAuthCredentials, n
   //Promise.resolve(getUserInfo(api, nexus));
 }
 
+/**
+ * Codes for "we never reached the site", as opposed to the site telling us the credentials
+ * are no good. While the network is down the Disableable proxy stands in for every request
+ * and rejects with ProcessCanceled, and the calls that bypass it fail with a socket error.
+ */
+const CONNECTION_ERROR_CODES = [
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ESOCKETTIMEDOUT",
+  "ETIMEDOUT",
+];
+
+const isConnectionError = (err: Error): boolean =>
+  err instanceof ProcessCanceled ||
+  err instanceof TimeoutError ||
+  CONNECTION_ERROR_CODES.includes(getErrorCode(err) ?? "") ||
+  getErrorMessage(err).includes("getaddrinfo");
+
+/**
+ * The account the access token describes on its own. All of this is signed into the token, so
+ * reading it needs no request, which makes it the fallback for a session we hold credentials
+ * for but can't reach the site to flesh out. The avatar and email only exist server-side and
+ * come out empty; the header falls back to the generic account icon for an empty avatar.
+ */
+export function userInfoFromToken(token: string): IValidateKeyDataV2 | undefined {
+  const parsed = accessTokenSchema.safeParse(jwt.decode(token));
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  return {
+    email: "",
+    name: parsed.data.user.username,
+    profileUrl: "",
+    userId: parsed.data.user.id,
+    ...deriveMembership(parsed.data.user),
+  };
+}
+
 export function updateToken(
   api: IExtensionApi,
   nexus: Nexus,
@@ -1981,6 +2027,27 @@ export function updateToken(
     .then(() => getUserInfo(api, nexus)) // update userinfo as we've set some new nexus credentials, either by launch, login or token refresh
     .then(() => true)
     .catch((err) => {
+      if (isConnectionError(err)) {
+        // Being offline is not a rejected login. setOAuthCredentials keeps the credentials and
+        // only fails on the avatar lookup it makes afterwards, so the session is still good and
+        // the last known account is still the best answer we have. Clearing it here left the
+        // header with no account *and* no login button: the credentials that stay in state count
+        // as logged in, so nothing rendered the "Log in" call to action either.
+        log("info", "no connection to validate the login with, keeping the known account", {
+          message: err.message,
+        });
+        if (userInfoSelector(api.getState()) === undefined) {
+          // nothing persisted to keep - a first run offline, or a session an older build
+          // already wiped - so fall back to what the token itself says
+          const fromToken = userInfoFromToken(credentials.token);
+          if (fromToken !== undefined) {
+            api.store.dispatch(setUserInfo(fromToken));
+          }
+        }
+        api.events.emit("did-login", err);
+        return false;
+      }
+
       api.showErrorNotification("Authentication failed, please log in again", err, {
         allowReport: false,
       });

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -26,6 +26,7 @@ import {
   getErrorCode,
   getErrorMessage,
   getErrorMessageOrDefault,
+  getErrorStatusCode,
   unknownToError,
 } from "@vortex/shared";
 import { VortexError } from "@vortex/shared";
@@ -1955,14 +1956,16 @@ function onJWTTokenRefresh(api: IExtensionApi, credentials: IOAuthCredentials, n
   //Promise.resolve(getUserInfo(api, nexus));
 }
 
+// nexus-api retries a 401 through a token refresh of its own and rethrows it only once that
+// hasn't helped, so one reaching us is final; 403 is an account we may no longer act for at all.
+const REFUSED_STATUS_CODES = [401, 403];
+
 /**
- * Whether the site turned the credentials down, which is the only answer that means the
- * session is over. nexus-api retries a 401 through a token refresh of its own and rethrows
- * it only once that hasn't helped, so one reaching us is final; a 403 is an account we may
- * no longer act for at all. Every other failure says nothing about the credentials.
+ * Whether the site turned the credentials down, which is the only answer that means the session
+ * is over — every other way a request can fail says nothing about the credentials.
  */
-const isLoginRefused = (err: { statusCode?: number }): boolean =>
-  err.statusCode === 401 || err.statusCode === 403;
+const isLoginRefused = (err: unknown): boolean =>
+  REFUSED_STATUS_CODES.includes(getErrorStatusCode(err) ?? 0);
 
 /**
  * The account the access token describes on its own. All of this is signed into the token, so
@@ -2010,7 +2013,7 @@ export function updateToken(
   )
     .then(() => getUserInfo(api, nexus)) // update userinfo as we've set some new nexus credentials, either by launch, login or token refresh
     .then(() => true)
-    .catch((err) => {
+    .catch((err: unknown) => {
       if (isLoginRefused(err)) {
         api.showErrorNotification("Authentication failed, please log in again", err, {
           allowReport: false,
@@ -2026,7 +2029,7 @@ export function updateToken(
       // Clearing it left the header with no account *and* no login button, because the
       // credentials that stay in state still count as logged in.
       log("info", "couldn't validate the login, keeping the known account", {
-        message: err.message,
+        message: getErrorMessage(err),
       });
       if (userInfoSelector(api.getState()) === undefined) {
         // nothing persisted to keep - a first run offline, or a session an older build

--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -1956,29 +1956,13 @@ function onJWTTokenRefresh(api: IExtensionApi, credentials: IOAuthCredentials, n
 }
 
 /**
- * Codes for "we never reached the site", as opposed to the site telling us the credentials
- * are no good. While the network is down the Disableable proxy stands in for every request
- * and rejects with ProcessCanceled, and the calls that bypass it fail with a socket error.
+ * Whether the site turned the credentials down, which is the only answer that means the
+ * session is over. nexus-api retries a 401 through a token refresh of its own and rethrows
+ * it only once that hasn't helped, so one reaching us is final; a 403 is an account we may
+ * no longer act for at all. Every other failure says nothing about the credentials.
  */
-const CONNECTION_ERROR_CODES = [
-  "EAI_AGAIN",
-  "ECONNABORTED",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EHOSTUNREACH",
-  "ENETDOWN",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "EPIPE",
-  "ESOCKETTIMEDOUT",
-  "ETIMEDOUT",
-];
-
-const isConnectionError = (err: Error): boolean =>
-  err instanceof ProcessCanceled ||
-  err instanceof TimeoutError ||
-  CONNECTION_ERROR_CODES.includes(getErrorCode(err) ?? "") ||
-  getErrorMessage(err).includes("getaddrinfo");
+const isLoginRefused = (err: { statusCode?: number }): boolean =>
+  err.statusCode === 401 || err.statusCode === 403;
 
 /**
  * The account the access token describes on its own. All of this is signed into the token, so
@@ -2027,31 +2011,31 @@ export function updateToken(
     .then(() => getUserInfo(api, nexus)) // update userinfo as we've set some new nexus credentials, either by launch, login or token refresh
     .then(() => true)
     .catch((err) => {
-      if (isConnectionError(err)) {
-        // Being offline is not a rejected login. setOAuthCredentials keeps the credentials and
-        // only fails on the avatar lookup it makes afterwards, so the session is still good and
-        // the last known account is still the best answer we have. Clearing it here left the
-        // header with no account *and* no login button: the credentials that stay in state count
-        // as logged in, so nothing rendered the "Log in" call to action either.
-        log("info", "no connection to validate the login with, keeping the known account", {
-          message: err.message,
+      if (isLoginRefused(err)) {
+        api.showErrorNotification("Authentication failed, please log in again", err, {
+          allowReport: false,
         });
-        if (userInfoSelector(api.getState()) === undefined) {
-          // nothing persisted to keep - a first run offline, or a session an older build
-          // already wiped - so fall back to what the token itself says
-          const fromToken = userInfoFromToken(credentials.token);
-          if (fromToken !== undefined) {
-            api.store.dispatch(setUserInfo(fromToken));
-          }
-        }
+        api.store.dispatch(setUserInfo(undefined));
         api.events.emit("did-login", err);
         return false;
       }
 
-      api.showErrorNotification("Authentication failed, please log in again", err, {
-        allowReport: false,
+      // Anything else - offline, a timeout, a 500 - leaves the session untouched, and
+      // setOAuthCredentials has already kept the credentials by the time the avatar request
+      // that failed here was made, so the last known account is still the best answer we have.
+      // Clearing it left the header with no account *and* no login button, because the
+      // credentials that stay in state still count as logged in.
+      log("info", "couldn't validate the login, keeping the known account", {
+        message: err.message,
       });
-      api.store.dispatch(setUserInfo(undefined));
+      if (userInfoSelector(api.getState()) === undefined) {
+        // nothing persisted to keep - a first run offline, or a session an older build
+        // already wiped - so fall back to what the token itself says
+        const fromToken = userInfoFromToken(credentials.token);
+        if (fromToken !== undefined) {
+          api.store.dispatch(setUserInfo(fromToken));
+        }
+      }
       api.events.emit("did-login", err);
       return false;
     });

--- a/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
@@ -1,3 +1,4 @@
+import { NexusError } from "@nexusmods/nexus-api";
 import jwt from "jsonwebtoken";
 import { describe, expect, vi } from "vitest";
 
@@ -49,51 +50,70 @@ const makeNexus = (err: Error) => {
   return { nexus: { setOAuthCredentials, getUserInfo } as never, setOAuthCredentials, getUserInfo };
 };
 
+const refused = (statusCode: number) =>
+  new NexusError("Unauthorized", statusCode, "https://api.nexusmods.com", "unauthorized");
+
 /**
- * setOAuthCredentials keeps the credentials it was handed and then looks the avatar up over the
- * network, so an offline session fails that call with a live login. Treating it as a rejected
- * login used to clear userInfo while leaving the credentials in place, which reads as signed in
- * to the header and signed out to the user: no account menu, and no login button either.
+ * setOAuthCredentials keeps the credentials it is handed and then looks the avatar up over the
+ * network, so most of the ways that call can fail say nothing about the session. Only the site
+ * turning the credentials down means the user has to log in again — and clearing the account on
+ * anything else read as signed in to the header and signed out to the user: no account menu,
+ * and no login button either.
  */
-describe("updateToken while offline", () => {
-  test("keeps the known account", async ({ makeApi }) => {
-    const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
-    const { nexus } = makeNexus(new ProcessCanceled("network disconnected: setOAuthCredentials"));
+describe("updateToken", () => {
+  describe("when the site refuses the login", () => {
+    test.for([401, 403])("clears the account on %i", async (statusCode, { makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(refused(statusCode));
 
-    await updateToken(harness.api, nexus, credentials());
+      await updateToken(harness.api, nexus, credentials());
 
-    expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
-    expect(harness.errorNotifications).toEqual([]);
+      expect(harness.getState().persistent["nexus"].userInfo).toBeUndefined();
+      expect(harness.errorNotifications).toEqual([
+        expect.objectContaining({ title: "Authentication failed, please log in again" }),
+      ]);
+    });
   });
 
-  test("falls back to the account the token describes when nothing is stored", async ({
-    makeApi,
-  }) => {
-    const harness = makeApi({ userInfo: undefined });
-    const socketError = Object.assign(new Error("getaddrinfo ENOTFOUND api.nexusmods.com"), {
-      code: "ENOTFOUND",
+  describe("when the request just fails", () => {
+    // the Disableable proxy stands in for every request while the network is down
+    test("keeps the known account offline", async ({ makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(new ProcessCanceled("network disconnected: setOAuthCredentials"));
+
+      await updateToken(harness.api, nexus, credentials());
+
+      expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
+      expect(harness.errorNotifications).toEqual([]);
     });
-    const { nexus } = makeNexus(socketError);
 
-    await updateToken(harness.api, nexus, credentials([MEMBERSHIP_ROLE.premium]));
+    test("keeps the known account when the site errors", async ({ makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(refused(500));
 
-    expect(harness.getState().persistent["nexus"].userInfo).toMatchObject({
-      name: "Ada",
-      userId: 7,
-      isPremium: true,
+      await updateToken(harness.api, nexus, credentials());
+
+      expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
+      expect(harness.errorNotifications).toEqual([]);
     });
-    expect(harness.errorNotifications).toEqual([]);
-  });
 
-  test("still clears the account when the site rejects the credentials", async ({ makeApi }) => {
-    const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
-    const { nexus } = makeNexus(new Error("Unauthorized"));
+    test("falls back to the account the token describes when nothing is stored", async ({
+      makeApi,
+    }) => {
+      const harness = makeApi({ userInfo: undefined });
+      const socketError = Object.assign(new Error("getaddrinfo ENOTFOUND api.nexusmods.com"), {
+        code: "ENOTFOUND",
+      });
+      const { nexus } = makeNexus(socketError);
 
-    await updateToken(harness.api, nexus, credentials());
+      await updateToken(harness.api, nexus, credentials([MEMBERSHIP_ROLE.premium]));
 
-    expect(harness.getState().persistent["nexus"].userInfo).toBeUndefined();
-    expect(harness.errorNotifications).toEqual([
-      expect.objectContaining({ title: "Authentication failed, please log in again" }),
-    ]);
+      expect(harness.getState().persistent["nexus"].userInfo).toMatchObject({
+        name: "Ada",
+        userId: 7,
+        isPremium: true,
+      });
+      expect(harness.errorNotifications).toEqual([]);
+    });
   });
 });

--- a/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
@@ -1,0 +1,99 @@
+import jwt from "jsonwebtoken";
+import { describe, expect, vi } from "vitest";
+
+import { makeUserInfo } from "@/test-utils/builders";
+import { test } from "@/test-utils/harnessTest";
+import { ProcessCanceled } from "@/util/CustomErrors";
+
+import { MEMBERSHIP_ROLE, updateToken } from "./util";
+
+/**
+ * An access token as the site issues it. Only the payload matters here: nothing verifies the
+ * signature, the account details are read straight out of the claims.
+ */
+const makeToken = (roles: string[] = []) =>
+  jwt.sign(
+    {
+      application_id: 1,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+      iss: "nexusmods",
+      jti: "a-token-id",
+      sub: "7",
+      user: {
+        group_id: 1,
+        id: 7,
+        joined: 0,
+        membership_roles: roles,
+        other_group_ids: "",
+        permissions: {},
+        premium_expiry: 0,
+        age_verified: true,
+        username: "Ada",
+      },
+    },
+    "not-verified-here",
+  );
+
+const credentials = (roles: string[] = []) => ({
+  fingerprint: "a-fingerprint",
+  refreshToken: "a-refresh-token",
+  token: makeToken(roles),
+});
+
+/** A nexus connection whose credential handover fails the way `err` says. */
+const makeNexus = (err: Error) => {
+  const setOAuthCredentials = vi.fn().mockRejectedValue(err);
+  const getUserInfo = vi.fn();
+
+  return { nexus: { setOAuthCredentials, getUserInfo } as never, setOAuthCredentials, getUserInfo };
+};
+
+/**
+ * setOAuthCredentials keeps the credentials it was handed and then looks the avatar up over the
+ * network, so an offline session fails that call with a live login. Treating it as a rejected
+ * login used to clear userInfo while leaving the credentials in place, which reads as signed in
+ * to the header and signed out to the user: no account menu, and no login button either.
+ */
+describe("updateToken while offline", () => {
+  test("keeps the known account", async ({ makeApi }) => {
+    const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+    const { nexus } = makeNexus(new ProcessCanceled("network disconnected: setOAuthCredentials"));
+
+    await updateToken(harness.api, nexus, credentials());
+
+    expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
+    expect(harness.errorNotifications).toEqual([]);
+  });
+
+  test("falls back to the account the token describes when nothing is stored", async ({
+    makeApi,
+  }) => {
+    const harness = makeApi({ userInfo: undefined });
+    const socketError = Object.assign(new Error("getaddrinfo ENOTFOUND api.nexusmods.com"), {
+      code: "ENOTFOUND",
+    });
+    const { nexus } = makeNexus(socketError);
+
+    await updateToken(harness.api, nexus, credentials([MEMBERSHIP_ROLE.premium]));
+
+    expect(harness.getState().persistent["nexus"].userInfo).toMatchObject({
+      name: "Ada",
+      userId: 7,
+      isPremium: true,
+    });
+    expect(harness.errorNotifications).toEqual([]);
+  });
+
+  test("still clears the account when the site rejects the credentials", async ({ makeApi }) => {
+    const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+    const { nexus } = makeNexus(new Error("Unauthorized"));
+
+    await updateToken(harness.api, nexus, credentials());
+
+    expect(harness.getState().persistent["nexus"].userInfo).toBeUndefined();
+    expect(harness.errorNotifications).toEqual([
+      expect.objectContaining({ title: "Authentication failed, please log in again" }),
+    ]);
+  });
+});

--- a/src/renderer/src/views/components/Header/profile/ProfileSection.test.tsx
+++ b/src/renderer/src/views/components/Header/profile/ProfileSection.test.tsx
@@ -32,6 +32,12 @@ const signedOut = () => ({
   persistent: {},
 });
 
+/** Credentials in hand but no account details — what an offline start leaves behind. */
+const unvalidated = () => ({
+  confidential: { account: { nexus: { APIKey: "an-api-key" } } },
+  persistent: { nexus: {} },
+});
+
 vi.mock("react-redux", async () => {
   const actual = await vi.importActual<typeof ReactReduxTypes>("react-redux");
 
@@ -139,6 +145,37 @@ describe("ProfileSection", () => {
 
       expect(screen.queryByRole("menuitem", { name: /profile/i })).not.toBeInTheDocument();
       expect(screen.queryByRole("menuitem", { name: /logout/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // The credentials say signed in, so the premium slot won't offer a login button. Logging out
+  // here is the only way back to one, so the menu has to open on a generic account.
+  describe("signed in but not validated", () => {
+    beforeEach(() => {
+      store.state = unvalidated();
+    });
+
+    it("names the trigger generically", () => {
+      render(<ProfileSection />);
+      expect(screen.getByRole("button", { name: "Account" })).toBeInTheDocument();
+    });
+
+    it("still offers a way out", async () => {
+      await openMenu(/account/i);
+
+      expect(screen.getByRole("menuitem", { name: "Logout" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Refresh user info" })).toBeInTheDocument();
+    });
+
+    // There is no user id to open a profile for, and dropping the row must not leave the
+    // divider that separated it behind.
+    it("drops the profile row and its divider", async () => {
+      await openMenu(/account/i);
+
+      expect(
+        screen.queryByRole("menuitem", { name: "View profile on web" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByRole("separator")).toHaveLength(1);
     });
   });
 });

--- a/src/renderer/src/views/components/Header/profile/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/profile/ProfileSection.tsx
@@ -40,22 +40,24 @@ export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
 
   // Signed out there is no account to open, so the slot carries the help options on
   // their own — the login call to action lives in the premium slot instead.
-  if (!loggedIn || !userInfo) {
+  if (!loggedIn) {
     return <HelpMenu />;
   }
 
-  const label = userInfo.name ?? t("Account");
+  const label = userInfo?.name ?? t("Account");
 
   const sections: IMenuAction[][] = [
-    [
-      {
-        iconPath: mdiAccountCircle,
-        label: t("View profile on web"),
-        onClick: () => {
-          opn(`${NEXUS_BASE_URL}/users/${userInfo.userId}`).catch(() => {});
-        },
-      },
-    ],
+    !userInfo
+      ? []
+      : [
+          {
+            iconPath: mdiAccountCircle,
+            label: t("View profile on web"),
+            onClick: () => {
+              opn(`${NEXUS_BASE_URL}/users/${userInfo.userId}`).catch(() => {});
+            },
+          },
+        ],
     [
       {
         iconPath: mdiRefresh,
@@ -88,7 +90,7 @@ export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
               brand="neutral"
               data-testid="profile-menu-trigger"
               leftIcon={
-                userInfo.profileUrl ? (
+                userInfo?.profileUrl ? (
                   <Image
                     alt={userInfo.name ?? ""}
                     className="size-5 rounded-full"

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { computeErrorFingerprint, isEnvironmentalError, sanitizeFramePath } from "./errors";
+import {
+  computeErrorFingerprint,
+  getErrorStatusCode,
+  isEnvironmentalError,
+  sanitizeFramePath,
+} from "./errors";
 import { CAUSE_SEPARATOR, VortexError } from "./errors/base";
 
 // ---------------------------------------------------------------------------
@@ -518,5 +523,33 @@ describe("computeErrorFingerprint on a chained stack", () => {
     expect(computeErrorFingerprint(err.stack, VERSION)).toBe(
       computeErrorFingerprint(raw.stack, VERSION),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getErrorStatusCode
+// ---------------------------------------------------------------------------
+
+/** An error carrying its status behind a getter, as nexus-api's NexusError does. */
+const withStatus = (statusCode: unknown) =>
+  Object.defineProperty(new Error("refused"), "statusCode", { get: () => statusCode });
+
+describe("getErrorStatusCode", () => {
+  it("reads the status off an error that has one", () => {
+    expect(getErrorStatusCode(withStatus(403))).toBe(403);
+  });
+
+  it("answers null for an error without one", () => {
+    expect(getErrorStatusCode(new Error("offline"))).toBeNull();
+  });
+
+  // a status that arrived as text can't be compared with a number, so it isn't one
+  it("answers null for a status that isn't a number", () => {
+    expect(getErrorStatusCode(withStatus("403"))).toBeNull();
+  });
+
+  it("answers null for anything that isn't an error", () => {
+    expect(getErrorStatusCode({ statusCode: 403 })).toBeNull();
+    expect(getErrorStatusCode(undefined)).toBeNull();
   });
 });

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -57,6 +57,28 @@ export function getErrorCode(err: unknown): string | null {
 }
 
 /**
+ * Extracts the HTTP status code from a potential error object. What carries it
+ * varies by source - nexus-api raises both `NexusError` and `HTTPError` with a
+ * `statusCode` getter, and Vortex's own `HTTPError` matches them - so read the
+ * property rather than test for a class.
+ */
+export function getErrorStatusCode(err: unknown): number | null {
+  if (!(err instanceof Error)) {
+    return null;
+  }
+
+  if (!("statusCode" in err)) {
+    return null;
+  }
+
+  if (typeof err.statusCode !== "number") {
+    return null;
+  }
+
+  return err.statusCode;
+}
+
+/**
  * Extracts the native error code from Windows errors.
  * Checks both `nativeCode` and `systemCode` properties that are
  * attached by the native error handling in renderer.tsx.


### PR DESCRIPTION
Reports of users who are logged out and offline seeing no login button. They are not logged out — the app has thrown their account details away and kept their credentials.

`setOAuthCredentials` stores the credentials it is handed and then looks the avatar up over the network, so most of the ways that call can fail say nothing about the session, an offline start among them. `updateToken` read any failure as a rejected login and cleared `userInfo`, leaving the credentials in state. Those still satisfy `isLoggedIn`, so the header had nothing to show in either slot: no account menu, because there were no details, and no "Log in" button, because as far as the store was concerned the user was already signed in — while the toast told them to log in again.

Only the site refusing the credentials clears the account now: 401, which nexus-api rethrows once its own token refresh hasn't helped and which `errorFromNexusError` already reads as a refused login, and 403. Every other failure — offline, a timeout, a 500 — keeps the last known account. A session with nothing persisted, a first run offline or one an older build already wiped, is seeded from the claims the access token carries, which needs no request; the avatar and email only exist server-side, so the header falls back to its generic icon until the next successful refresh.

The profile menu also opens on a generic account when details are missing, so logging out — the way back to a login button — stays reachable however a session ends up in that state.

Reading a status code off an `unknown` error is mechanical, and the shared error helpers already do it for `code` and `systemCode`, so `getErrorStatusCode` joins them in `src/shared/src/errors.ts`; what stays in `nexus_integration` is the part only it can judge, that 401 and 403 end the session. The other 21 bare `statusCode` reads in that extension are left for a follow-up.

One thing left alone deliberately: a genuinely rejected session still keeps its dead credentials, so *"please log in again"* does not produce a login button by itself — the user has to log out first. Clearing credentials on a real rejection is the fix for that, and is a separate change.

Verified with `pnpm run verify`; the E2E suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)