### PR TITLE
fix: select a game's default primary tool when discovered later

### DIFF
--- a/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
+++ b/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
@@ -503,9 +503,8 @@ class GameModeManager {
   }
 
   private onDiscoveredTool = (gameId: string, result: IDiscoveredTool) => {
-    const state = this.mStore.getState();
     const existing = getSafe(
-      state,
+      this.mStore.getState(),
       ["settings", "gameMode", "discovered", gameId, "tools", result.id],
       undefined,
     );
@@ -519,12 +518,9 @@ class GameModeManager {
     // appeared later was shown in Tools but Quick Launch kept starting the vanilla executable.
     // Select any game's declared default as soon as it becomes available, while preserving every
     // explicit user choice.
-    const active = activeProfile(this.mStore.getState());
-    const primary = getSafe(
-      this.mStore.getState(),
-      ["settings", "interface", "primaryTool", gameId],
-      undefined,
-    );
+    const state = this.mStore.getState();
+    const active = activeProfile(state);
+    const primary = state.settings.interface.primaryTool?.[gameId];
     if (active?.gameId === gameId && primary === undefined && result.defaultPrimary === true) {
       this.mStore.dispatch(setPrimaryTool(gameId, result.id));
     }

--- a/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
+++ b/src/renderer/src/extensions/gamemode_management/GameModeManager.ts
@@ -503,8 +503,9 @@ class GameModeManager {
   }
 
   private onDiscoveredTool = (gameId: string, result: IDiscoveredTool) => {
+    const state = this.mStore.getState();
     const existing = getSafe(
-      this.mStore.getState(),
+      state,
       ["settings", "gameMode", "discovered", gameId, "tools", result.id],
       undefined,
     );
@@ -512,6 +513,20 @@ class GameModeManager {
     if (existing === undefined || !existing.custom) {
       delete result.executable;
       this.mStore.dispatch(addDiscoveredTool(gameId, result.id, result, false));
+    }
+    // Tool discovery also runs after deployment and on an already-active game. Previously the
+    // default was selected only during the narrow game-activation path, so a script extender that
+    // appeared later was shown in Tools but Quick Launch kept starting the vanilla executable.
+    // Select any game's declared default as soon as it becomes available, while preserving every
+    // explicit user choice.
+    const active = activeProfile(this.mStore.getState());
+    const primary = getSafe(
+      this.mStore.getState(),
+      ["settings", "interface", "primaryTool", gameId],
+      undefined,
+    );
+    if (active?.gameId === gameId && primary === undefined && result.defaultPrimary === true) {
+      this.mStore.dispatch(setPrimaryTool(gameId, result.id));
     }
   };
 


### PR DESCRIPTION
## Problem

Installing a collection that ships a script extender leaves the script extender unselected as the primary tool, so **Play** launches the vanilla executable. For collections that also apply base-game `.ini` tweaks, the vanilla launcher then reverts them.

Reported in #19543 (Windows 11).

## Cause

`defaultPrimary` is only ever consulted in the game-activation path in `setupGameMode`:

https://github.com/Nexus-Mods/Vortex/blob/c348fd013ad191261583968369add76b906865ab/src/renderer/src/extensions/gamemode_management/GameModeManager.ts#L157-L170

That block reads `discovery.tools` once, at activation time. `onDiscoveredTool` — which also fires for tools discovered after deployment and while the game is already active — registers the tool but never promotes it.

So a script extender arriving after activation (the collection-install case) is listed under Tools with nothing selecting it. `defaultPrimary` does reach the callback: `testApplicationDirValid` spreads the whole tool object into it (`{ ...application, path, hidden, custom }`).

## Change

Select a declared default in `onDiscoveredTool`, as soon as it becomes available.

Existing guards are preserved:

- only for the active profile's game
- only when `settings.interface.primaryTool[gameId]` is unset, so an explicit user choice is never overridden
- customised tools are still not overwritten

## How to reproduce manually

Fallout New Vegas is used here because its `nvse` tool declares `defaultPrimary: true`; the Skyrim/Fallout script extenders and SMAPI behave the same way.

1. Start from a Fallout New Vegas install with **no script extender present** — no `nvse_loader.exe` in the game folder. Manage the game.
2. Go to **Tools**. The **Default launcher** panel shows its placeholder, "Runs instead of the game when you hit Play." Nothing is selected, which is correct at this point: the tool does not exist yet.
3. Now make the script extender appear, which is what a collection install does when it delivers xNVSE: install xNVSE, or just drop `nvse_loader.exe` into the game folder.
4. Trigger a deployment — **Mods → ⋯ → Deploy Mods**. This fires `did-deploy`, which re-runs tool discovery on the already-active game, so xNVSE is discovered here.
5. Go back to **Tools**.

**Actual:** the Default launcher panel still shows the placeholder. xNVSE is listed under Tools but is not the default launcher, so **Play** starts the vanilla executable.

**Expected:** xNVSE is the Default launcher.

The original report reaches the same state via a collection install rather than steps 3-4; the mechanism is the same — the extender is discovered after the game was already activated.

To confirm the tool really was discovered (rather than simply not found), the log shows `discovering relative tools` followed by `potential match ...\nvse_loader.exe` after the deployment in step 4.

Fixes #19543
