### PR TITLE
Remove `AssertSerializable`; simplify IPC types

### DIFF
--- a/src/main/src/ipc.ts
+++ b/src/main/src/ipc.ts
@@ -3,8 +3,6 @@ import type {
   RendererChannels,
   MainChannels,
   InvokeChannels,
-  SerializableArgs,
-  AssertSerializable,
   CallbackChannels,
   MainCallbackChannels,
   WireReply,
@@ -47,15 +45,12 @@ function ipcLogger(
 
 function mainOn<C extends keyof RendererChannels>(
   channel: C,
-  listener: (
-    event: Electron.IpcMainEvent,
-    ...args: SerializableArgs<Parameters<RendererChannels[C]>>
-  ) => void,
+  listener: (event: Electron.IpcMainEvent, ...args: Parameters<RendererChannels[C]>) => void,
   logOptions: LogOptions = false,
 ): () => void {
   const outerListener = (
     event: Electron.IpcMainEvent,
-    ...args: SerializableArgs<Parameters<RendererChannels[C]>>
+    ...args: Parameters<RendererChannels[C]>
   ) => {
     ipcLogger(logOptions, channel, event, args);
     assertTrustedSender(event);
@@ -70,21 +65,17 @@ function mainCallback<C extends keyof CallbackChannels>(
   channel: C,
   webContents: WebContents,
   timeout: number,
-  ...args: SerializableArgs<Parameters<MainCallbackChannels[C]>>
-): Promise<AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>> {
+  ...args: Parameters<MainCallbackChannels[C]>
+): Promise<Awaited<ReturnType<CallbackChannels[C]>>> {
   const collationId = args[0];
 
-  let resolve:
-    | ((value: AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>) => void)
-    | undefined = undefined;
+  let resolve: ((value: Awaited<ReturnType<CallbackChannels[C]>>) => void) | undefined = undefined;
   let reject: ((reason?: Error) => void) | undefined = undefined;
 
-  const promise = new Promise<AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>>(
-    (res, rej) => {
-      resolve = res;
-      reject = rej;
-    },
-  );
+  const promise = new Promise<Awaited<ReturnType<CallbackChannels[C]>>>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
 
   const settle = () => {
     resolve = undefined;
@@ -130,9 +121,8 @@ function mainCallback<C extends keyof CallbackChannels>(
     resolve = undefined;
     reject = undefined;
 
-    const result = args[1] as unknown as WireReply<
-      AssertSerializable<Awaited<ReturnType<CallbackChannels[C]>>>
-    >;
+    const result = args[1] as unknown as WireReply<Awaited<ReturnType<CallbackChannels[C]>>>;
+
     if (result.error) {
       rej(deserializeVortexError(result.error));
     } else {
@@ -152,18 +142,16 @@ function mainHandle<C extends keyof InvokeChannels>(
   channel: C,
   listener: (
     event: Electron.IpcMainInvokeEvent,
-    ...args: SerializableArgs<Parameters<InvokeChannels[C]>>
-  ) =>
-    | Promise<AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>>
-    | AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>,
+    ...args: Parameters<InvokeChannels[C]>
+  ) => Promise<Awaited<ReturnType<InvokeChannels[C]>>> | Awaited<ReturnType<InvokeChannels[C]>>,
   logOptions: LogOptions = false,
 ): void {
   ipcMain.handle(
     channel,
     async (
       event,
-      ...args: SerializableArgs<Parameters<InvokeChannels[C]>>
-    ): Promise<WireReply<AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>>> => {
+      ...args: Parameters<InvokeChannels[C]>
+    ): Promise<WireReply<Awaited<ReturnType<InvokeChannels[C]>>>> => {
       ipcLogger(logOptions, channel, event, args);
       try {
         assertTrustedSender(event);
@@ -179,7 +167,7 @@ function mainHandle<C extends keyof InvokeChannels>(
 function mainSend<C extends keyof MainChannels>(
   webContents: WebContents,
   channel: C,
-  ...args: SerializableArgs<Parameters<MainChannels[C]>>
+  ...args: Parameters<MainChannels[C]>
 ): void {
   webContents.send(channel, ...args);
 }

--- a/src/preload/src/ipc.ts
+++ b/src/preload/src/ipc.ts
@@ -11,8 +11,6 @@ import type {
   InvokeChannels,
   MainChannels,
   CallbackChannels,
-  SerializableArgs,
-  AssertSerializable,
   WireReply,
 } from "@vortex/shared/ipc";
 import { ipcRenderer } from "electron";
@@ -49,10 +47,12 @@ export const errorOriginTracker: ErrorOriginTracker = {
 
 export async function rendererInvoke<C extends keyof InvokeChannels>(
   channel: C,
-  ...args: SerializableArgs<Parameters<InvokeChannels[C]>>
-): Promise<AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>> {
-  const reply: WireReply<AssertSerializable<Awaited<ReturnType<InvokeChannels[C]>>>> =
-    await ipcRenderer.invoke(channel, ...args);
+  ...args: Parameters<InvokeChannels[C]>
+): Promise<Awaited<ReturnType<InvokeChannels[C]>>> {
+  const reply: WireReply<Awaited<ReturnType<InvokeChannels[C]>>> = await ipcRenderer.invoke(
+    channel,
+    ...args,
+  );
   if (reply.error) {
     throw deserializeVortexError(reply.error, errorOriginTracker);
   } else {
@@ -62,27 +62,21 @@ export async function rendererInvoke<C extends keyof InvokeChannels>(
 
 export function rendererSend<C extends keyof RendererChannels>(
   channel: C,
-  ...args: SerializableArgs<Parameters<RendererChannels[C]>>
+  ...args: Parameters<RendererChannels[C]>
 ): void {
   ipcRenderer.send(channel, ...args);
 }
 
 export function rendererOn<C extends keyof MainChannels>(
   channel: C,
-  listener: (
-    event: Electron.IpcRendererEvent,
-    ...args: SerializableArgs<Parameters<MainChannels[C]>>
-  ) => void,
+  listener: (event: Electron.IpcRendererEvent, ...args: Parameters<MainChannels[C]>) => void,
 ): void {
   ipcRenderer.on(channel, listener);
 }
 
 export function rendererOff<C extends keyof MainChannels>(
   channel: C,
-  listener: (
-    event: Electron.IpcRendererEvent,
-    ...args: SerializableArgs<Parameters<MainChannels[C]>>
-  ) => void,
+  listener: (event: Electron.IpcRendererEvent, ...args: Parameters<MainChannels[C]>) => void,
 ): void {
   ipcRenderer.off(channel, listener);
 }
@@ -97,13 +91,13 @@ export function rendererCallback<C extends keyof CallbackChannels>(
   channel: C,
   handler: (
     collationId: number,
-    ...args: SerializableArgs<Parameters<CallbackChannels[C]>>
+    ...args: Parameters<CallbackChannels[C]>
   ) => Promise<Awaited<ReturnType<CallbackChannels[C]>>>,
 ): () => void {
   const listener = (
     _event: Electron.IpcRendererEvent,
     collationId: number,
-    ...args: SerializableArgs<Parameters<CallbackChannels[C]>>
+    ...args: Parameters<CallbackChannels[C]>
   ) => {
     handler(collationId, ...args)
       .then((value) => {

--- a/src/shared/src/types/ipc.ts
+++ b/src/shared/src/types/ipc.ts
@@ -620,38 +620,3 @@ export type Serializable =
   | { [key: string]: Serializable }
   | Map<Serializable, Serializable>
   | Set<Serializable>;
-
-type IsAny<T> = 0 extends 1 & T ? true : false;
-
-type HasError<T> = T extends { __error__: string }
-  ? true
-  : T extends object
-    ? { [K in keyof T]: HasError<T[K]> }[keyof T] extends true
-      ? true
-      : false
-    : false;
-
-// NOTE(erri120): If you found this type because you got an error, that means you're trying to pass data across the IPC
-// that can't be serialized. Check the list of supported types above and pick one of them. If you think there is a type missing
-// from the list above, write a small proof and we can discuss it.
-//
-/** Utility type to assert that the type is serializable */
-export type AssertSerializable<T> =
-  // any
-  IsAny<T> extends true
-    ? { __error__: "any is not serializable for IPC" }
-    : // known serializables
-      T extends Serializable
-      ? T
-      : // objects
-        T extends object
-        ? HasError<{ [K in keyof T]: AssertSerializable<T[K]> }> extends true
-          ? { __error__: "Type is not serializable for IPC" }
-          : T
-        : // everything else
-          { __error__: "Type is not serializable for IPC" };
-
-/** Utility type to check all args are serializable */
-export type SerializableArgs<T extends readonly unknown[]> = {
-  [K in keyof T]: AssertSerializable<T[K]>;
-};


### PR DESCRIPTION
This has just overcomplicated the typesystem.