### PR TITLE
add characterization and desired-contract suites for autosort

### DIFF
--- a/src/renderer/src/extensions/gamebryo_plugin_management/autosort.doSort.test.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/autosort.doSort.test.ts
@@ -1,0 +1,288 @@
+import { utimes, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { describe, expect, vi } from "vitest";
+
+import { startActivity, stopActivity } from "../../actions/session";
+import { test } from "../../test-utils/gamebryoTest";
+import type { ILootHarness } from "../../test-utils/harnessTypes";
+import {
+  clearPendingPluginSort,
+  setPendingPluginSort,
+} from "../mod_management/actions/transactions";
+import { updatePluginOrder } from "./actions/loadOrder";
+import { setAutoEnable } from "./actions/settings";
+import { setGroup } from "./actions/userlist";
+import LootInterface from "./autosort";
+import { EdgeType, type ICycleEdge } from "./types/ILoot";
+
+// the five seams the autosort suites share; each factory delegates to lootMocks so the
+// replacement behavior is arranged per test through makeLoot
+// TODO LAZ-1037: these module paths follow the decomposition as the mocked modules move
+vi.mock(
+  "../../util/webpack-hacks",
+  async () => (await import("./lootMocks.js")).webpackHacksModule,
+);
+vi.mock(
+  "../../util/getVortexPath",
+  async () => (await import("./lootMocks.js")).getVortexPathModule,
+);
+vi.mock("./util/gameSupport", async () => (await import("./lootMocks.js")).gameSupportModule);
+vi.mock("./util/masterlist", async () => (await import("./lootMocks.js")).masterlistModule);
+vi.mock(
+  "./util/findInvalidPlugins",
+  async () => (await import("./lootMocks.js")).invalidPluginsModule,
+);
+
+function pendingSort(harness: ILootHarness): unknown {
+  return harness.getState().persistent.transactions.pendingPluginSort[harness.profileId];
+}
+
+describe("LootInterface doSort", () => {
+  test("dispatches the sorted order with the autoEnable setting", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp", "B.esp"]);
+    harness.api.store.dispatch(setAutoEnable(true));
+    harness.loot.sortPluginsAsync.mockResolvedValueOnce(["B.esp", "A.esp"]);
+
+    const err = await harness.sort(true);
+
+    expect(err).toBeNull();
+    expect(harness.dispatched).toContainEqual(updatePluginOrder(["B.esp", "A.esp"], false, true));
+    // the bound loadOrder reducer applied the write, so it reads back from the hive
+    const loadOrder = harness.getGamebryoState().loadOrder;
+    expect(loadOrder["b.esp"]).toEqual({ name: "B.esp", enabled: true, loadOrder: 0 });
+    expect(loadOrder["a.esp"]).toEqual({ name: "A.esp", enabled: true, loadOrder: 1 });
+  });
+
+  test("clears the pending plugin-sort marker after a successful sort", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp"]);
+    harness.api.store.dispatch(setPendingPluginSort(harness.profileId, "col-1", 1));
+
+    await harness.sort(true);
+
+    expect(harness.dispatched).toContainEqual(clearPendingPluginSort(harness.profileId));
+    expect(pendingSort(harness)).toBeUndefined();
+  });
+
+  // the desired contract from LAZ-1049: the implementation still clears the marker and toasts
+  // success when the plugin list was empty. Expected-fail until the fix lands, which flips this
+  // to a plain test.
+  test.fails("reports an empty-list sort as a distinct outcome instead of success", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setPendingPluginSort(harness.profileId, "col-1", 1));
+
+    await harness.sort(true);
+
+    expect(harness.notifications).not.toContainEqual(
+      expect.objectContaining({ id: "loot-sorted" }),
+    );
+    expect(pendingSort(harness)).toEqual({ "col-1": 1 });
+  });
+
+  // the desired contract from LAZ-1092 and LAZ-1049: the implementation answers the callback
+  // with null and toasts success after handling the failure internally. Expected-fail until the
+  // fix lands, which flips this to a plain test.
+  test.fails("reports a failed sort to its caller instead of success", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp"]);
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(new Error("access violation"));
+
+    const err = await harness.sort(true);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(harness.notifications).not.toContainEqual(
+      expect.objectContaining({ id: "loot-sorted" }),
+    );
+  });
+
+  test("keeps the pending plugin-sort marker when loot closes mid-sort", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp"]);
+    harness.api.store.dispatch(setPendingPluginSort(harness.profileId, "col-1", 1));
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(new Error("Already closed"));
+
+    await harness.sort(true);
+
+    // the interruption keeps the sort owed so the next profile activation retries it
+    expect(pendingSort(harness)).toEqual({ "col-1": 1 });
+  });
+
+  test("excludes invalid plugins before sorting and reports them once sorted", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface, { invalidPlugins: ["Bad.esp"] });
+    await harness.seedPlugins(["Good.esp", "Bad.esp"]);
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledWith(["Good.esp"]);
+    expect(harness.notifications).toContainEqual(
+      expect.objectContaining({ id: "loot-skipped-invalid-plugins", type: "warning" }),
+    );
+  });
+
+  test("brackets the sort in a plugins/sorting activity, releasing it on failure", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(new Error("access violation"));
+
+    await harness.sort(true);
+
+    expect(harness.dispatched).toContainEqual(startActivity("plugins", "sorting"));
+    expect(harness.dispatched).toContainEqual(stopActivity("plugins", "sorting"));
+    expect(harness.getState().session.base.activity["plugins"] ?? []).toEqual([]);
+    expect(harness.errorNotifications).toContainEqual(
+      expect.objectContaining({ title: "LOOT operation failed", allowReport: false }),
+    );
+  });
+
+  test("reports a cyclic-interaction error with the cycle dialog", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setGroup("A.esp", "early"));
+    const cycle: ICycleEdge[] = [
+      { name: "A.esp", typeOfEdgeToNextVertex: EdgeType.userGroup },
+      { name: "B.esp", typeOfEdgeToNextVertex: EdgeType.userLoadAfter },
+    ];
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(
+      Object.assign(new Error('Cyclic interaction detected between "A.esp" and "B.esp"'), {
+        cycle,
+      }),
+    );
+
+    await harness.sort(true);
+
+    await vi.waitFor(() => {
+      expect(harness.notifications).toContainEqual(
+        expect.objectContaining({ id: "loot-cycle-warning", type: "warning" }),
+      );
+    });
+    // the group edge is explained through the groups path
+    expect(harness.loot.getGroupsPathAsync).toHaveBeenCalled();
+
+    const warning = harness.notifications.find(
+      (notification) => notification.id === "loot-cycle-warning",
+    );
+    warning?.actions?.[0]?.action?.(() => undefined);
+    await vi.waitFor(() => {
+      expect(harness.dialogCalls).toContainEqual({ type: "info", title: "Cyclic interaction" });
+    });
+  });
+
+  test("warns without re-sorting when loot rejects a plugin it could not load", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(
+      Object.assign(new Error("plugin not loaded"), {
+        name: "PluginNotLoaded",
+        plugin: "A.esp",
+      }),
+    );
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toContainEqual(
+      expect.objectContaining({ id: "loot-failed", type: "warning" }),
+    );
+  });
+
+  test("drops dangling group references and re-sorts once when a loot group is missing", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp"]);
+    // a dangling reference to a group neither list knows
+    harness.api.store.dispatch(setGroup("A.esp", "gone-group"));
+    harness.loot.sortPluginsAsync
+      .mockRejectedValueOnce(new Error('The group "gone-group" does not exist.'))
+      .mockResolvedValueOnce(["A.esp"]);
+
+    // the recovery path waits 500ms for the userlist persistor before re-sorting
+    const err = await harness.sort(true);
+
+    expect(err).toBeNull();
+    expect(harness.dispatched).toContainEqual(setGroup("A.esp", undefined));
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(2);
+    expect(harness.dispatched).toContainEqual(updatePluginOrder(["A.esp"], false, false));
+  });
+
+  test("warns instead of re-sorting when a missing loot group has no recoverable references", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(
+      new Error('The group "gone-group" does not exist.'),
+    );
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toContainEqual(
+      expect.objectContaining({ id: "loot-failed", type: "warning" }),
+    );
+  });
+
+  test("reports a version-condition failure as a non-reportable error with file details", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.setState((draft) => {
+      draft.settings.gameMode.discovered["skyrimse"] = { path: harness.dataDir };
+    });
+    await writeFile(path.join(harness.dataDir, "SkyrimSE.exe"), "not a real executable");
+    const sortError = new Error(
+      'Failed to evaluate condition "version("SkyrimSE.exe", "1.5.97.0", >=)"',
+    );
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(sortError);
+
+    await harness.sort(true);
+
+    // the report waits for the exe md5 probe, so it lands after the sort resolves
+    await vi.waitFor(() => {
+      expect(harness.errorNotifications).toContainEqual(
+        expect.objectContaining({ title: "LOOT operation failed", allowReport: false }),
+      );
+    });
+    expect(sortError.message).toContain("pirated copies of the game");
+  });
+
+  test("reports a died loot process without offering a report", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.sortPluginsAsync.mockRejectedValueOnce(
+      Object.assign(new Error("connection interrupted"), { name: "RemoteDied" }),
+    );
+
+    await harness.sort(true);
+
+    expect(harness.errorNotifications).toContainEqual(
+      expect.objectContaining({ title: "LOOT process died", allowReport: false }),
+    );
+  });
+
+  test("re-loads the loot lists only when the userlist changed", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+
+    await harness.sort(true);
+    // no userlist on disk yet, so there is nothing to (re-)load
+    expect(harness.loot.loadListsAsync).not.toHaveBeenCalled();
+
+    await writeFile(harness.userlistPath, "plugins: []");
+    await harness.sort(true);
+    expect(harness.loot.loadListsAsync).toHaveBeenCalledTimes(1);
+
+    // unchanged mtime hits the cache
+    await harness.sort(true);
+    expect(harness.loot.loadListsAsync).toHaveBeenCalledTimes(1);
+
+    const later = new Date(Date.now() + 5000);
+    await utimes(harness.userlistPath, later, later);
+    await harness.sort(true);
+    expect(harness.loot.loadListsAsync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/src/extensions/gamebryo_plugin_management/autosort.onSort.test.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/autosort.onSort.test.ts
@@ -1,0 +1,190 @@
+import * as path from "node:path";
+
+import { describe, expect, vi } from "vitest";
+
+import { startActivity } from "../../actions/session";
+import { makeProfile } from "../../test-utils/builders";
+import { test } from "../../test-utils/gamebryoTest";
+import { setPluginOrder } from "./actions/loadOrder";
+import { setAutoSortEnabled } from "./actions/settings";
+import LootInterface from "./autosort";
+
+// the five seams the autosort suites share; each factory delegates to lootMocks so the
+// replacement behavior is arranged per test through makeLoot
+// TODO LAZ-1037: these module paths follow the decomposition as the mocked modules move
+vi.mock(
+  "../../util/webpack-hacks",
+  async () => (await import("./lootMocks.js")).webpackHacksModule,
+);
+vi.mock(
+  "../../util/getVortexPath",
+  async () => (await import("./lootMocks.js")).getVortexPathModule,
+);
+vi.mock("./util/gameSupport", async () => (await import("./lootMocks.js")).gameSupportModule);
+vi.mock("./util/masterlist", async () => (await import("./lootMocks.js")).masterlistModule);
+vi.mock(
+  "./util/findInvalidPlugins",
+  async () => (await import("./lootMocks.js")).invalidPluginsModule,
+);
+
+// drain the queued Bluebird continuations (setImmediate-scheduled) and microtasks so an emitted
+// sort settles before a negative assertion, without betting on a wall-clock delay
+async function flushAsync(): Promise<void> {
+  for (let round = 0; round < 5; round += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe("LootInterface autosort-plugins", () => {
+  test("defers sorting while a dependency install is running", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(startActivity("installing_dependencies", "collection-1"));
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).not.toHaveBeenCalled();
+    expect(harness.notifications).toEqual([]);
+  });
+
+  // the desired contract from LAZ-1092: deployment relinks plugin files, so a sort started
+  // mid-deployment sees transient missing plugins; the implementation only defers on
+  // installing_dependencies. Expected-fail until the fix lands, which flips this to a plain test.
+  test.fails("defers sorting while a mod deployment is running", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(startActivity("mods", "deployment"));
+
+    await harness.sort(false);
+
+    expect(harness.loot.sortPluginsAsync).not.toHaveBeenCalled();
+  });
+
+  test("skips sorting when not manual and autoSort is disabled", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setAutoSortEnabled(false));
+
+    await harness.sort(false);
+
+    expect(harness.loot.sortPluginsAsync).not.toHaveBeenCalled();
+  });
+
+  // the desired contract from LAZ-1049: the implementation still toasts success on this skip
+  // path. Expected-fail until the fix lands, which flips this to a plain test.
+  test.fails("does not claim a successful sort when the autoSort gate skipped sorting", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setAutoSortEnabled(false));
+
+    await harness.sort(false);
+
+    expect(harness.notifications).not.toContainEqual(
+      expect.objectContaining({ id: "loot-sorted" }),
+    );
+  });
+
+  // the desired contract from LAZ-1048: the implementation still returns without answering,
+  // which is the silent hang lootSortAsync's stuck spinner is built on. Expected-fail until the
+  // fix lands, which flips this to a plain test.
+  test.fails("answers the callback when the active game changed since initialization", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.setState((draft) => {
+      draft.persistent.profiles["profile-2"] = makeProfile({ id: "profile-2", gameId: "oblivion" });
+      draft.settings.profiles.activeProfileId = "profile-2";
+    });
+
+    const callback = vi.fn<(err: Error | null) => void>();
+    harness.emit("autosort-plugins", true, callback);
+    await harness.lootInterface.wait();
+    await flushAsync();
+
+    expect(callback).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test("reports an error to the callback when loot failed to initialize", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface, { initError: new Error("no loot binding") });
+
+    const err = await harness.sort(true);
+
+    expect(err?.message).toBe("LOOT is uninitialized/closed");
+    expect(harness.errorNotifications).toContainEqual(
+      expect.objectContaining({ title: "Failed to initialize LOOT", allowReport: false }),
+    );
+  });
+
+  test("reports an error to the callback when loot is closed", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.isClosed.mockReturnValue(true);
+
+    const err = await harness.sort(true);
+
+    expect(err?.message).toBe("LOOT is uninitialized/closed");
+    expect(harness.loot.sortPluginsAsync).not.toHaveBeenCalled();
+  });
+
+  test("sorts only deployed non-ghost plugins plus natives", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins([
+      "One.esp",
+      { name: "Two.esp", deployed: false },
+      "Three.esp.ghost",
+      { name: "Four.esp", deployed: false, isNative: true },
+    ]);
+
+    const err = await harness.sort(true);
+
+    expect(err).toBeNull();
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledWith(["One.esp", "Four.esp"]);
+  });
+
+  test("hands plugins to loot in current load order, unknown plugins first", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins(["A.esp", "B.esp", "C.esp"]);
+    // A and B have load order 0 and 1; C is unknown to the hive and defaults to -1
+    harness.api.store.dispatch(setPluginOrder(["A.esp", "B.esp"], true));
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledWith(["C.esp", "A.esp", "B.esp"]);
+  });
+
+  test("drops plugins whose file is missing and passes file basenames", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    await harness.seedPlugins([
+      "Real.esp",
+      // state claims the plugin but no file backs it
+      { name: "Gone.esp", filePath: path.join(harness.dataDir, "Gone.esp") },
+    ]);
+
+    await harness.sort(true);
+
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledWith(["Real.esp"]);
+  });
+
+  test("queues a second sort behind the pending one", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    let release: (sorted: string[]) => void;
+    harness.loot.sortPluginsAsync.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    const first = harness.sort(true);
+    await vi.waitFor(() => expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(1));
+    const second = harness.sort(true);
+    await flushAsync();
+
+    // the second sort waits on the pending sort promise instead of interleaving
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(1);
+
+    release([]);
+    expect(await first).toBeNull();
+    expect(await second).toBeNull();
+    expect(harness.loot.sortPluginsAsync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/src/extensions/gamebryo_plugin_management/autosort.pluginDetails.test.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/autosort.pluginDetails.test.ts
@@ -1,0 +1,221 @@
+import * as path from "node:path";
+
+import type { PluginCleaningData } from "loot";
+import { describe, expect, vi } from "vitest";
+
+import { startActivity } from "../../actions/session";
+import {
+  makeLootPluginInterface,
+  makePlugin,
+  makePluginLoot,
+  makePluginMetadata,
+} from "../../test-utils/builders";
+import { test } from "../../test-utils/gamebryoTest";
+import { setPluginList } from "./actions/plugins";
+import LootInterface from "./autosort";
+import { downloadMasterlistMock, downloadPreludeMock } from "./lootMocks";
+
+// the five seams the autosort suites share; each factory delegates to lootMocks so the
+// replacement behavior is arranged per test through makeLoot
+// TODO LAZ-1037: these module paths follow the decomposition as the mocked modules move
+vi.mock(
+  "../../util/webpack-hacks",
+  async () => (await import("./lootMocks.js")).webpackHacksModule,
+);
+vi.mock(
+  "../../util/getVortexPath",
+  async () => (await import("./lootMocks.js")).getVortexPathModule,
+);
+vi.mock("./util/gameSupport", async () => (await import("./lootMocks.js")).gameSupportModule);
+vi.mock("./util/masterlist", async () => (await import("./lootMocks.js")).masterlistModule);
+vi.mock(
+  "./util/findInvalidPlugins",
+  async () => (await import("./lootMocks.js")).invalidPluginsModule,
+);
+
+describe("LootInterface plugin-details", () => {
+  test("emits loot-info-updated before answering", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    const order: string[] = [];
+    harness.api.events.on("trigger-test-run", (id: string) => order.push(`trigger:${id}`));
+
+    await new Promise<void>((resolve) => {
+      harness.emit("plugin-details", "skyrimse", [], () => {
+        order.push("callback");
+        resolve();
+      });
+    });
+
+    expect(order).toEqual(["trigger:loot-info-updated", "callback"]);
+  });
+
+  test("answers with no details while a dependency install is running", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(startActivity("installing_dependencies", "collection-1"));
+
+    const result = await harness.requestDetails(["one.esp"]);
+
+    expect(result).toEqual({});
+    expect(harness.loot.clearConditionCacheAsync).not.toHaveBeenCalled();
+  });
+
+  test("answers with no details when loot is closed", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.isClosed.mockReturnValue(true);
+
+    const result = await harness.requestDetails(["one.esp"]);
+
+    expect(result).toEqual({});
+  });
+
+  test("answers with no details when loot failed to initialize", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface, { initError: new Error("no loot binding") });
+
+    const result = await harness.requestDetails(["one.esp"]);
+
+    expect(result).toEqual({});
+  });
+
+  test("loads only deployed non-invalid plugins and reports the skipped ones once", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface, { invalidPlugins: ["three.esp"] });
+    harness.api.store.dispatch(
+      setPluginList({
+        "one.esp": makePlugin(),
+        "two.esp": makePlugin({ deployed: false }),
+        "three.esp": makePlugin(),
+      }),
+    );
+
+    const result = await harness.requestDetails(["one.esp", "two.esp", "three.esp"]);
+
+    expect(harness.loot.loadPluginsAsync).toHaveBeenCalledWith(["one.esp"], false);
+    expect(
+      harness.notifications.filter(
+        (notification) => notification.id === "loot-skipped-invalid-plugins",
+      ),
+    ).toHaveLength(1);
+    // every requested plugin still gets a details entry
+    expect(Object.keys(result).sort()).toEqual(["one.esp", "three.esp", "two.esp"]);
+  });
+
+  test("maps loot metadata and plugin info into the plugin details", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setPluginList({ "one.esp": makePlugin() }));
+    const cleaning: PluginCleaningData = {
+      CRC: 1,
+      itmCount: 2,
+      deletedReferenceCount: 0,
+      deletedNavmeshCount: 0,
+      cleaningUtility: "xEdit",
+      info: [],
+    };
+    const meta = makePluginMetadata({
+      messages: [{ type: 1, content: "watch out", condition: "" }],
+      tags: [{ isAddition: true, name: "Delev", condition: "" }],
+      cleanInfo: [cleaning],
+      dirtyInfo: [cleaning],
+      group: "late loaders",
+      requirements: [{ name: "Req.esp", displayName: "Req" }],
+    });
+    const info = makeLootPluginInterface({
+      bashTags: [{ isAddition: false, name: "C.Water", condition: "" }],
+      isValidAsLightPlugin: true,
+      loadsArchive: true,
+      version: "1.2.0",
+    });
+    harness.loot.getPluginMetadataAsync.mockResolvedValue(meta);
+    harness.loot.getPluginAsync.mockResolvedValue(info);
+
+    const result = await harness.requestDetails(["one.esp"]);
+
+    expect(result["one.esp"]).toEqual(
+      makePluginLoot({
+        messages: meta.messages,
+        currentTags: info.bashTags,
+        suggestedTags: meta.tags,
+        cleanliness: meta.cleanInfo,
+        dirtyness: meta.dirtyInfo,
+        group: "late loaders",
+        requirements: [{ name: "Req.esp", display: "Req" }],
+        isValidAsLightPlugin: true,
+        loadsArchive: true,
+        version: "1.2.0",
+      }),
+    );
+  });
+
+  test("flags plugins without loot metadata for manual grouping", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.api.store.dispatch(setPluginList({ "one.esp": makePlugin() }));
+
+    const result = await harness.requestDetails(["one.esp"]);
+
+    const messages = result["one.esp"].messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe(-1);
+    expect(messages[0].condition).toBe("always");
+    expect(messages[0].content).toContain("No LOOT metadata could be found");
+  });
+
+  test("answers empty details per plugin and aggregates one error when metadata lookups fail", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.getPluginMetadataAsync.mockRejectedValue(new Error("metadata query failed"));
+
+    const result = await harness.requestDetails(["one.esp", "two.esp"]);
+
+    expect(result["one.esp"]).toEqual(makePluginLoot());
+    expect(result["two.esp"]).toEqual(makePluginLoot());
+    expect(
+      harness.errorNotifications.filter(
+        (entry) => entry.title === "There were errors getting plugin information from LOOT",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("suppresses the error report when loot closed mid-iteration", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    harness.loot.getPluginMetadataAsync.mockImplementation((pluginName) =>
+      Promise.reject(
+        new Error(pluginName === "one.esp" ? "already closed" : "metadata query failed"),
+      ),
+    );
+
+    const result = await harness.requestDetails(["one.esp", "two.esp"]);
+
+    expect(result["two.esp"]).toEqual(makePluginLoot());
+    expect(harness.errorNotifications).toEqual([]);
+  });
+
+  test("downloads the base game's masterlist for VR variants and reports the update", async ({
+    makeLoot,
+  }) => {
+    const harness = await makeLoot(LootInterface);
+    const events: string[] = [];
+    harness.api.events.on("did-update-masterlist", () => events.push("did-update-masterlist"));
+
+    await harness.lootInterface.downloadMasterlist("skyrimvr");
+
+    expect(downloadPreludeMock).toHaveBeenCalled();
+    // the repo id maps to the base game while the local path keeps the VR game's own folder
+    expect(downloadMasterlistMock).toHaveBeenCalledWith(
+      "skyrimse",
+      expect.stringContaining(path.join("skyrimvr", "masterlist")),
+    );
+    expect(events).toEqual(["did-update-masterlist"]);
+  });
+
+  test("reports a failed masterlist download without offering a report", async ({ makeLoot }) => {
+    const harness = await makeLoot(LootInterface);
+    downloadMasterlistMock.mockRejectedValueOnce(new Error("network down"));
+
+    await harness.lootInterface.downloadMasterlist("skyrimse");
+
+    expect(harness.errorNotifications).toContainEqual(
+      expect.objectContaining({ title: "Failed to update masterlist", allowReport: false }),
+    );
+  });
+});

