### PR TITLE
chore(health-check): remove the scan-complete Mixpanel event (LAZ-1115)

### DIFF
--- a/src/renderer/src/extensions/health_check/api/index.ts
+++ b/src/renderer/src/extensions/health_check/api/index.ts
@@ -32,7 +32,7 @@ export function createHealthCheckApi(
   const customApi = createCustomCheckApi(registry, api);
   const legacyApi = createLegacyApi(legacyAdapter, registry);
   const resultsApi = createResultsApi(registry);
-  const { trackScanCompleted, trackScanTriggered } = createHealthCheckTracker(api);
+  const { trackScanTriggered } = createHealthCheckTracker(api);
 
   return {
     custom: customApi,
@@ -47,11 +47,10 @@ export function createHealthCheckApi(
       return registry.runAllHealthChecks(api);
     },
     /**
-     * Run the checks registered for a trigger, bracketed by the scan_triggered /
-     * scan_completed analytics events. Every scan funnels through here —
-     * the refresh button, the automatic triggers, and the settings/flag listeners —
-     * so this is the one place the pair can be emitted without double counting.
-     * A run that throws deliberately leaves no scan_completed behind.
+     * Run the checks registered for a trigger, reporting the scan_triggered analytics
+     * event. Every scan funnels through here — the refresh button, the automatic
+     * triggers, and the settings/flag listeners — so this is the one place it can be
+     * emitted without double counting.
      */
     runChecksByTrigger: async (trigger: HealthCheckTrigger) => {
       trackScanTriggered({
@@ -59,19 +58,7 @@ export function createHealthCheckApi(
         previous_issue_count: countActiveIssues(api.getState()).total,
       });
 
-      const startedAt = Date.now();
-      const results = await registry.runChecksByTrigger(trigger, api);
-      const counts = countActiveIssues(api.getState());
-
-      trackScanCompleted({
-        duration_ms: Date.now() - startedAt,
-        total_issues_found: counts.total,
-        warning_count: counts.warning,
-        suggestion_count: counts.suggestion,
-        health_check_passed: counts.total === 0,
-      });
-
-      return results;
+      return registry.runChecksByTrigger(trigger, api);
     },
   };
 }

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.test.ts
@@ -114,21 +114,12 @@ describe("createHealthCheckTracker", () => {
     expect(events[0].properties).not.toHaveProperty("check_id");
   });
 
-  it("emits the scan lifecycle pair", () => {
+  it("emits the scan trigger, and nothing on completion", () => {
     const { tracker, events } = harness();
     tracker.trackScanTriggered({ is_manual: true, previous_issue_count: 4 });
-    tracker.trackScanCompleted({
-      duration_ms: 1200,
-      total_issues_found: 2,
-      warning_count: 1,
-      suggestion_count: 1,
-      health_check_passed: false,
-    });
-    expect(events.map((e) => e.eventName)).toEqual([
-      "health_check_scan_triggered",
-      "health_check_scan_completed",
-    ]);
+    expect(events.map((e) => e.eventName)).toEqual(["health_check_scan_triggered"]);
     expect(events[0].properties).toEqual({ is_manual: true, previous_issue_count: 4 });
+    expect(tracker).not.toHaveProperty("trackScanCompleted");
   });
 
   it("omits issue_id from install events when the install isn't tied to one issue", () => {

--- a/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
+++ b/src/renderer/src/extensions/health_check/hooks/healthCheckTracker.ts
@@ -69,18 +69,12 @@ export const createHealthCheckTracker = (api: IExtensionApi) => {
 
     trackPassedViewed: () => track("health_check_passed_viewed"),
 
-    // Scan lifecycle. Emitted by the non-React api layer around every check run,
-    // manual (refresh button) or automatic (game / profile / mods / settings change).
+    // Emitted by the non-React api layer for every check run, manual (refresh button) or
+    // automatic (game / profile / mods change). There is deliberately no completion
+    // event: a scan is mostly automatic, so one per run spent a large share of the
+    // event quota to say little. See LAZ-1115.
     trackScanTriggered: (props: { is_manual: boolean; previous_issue_count: number }) =>
       track("health_check_scan_triggered", props),
-
-    trackScanCompleted: (props: {
-      duration_ms: number;
-      total_issues_found: number;
-      warning_count: number;
-      suggestion_count: number;
-      health_check_passed: boolean;
-    }) => track("health_check_scan_completed", props),
 
     trackTabSwitched: (props: { tab: HealthCheckTab; issue_count_in_tab: number }) =>
       track("health_check_tab_switched", props),


### PR DESCRIPTION
Removes the `health_check_scan_completed` Mixpanel event. [LAZ-1115](https://linear.app/nexus-mods/issue/LAZ-1115/remove-health-check-scan-complete-mixpanel-event) · [Mixpanel event](https://eu.mixpanel.com/s/Y1clu)

It fired once per scan, and scans are overwhelmingly automatic rather than something a user asked for — a game or profile switch, a login change, and every mod install, enable, disable or removal, plus any change to the set of downloads (`health_check/api/triggers.ts`). An evening of modding is therefore tens of scans, which is how it reached ~44M events, and the event carried no way to tell those apart: unlike `scan_triggered` it has no `is_manual` or trigger property.

## What changed

- `hooks/healthCheckTracker.ts` — `trackScanCompleted` deleted. The comment above `trackScanTriggered` now records why there is no completion event, so it doesn't come back as an oversight.
- `api/index.ts` — dropped the call, and with it the `Date.now()` timing that only fed `duration_ms` and the second `countActiveIssues` read that only fed the counts. `runChecksByTrigger` no longer needs to await the run.
- `hooks/healthCheckTracker.test.ts` — the lifecycle-pair test becomes "emits the scan trigger, and nothing on completion", asserting the single event and that the method is gone.

## Worth knowing

`scan_triggered` stays, so the useful half survives — `is_manual` separates the refresh button from the automatic scans, and `previous_issue_count` keeps the issue trend. It fires on the same triggers, though, so this saves roughly half the volume those 44M represented rather than all of it. If the quota is still the pressure, the next lever is sampling or dropping the automatic `scan_triggered` events, which needs a call on what analysis depends on them.