### PR TITLE
fix: drop stale deployment entries for uninstalled mods

### DIFF
--- a/src/renderer/src/extensions/mod_management/util/externalChanges.test.ts
+++ b/src/renderer/src/extensions/mod_management/util/externalChanges.test.ts
@@ -50,7 +50,7 @@ vi.mock("../actions/session", () => ({
 }));
 
 import InstallManager from "../InstallManager";
-import { dealWithExternalChanges } from "./externalChanges";
+import { classifyExternalChange, dealWithExternalChanges } from "./externalChanges";
 
 function makeRefchange(source: string, filePath: string): IFileChange {
   return {
@@ -62,24 +62,44 @@ function makeRefchange(source: string, filePath: string): IFileChange {
   };
 }
 
-function makeApi(opts: { externalChanges: IFileChange[]; activeSession?: unknown }): {
+function makeSrcDeleted(source: string, filePath: string): IFileChange {
+  return {
+    filePath,
+    source,
+    sourceTime: new Date(0),
+    destTime: new Date(0),
+    changeType: "srcdeleted",
+  };
+}
+
+function makeApi(opts: {
+  externalChanges: IFileChange[];
+  activeSession?: unknown;
+  // Mods Vortex still has in state, keyed by installationPath. Omitted means
+  // "no mods table for this game", which is deliberately distinct from an
+  // empty table.
+  mods?: { [installationPath: string]: unknown };
+  profiles?: { [profileId: string]: unknown };
+  activeProfileId?: string;
+}): {
   api: IExtensionApi;
   activator: IDeploymentMethod;
 } {
   const state = {
     persistent: {
-      profiles: {
+      profiles: opts.profiles ?? {
         "test-profile": {
           id: "test-profile",
           gameId: "skyrimse",
         },
       },
+      ...(opts.mods === undefined ? {} : { mods: { skyrimse: opts.mods } }),
     },
     session: {
       collections: { activeSession: opts.activeSession ?? undefined },
     },
     settings: {
-      profiles: { activeProfileId: "test-profile" },
+      profiles: { activeProfileId: opts.activeProfileId ?? "test-profile" },
     },
   } as unknown as IState;
 
@@ -257,5 +277,144 @@ describe("dealWithExternalChanges", () => {
 
     // The next deployment cycle would pick up B.
     expect(installManager.consumeRecentChanges()).toEqual(new Set([modB]));
+  });
+});
+
+describe("classifyExternalChange", () => {
+  it("auto-resolves a deleted source when its owning mod was uninstalled", () => {
+    const change: IFileChange = {
+      filePath: "SKSE/Plugins/example.dll",
+      source: "removed-mod-installation-path",
+      changeType: "srcdeleted",
+    };
+
+    expect(
+      classifyExternalChange(change, {
+        isInstallingCollection: false,
+        recentChanges: new Set(),
+        installedSources: new Set(),
+      }),
+    ).toBe("autoResolved");
+  });
+
+  it("still surfaces a deleted source for a mod Vortex considers installed", () => {
+    const change: IFileChange = {
+      filePath: "SKSE/Plugins/example.dll",
+      source: "installed-mod",
+      changeType: "srcdeleted",
+    };
+
+    expect(
+      classifyExternalChange(change, {
+        isInstallingCollection: false,
+        recentChanges: new Set(),
+        installedSources: new Set(["installed-mod"]),
+      }),
+    ).toBe("rest");
+  });
+});
+
+// Cross-session case. The recentChanges allow-list is in-memory, so after a
+// restart it is empty and cannot explain a srcdeleted left behind by a mod the
+// user uninstalled before quitting. Vortex's own state is the durable signal:
+// if the owning mod is gone, a missing staging source is expected.
+describe("dealWithExternalChanges: uninstalled mods", () => {
+  const KEEPER = "still-installed-mod";
+  const REMOVED = "uninstalled-mod";
+  const INSTALLED = { [KEEPER]: { id: KEEPER, installationPath: KEEPER } };
+
+  beforeEach(() => {
+    showExternalChangesCalls.length = 0;
+  });
+
+  const run = (changes: IFileChange[], recentChanges: Set<string> | undefined) => {
+    const { api, activator } = makeApi({ externalChanges: changes, mods: INSTALLED });
+    return dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      recentChanges,
+    );
+  };
+
+  it("does not ask the user about a mod they uninstalled", async () => {
+    await run([makeSrcDeleted(REMOVED, "SKSE/Plugins/example.dll")], new Set());
+    expect(showExternalChangesCalls).toHaveLength(0);
+  });
+
+  it("does not ask the user when recentChanges is undefined", async () => {
+    await run([makeSrcDeleted(REMOVED, "SKSE/Plugins/example.dll")], undefined);
+    expect(showExternalChangesCalls).toHaveLength(0);
+  });
+
+  it("still surfaces a deleted source when the mod is still installed", async () => {
+    await run([makeSrcDeleted(KEEPER, "Data/keeper.esp")], new Set());
+    expect(showExternalChangesCalls).toHaveLength(1);
+    expect(showExternalChangesCalls[0][""]?.[0].source).toBe(KEEPER);
+  });
+
+  it("drops only the orphan when both appear in one batch", async () => {
+    await run(
+      [
+        makeSrcDeleted(REMOVED, "SKSE/Plugins/example.dll"),
+        makeSrcDeleted(KEEPER, "Data/keeper.esp"),
+      ],
+      new Set(),
+    );
+    expect(showExternalChangesCalls).toHaveLength(1);
+    const surfaced = showExternalChangesCalls[0][""];
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced?.[0].source).toBe(KEEPER);
+  });
+
+  // Removing the LAST mod takes the game's whole mod table with it, so the
+  // lookup yields no table at all rather than an empty one. That still means
+  // "nothing installed", not "unknown", and the orphan must be dropped.
+  it("drops the orphan when the removed mod was the only one", async () => {
+    const { api, activator } = makeApi({
+      externalChanges: [makeSrcDeleted(REMOVED, "Data/only.esp")],
+      // no `mods` key at all for this game
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "test-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      new Set(),
+    );
+
+    expect(showExternalChangesCalls).toHaveLength(0);
+  });
+
+  // checkForExternalChanges tolerates a stale profileId via its activeProfile
+  // fallback, so the suppression must resolve the game the same way. Deriving
+  // it from persistent.profiles[profileId] alone yields undefined for a stale
+  // id, and an empty installedSources Set would then make every source look
+  // uninstalled and auto-resolve genuine changes.
+  it("still surfaces a deleted source when profileId is stale", async () => {
+    const { api, activator } = makeApi({
+      externalChanges: [makeSrcDeleted(KEEPER, "Data/keeper.esp")],
+      mods: INSTALLED,
+      profiles: { "active-profile": { id: "active-profile", gameId: "skyrimse" } },
+      activeProfileId: "active-profile",
+    });
+
+    await dealWithExternalChanges(
+      api,
+      activator,
+      "stale-profile",
+      FAKE_STAGING,
+      FAKE_MOD_PATHS,
+      FAKE_LAST_DEPLOYMENT,
+      new Set(),
+    );
+
+    expect(showExternalChangesCalls).toHaveLength(1);
   });
 });

--- a/src/renderer/src/extensions/mod_management/util/externalChanges.ts
+++ b/src/renderer/src/extensions/mod_management/util/externalChanges.ts
@@ -190,12 +190,27 @@ export type ExternalChangeBucket = "merged" | "autoResolved" | "rest";
  */
 export function classifyExternalChange(
   change: IFileChange,
-  context: { isInstallingCollection: boolean; recentChanges?: Set<string> },
+  context: {
+    isInstallingCollection: boolean;
+    recentChanges?: Set<string>;
+    installedSources?: Set<string>;
+  },
 ): ExternalChangeBucket {
   if (path.basename(change.source).startsWith(MERGED_PATH)) {
     return "merged";
   }
   if (context.isInstallingCollection || context.recentChanges?.has(change.source)) {
+    return "autoResolved";
+  }
+  // If Vortex has removed the owning mod from its state, a missing staging
+  // source is the expected result of uninstalling it.  The destination is a
+  // surviving hardlink, not a user edit, so silently drop the stale manifest
+  // entry instead of reporting "changed outside Vortex".
+  if (
+    change.changeType === "srcdeleted" &&
+    context.installedSources !== undefined &&
+    !context.installedSources.has(change.source)
+  ) {
     return "autoResolved";
   }
   return "rest";
@@ -287,7 +302,27 @@ export function dealWithExternalChanges(
       let count = 0;
       const state = api.store.getState() as IState;
       const isInstallingCollection = getCollectionActiveSession(state) !== undefined;
-      const context = { isInstallingCollection, recentChanges };
+      // Resolve the game the same way checkForExternalChanges does. profileId can
+      // be stale (that is why the activeProfile fallback exists there), and
+      // reading persistent.profiles[profileId] directly would yield undefined for
+      // a stale id, which would make every source look uninstalled.
+      //
+      // The unknown case is specifically "we could not work out which game this
+      // is": only then is undefined right, so classifyExternalChange skips the
+      // check. Once the game IS known, a missing or empty mod table means
+      // exactly what it says — nothing is installed — so an empty Set is
+      // correct. Treating that as unknown would miss the common case of
+      // removing the last remaining mod, where the game's mod table goes away.
+      const profile = profileById(state, profileId) ?? activeProfile(state);
+      const installedSources =
+        profile === undefined
+          ? undefined
+          : new Set(
+              Object.values(state.persistent.mods?.[profile.gameId] ?? {})
+                .map((mod) => mod?.installationPath)
+                .filter(truthy),
+            );
+      const context = { isInstallingCollection, recentChanges, installedSources };
 
       for (const typeId of Object.keys(changes)) {
         for (const change of changes[typeId]) {


### PR DESCRIPTION
## Problem

The "changed outside Vortex" dialog can fire for mods the user deliberately uninstalled. Accepting the default action can reinstate manifest entries pointing at content that is already gone.

## Cause

#22854 added an allow-list that suppresses the dialog for Vortex's own remove/replace operations. That allow-list is held in memory for the lifetime of the session.

If Vortex exits between removing a mod and the next successful deploy, the orphaned manifest entries survive into the next session, where the allow-list starts empty. Those `srcdeleted` entries then surface as external changes with no record that Vortex caused them.

## Change

In `classifyExternalChange`, treat a missing staging source as the expected outcome when the owning mod is no longer present in Vortex's state — the destination is a surviving hardlink, not a user edit — and drop the stale manifest entry. `installedSources` comes from persisted Redux state rather than an in-memory set, so the suppression holds across restarts.

Two details that the tests below pin down:

- The game is resolved the same way `checkForExternalChanges` resolves it (`profileById` with an `activeProfile` fallback). A stale `profileId` is tolerated there, so deriving the game from `persistent.profiles[profileId]` alone would yield `undefined` for that same id and make every source look uninstalled.
- `installedSources` is left `undefined` **only** when the game cannot be determined. Once it is known, a missing or empty mod table means nothing is installed. That matters because removing the last remaining mod takes the game's whole mod table with it.

Scope stays narrow: only `srcdeleted`, and only when the owning mod is absent from state.

## Verification

**End-to-end, against a real Fallout New Vegas install**, across two app sessions sharing one user-data directory. Session 1 installs a mod, lets it deploy, then removes it through the UI. A clean removal undeploys and rewrites the manifest, so the cross-session state is staged from the app's own artifacts: its deployment manifest and its deployed file are restored after the removal, reproducing exactly what survives a quit between the removal and the next deploy. Session 2 relaunches and deploys.

Both runs detect the same orphan — `checking external changes {"modType":"","count":2}`:

| | surfaced to user | dialog |
|---|---|---|
| without this change | `found external changes {"automated":0,"user":2}`, both entries `srcdeleted` from `E2ETestMod` | **shown** |
| with this change | none | **none** |

The unfixed run's diagnostic names the entries exactly: `{filePath:"e2e-marker.txt", source:"E2ETestMod", changeType:"srcdeleted"}`. `automated:0` confirms the in-memory allow-list matched nothing, which is the cross-session gap.

Unit coverage in `externalChanges.test.ts` drives the real `dealWithExternalChanges` and asserts on what reaches `showExternalChanges`: the orphan is dropped (with an empty allow-list and with `recentChanges` undefined), only the orphan is dropped in a mixed batch, a still-installed mod's `srcdeleted` still surfaces, the last-mod-removed case is dropped, and a stale `profileId` still surfaces.

Renderer suite with the change: all tests pass; `typecheck` and `lint` clean.
