### PR TITLE
Fix component crash on uninitialised FlagService 

### DIFF
--- a/src/renderer/src/contexts/FlagsContext.tsx
+++ b/src/renderer/src/contexts/FlagsContext.tsx
@@ -32,18 +32,18 @@ export interface IFlagsProviderProps {
 
 export const FlagsProvider: FC<React.PropsWithChildren<IFlagsProviderProps>> = ({ children }) => {
   const [flags, setFlags] = useState<ReadonlyMap<KnownFlagName, FeatureFlag>>(
-    () => FlagService.instance.flags,
+    () => FlagService.instance?.flags ?? new Map(),
   );
 
   useEffect(() => {
-    return FlagService.instance.subscribe((flags) => {
+    return FlagService.instance?.subscribe((flags) => {
       setFlags(flags);
     });
   }, []);
 
   const getFlag = useCallback(
     <N extends KnownFlagName>(name: N): FlagByName<N> | undefined =>
-      FlagService.instance.getFlag(name),
+      FlagService.instance?.getFlag(name),
     // flags is listed so getFlag referential identity changes when flags do,
     // ensuring consumers that memoize on getFlag re-evaluate after a push.
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
+++ b/src/renderer/src/extensions/health_check/checks/fileRequirementsCheck.ts
@@ -146,7 +146,7 @@ export const fileRequirementsHealthCheck: IHealthCheck = {
   ],
   check: async (api: IExtensionApi, signal?: AbortSignal): Promise<IHealthCheckResult> => {
     // Reading the flag through FlagService reports an evaluation metric to the server.
-    const flagEnabled = FlagService.instance.getFlag(FILE_REQUIREMENTS_FLAG) !== undefined;
+    const flagEnabled = FlagService.instance?.getFlag(FILE_REQUIREMENTS_FLAG) !== undefined;
     if (!flagEnabled || !isFileRequirementsUserEnabled(api.getState())) {
       return {
         checkId: FILE_REQUIREMENTS_CHECK_ID,


### PR DESCRIPTION
FlagsProvider assumed FlagService.instance was always set, so it threw when rendered before the service had been initialized. Guard the three instance accesses with optional chaining and fall back to an empty map for the initial flag state.

Fixes LAZ-1110