### PR TITLE
CI Deadlock fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,40 +3,8 @@ name: Main
 on:
   push:
     branches: [master, release/*]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "locales/**"
-      - ".devcontainer/**"
-      - "docker/**"
-      - "flatpak/**"
-      - "*.nix"
-      - "flake.*"
-      - "default.nix"
-      - "shell.nix"
-      - ".env.example"
-      - ".envrc"
-      - ".editorconfig"
-      - "vortex.bat"
-      - "translation-strings.txt"
   pull_request:
     branches: [master, release/*]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "locales/**"
-      - ".devcontainer/**"
-      - "docker/**"
-      - "flatpak/**"
-      - "*.nix"
-      - "flake.*"
-      - "default.nix"
-      - "shell.nix"
-      - ".env.example"
-      - ".envrc"
-      - ".editorconfig"
-      - "vortex.bat"
-      - "translation-strings.txt"
   workflow_dispatch:
 
 concurrency:
@@ -44,7 +12,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Required status checks stay "Expected" forever when a workflow is skipped by
+  # paths-ignore, so filter inside the workflow instead: a skipped job reports success.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - "!**.md"
+              - "!docs/**"
+              - "!locales/**"
+              - "!.devcontainer/**"
+              - "!docker/**"
+              - "!flatpak/**"
+              - "!*.nix"
+              - "!flake.*"
+              - "!default.nix"
+              - "!shell.nix"
+              - "!.env.example"
+              - "!.envrc"
+              - "!.editorconfig"
+              - "!vortex.bat"
+              - "!translation-strings.txt"
+
   build:
+    needs: changes
+    # Fails open: if the filter job itself fails, code is empty and the full build runs.
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.code != 'false') }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Cherry-pick of #24147 into `master`.

---

Fixed a deadlock where we require the main.yml workflow to be run and be successful and paths-ignore actually skipping the workflow execution

We now check whether the workflow should be skipped inside the workflow execution.

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
> Avoid requiring workflows that can be skipped.

Since we can't skip it, lets just mark it as successful 🤷‍♂️