### PR TITLE
Prevent renderer crash looping

### DIFF
--- a/src/main/src/MainWindow.ts
+++ b/src/main/src/MainWindow.ts
@@ -6,16 +6,20 @@ import { getErrorMessageOrDefault } from "@vortex/shared";
 import type { IWindow } from "@vortex/shared/state";
 import { app, ipcMain, screen, webContents, BrowserWindow } from "electron";
 
-import { terminate } from "./errorHandling";
+import { terminate, terminateAsync } from "./errorHandling";
 import { reportCrash } from "./errorReporting";
 import { getVortexPath } from "./getVortexPath";
 import { log } from "./logging";
 import Debouncer from "./NodeDebouncer";
 import { openUrl } from "./open";
+import { ReloadBudget } from "./reloadBudget";
 import { isTelemetryEnabled } from "./telemetry/state";
 import { closeAllViews } from "./webview";
 
 const MIN_HEIGHT = 700;
+// a renderer that dies more often than this isn't recovering, it's looping
+const MAX_RENDERER_RELOADS = 3;
+const RENDERER_RELOAD_WINDOW_MS = 60_000;
 const REQUEST_HEADER_FILTER = {
   urls: ["*://enbdev.com/*"],
 };
@@ -76,6 +80,7 @@ class MainWindow {
   private mInspector: boolean;
   private mInitialWindowSettings: IWindow | null = null;
   private mRendererPid: number | undefined;
+  private mReloadBudget = new ReloadBudget(MAX_RENDERER_RELOADS, RENDERER_RELOAD_WINDOW_MS);
 
   /**
    * Create a MainWindow instance.
@@ -189,6 +194,7 @@ class MainWindow {
             undefined,
             "renderer",
             isTelemetryEnabled(),
+            { "crash.exitCode": details.exitCode },
           ).catch((err: unknown) => {
             log("warn", "failed to report renderer crash", {
               error: getErrorMessageOrDefault(err),
@@ -197,6 +203,17 @@ class MainWindow {
         }
 
         if (details.reason !== "killed") {
+          if (!this.mReloadBudget.allow()) {
+            terminateAsync(
+              new Error(
+                `The Vortex window crashed ${this.mReloadBudget.count} times in a row ` +
+                  `(${details.reason}, exit code ${details.exitCode}) and can't be restarted.`,
+              ),
+            ).catch(() => {
+              /* best-effort */
+            });
+            return;
+          }
           // workaround for electron issue #19887
           setImmediate(() => {
             if (this.mWindow !== null) {

--- a/src/main/src/reloadBudget.test.ts
+++ b/src/main/src/reloadBudget.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { ReloadBudget } from "./reloadBudget";
+
+describe("ReloadBudget", () => {
+  it("allows up to max reloads inside the window and refuses the next", () => {
+    const budget = new ReloadBudget(3, 60_000);
+
+    expect(budget.allow(0)).toBe(true);
+    expect(budget.allow(10)).toBe(true);
+    expect(budget.allow(20)).toBe(true);
+    expect(budget.allow(30)).toBe(false);
+    expect(budget.count).toBe(4);
+  });
+
+  it("forgets deaths older than the window", () => {
+    const budget = new ReloadBudget(2, 1_000);
+
+    expect(budget.allow(0)).toBe(true);
+    expect(budget.allow(100)).toBe(true);
+    expect(budget.allow(200)).toBe(false);
+    // a minute later only the new death counts
+    expect(budget.allow(61_000)).toBe(true);
+    expect(budget.count).toBe(1);
+  });
+
+  it("keeps refusing while deaths keep arriving inside the window", () => {
+    const budget = new ReloadBudget(1, 1_000);
+
+    expect(budget.allow(0)).toBe(true);
+    for (let t = 15; t < 1_000; t += 15) {
+      expect(budget.allow(t)).toBe(false);
+    }
+  });
+});

--- a/src/main/src/reloadBudget.ts
+++ b/src/main/src/reloadBudget.ts
@@ -1,0 +1,27 @@
+/**
+ * Bounds how often a dead renderer is reloaded. A renderer that dies on every
+ * launch would otherwise be reloaded indefinitely
+ */
+export class ReloadBudget {
+  readonly #deaths: number[] = [];
+  readonly #max: number;
+  readonly #windowMs: number;
+
+  constructor(max: number, windowMs: number) {
+    this.#max = max;
+    this.#windowMs = windowMs;
+  }
+
+  /** Records a death at `now` and returns whether reloading is still worth trying. */
+  public allow(now: number = Date.now()): boolean {
+    const firstInWindow = this.#deaths.findIndex((death) => now - death < this.#windowMs);
+    this.#deaths.splice(0, firstInWindow === -1 ? this.#deaths.length : firstInWindow);
+    this.#deaths.push(now);
+    return this.#deaths.length <= this.#max;
+  }
+
+  /** Deaths inside the current window, including the one just recorded. */
+  public get count(): number {
+    return this.#deaths.length;
+  }
+}


### PR DESCRIPTION
The v2.6.2 telemetry has shown something pretty bad - there were 700 sessions that had Vortex looping with the renderer crashing.
Based on the code, the loop will never stop, which is definitely not good, since each crash goes to the telemetry. I'm adding a circuit breaker that will make Vortex exit if there's a loop detected.

| Category | Exit code | Spans | Sessions | Median per session | Max in one session |
|---|---|---|---|---|---|
| Renderer crashed | -2147483645 (0x80000003, breakpoint) | 1,376,934 | 727 | 2 | 294,607 |
| Renderer launch-failed | 63 | 599,537 | 40 | 3 | 538,548 |
| Renderer crashed | -1073741819 (0xC0000005, access violation) | 42,667 | 1,146 | 1 | 30,910 |
| Renderer OOM | -536870904 | 1,111 | 786 | 1 | 96 |
| Renderer crashed | -529697949 | 808 | 584 | 1 | 8 |