### PR TITLE
Fixed a signed-in session with no account and no login button

### DIFF
--- a/src/renderer/src/extensions/nexus_integration/util.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.ts
@@ -26,6 +26,7 @@ import {
   getErrorCode,
   getErrorMessage,
   getErrorMessageOrDefault,
+  getErrorStatusCode,
   unknownToError,
 } from "@vortex/shared";
 import { VortexError } from "@vortex/shared";
@@ -1955,6 +1956,38 @@ function onJWTTokenRefresh(api: IExtensionApi, credentials: IOAuthCredentials, n
   //Promise.resolve(getUserInfo(api, nexus));
 }
 
+// nexus-api retries a 401 through a token refresh of its own and rethrows it only once that
+// hasn't helped, so one reaching us is final; 403 is an account we may no longer act for at all.
+const REFUSED_STATUS_CODES = [401, 403];
+
+/**
+ * Whether the site turned the credentials down, which is the only answer that means the session
+ * is over — every other way a request can fail says nothing about the credentials.
+ */
+const isLoginRefused = (err: unknown): boolean =>
+  REFUSED_STATUS_CODES.includes(getErrorStatusCode(err) ?? 0);
+
+/**
+ * The account the access token describes on its own. All of this is signed into the token, so
+ * reading it needs no request, which makes it the fallback for a session we hold credentials
+ * for but can't reach the site to flesh out. The avatar and email only exist server-side and
+ * come out empty; the header falls back to the generic account icon for an empty avatar.
+ */
+export function userInfoFromToken(token: string): IValidateKeyDataV2 | undefined {
+  const parsed = accessTokenSchema.safeParse(jwt.decode(token));
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  return {
+    email: "",
+    name: parsed.data.user.username,
+    profileUrl: "",
+    userId: parsed.data.user.id,
+    ...deriveMembership(parsed.data.user),
+  };
+}
+
 export function updateToken(
   api: IExtensionApi,
   nexus: Nexus,
@@ -1980,11 +2013,32 @@ export function updateToken(
   )
     .then(() => getUserInfo(api, nexus)) // update userinfo as we've set some new nexus credentials, either by launch, login or token refresh
     .then(() => true)
-    .catch((err) => {
-      api.showErrorNotification("Authentication failed, please log in again", err, {
-        allowReport: false,
+    .catch((err: unknown) => {
+      if (isLoginRefused(err)) {
+        api.showErrorNotification("Authentication failed, please log in again", err, {
+          allowReport: false,
+        });
+        api.store.dispatch(setUserInfo(undefined));
+        api.events.emit("did-login", err);
+        return false;
+      }
+
+      // Anything else - offline, a timeout, a 500 - leaves the session untouched, and
+      // setOAuthCredentials has already kept the credentials by the time the avatar request
+      // that failed here was made, so the last known account is still the best answer we have.
+      // Clearing it left the header with no account *and* no login button, because the
+      // credentials that stay in state still count as logged in.
+      log("info", "couldn't validate the login, keeping the known account", {
+        message: getErrorMessage(err),
       });
-      api.store.dispatch(setUserInfo(undefined));
+      if (userInfoSelector(api.getState()) === undefined) {
+        // nothing persisted to keep - a first run offline, or a session an older build
+        // already wiped - so fall back to what the token itself says
+        const fromToken = userInfoFromToken(credentials.token);
+        if (fromToken !== undefined) {
+          api.store.dispatch(setUserInfo(fromToken));
+        }
+      }
       api.events.emit("did-login", err);
       return false;
     });

--- a/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
+++ b/src/renderer/src/extensions/nexus_integration/util.updateToken.test.ts
@@ -1,0 +1,119 @@
+import { NexusError } from "@nexusmods/nexus-api";
+import jwt from "jsonwebtoken";
+import { describe, expect, vi } from "vitest";
+
+import { makeUserInfo } from "@/test-utils/builders";
+import { test } from "@/test-utils/harnessTest";
+import { ProcessCanceled } from "@/util/CustomErrors";
+
+import { MEMBERSHIP_ROLE, updateToken } from "./util";
+
+/**
+ * An access token as the site issues it. Only the payload matters here: nothing verifies the
+ * signature, the account details are read straight out of the claims.
+ */
+const makeToken = (roles: string[] = []) =>
+  jwt.sign(
+    {
+      application_id: 1,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+      iss: "nexusmods",
+      jti: "a-token-id",
+      sub: "7",
+      user: {
+        group_id: 1,
+        id: 7,
+        joined: 0,
+        membership_roles: roles,
+        other_group_ids: "",
+        permissions: {},
+        premium_expiry: 0,
+        age_verified: true,
+        username: "Ada",
+      },
+    },
+    "not-verified-here",
+  );
+
+const credentials = (roles: string[] = []) => ({
+  fingerprint: "a-fingerprint",
+  refreshToken: "a-refresh-token",
+  token: makeToken(roles),
+});
+
+/** A nexus connection whose credential handover fails the way `err` says. */
+const makeNexus = (err: Error) => {
+  const setOAuthCredentials = vi.fn().mockRejectedValue(err);
+  const getUserInfo = vi.fn();
+
+  return { nexus: { setOAuthCredentials, getUserInfo } as never, setOAuthCredentials, getUserInfo };
+};
+
+const refused = (statusCode: number) =>
+  new NexusError("Unauthorized", statusCode, "https://api.nexusmods.com", "unauthorized");
+
+/**
+ * setOAuthCredentials keeps the credentials it is handed and then looks the avatar up over the
+ * network, so most of the ways that call can fail say nothing about the session. Only the site
+ * turning the credentials down means the user has to log in again — and clearing the account on
+ * anything else read as signed in to the header and signed out to the user: no account menu,
+ * and no login button either.
+ */
+describe("updateToken", () => {
+  describe("when the site refuses the login", () => {
+    test.for([401, 403])("clears the account on %i", async (statusCode, { makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(refused(statusCode));
+
+      await updateToken(harness.api, nexus, credentials());
+
+      expect(harness.getState().persistent["nexus"].userInfo).toBeUndefined();
+      expect(harness.errorNotifications).toEqual([
+        expect.objectContaining({ title: "Authentication failed, please log in again" }),
+      ]);
+    });
+  });
+
+  describe("when the request just fails", () => {
+    // the Disableable proxy stands in for every request while the network is down
+    test("keeps the known account offline", async ({ makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(new ProcessCanceled("network disconnected: setOAuthCredentials"));
+
+      await updateToken(harness.api, nexus, credentials());
+
+      expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
+      expect(harness.errorNotifications).toEqual([]);
+    });
+
+    test("keeps the known account when the site errors", async ({ makeApi }) => {
+      const harness = makeApi({ userInfo: makeUserInfo({ name: "Ada" }) });
+      const { nexus } = makeNexus(refused(500));
+
+      await updateToken(harness.api, nexus, credentials());
+
+      expect(harness.getState().persistent["nexus"].userInfo?.name).toBe("Ada");
+      expect(harness.errorNotifications).toEqual([]);
+    });
+
+    test("falls back to the account the token describes when nothing is stored", async ({
+      makeApi,
+    }) => {
+      const harness = makeApi({ userInfo: undefined });
+      const socketError = Object.assign(new Error("getaddrinfo ENOTFOUND api.nexusmods.com"), {
+        code: "ENOTFOUND",
+      });
+      const { nexus } = makeNexus(socketError);
+
+      await updateToken(harness.api, nexus, credentials([MEMBERSHIP_ROLE.premium]));
+
+      expect(harness.getState().persistent["nexus"].userInfo).toMatchObject({
+        name: "Ada",
+        userId: 7,
+        isPremium: true,
+      });
+      expect(harness.errorNotifications).toEqual([]);
+    });
+  });
+});

--- a/src/renderer/src/views/components/Header/profile/ProfileSection.test.tsx
+++ b/src/renderer/src/views/components/Header/profile/ProfileSection.test.tsx
@@ -32,6 +32,12 @@ const signedOut = () => ({
   persistent: {},
 });
 
+/** Credentials in hand but no account details — what an offline start leaves behind. */
+const unvalidated = () => ({
+  confidential: { account: { nexus: { APIKey: "an-api-key" } } },
+  persistent: { nexus: {} },
+});
+
 vi.mock("react-redux", async () => {
   const actual = await vi.importActual<typeof ReactReduxTypes>("react-redux");
 
@@ -139,6 +145,37 @@ describe("ProfileSection", () => {
 
       expect(screen.queryByRole("menuitem", { name: /profile/i })).not.toBeInTheDocument();
       expect(screen.queryByRole("menuitem", { name: /logout/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // The credentials say signed in, so the premium slot won't offer a login button. Logging out
+  // here is the only way back to one, so the menu has to open on a generic account.
+  describe("signed in but not validated", () => {
+    beforeEach(() => {
+      store.state = unvalidated();
+    });
+
+    it("names the trigger generically", () => {
+      render(<ProfileSection />);
+      expect(screen.getByRole("button", { name: "Account" })).toBeInTheDocument();
+    });
+
+    it("still offers a way out", async () => {
+      await openMenu(/account/i);
+
+      expect(screen.getByRole("menuitem", { name: "Logout" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Refresh user info" })).toBeInTheDocument();
+    });
+
+    // There is no user id to open a profile for, and dropping the row must not leave the
+    // divider that separated it behind.
+    it("drops the profile row and its divider", async () => {
+      await openMenu(/account/i);
+
+      expect(
+        screen.queryByRole("menuitem", { name: "View profile on web" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByRole("separator")).toHaveLength(1);
     });
   });
 });

--- a/src/renderer/src/views/components/Header/profile/ProfileSection.tsx
+++ b/src/renderer/src/views/components/Header/profile/ProfileSection.tsx
@@ -40,22 +40,24 @@ export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
 
   // Signed out there is no account to open, so the slot carries the help options on
   // their own — the login call to action lives in the premium slot instead.
-  if (!loggedIn || !userInfo) {
+  if (!loggedIn) {
     return <HelpMenu />;
   }
 
-  const label = userInfo.name ?? t("Account");
+  const label = userInfo?.name ?? t("Account");
 
   const sections: IMenuAction[][] = [
-    [
-      {
-        iconPath: mdiAccountCircle,
-        label: t("View profile on web"),
-        onClick: () => {
-          opn(`${NEXUS_BASE_URL}/users/${userInfo.userId}`).catch(() => {});
-        },
-      },
-    ],
+    !userInfo
+      ? []
+      : [
+          {
+            iconPath: mdiAccountCircle,
+            label: t("View profile on web"),
+            onClick: () => {
+              opn(`${NEXUS_BASE_URL}/users/${userInfo.userId}`).catch(() => {});
+            },
+          },
+        ],
     [
       {
         iconPath: mdiRefresh,
@@ -88,7 +90,7 @@ export const ProfileSection: FC<React.PropsWithChildren<unknown>> = () => {
               brand="neutral"
               data-testid="profile-menu-trigger"
               leftIcon={
-                userInfo.profileUrl ? (
+                userInfo?.profileUrl ? (
                   <Image
                     alt={userInfo.name ?? ""}
                     className="size-5 rounded-full"

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { computeErrorFingerprint, isEnvironmentalError, sanitizeFramePath } from "./errors";
+import {
+  computeErrorFingerprint,
+  getErrorStatusCode,
+  isEnvironmentalError,
+  sanitizeFramePath,
+} from "./errors";
 import { CAUSE_SEPARATOR, VortexError } from "./errors/base";
 
 // ---------------------------------------------------------------------------
@@ -518,5 +523,33 @@ describe("computeErrorFingerprint on a chained stack", () => {
     expect(computeErrorFingerprint(err.stack, VERSION)).toBe(
       computeErrorFingerprint(raw.stack, VERSION),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getErrorStatusCode
+// ---------------------------------------------------------------------------
+
+/** An error carrying its status behind a getter, as nexus-api's NexusError does. */
+const withStatus = (statusCode: unknown) =>
+  Object.defineProperty(new Error("refused"), "statusCode", { get: () => statusCode });
+
+describe("getErrorStatusCode", () => {
+  it("reads the status off an error that has one", () => {
+    expect(getErrorStatusCode(withStatus(403))).toBe(403);
+  });
+
+  it("answers null for an error without one", () => {
+    expect(getErrorStatusCode(new Error("offline"))).toBeNull();
+  });
+
+  // a status that arrived as text can't be compared with a number, so it isn't one
+  it("answers null for a status that isn't a number", () => {
+    expect(getErrorStatusCode(withStatus("403"))).toBeNull();
+  });
+
+  it("answers null for anything that isn't an error", () => {
+    expect(getErrorStatusCode({ statusCode: 403 })).toBeNull();
+    expect(getErrorStatusCode(undefined)).toBeNull();
   });
 });

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -57,6 +57,28 @@ export function getErrorCode(err: unknown): string | null {
 }
 
 /**
+ * Extracts the HTTP status code from a potential error object. What carries it
+ * varies by source - nexus-api raises both `NexusError` and `HTTPError` with a
+ * `statusCode` getter, and Vortex's own `HTTPError` matches them - so read the
+ * property rather than test for a class.
+ */
+export function getErrorStatusCode(err: unknown): number | null {
+  if (!(err instanceof Error)) {
+    return null;
+  }
+
+  if (!("statusCode" in err)) {
+    return null;
+  }
+
+  if (typeof err.statusCode !== "number") {
+    return null;
+  }
+
+  return err.statusCode;
+}
+
+/**
  * Extracts the native error code from Windows errors.
  * Checks both `nativeCode` and `systemCode` properties that are
  * attached by the native error handling in renderer.tsx.


### PR DESCRIPTION
Cherry-pick of #24140 into `release/v2.7`, squashed into one commit.