### PR TITLE
Add oxlint config

### DIFF
--- a/src/main/.oxlintrc.json
+++ b/src/main/.oxlintrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../oxlint.base.config.json"],
+  "rules": {
+    "vitest/require-mock-type-parameters": "warn"
+  },
+  "env": {
+    "builtin": true,
+    "node": true
+  }
+}

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -15,6 +15,7 @@
     "typecheck": "pnpm tsc",
     "lint": "pnpm eslint --quiet --concurrency auto .",
     "lint:verbose": "pnpm eslint --concurrency auto .",
+    "lint:oxlint": "pnpm exec oxlint --quiet",
     "test": "pnpm vitest run --config ./vitest.config.ts",
     "test:integration": "pnpm exec vitest run --config ./vitest.integration.config.ts",
     "publish": "pnpm exec rimraf ./dist && pnpm cross-env pnpm_config_inject_workspace_packages=true pnpm_config_node_linker=hoisted pnpm -F @vortex/main deploy ./dist && node ./dist/prepare-dist-package.mjs",


### PR DESCRIPTION
To combat our ever decreasing code quality, this PR enables oxlint on the main project for LSPs. It won't run on CI because that'll break out builds, but you'll get errors in your editor to help you write better code.

Part of APP-11.