--- a/src/renderer/src/extensions/gamebryo_plugin_management/autosort.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/autosort.ts
@@ -625,7 +625,7 @@ class LootInterface {
           return;
         }
         try {
-          const meta: PluginMetadata = await loot.getPluginMetadataAsync(pluginName);
+          const meta: PluginMetadata | undefined = await loot.getPluginMetadataAsync(pluginName);
           let info;
           try {
             const id = toPluginId(pluginName);

--- a/src/renderer/src/extensions/gamebryo_plugin_management/lootMocks.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/lootMocks.ts
@@ -1,0 +1,75 @@
+/**
+ * The vi.mock replacement modules for the LootInterface (autosort) suites, backed by mutable
+ * seams that test-utils/gamebryoTest.makeLootHarness arranges per test.
+ *
+ * TODO LAZ-1037: the decomposition moves the modules mocked here, so the replacement objects and
+ * the vi.mock paths in the autosort suites have to follow it.
+ */
+import * as path from "node:path";
+
+import { vi } from "vitest";
+
+import type { IFakeLoot } from "../../test-utils/harnessTypes";
+import type { IPlugins } from "./types/IPlugins";
+
+interface ILootSeams {
+  // getVortexPath root for the current test (a per-test temp dir)
+  base: string;
+  // the harness game, the one gameSupported answers true for
+  gameId: string;
+  // the plugin names findInvalidPlugins reports as invalid
+  invalid: string[];
+  // the loot instance createAsync resolves; makeLootHarness arranges a fresh fake per test
+  loot: IFakeLoot | undefined;
+}
+
+/** The mutable state behind the mocked modules; makeLootHarness resets it per test. */
+export const seams: ILootSeams = {
+  base: "",
+  gameId: "",
+  invalid: [],
+  loot: undefined,
+};
+
+/** Resolves the current fake loot; reject once to drive the init-failure path. */
+export const createLootMock = vi.fn<() => Promise<IFakeLoot>>(() =>
+  seams.loot === undefined
+    ? Promise.reject(new Error("no fake loot arranged - build the harness through makeLoot"))
+    : Promise.resolve(seams.loot),
+);
+
+// ../../util/webpack-hacks: the raw-require seam autosort loads the loot binding through
+export const webpackHacksModule = {
+  webpackRequireHack: () => ({ LootAsync: { createAsync: createLootMock } }),
+};
+
+// ../../util/getVortexPath: every vortex path keyed under the per-test temp root
+export const getVortexPathModule = {
+  default: (key: string) => path.join(seams.base, key),
+};
+
+// ./util/gameSupport: consults a module-level api handle set at extension init; pin the answers
+export const gameSupportModule = {
+  gameSupported: (gameMode: string) => gameMode === seams.gameId,
+  pluginPath: (gameMode: string) => path.join(seams.base, "local", gameMode),
+  gameDataPath: () => path.join(seams.base, "data"),
+  nativePlugins: () => [] as string[],
+};
+
+export const downloadMasterlistMock = vi.fn<(gameId: string, localPath: string) => Promise<void>>(
+  () => Promise.resolve(),
+);
+export const downloadPreludeMock = vi.fn<(localPath: string) => Promise<void>>(() =>
+  Promise.resolve(),
+);
+// ./util/masterlist: no live masterlist downloads in tests
+export const masterlistModule = {
+  downloadMasterlist: downloadMasterlistMock,
+  downloadPrelude: downloadPreludeMock,
+};
+
+export const findInvalidPluginsMock = vi.fn<
+  (pluginIds: string[], pluginList: IPlugins, gameMode: string) => Promise<Set<string>>
+>(() => Promise.resolve(new Set(seams.invalid)));
+// ./util/findInvalidPlugins: header parsing has its own suite; the answer is arranged here
+export const invalidPluginsModule = { findInvalidPlugins: findInvalidPluginsMock };

--- a/src/renderer/src/extensions/gamebryo_plugin_management/types/ILoot.ts
+++ b/src/renderer/src/extensions/gamebryo_plugin_management/types/ILoot.ts
@@ -34,8 +34,8 @@ export interface ILootProm {
   clearConditionCacheAsync: () => Promise<void>;
   close: () => void;
   getGroupsPathAsync: (fromGroupName: string, toGroupName: string) => Promise<ICycleEdge[]>;
-  getPluginAsync: (pluginName: string) => Promise<PluginInterface>;
-  getPluginMetadataAsync: (pluginName: string) => Promise<PluginMetadata>;
+  getPluginAsync: (pluginName: string) => Promise<PluginInterface | undefined>;
+  getPluginMetadataAsync: (pluginName: string) => Promise<PluginMetadata | undefined>;
   isClosed: () => boolean;
   loadCurrentLoadOrderStateAsync: () => Promise<void>;
   loadListsAsync: (

--- a/src/renderer/src/test-utils/builders.ts
+++ b/src/renderer/src/test-utils/builders.ts
@@ -26,6 +26,7 @@ import type { IFileInfo, IPreference, IUserInfo } from "@nexusmods/nexus-api";
 import type NexusT from "@nexusmods/nexus-api";
 import type { WireDownloadCheckpoint, WireResolvedResource } from "@vortex/shared/ipc";
 import type { Api, DownloaderApi } from "@vortex/shared/preload";
+import type { PluginInterface, PluginMetadata } from "loot";
 import { applyMiddleware, createStore, type Middleware } from "redux";
 import { batch } from "redux-act";
 import thunkMiddleware from "redux-thunk";
@@ -45,7 +46,8 @@ import { downloadPathForGame } from "../extensions/download_management/selectors
 import type { IDownload, IModInfo } from "../extensions/download_management/types/IDownload";
 import type { ILoadOrderEntry } from "../extensions/file_based_loadorder/types/types";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
-import type { IPlugin } from "../extensions/gamebryo_plugin_management/types/IPlugins";
+import type { ICycleEdge, ILootProm } from "../extensions/gamebryo_plugin_management/types/ILoot";
+import type { IPlugin, IPluginLoot } from "../extensions/gamebryo_plugin_management/types/IPlugins";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
 import type {
@@ -104,6 +106,7 @@ import type {
   IDownloadAdapterOpts,
   IDriverHarness,
   IDriverHarnessState,
+  IFakeLoot,
   IFbloHarness,
   IFbloHarnessOpts,
   IGameHarness,
@@ -184,6 +187,91 @@ export function makePlugin(overrides: Partial<IPlugin> = {}): IPlugin {
     filePath: path.join(os.tmpdir(), "vortex-test-plugins", "One.esp"),
     isNative: false,
     deployed: true,
+    ...overrides,
+  };
+}
+
+/** LOOT's masterlist/userlist metadata answer for a plugin (getPluginMetadata). */
+export function makePluginMetadata(overrides: Partial<PluginMetadata> = {}): PluginMetadata {
+  return {
+    name: "One.esp",
+    group: "",
+    messages: [],
+    tags: [],
+    cleanInfo: [],
+    dirtyInfo: [],
+    incompatibilities: [],
+    loadAfterFiles: [],
+    locations: [],
+    requirements: [],
+    ...overrides,
+  };
+}
+
+/** LOOT's loaded-plugin answer (getPlugin), as read after a loadPlugins pass. */
+export function makeLootPluginInterface(overrides: Partial<PluginInterface> = {}): PluginInterface {
+  return {
+    name: "One.esp",
+    version: "",
+    masters: [],
+    bashTags: [],
+    crc: 0,
+    isMaster: false,
+    isLightPlugin: false,
+    isValidAsLightPlugin: false,
+    IsMediumPlugin: false,
+    IsValidAsMediumPlugin: false,
+    IsUpdatePlugin: false,
+    IsValidAsUpdatePlugin: false,
+    isEmpty: false,
+    loadsArchive: false,
+    ...overrides,
+  };
+}
+
+/**
+ * The loot answers denormalised onto one plugin (IPluginLoot). Defaults to the empty shape
+ * autosort answers for a plugin loot knows nothing about.
+ */
+export function makePluginLoot(overrides: Partial<IPluginLoot> = {}): IPluginLoot {
+  return {
+    messages: [],
+    currentTags: [],
+    suggestedTags: [],
+    cleanliness: [],
+    dirtyness: [],
+    group: undefined,
+    isValidAsLightPlugin: false,
+    loadsArchive: false,
+    isEmpty: false,
+    incompatibilities: [],
+    requirements: [],
+    version: "",
+    ...overrides,
+  };
+}
+
+/** A fake loot instance: open, every call succeeding, sort echoing its input. */
+export function makeFakeLoot(overrides: Partial<IFakeLoot> = {}): IFakeLoot {
+  return {
+    clearConditionCacheAsync: vi.fn<ILootProm["clearConditionCacheAsync"]>(() => Promise.resolve()),
+    close: vi.fn<ILootProm["close"]>(),
+    getGroupsPathAsync: vi.fn<ILootProm["getGroupsPathAsync"]>(() =>
+      Promise.resolve<ICycleEdge[]>([]),
+    ),
+    getPluginAsync: vi.fn<ILootProm["getPluginAsync"]>(() => Promise.resolve(undefined)),
+    getPluginMetadataAsync: vi.fn<ILootProm["getPluginMetadataAsync"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    isClosed: vi.fn<ILootProm["isClosed"]>(() => false),
+    loadCurrentLoadOrderStateAsync: vi.fn<ILootProm["loadCurrentLoadOrderStateAsync"]>(() =>
+      Promise.resolve(),
+    ),
+    loadListsAsync: vi.fn<ILootProm["loadListsAsync"]>(() => Promise.resolve()),
+    loadPluginsAsync: vi.fn<ILootProm["loadPluginsAsync"]>(() => Promise.resolve()),
+    sortPluginsAsync: vi.fn<ILootProm["sortPluginsAsync"]>((pluginNames) =>
+      Promise.resolve([...pluginNames]),
+    ),
     ...overrides,
   };
 }

--- a/src/renderer/src/test-utils/gamebryoTest.ts
+++ b/src/renderer/src/test-utils/gamebryoTest.ts
@@ -1,11 +1,28 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { onTestFinished, vi } from "vitest";
+
+import { setPluginList } from "../extensions/gamebryo_plugin_management/actions/plugins";
+import type LootInterface from "../extensions/gamebryo_plugin_management/autosort";
+import { createLootMock, seams } from "../extensions/gamebryo_plugin_management/lootMocks";
 import { REDUCER_BINDINGS } from "../extensions/gamebryo_plugin_management/reducers/bindings";
+import type { IPluginsLoot } from "../extensions/gamebryo_plugin_management/types/IPlugins";
 import type { IStateWithGamebryo } from "../extensions/gamebryo_plugin_management/types/IStateWithGamebryo";
+import toPluginId from "../extensions/gamebryo_plugin_management/util/toPluginId";
 import { transactionsReducer } from "../extensions/mod_management/reducers/transactions";
 import { sessionReducer } from "../reducers/session";
+import type { IExtensionApi } from "../types/IExtensionContext";
 import type { IState } from "../types/IState";
-import { makeGameHarness, type IHarnessReducerBinding } from "./builders";
+import { makeFakeLoot, makeGameHarness, makePlugin, type IHarnessReducerBinding } from "./builders";
 import { test as harnessTest } from "./harnessTest";
-import type { IGamebryoHarness, IGamebryoHarnessOpts } from "./harnessTypes";
+import type {
+  IGamebryoHarness,
+  IGamebryoHarnessOpts,
+  ILootHarness,
+  ILootHarnessOpts,
+} from "./harnessTypes";
 
 const asGamebryo = (state: IState): IStateWithGamebryo => state as IStateWithGamebryo;
 
@@ -34,9 +51,96 @@ export function makeGamebryoHarness(opts: IGamebryoHarnessOpts = {}): IGamebryoH
   return { ...base, getGamebryoState: () => asGamebryo(base.getState()) };
 }
 
+/**
+ * A gamebryo harness plus a LootInterface constructed against it, awaited through its init: fresh
+ * temp vortex paths with the game's masterlist.yaml in place (so init loads lists cleanly) and a
+ * fresh fake loot behind the lootMocks seams (torn down when the test finishes). Mock call
+ * records are cleared after init so tests assert only their own traffic - so arrange mocks after
+ * building the harness. Requires the suite to vi.mock the five modules the lootMocks replacements
+ * cover; the ctor is passed in (like makeFbloHarness) to keep the autosort import out of this
+ * module.
+ */
+export async function makeLootHarness(
+  LootCtor: new (api: IExtensionApi) => LootInterface,
+  opts: ILootHarnessOpts = {},
+): Promise<ILootHarness> {
+  const { initError, invalidPlugins, ...gamebryoOpts } = opts;
+  const gameId = gamebryoOpts.gameId ?? "skyrimse";
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "vortex-loot-"));
+  onTestFinished(async () => {
+    seams.loot = undefined;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+  seams.base = tempDir;
+  seams.gameId = gameId;
+  seams.invalid = invalidPlugins ?? [];
+  seams.loot = makeFakeLoot();
+
+  const masterlistDir = path.join(tempDir, "userData", gameId, "masterlist");
+  const dataDir = path.join(tempDir, "data");
+  const pluginsDir = path.join(tempDir, "plugins");
+  await Promise.all([
+    mkdir(masterlistDir, { recursive: true }),
+    mkdir(dataDir, { recursive: true }),
+    mkdir(pluginsDir, { recursive: true }),
+  ]);
+  await writeFile(path.join(masterlistDir, "masterlist.yaml"), "");
+
+  if (initError !== undefined) {
+    createLootMock.mockRejectedValueOnce(initError);
+  }
+
+  const base = makeGamebryoHarness({ ...gamebryoOpts, gameId });
+  const lootInterface = new LootCtor(base.api);
+  await lootInterface.wait();
+
+  // drop the init traffic (createAsync, one loadListsAsync, the masterlist download)
+  vi.clearAllMocks();
+
+  const addPluginFile = async (name: string): Promise<string> => {
+    const filePath = path.join(pluginsDir, name);
+    await writeFile(filePath, "TES4");
+    return filePath;
+  };
+
+  return {
+    ...base,
+    loot: seams.loot,
+    lootInterface,
+    addPluginFile,
+    seedPlugins: async (specs) => {
+      const entries = await Promise.all(
+        specs.map(async (spec) => {
+          const { name, ...overrides } = typeof spec === "string" ? { name: spec } : spec;
+          // an explicit filePath override keeps the harness from backing the plugin with a file
+          const filePath = overrides.filePath ?? (await addPluginFile(name));
+          return [toPluginId(name), makePlugin({ ...overrides, filePath })] as const;
+        }),
+      );
+      base.api.store.dispatch(setPluginList(Object.fromEntries(entries)));
+    },
+    userlistPath: path.join(tempDir, "userData", gameId, "userlist.yaml"),
+    dataDir,
+    sort: (manual: boolean) =>
+      new Promise((resolve) => {
+        base.emit("autosort-plugins", manual, (err: Error | null) => resolve(err));
+      }),
+    requestDetails: (plugins: string[]) =>
+      new Promise((resolve) => {
+        base.emit("plugin-details", gameId, plugins, (result: IPluginsLoot) => resolve(result));
+      }),
+  };
+}
+
 export interface IGamebryoFixtures {
   // build a gamebryo harness over the given seeded state
   makeGamebryo: (opts?: IGamebryoHarnessOpts) => IGamebryoHarness;
+  // build a gamebryo harness with a LootInterface driven through init (temp dirs torn down after)
+  makeLoot: (
+    LootCtor: new (api: IExtensionApi) => LootInterface,
+    opts?: ILootHarnessOpts,
+  ) => Promise<ILootHarness>;
 }
 
 /**
@@ -49,5 +153,8 @@ export const test = harnessTest.extend<IGamebryoFixtures>({
   // positive on new code
   makeGamebryo: async ({ task: _task }, run) => {
     await run(makeGamebryoHarness);
+  },
+  makeLoot: async ({ task: _task }, run) => {
+    await run(makeLootHarness);
   },
 });

--- a/src/renderer/src/test-utils/harnessTypes.ts
+++ b/src/renderer/src/test-utils/harnessTypes.ts
@@ -12,6 +12,12 @@ import type { ICollectionMod } from "../extensions/collections/types/ICollection
 import type InstallDriver from "../extensions/collections/util/InstallDriver";
 import type { IDownload } from "../extensions/download_management/types/IDownload";
 import type UpdateSet from "../extensions/file_based_loadorder/UpdateSet";
+import type LootInterface from "../extensions/gamebryo_plugin_management/autosort";
+import type { ILootProm } from "../extensions/gamebryo_plugin_management/types/ILoot";
+import type {
+  IPlugin,
+  IPluginsLoot,
+} from "../extensions/gamebryo_plugin_management/types/IPlugins";
 import type { IStateWithGamebryo } from "../extensions/gamebryo_plugin_management/types/IStateWithGamebryo";
 import type { IGameStored } from "../extensions/gamemode_management/types/IGameStored";
 import type { HealthCheckRegistry } from "../extensions/health_check/core/HealthCheckRegistry";
@@ -129,6 +135,41 @@ export type IGamebryoHarnessOpts = IGameHarnessOpts;
 export interface IGamebryoHarness extends IGameHarness {
   // read the live fake state including the gamebryo hives
   getGamebryoState: () => IStateWithGamebryo;
+}
+
+/**
+ * A controllable stand-in for a promisifyAll'd LootAsync instance: every ILootProm member as a
+ * mock. The *Async members are pre-defined, so autosort's Bluebird.promisifyAll wraps leave them
+ * untouched (they only add unused closeAsync/isClosedAsync plain functions to the object).
+ */
+export type IFakeLoot = { [K in keyof ILootProm]: Mock<ILootProm[K]> };
+
+/** What a LootInterface test arranges on top of the gamebryo harness. */
+export interface ILootHarnessOpts extends IGamebryoHarnessOpts {
+  // reject the loot construction, leaving the interface with loot undefined
+  initError?: Error;
+  // the plugin names findInvalidPlugins reports as invalid
+  invalidPlugins?: string[];
+}
+
+export interface ILootHarness extends IGamebryoHarness {
+  // the loot instance the interface holds, arranged per test
+  loot: IFakeLoot;
+  // the LootInterface under test, constructed against the fake api and awaited through init
+  lootInterface: LootInterface;
+  // create a real plugin file (the sort path stats plugin files) and return its absolute path
+  addPluginFile: (name: string) => Promise<string>;
+  // seed session.plugins.pluginList, keyed by toPluginId, with a real file per plugin (unless
+  // filePath is overridden); a spec is a file name or a name plus IPlugin overrides
+  seedPlugins: (specs: Array<string | ({ name: string } & Partial<IPlugin>)>) => Promise<void>;
+  // where readLists looks for the game's userlist.yaml (absent unless a test creates it)
+  userlistPath: string;
+  // where gameDataPath resolves for the harness game (a real, empty directory)
+  dataDir: string;
+  // emit autosort-plugins and resolve with the value the sort passed to its callback
+  sort: (manual: boolean) => Promise<Error | null>;
+  // emit plugin-details for the harness game and resolve with the answered details
+  requestDetails: (plugins: string[]) => Promise<IPluginsLoot>;
 }
 
 // What a download-adapter test arranges: the single seeded download's fields, an optional stored


### PR DESCRIPTION
Three suites drive the LootInterface through the gamebryo api harness: the autosort-plugins event, the doSort pipeline with its error matrix, and plugin-details.

Five tests assert desired contracts from open bug tickets instead of current behavior, marked test.fails so the suite stays green until each fix flips its test to a plain one: deployment deferral and failure-reported-as-success (LAZ-1092), skip/empty-list success toasts and the pending-sort marker (LAZ-1049), the unanswered callback on game change (LAZ-1048).

Harness support - makeLootHarness/makeLoot fixture in gamebryoTest, loot payload builders typed off the real loot declarations, lootMocks.ts for the vi.mock seams; they're hoisted per test suite right now but will change that as we refactor the code further.

part of LAZ-1025
part of LAZ-1048
part of LAZ-1049
part of LAZ-1092
