### PR TITLE
Compute a fingerprint for a native crash

### DIFF
--- a/etc/vortex.api.md
+++ b/etc/vortex.api.md
@@ -5275,7 +5275,7 @@ export interface VortexErrorKindMap {
     "not-supported": {
         feature?: string;
     };
-    "os:generic": Pick<OsErrorData, "originalCode"> & Partial<OsErrorData>;
+    "os:generic": OsErrorData;
     "os:unsupported": {};
     "process-canceled": {
         extraInfo?: unknown;

--- a/src/main/src/Application.ts
+++ b/src/main/src/Application.ts
@@ -252,12 +252,14 @@ class Application {
         reportCrash(
           "ChildProcessGone",
           {
+            title: `${details.type} process crashed`,
             message: `${details.type} process gone: ${details.reason} (exit code ${details.exitCode})`,
             code: details.reason,
           },
           undefined,
           details.type.toLowerCase(),
           isTelemetryEnabled(),
+          { "crash.exitCode": details.exitCode },
         ).catch((err: unknown) => {
           log("warn", "failed to report child process crash", {
             error: getErrorMessageOrDefault(err),

--- a/src/main/src/errorReporting.test.ts
+++ b/src/main/src/errorReporting.test.ts
@@ -5,7 +5,7 @@ vi.mock("electron", () => ({ app: { getPath: vi.fn(), getVersion: vi.fn() } }));
 vi.mock("./logging", () => ({ log: vi.fn() }));
 vi.mock("./minidump", () => ({ summarizeMinidumpFile: vi.fn() }));
 
-import { errorToReportableError } from "./errorReporting";
+import { crashFingerprint, errorToReportableError } from "./errorReporting";
 
 describe("errorToReportableError", () => {
   it("renders a VortexError's payload fields legibly in details", () => {
@@ -28,5 +28,57 @@ describe("errorToReportableError", () => {
 
     expect(report.details).toContain("code: EPERM");
     expect(report.allowReport).toBe(false);
+  });
+});
+
+describe("crashFingerprint", () => {
+  const nativeCrash = (overrides: Record<string, string | number> = {}) =>
+    crashFingerprint(
+      "2.7.0",
+      "PreviousSessionCrash",
+      { message: "Previous session crashed", code: "0xc0000005" },
+      {
+        "crash.sourceProcess": "main",
+        "crash.native.exceptionCode": "0xc0000005",
+        "crash.native.module": "Vortex.exe",
+        "crash.native.moduleOffset": "0x398fe0",
+        "crash.native.exceptionAddress": "0x7ff782a98fe0",
+        "crash.native.dumpCount": 1,
+        ...overrides,
+      },
+    );
+
+  it("is an 8-char hex hash", () => {
+    expect(nativeCrash()).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("groups the same native crash site regardless of address and dump count", () => {
+    expect(
+      nativeCrash({ "crash.native.exceptionAddress": "0x1", "crash.native.dumpCount": 3 }),
+    ).toBe(nativeCrash());
+  });
+
+  it("separates crash sites by module offset", () => {
+    expect(nativeCrash({ "crash.native.moduleOffset": "0x6d3aff9" })).not.toBe(nativeCrash());
+  });
+
+  it("separates gone processes by exit code and process", () => {
+    const gone = (sourceProcess: string, exitCode: number) =>
+      crashFingerprint(
+        "2.7.0",
+        "ChildProcessGone",
+        { message: "process gone", code: "crashed" },
+        { "crash.sourceProcess": sourceProcess, "crash.exitCode": exitCode },
+      );
+
+    expect(gone("utility", -1073741205)).toBe(gone("utility", -1073741205));
+    expect(gone("utility", -1073741205)).not.toBe(gone("utility", 133));
+    expect(gone("utility", 133)).not.toBe(gone("gpu", 133));
+  });
+
+  it("changes with the app version, like stack fingerprints do", () => {
+    const withVersion = (version: string) =>
+      crashFingerprint(version, "EarlyCrash", { message: "boom" }, {});
+    expect(withVersion("2.7.0")).not.toBe(withVersion("2.7.1"));
   });
 });

--- a/src/main/src/errorReporting.ts
+++ b/src/main/src/errorReporting.ts
@@ -11,7 +11,7 @@ import {
   getErrorMessageOrDefault,
   sanitizeFramePath,
 } from "@vortex/shared";
-import type { ReportableError } from "@vortex/shared/errors";
+import { type CrashType, type ReportableError, CrashTypeTitle } from "@vortex/shared/errors";
 import { recordErrorOnSpan, SanitizingSpanExporter } from "@vortex/shared/telemetry";
 import { app } from "electron";
 
@@ -57,7 +57,7 @@ export function errorToReportableError(error: Error): ReportableError {
 }
 
 interface ICrashInfo {
-  type: string;
+  type: CrashType;
   error: ReportableError;
   context?: Record<string, string>;
   reportProcess?: string;
@@ -321,14 +321,6 @@ async function collectCrashDumps(): Promise<IDumpFile[]> {
   return found;
 }
 
-const CRASH_TITLES: Record<string, string> = {
-  Crash: "Unrecoverable error",
-  EarlyCrash: "Crash during startup",
-  PreviousSessionCrash: "Native crash",
-  ChildProcessGone: "Child process crashed",
-  RenderProcessGone: "Renderer process crashed",
-};
-
 /** What identifies a crash site when there is no JavaScript stack to hash. */
 const CRASH_IDENTITY_ATTRIBUTES = [
   "crash.sourceProcess",
@@ -344,7 +336,7 @@ const CRASH_IDENTITY_ATTRIBUTES = [
  */
 export function crashFingerprint(
   appVersion: string,
-  type: string,
+  type: CrashType,
   error: ReportableError,
   attributes: Record<string, string | number | boolean>,
 ): string {
@@ -361,7 +353,7 @@ export function crashFingerprint(
  * flush the export, and shut down.
  */
 export async function reportCrash(
-  type: string,
+  type: CrashType,
   error: ReportableError,
   context?: Record<string, string>,
   sourceProcess?: string,
@@ -401,7 +393,7 @@ export async function reportCrash(
     const errorObj = new Error(error.message);
     errorObj.stack = error.stack;
     recordErrorOnSpan(span, errorObj, app.getVersion(), context, {
-      "error.title": error.title ?? CRASH_TITLES[type] ?? type,
+      "error.title": error.title ?? CrashTypeTitle[type],
       // overridden by the stack fingerprint when the error has a stack
       "error.fingerprint": crashFingerprint(app.getVersion(), type, error, spanAttributes),
     });

--- a/src/main/src/errorReporting.ts
+++ b/src/main/src/errorReporting.ts
@@ -5,7 +5,12 @@ import { inspect } from "node:util";
 
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BasicTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { getErrorCode, getErrorMessageOrDefault, sanitizeFramePath } from "@vortex/shared";
+import {
+  computeIdentityFingerprint,
+  getErrorCode,
+  getErrorMessageOrDefault,
+  sanitizeFramePath,
+} from "@vortex/shared";
 import type { ReportableError } from "@vortex/shared/errors";
 import { recordErrorOnSpan, SanitizingSpanExporter } from "@vortex/shared/telemetry";
 import { app } from "electron";
@@ -201,6 +206,10 @@ export async function sendPendingNativeCrashReport(): Promise<void> {
   }
 
   const error: ReportableError = {
+    title:
+      primary?.module !== undefined
+        ? `Native crash in ${primary.module}`
+        : "Native crash (unreadable dump)",
     message: describeNativeCrash(primary, unreported.length),
     code: primary?.exceptionCode ?? "native-crash",
   };
@@ -312,6 +321,41 @@ async function collectCrashDumps(): Promise<IDumpFile[]> {
   return found;
 }
 
+const CRASH_TITLES: Record<string, string> = {
+  Crash: "Unrecoverable error",
+  EarlyCrash: "Crash during startup",
+  PreviousSessionCrash: "Native crash",
+  ChildProcessGone: "Child process crashed",
+  RenderProcessGone: "Renderer process crashed",
+};
+
+/** What identifies a crash site when there is no JavaScript stack to hash. */
+const CRASH_IDENTITY_ATTRIBUTES = [
+  "crash.sourceProcess",
+  "crash.exitCode",
+  "crash.native.exceptionCode",
+  "crash.native.module",
+  "crash.native.moduleOffset",
+];
+
+/**
+ * Fingerprint for crashes without a JavaScript stack (native dumps, processes
+ * gone), so the backend dedupes and resolves them like error reports.
+ */
+export function crashFingerprint(
+  appVersion: string,
+  type: string,
+  error: ReportableError,
+  attributes: Record<string, string | number | boolean>,
+): string {
+  return computeIdentityFingerprint(
+    appVersion,
+    type,
+    error.code ?? "",
+    ...CRASH_IDENTITY_ATTRIBUTES.map((key) => String(attributes[key] ?? "")),
+  );
+}
+
 /**
  * Create a short-lived OTel provider, record a crash error span,
  * flush the export, and shut down.
@@ -345,20 +389,21 @@ export async function reportCrash(
 
   try {
     const tracer = provider.getTracer("vortex.crash");
-    const span = tracer.startSpan("crash.report", {
-      attributes: {
-        "crash.type": type,
-        "crash.sourceProcess": sourceProcess ?? "unknown",
-        "error.message": sanitizeFramePath(error.message),
-        "error.code": error.code ?? "",
-      },
-    });
+    const spanAttributes: Record<string, string | number | boolean> = {
+      "crash.type": type,
+      "crash.sourceProcess": sourceProcess ?? "unknown",
+      "error.message": sanitizeFramePath(error.message),
+      "error.code": error.code ?? "",
+      ...attributes,
+    };
+    const span = tracer.startSpan("crash.report", { attributes: spanAttributes });
 
     const errorObj = new Error(error.message);
     errorObj.stack = error.stack;
     recordErrorOnSpan(span, errorObj, app.getVersion(), context, {
-      "error.title": error.title ?? "",
-      ...attributes,
+      "error.title": error.title ?? CRASH_TITLES[type] ?? type,
+      // overridden by the stack fingerprint when the error has a stack
+      "error.fingerprint": crashFingerprint(app.getVersion(), type, error, spanAttributes),
     });
     span.end();
   } finally {

--- a/src/renderer/src/util/errorHandling.ts
+++ b/src/renderer/src/util/errorHandling.ts
@@ -3,6 +3,7 @@ import { inspect } from "util";
 
 import { type Span, context, ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api";
 import { isEnvironmentalError, parseError, unknownToError } from "@vortex/shared";
+import type { CrashType } from "@vortex/shared/errors";
 import { recordErrorOnSpan } from "@vortex/shared/telemetry";
 import type PromiseBB from "bluebird";
 import type { BrowserWindow } from "electron";
@@ -40,7 +41,7 @@ type IErrorContext = Record<string, string>;
 const globalContext: IErrorContext = {};
 
 export function createErrorReport(
-  type: string,
+  type: CrashType,
   error: IError,
   context: IErrorContext,
   state: IState | undefined,

--- a/src/shared/src/errors.test.ts
+++ b/src/shared/src/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   computeErrorFingerprint,
+  computeIdentityFingerprint,
   getErrorStatusCode,
   isEnvironmentalError,
   sanitizeFramePath,
@@ -551,5 +552,34 @@ describe("getErrorStatusCode", () => {
   it("answers null for anything that isn't an error", () => {
     expect(getErrorStatusCode({ statusCode: 403 })).toBeNull();
     expect(getErrorStatusCode(undefined)).toBeNull();
+  });
+});
+
+describe("computeIdentityFingerprint", () => {
+  it("is an 8-char hex hash, stable for the same parts", () => {
+    const first = computeIdentityFingerprint(
+      "2.7.0",
+      "PreviousSessionCrash",
+      "Vortex.exe",
+      "0x398fe0",
+    );
+    expect(first).toMatch(/^[0-9a-f]{8}$/);
+    expect(
+      computeIdentityFingerprint("2.7.0", "PreviousSessionCrash", "Vortex.exe", "0x398fe0"),
+    ).toBe(first);
+  });
+
+  it("changes when any part or the version changes", () => {
+    const base = computeIdentityFingerprint("2.7.0", "ChildProcessGone", "utility", "133");
+    expect(computeIdentityFingerprint("2.7.0", "ChildProcessGone", "gpu", "133")).not.toBe(base);
+    expect(computeIdentityFingerprint("2.7.1", "ChildProcessGone", "utility", "133")).not.toBe(
+      base,
+    );
+  });
+
+  it("does not collide when parts are shifted", () => {
+    expect(computeIdentityFingerprint("2.7.0", "a", "b")).not.toBe(
+      computeIdentityFingerprint("2.7.0", "ab", ""),
+    );
   });
 });

--- a/src/shared/src/errors.ts
+++ b/src/shared/src/errors.ts
@@ -252,6 +252,14 @@ export const computeErrorFingerprint = (
   return fnv1aHash(input);
 };
 
+/**
+ * Fingerprint for a failure with no stack to hash (native crashes, processes
+ * gone): the identifying `parts` plus the app version, hashed like
+ * {@link computeErrorFingerprint} so the backend dedupes both the same way.
+ */
+export const computeIdentityFingerprint = (appVersion: string, ...parts: string[]): string =>
+  fnv1aHash([...parts, appVersion].join("\n"));
+
 /** FNV-1a hash producing an 8-char hex string. Not cryptographic —
  *  used only for error deduplication fingerprints. */
 const fnv1aHash = (input: string): string => {

--- a/src/shared/src/telemetry/sanitizer.ts
+++ b/src/shared/src/telemetry/sanitizer.ts
@@ -61,6 +61,7 @@ export const SPAN_ATTRIBUTE_ALLOWLIST: ReadonlySet<string> = new Set([
   "componentStack",
   "crash.type",
   "crash.sourceProcess",
+  "crash.exitCode",
   // Native crash facts extracted from minidumps — codes, module names and
   // offsets only, never memory contents
   "crash.native.dumpCount",

--- a/src/shared/src/types/errors.ts
+++ b/src/shared/src/types/errors.ts
@@ -1,5 +1,25 @@
 import { VortexError } from "../errors/base";
 
+/**
+ * A map of every crash type and it's corresponding human-readable title.
+ * @public
+ */
+export const CrashTypeTitle = {
+  Crash: "Unrecoverable error",
+  EarlyCrash: "Crash during startup",
+  PreviousSessionCrash: "Native crash",
+  ChildProcessGone: "Child process crashed",
+  RenderProcessGone: "Renderer process crashed",
+  "Installer failed": "Installer failed",
+  "Unknown error": "Unknown error",
+} as const;
+
+/**
+ * Catalog of every crash kind Vortex knows how to produce and classify.
+ * @public
+ */
+export type CrashType = keyof typeof CrashTypeTitle;
+
 export interface ReportableError {
   message: string;
   title?: string;


### PR DESCRIPTION
We didn't provide any fingerprint to a native crash, which is definitely not correct.
Now we'll be computing the fingerprint based on the app version (always), title, process and the offset and anything else that is available